### PR TITLE
Dockerfile.prod should not run gulp twice

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,4 +3,4 @@ FROM node:4.2.3
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-CMD bash provision.sh && cd tools && node_modules/.bin/gulp
+CMD bash provision.sh

--- a/provision.sh
+++ b/provision.sh
@@ -7,5 +7,4 @@ cd $TOOLS_DIR
 npm install
 PATH=$PATH:$TOOLS_DIR/node_modules/.bin
 node_modules/.bin/bower install --allow-root --force
-node_modules/.bin/gulp clean:dist
-node_modules/.bin/gulp
+npm run build


### PR DESCRIPTION
The provision.sh script already runs gulp so Dockerfile.prod shouldn't run it again. Also simplified the provision script to use `npm run build`.
