### PR TITLE
Fix table last column alignment

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/pipeline-subflow/pipeline-subflow.scss
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/pipeline-subflow/pipeline-subflow.scss
@@ -4,8 +4,8 @@ table.table {
   }
 
   // TODO: From here onwards, code will be moved to helion-ui-theme
-  > thead > tr > th,
-  > tbody > tr:not([table-inline-message]) > td {
+  > thead > tr > th.text-left,
+  > tbody > tr:not([table-inline-message]) > td.text-left {
     &:last-child:not(.text-center) {
       text-align: left;
 

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/pipeline-subflow/select-repository.html
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/pipeline-subflow/select-repository.html
@@ -6,7 +6,7 @@
   st-safe-src="wizardCtrl.options.repos">
   <thead>
     <tr>
-      <th colspan="3" class="filter-header">
+      <th colspan="3" class="filter-header text-left">
         <form class="form-horizontal">
           <div class="form-group col-md-3">
             <label class="control-label" translate>Repositories</label>


### PR DESCRIPTION
The last column should be text-aligned by default, but that hasn't been fixed yet. So, the `text-align` class here is used to override that in the select repo step of add app workflow.
