### PR TITLE
Fix ITOps cluster registration flyout header

### DIFF
--- a/src/app/view/cluster-registration/add-cluster-form/add-cluster-form.scss
+++ b/src/app/view/cluster-registration/add-cluster-form/add-cluster-form.scss
@@ -4,6 +4,10 @@ add-cluster-form {
 
   .add-cluster-form {
     max-width: 350px;
+
+    h2 {
+      margin-top: $hpe-unit-space * 2.5;
+    }
   }
 
   form {


### PR DESCRIPTION
The ITOps cluster registration flyout header should align with close button
