### PR TITLE
Re-add manage services link back to app summary

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
@@ -44,9 +44,9 @@
 <div>
   <div class="action-header">
     <span translate>Service Instances</span>
-    <a class="btn btn-link">
+    <a class="btn btn-link" ui-sref="cf.applications.application.services({guid: appCtrl.id})">
       <i class="helion-icon helion-icon-Right_Arrow"></i>
-      <span translate>Add service</span>
+      <span translate>Manage Services</span>
     </a>
   </div>
   <div class="panel panel-default">


### PR DESCRIPTION
Re-adding the manage services link back to application summary. This should like correctly change the view to the services panel.

@sean-sq-chen 
