### PR TITLE
Hiding navber instead of late initialization

### DIFF
--- a/src/app/view/application.html
+++ b/src/app/view/application.html
@@ -1,3 +1,3 @@
-<navbar ng-if="applicationCtrl.loggedIn"></navbar>
+<navbar ng-show="applicationCtrl.loggedIn"></navbar>
 <login-page ng-if="!applicationCtrl.loggedIn"></login-page>
 <console-view ng-if="applicationCtrl.loggedIn"></console-view>


### PR DESCRIPTION
The navigation directive need to be initialized before login to receive LOGGED_IN event.
