### PR TITLE
Fix e2e random parse error

### DIFF
--- a/e2e/admin/cluster-registration.spec.js
+++ b/e2e/admin/cluster-registration.spec.js
@@ -8,9 +8,11 @@ var registration = require('../po/service-instance-registration.po');
 
 describe('Cluster Registration (ITOps)', function () {
   beforeAll(function () {
-    resetTo.zeroClusterAdminWorkflow();
-    helpers.setBrowserNormal();
-    helpers.loadApp();
+    browser.driver.wait(resetTo.zeroClusterAdminWorkflow())
+      .then(function () {
+        helpers.setBrowserNormal();
+        helpers.loadApp();
+      });
   });
 
   it('should be displayed with cluster count === 0', function () {

--- a/e2e/dev/applications.gallery.spec.js
+++ b/e2e/dev/applications.gallery.spec.js
@@ -7,10 +7,12 @@ var galleryPage = require('../po/applications.po');
 
 describe('Applications - Gallery View', function () {
   beforeAll(function () {
-    resetTo.devWorkflow(false);
-    helpers.setBrowserNormal();
-    helpers.loadApp();
-    loginPage.login('dev', 'dev');
+    browser.driver.wait(resetTo.devWorkflow(false))
+      .then(function () {
+        helpers.setBrowserNormal();
+        helpers.loadApp();
+        loginPage.login('dev', 'dev');
+      });
   });
 
   it('should show applications as cards', function() {

--- a/e2e/dev/applications.services.spec.js
+++ b/e2e/dev/applications.services.spec.js
@@ -7,13 +7,15 @@ var galleryPage = require('../po/applications.po');
 
 describe('Application - Services', function () {
   beforeAll(function () {
-    resetTo.devWorkflow(false);
-    helpers.setBrowserNormal();
-    helpers.loadApp();
-    loginPage.login('dev', 'dev');
-    galleryPage.showApplications();
-    galleryPage.showApplicationDetails(0);
-    galleryPage.showServices();
+    browser.driver.wait(resetTo.devWorkflow(false))
+      .then(function () {
+        helpers.setBrowserNormal();
+        helpers.loadApp();
+        loginPage.login('dev', 'dev');
+        galleryPage.showApplications();
+        galleryPage.showApplicationDetails(0);
+        galleryPage.showServices();
+      });
   });
 
   it('should show application services URL', function () {

--- a/e2e/dev/service-instance-registration.spec.js
+++ b/e2e/dev/service-instance-registration.spec.js
@@ -8,10 +8,12 @@ var registration = require('../po/service-instance-registration.po');
 
 describe('Service Instance Registration', function () {
   beforeAll(function () {
-    resetTo.devWorkflow(true);
-    helpers.setBrowserNormal();
-    helpers.loadApp();
-    loginPage.login('dev', 'dev');
+    browser.driver.wait(resetTo.devWorkflow(true))
+      .then(function () {
+        helpers.setBrowserNormal();
+        helpers.loadApp();
+        loginPage.login('dev', 'dev');
+      });
   });
 
   describe('service instances table', function () {

--- a/e2e/po/resets.po.js
+++ b/e2e/po/resets.po.js
@@ -202,6 +202,8 @@ function removeClusters(req) {
             Promise.all(promises).then(function () {
               resolve();
             });
+          } else {
+            resolve();
           }
         } else {
           resolve();
@@ -264,6 +266,8 @@ function removeUserServiceInstances(req) {
             Promise.all(promises).then(function () {
               resolve();
             });
+          } else {
+            resolve();
           }
         } else {
           resolve();


### PR DESCRIPTION
Sometimes, the e2e tests fail because in attempt to remove clusters/users/service instances, the request sent returns 'Forbidden'. This was due to the promise not being resolved while adding session to the database before the request was returned. This has been corrected in: https://github.com/hpcloud/stratos-node-server/pull/42.

In this PR, additional precautions have been taken to wait for the resets to finish before continuing on with the tests.
