### PR TITLE
TEAMFOUR-107 Convert login page Stratos references

### DIFF
--- a/src/app/view/login-page/login-page.html
+++ b/src/app/view/login-page/login-page.html
@@ -11,7 +11,7 @@
     <div>
       <h1 class="text-center" translate>CNAP</h1>
       <p class="text-center" translate>
-        Stratos tag line: discovering, composing, developing and managing Cloud Native workloads which are hosted in a myriad of: public, managed and private cloud/compute providers.
+        CNAP tag line: discovering, composing, developing and managing Cloud Native workloads which are hosted in a myriad of: public, managed and private cloud/compute providers.
       </p>
     </div>
   </section>
@@ -36,7 +36,7 @@
       </p>
       <h1 class="text-center" translate>Develop</h1>
       <p class="text-center" translate>
-        Built for Enterprise applications, Stratos has open source Cloud Foundry as a core component and adds support for things that Enterprise operations teams need most such as resiliency, ease of management, and ease of install. It also provides additional capabilities for developers such as a continuous integration and deployment service that automates build, test, and deployment actions.
+        Built for Enterprise applications, CNAP has open source Cloud Foundry as a core component and adds support for things that Enterprise operations teams need most such as resiliency, ease of management, and ease of install. It also provides additional capabilities for developers such as a continuous integration and deployment service that automates build, test, and deployment actions.
       </p>
       <p class="text-center">
         <a href="#" class="btn btn-default" translate>Learn More</a>


### PR DESCRIPTION
There were 2 remaining references on the login page from Stratos to
CNAP.  I've converted them.
