### PR TITLE
Adding jQuery for karma tests

### DIFF
--- a/tools/bower.json
+++ b/tools/bower.json
@@ -29,7 +29,8 @@
     "angular-cookies": "1.4"
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.9"
+    "angular-mocks": "~1.4.9",
+    "jquery": "~1.11.3"
   },
   "resolutions": {
     "angular-bootstrap": "~1.1.1",

--- a/tools/karma.conf.js
+++ b/tools/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function (config) {
     },
 
     files: [
+      'lib/jquery/dist/jquery.js',
       'lib/angular-mocks/angular-mocks.js',
 
       'config.js',


### PR DESCRIPTION
Because jqLite is so lacking in selectors, writing unittests is much
harder than it needs to be without jQuery.  BUT... we don't want to add
jQuery to our production product.  So, we can just add it to the
devDependencies in bower, and then unittests will need to explicitly
wrap angular.element objects with $().
