### PR TITLE
Fixing typo

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/list.html
+++ b/src/plugins/cloud-foundry/view/applications/list/list.html
@@ -1,5 +1,5 @@
 <div class="action-bar app-actions-bar col-md-12">
-  <h1 class="pull-left" translate>Applications</h2>
+  <h1 class="pull-left" translate>Applications</h1>
   <div class="pull-right">
     <button class="btn btn-primary"
       translate


### PR DESCRIPTION
This fix is assuming `<h1>` is intended. sorry I missed this in CR.

@domvieira 
