### PR TITLE
299 Stopped app shows start button

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/application.html
+++ b/src/plugins/cloud-foundry/view/applications/application/application.html
@@ -10,9 +10,18 @@
 
   <div class="pull-right">
     <span class="btn-group">
+      <!--Either the start or restart button should be present at any given time.-->
       <button class="btn btn-default"
         translate
         ng-disabled="appCtrl.model.application.summary.state==='PENDING'"
+        ng-if="appCtrl.model.application.summary.state==='STOPPED'"
+        ng-click="appCtrl.model.startApp(appCtrl.id)">
+        Start
+      </button>
+      <button class="btn btn-default"
+        translate
+        ng-disabled="appCtrl.model.application.summary.state==='PENDING'"
+        ng-if="appCtrl.model.application.summary.state!=='STOPPED'"
         ng-click="appCtrl.model.restartApp(appCtrl.id)">
         Restart
       </button>


### PR DESCRIPTION
When an app is in a "STOPPED" state, it shouldn't show a "restart" button,
but instead a "Start" button.
