### PR TITLE
Adding active status to currently selected navigation item

### DIFF
--- a/src/app/view/navbar/navigation/navigation.html
+++ b/src/app/view/navbar/navigation/navigation.html
@@ -1,5 +1,7 @@
 <ul class="nav navbar-nav">
-  <li ng-repeat="menuitem in NavigationCtrl.menu">
-    <a ui-sref="{{ menuitem.href }}" >{{ menuitem.text }}</a>
+  <li ng-repeat="menuItem in NavigationCtrl.menu"
+      ng-class="{ active: NavigationCtrl.activeMenuitem === menuItem }"
+      ng-click="NavigationCtrl.activeMenuitem = menuItem">
+    <a ui-sref="{{ menuItem.href }}">{{ menuItem.text }}</a>
   </li>
 </ul>


### PR DESCRIPTION
Currently, when select a item in the top navigation bar, the item has only
text highlighted, with background color stay the same. When click on somewhere
else on the screen, the highlight disappeared. This is because we did't apply a
`active` class to the selected item.

This PR fixes the issue.
