### PR TITLE
Registration overlay should only run once

### DIFF
--- a/src/app/model/serviceInstance/serviceInstance.model.js
+++ b/src/app/model/serviceInstance/serviceInstance.model.js
@@ -100,7 +100,7 @@
           that.serviceInstances.length = 0;
           that.serviceInstances.push.apply(that.serviceInstances, _.sortBy(items, 'name'));
           that.numRegistered = _.sumBy(items, function (o) { return o.valid ? 1 : 0; }) || 0;
-          var numCompleted = _.sumBy(items, function (o) { return o.valid && o.registered ? 1 : 0; }) || 0;
+          var numCompleted = _.sumBy(items, function (o) { return o.registered ? 1 : 0; }) || 0;
 
           return {
             serviceInstances: that.serviceInstances,


### PR DESCRIPTION
After talking to UX, the registration overlay (first-time registration) should only show once - the first time the user logs in. After registering at least one service instance and clicking "Done", the user no longer sees this page.

When all service instances expire, the user will still be redirected to the default dashboard on login; however, the bell icon in the header will now show notifications that there are expired service instances.

Requires changes in this PR: https://github.com/hpcloud/stratos-node-server/pull/20

@randyochoa @sean-sq-chen 
