### PR TITLE
Unfix the version of Bower

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bower": "1.7.1",
+    "bower": "^1.7.1",
     "del": "^2.2.0",
     "gulp": "^3.9.0",
     "gulp-concat-util": "^0.5.4",


### PR DESCRIPTION
Bower version was fixed at `1.7.1`. This PR sets it at `^1.7.1`.
