### PR TITLE
Application Gallery View header fix

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/gallery-view/gallery-view.html
+++ b/src/plugins/cloud-foundry/view/applications/list/gallery-view/gallery-view.html
@@ -1,5 +1,3 @@
-<h1>Applications Gallery View (<a ui-sref="cf.applications.list.table-view">Table View</a>)</h1>
-
 <div class="col-md-4 col-sm-1"
   ng-repeat="app in applicationsListCtrl.model.data.applications.resources track by app.metadata.guid">
   <application-gallery-card app="app"></application-gallery-card>

--- a/src/plugins/cloud-foundry/view/applications/list/list.html
+++ b/src/plugins/cloud-foundry/view/applications/list/list.html
@@ -1,4 +1,5 @@
-<div>
+<div class="action-bar no-top-margin app-actions-bar col-md-12">
+  <h1 class="pull-left" translate>Applications</h1>
   <div class="pull-right">
     <button class="btn btn-primary"
       translate


### PR DESCRIPTION
When the create application button was added to the application gallery view, the header text was removed. This PR removes that white bar, restores the header, and lines it up with the create application button.

@ongk @sean-sq-chen @wchrisjohnson @woodm1979 
