### PR TITLE
Fixed paths for helion-ui-framework for provisioning

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -7,7 +7,7 @@
 $fa-font-path: "lib/font-awesome/fonts";
 @import "lib/font-awesome/scss/font-awesome";
 @import "lib/bootstrap-sass-official/assets/stylesheets/bootstrap";
-@import "lib/helion-ui-framework/framework";
+@import "lib/helion-ui-framework/src/framework";
 
 // app
 @import "app/app";

--- a/tools/gulp.config.js
+++ b/tools/gulp.config.js
@@ -30,8 +30,8 @@ module.exports = function () {
     ],
 
     jsLibs: [
-      paths.dist + 'lib/helion-ui-framework/**/*.module.js',
-      paths.dist + 'lib/helion-ui-framework/**/*.js'
+      paths.dist + 'lib/helion-ui-framework/src/**/*.module.js',
+      paths.dist + 'lib/helion-ui-framework/src/**/*.js'
     ],
 
     jsSourceFiles: [


### PR DESCRIPTION
The paths for the helion-ui-framework SCSS and JS files are incorrect in the gulp.config.js and index.css. This PR fixes that.
