### PR TITLE
TEAMFOUR-340 - Re-add credentials form flyout

### DIFF
--- a/e2e/dev/service-instance-registration.spec.js
+++ b/e2e/dev/service-instance-registration.spec.js
@@ -44,7 +44,34 @@ describe('Service Instance Registration', function () {
       registration.connect(0);
     });
 
-    it('should update service instance data', function () {
+    it('should open the credentials form', function () {
+      expect(registration.credentialsForm().isDisplayed()).toBeTruthy();
+    });
+
+    it('should show the cluster name and URL as readonly in the credentials form', function () {
+      var serviceInstancesTable = registration.serviceInstancesTable();
+      var name = helpers.getTableCellAt(serviceInstancesTable, 0, 1).getText();
+      var url = helpers.getTableCellAt(serviceInstancesTable, 0, 2).getText();
+
+      var fields = registration.credentialsFormFields();
+      expect(fields.get(0).getAttribute('value')).toBe(name);
+      expect(fields.get(1).getAttribute('value')).toBe(url);
+      expect(fields.get(2).getAttribute('value')).toBe('');
+      expect(fields.get(3).getAttribute('value')).toBe('');
+    });
+
+    it('should disable register button if username and password are blank', function () {
+      expect(registration.registerButton().isEnabled()).toBeFalsy();
+    });
+
+    it('should enable register button if username and password are not blank', function () {
+      registration.fillCredentialsForm('username', 'password');
+      expect(registration.registerButton().isEnabled()).toBeTruthy();
+    });
+
+    it('should update service instance data on register', function () {
+      registration.registerServiceInstance();
+
       var serviceInstancesTable = registration.serviceInstancesTable();
       expect(helpers.getTableCellAt(serviceInstancesTable, 0, 3).getText()).not.toBe('');
       expect(helpers.getTableCellAt(serviceInstancesTable, 0, 4).getText()).not.toBe('');
@@ -82,6 +109,8 @@ describe('Service Instance Registration', function () {
     });
 
     it('should show applications view when `Done` clicked', function () {
+      registration.fillCredentialsForm('username', 'password');
+      registration.registerServiceInstance();
       registration.completeRegistration();
 
       expect(registration.registrationOverlay().isPresent()).toBeFalsy();

--- a/e2e/po/service-instance-registration.po.js
+++ b/e2e/po/service-instance-registration.po.js
@@ -4,6 +4,7 @@
 var helpers = require('./helpers.po');
 var loginPage = require('./login-page.po');
 var navbar = require('./navbar.po');
+var credentialsFormName = 'credentialsFormCtrl.credentialsForm';
 
 module.exports = {
 
@@ -16,8 +17,14 @@ module.exports = {
   disconnect: disconnect,
   completeRegistration: completeRegistration,
   registrationNotification: registrationNotification,
-  serviceInstanceStatus: serviceInstanceStatus
+  serviceInstanceStatus: serviceInstanceStatus,
 
+  credentialsForm: credentialsForm,
+  credentialsFormFields: credentialsFormFields,
+  registerButton: registerButton,
+  cancel: cancel,
+  fillCredentialsForm: fillCredentialsForm,
+  registerServiceInstance: registerServiceInstance
 };
 
 function registrationOverlay() {
@@ -39,11 +46,12 @@ function disconnectLink(rowIndex) {
 }
 
 function connect(rowIndex) {
-  return connectLink(rowIndex).click();
+  connectLink(rowIndex).click();
+  browser.driver.sleep(2000);
 }
 
 function disconnect(rowIndex) {
-  return disconnectLink(rowIndex).click();
+  disconnectLink(rowIndex).click();
 }
 
 function doneButton() {
@@ -51,7 +59,7 @@ function doneButton() {
 }
 
 function completeRegistration() {
-  return doneButton().click();
+  doneButton().click();
 }
 
 function serviceInstanceStatus(rowIndex, statusClass) {
@@ -61,4 +69,40 @@ function serviceInstanceStatus(rowIndex, statusClass) {
 
 function registrationNotification() {
   return registrationOverlay().element(by.css('.fixed-footer .registration-notification'));
+}
+
+/**
+ * Credentials Form page objects
+ */
+function credentialsForm() {
+  return element(by.id('registration-overlay')).element(by.css('flyout'))
+    .element(by.css('form[name="' + credentialsFormName + '"]'));
+}
+
+function credentialsFormFields() {
+  return helpers.getFormFields(credentialsFormName);
+}
+
+function registerButton() {
+  return helpers.getForm(credentialsFormName)
+    .element(by.buttonText('Register'));
+}
+
+function cancel() {
+  helpers.getForm(credentialsFormName)
+    .element(by.buttonText('Cancel')).click();
+  browser.driver.sleep(2000);
+}
+
+function fillCredentialsForm(username, password) {
+  var fields = credentialsFormFields();
+  fields.get(2).clear();
+  fields.get(3).clear();
+  fields.get(2).sendKeys(username || '');
+  fields.get(3).sendKeys(password || '');
+}
+
+function registerServiceInstance() {
+  registerButton().click();
+  browser.driver.sleep(2000);
 }

--- a/src/app/view/cluster-registration/cluster-registration.scss
+++ b/src/app/view/cluster-registration/cluster-registration.scss
@@ -2,6 +2,7 @@
 
 .cluster-registration {
   display: block;
+  overflow-y: auto;
 
   &.overlay-position {
     .registration-content {

--- a/src/app/view/service-registration/credentials-form/credentials-form.directive.js
+++ b/src/app/view/service-registration/credentials-form/credentials-form.directive.js
@@ -1,0 +1,123 @@
+(function () {
+  'use strict';
+
+  angular
+    .module('app.view')
+    .directive('credentialsForm', credentialsForm);
+
+  credentialsForm.$inject = ['app.basePath'];
+
+  /**
+   * @namespace app.view.credentialsForm
+   * @memberof app.view
+   * @name credentialsForm
+   * @description A credentials-form directive that allows
+   * user to enter a username and password to register
+   * accessible CNSIs.
+   * @param {string} path - the application base path
+   * @example
+   * <credentials-form cnsi="ctrl.serviceToRegister"
+   *   on-cancel="ctrl.registerCancelled()"
+   *   on-submit="ctrl.registerSubmitted()">
+   * </credentials-form>
+   * @returns {object} The credentials-form directive definition object
+   */
+  function credentialsForm(path) {
+    return {
+      bindToController: {
+        cnsi: '=',
+        onCancel: '&?',
+        onSubmit: '&?'
+      },
+      controller: CredentialsFormController,
+      controllerAs: 'credentialsFormCtrl',
+      scope: {},
+      templateUrl: path + 'view/service-registration/credentials-form/credentials-form.html'
+    };
+  }
+
+  CredentialsFormController.$inject = [
+    '$scope',
+    'app.event.eventService',
+    'app.model.modelManager'
+  ];
+
+  /**
+   * @namespace app.view.credentialsForm.CredentialsFormController
+   * @memberof app.view.credentialsForm
+   * @name CredentialsFormController
+   * @description Controller for credentialsForm directive that handles
+   * service/cluster registration
+   * @constructor
+   * @param {object} $scope - this controller's directive scope
+   * @param {app.event.eventService} eventService - the application event bus
+   * @param {app.model.modelManager} modelManager - the application model manager
+   * @property {app.event.eventService} eventService - the application event bus
+   * @property {boolean} authenticating - a flag that authentication is in process
+   * @property {boolean} failedRegister - an error flag for bad credentials
+   * @property {boolean} serverErrorOnRegister - an error flag for a server error
+   * @property {boolean} serverFailedToRespond - an error flag for no server response
+   * @property {object} _data - the view data (copy of service)
+   */
+  function CredentialsFormController($scope, eventService, modelManager) {
+    this.serviceInstanceModel = modelManager.retrieve('app.model.serviceInstance.user');
+    this.eventService = eventService;
+    this.authenticating = false;
+    this.failedRegister = false;
+    this.serverErrorOnRegister = false;
+    this.serverFailedToRespond = false;
+    this._data = {};
+  }
+
+  angular.extend(CredentialsFormController.prototype, {
+    /**
+     * @function cancel
+     * @memberOf app.view.credentialsForm.CredentialsFormController
+     * @description Cancel credentials form
+     * @returns {void}
+     */
+    cancel: function () {
+      this.reset();
+      if (angular.isDefined(this.onCancel)) {
+        this.onCancel();
+      }
+    },
+
+    /**
+     * @function connect
+     * @memberOf app.view.credentialsForm.CredentialsFormController
+     * @description Connect service instance for user
+     * @param {object} serviceInstance - the service instance to connect
+     * @returns {void}
+     */
+    connect: function () {
+      var that = this;
+      this.authenticating = true;
+      this.serviceInstanceModel.connect(this.cnsi.url)
+        .then(function success(response) {
+          that.reset();
+          if (angular.isDefined(that.onSubmit)) {
+            that.onSubmit({ serviceInstance: response.data });
+          }
+        });
+    },
+
+    /**
+     * @function reset
+     * @memberOf app.view.credentialsForm.CredentialsFormController
+     * @description Reset credentials form
+     * @returns {void}
+     */
+    reset: function () {
+      this._data = {};
+
+      this.failedRegister = false;
+      this.serverErrorOnRegister = false;
+      this.serverFailedToRespond = false;
+
+      this.authenticating = false;
+      this.credentialsForm.$setPristine();
+    }
+  });
+
+})();

--- a/src/app/view/service-registration/credentials-form/credentials-form.directive.spec.js
+++ b/src/app/view/service-registration/credentials-form/credentials-form.directive.spec.js
@@ -1,0 +1,160 @@
+(function () {
+  'use strict';
+
+  describe('credentials-form directive', function () {
+    var $compile, $httpBackend, $scope;
+
+    beforeEach(module('templates'));
+    beforeEach(module('green-box-console'));
+
+    beforeEach(inject(function ($injector) {
+      $compile = $injector.get('$compile');
+      $httpBackend = $injector.get('$httpBackend');
+      $scope = $injector.get('$rootScope').$new();
+      $scope.cnsi = { name: 'cluster1', url: 'cluster1_url' };
+    }));
+
+    describe('with default functionality', function () {
+      var element, credentialsFormCtrl;
+
+      beforeEach(function () {
+        var markup = '<credentials-form cnsi="cnsi"><credentials-form/>';
+
+        element = angular.element(markup);
+        $compile(element)($scope);
+
+        $scope.$apply();
+
+        credentialsFormCtrl = element.controller('credentialsForm');
+        spyOn(credentialsFormCtrl, 'reset').and.callThrough();
+      });
+
+      it('should be defined', function () {
+        expect(element).toBeDefined();
+      });
+
+      it('should have `eventService` property defined', function () {
+        expect(credentialsFormCtrl.eventService).toBeDefined();
+      });
+
+      it('should have `_data` property initially empty', function () {
+        expect(credentialsFormCtrl._data).toEqual({});
+      });
+
+      it('should call reset() on cancel', function () {
+        credentialsFormCtrl.cancel();
+        expect(credentialsFormCtrl.reset).toHaveBeenCalled();
+      });
+
+      it('should call reset() on connect', function () {
+        var mockResponse = {
+          id: 1,
+          name: 'cluster1',
+          url: 'cluster1_url',
+          username: 'cluster1_username',
+          account: 'cluster1_password',
+          expires_at: 3600
+        };
+        $httpBackend.when('POST', '/api/service-instances/user/connect').respond(200, mockResponse);
+
+        credentialsFormCtrl.connect();
+        $httpBackend.flush();
+
+        expect(credentialsFormCtrl.reset).toHaveBeenCalled();
+      });
+
+      it('should set error flags to false and set form as pristine on reset', function () {
+        credentialsFormCtrl.reset();
+
+        expect(credentialsFormCtrl._data.username).toBeUndefined();
+        expect(credentialsFormCtrl._data.password).toBeUndefined();
+        expect(credentialsFormCtrl.failedRegister).toBe(false);
+        expect(credentialsFormCtrl.serverErrorOnRegister).toBe(false);
+        expect(credentialsFormCtrl.serverFailedToRespond).toBe(false);
+        expect(credentialsFormCtrl.authenticating).toBe(false);
+        expect(credentialsFormCtrl.credentialsForm.$pristine).toBeTruthy();
+      });
+    });
+
+    describe('with onCancel', function () {
+      var element, credentialsFormCtrl;
+
+      beforeEach(function () {
+        $scope.cancel = angular.noop;
+
+        var markup = '<credentials-form cnsi="cnsi" on-cancel="cancel()">' +
+                     '<credentials-form/>';
+
+        element = angular.element(markup);
+        $compile(element)($scope);
+
+        $scope.$apply();
+
+        credentialsFormCtrl = element.controller('credentialsForm');
+        spyOn(credentialsFormCtrl, 'onCancel').and.callThrough();
+        spyOn($scope, 'cancel');
+      });
+
+      it('should be defined', function () {
+        expect(element).toBeDefined();
+      });
+
+      it('should have `onCancel` property defined', function () {
+        expect(credentialsFormCtrl.onCancel).toBeDefined();
+      });
+
+      it('should call onCancel() on cancel', function () {
+        credentialsFormCtrl.cancel();
+        expect(credentialsFormCtrl.onCancel).toHaveBeenCalled();
+        expect($scope.cancel).toHaveBeenCalled();
+      });
+    });
+
+    describe('with onSubmit', function () {
+      var element, credentialsFormCtrl;
+
+      beforeEach(function () {
+        $scope.register = angular.noop;
+
+        var markup = '<credentials-form cnsi="cnsi" on-submit="register()">' +
+                     '<credentials-form/>';
+
+        element = angular.element(markup);
+        $compile(element)($scope);
+
+        $scope.$apply();
+
+        credentialsFormCtrl = element.controller('credentialsForm');
+        spyOn(credentialsFormCtrl, 'onSubmit').and.callThrough();
+        spyOn($scope, 'register');
+      });
+
+      it('should be defined', function () {
+        expect(element).toBeDefined();
+      });
+
+      it('should have `onSubmit` property defined', function () {
+        expect(credentialsFormCtrl.onSubmit).toBeDefined();
+      });
+
+      it('should call onSubmit() on connect', function () {
+        var mockResponse = {
+          id: 1,
+          name: 'cluster1',
+          url: 'cluster1_url',
+          username: 'dev',
+          account: 'dev',
+          expires_at: 3600
+        };
+        $httpBackend.when('POST', '/api/service-instances/user/connect').respond(200, mockResponse);
+
+        credentialsFormCtrl.connect();
+        $httpBackend.flush();
+
+        expect(credentialsFormCtrl.onSubmit).toHaveBeenCalled();
+        expect($scope.register).toHaveBeenCalled();
+      });
+    });
+  });
+
+})();

--- a/src/app/view/service-registration/credentials-form/credentials-form.html
+++ b/src/app/view/service-registration/credentials-form/credentials-form.html
@@ -1,0 +1,62 @@
+<div class="credentials-form">
+  <h2 translate>Provide Credentials</h2>
+  <p translate>You should have received an email from your IT operator with credentials for clusters you have access to. Please contact your IT operator for help.</p>
+  <form class="form-stacked center-block" name="credentialsFormCtrl.credentialsForm" role="form"
+    ng-submit="credentialsFormCtrl.connect()">
+    <div class="form-group">
+      <label class="control-label" for="credentials-form-name" translate>
+        Service
+      </label>
+      <input type="text" class="form-control"
+        id="credentials-form-name" name="name"
+        ng-model="credentialsFormCtrl.cnsi.name" readonly/>
+    </div>
+    <div class="form-group">
+      <label class="control-label" for="credentials-form-url" translate>
+        URL
+      </label>
+      <input type="text" class="form-control"
+        id="credentials-form-url" name="url"
+        ng-model="credentialsFormCtrl.cnsi.url" readonly/>
+    </div>
+    <div class="form-group" focusable-input ng-class="credentialsFormCtrl.failedRegister ? 'has-error' : ''">
+      <label class="control-label required" for="credentials-form-username" translate>
+        Username
+      </label>
+      <input type="text" class="form-control"
+        id="credentials-form-username" name="username"
+        ng-model="credentialsFormCtrl._data.username" required autofocus/>
+    </div>
+    <div class="form-group has-feedback" focusable-input ng-class="credentialsFormCtrl.failedRegister ? 'has-error' : ''">
+      <label class="control-label required" for="credentials-form-password" translate>
+        Password
+      </label>
+      <input type="password" class="form-control" id="credentials-form-password" name="password"
+        ng-model="credentialsFormCtrl._data.password" password-reveal password-reveal-icon="'helion-icon helion-icon-View'" required/>
+    </div>
+
+    <div class="form-actions">
+      <button type="button" class="btn btn-default"
+        ng-click="credentialsFormCtrl.cancel()" translate>Cancel</button>
+      <button type="submit" class="btn btn-primary"
+        ng-disabled="credentialsFormCtrl.credentialsForm.$invalid || credentialsFormCtrl.authenticating"
+        translate>Register</button>
+    </div>
+
+    <div class="credentials-form-spinner" ng-show="credentialsFormCtrl.authenticating">
+      <span class="registration-notification" translate>
+        Authenticating Credentials
+      </span>
+      <spinner></spinner>
+    </div>
+  </form>
+  <div ng-if="credentialsFormCtrl.failedRegister" class="alert alert-danger">
+    <p translate>The username and password combination you used are incorrect. Please try again.</p>
+  </div>
+  <div ng-if="credentialsFormCtrl.serverErrorOnRegister" class="alert alert-danger">
+    <p translate>A server error occurred when attempting to register your service. Please try again. If this error persists, please contact the administrator.</p>
+  </div>
+  <div ng-if="credentialsFormCtrl.serverFailedToRespond" class="alert alert-danger">
+    <p translate>The authentication server failed to respond. Please try again. If this error persists, please contact the administrator.</p>
+  </div>
+</div>

--- a/src/app/view/service-registration/credentials-form/credentials-form.scss
+++ b/src/app/view/service-registration/credentials-form/credentials-form.scss
@@ -1,0 +1,43 @@
+credentials-form, [credentials-form] {
+  @include flex-centered();
+
+  .credentials-form {
+    max-width: 350px;
+
+    h2 {
+      margin-top: $hpe-unit-space * 2.5;
+    }
+
+    form {
+      margin-top: $hpe-unit-space;
+
+      .form-group {
+        width: 100%;
+      }
+    }
+  }
+
+  .alert {
+    margin-top: $hpe-unit-space;
+  }
+
+  .credentials-form-spinner {
+    @include flex-align(flex-end, center);
+    margin-top: 10px;
+
+    .registration-notification {
+      margin-right: 20px;
+      text-transform: uppercase;
+    }
+  }
+
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: $hpe-unit-space;
+
+    button:not(:first-child) {
+      margin-left: $hpe-unit-space / 4;
+    }
+  }
+}

--- a/src/app/view/service-registration/service-registration.directive.js
+++ b/src/app/view/service-registration/service-registration.directive.js
@@ -48,6 +48,7 @@
     this.serviceInstanceModel = modelManager.retrieve('app.model.serviceInstance.user');
     this.userModel = modelManager.retrieve('app.model.user');
     this.serviceInstances = this.serviceInstanceModel.serviceInstances;
+    this.credentialsFormOpen = false;
     this.warningMsg = gettext('Authentication failed, please try reconnect.');
     this.serviceInstanceModel.list();
   }
@@ -75,13 +76,8 @@
      * @param {object} serviceInstance - the service instance to connect
      */
     connect: function (serviceInstance) {
-      var that = this;
-      this.serviceInstanceModel.connect(serviceInstance.url)
-        .then(function success(response) {
-          angular.extend(serviceInstance, response.data);
-          serviceInstance.valid = true;
-          that.serviceInstanceModel.numValid += 1;
-        });
+      this.activeServiceInstance = serviceInstance;
+      this.credentialsFormOpen = true;
     },
 
     /**
@@ -99,6 +95,20 @@
           delete serviceInstance.valid;
           that.serviceInstanceModel.numValid -= 1;
         });
+    },
+
+    onConnectCancel: function () {
+      this.credentialsFormOpen = false;
+    },
+
+    onConnectSuccess: function (serviceInstance) {
+      angular.extend(this.activeServiceInstance, serviceInstance);
+      this.activeServiceInstance.valid = true;
+
+      this.serviceInstanceModel.numValid += 1;
+      this.credentialsFormOpen = false;
+
+      this.activeServiceInstance = null;
     }
   });
 

--- a/src/app/view/service-registration/service-registration.directive.spec.js
+++ b/src/app/view/service-registration/service-registration.directive.spec.js
@@ -57,26 +57,12 @@
         expect(serviceRegistrationCtrl.serviceInstances).toEqual([]);
       });
 
-      it('should call connect on model on connect()', function () {
-        $httpBackend.flush();
-
+      it('should open credentials flyout on connect()', function () {
         var serviceInstance = { name: 'c1', url: 'c1_url' };
-        var mockResponse = {
-          id: 1,
-          url: 'c1_url',
-          username: 'dev',
-          account: 'dev',
-          expires_at: 3600
-        };
-        $httpBackend.when('POST', '/api/service-instances/user/connect').respond(200, mockResponse);
-
         serviceRegistrationCtrl.connect(serviceInstance);
-        $httpBackend.flush();
 
-        expect(serviceInstance.account).toBe('dev');
-        expect(serviceInstance.expires_at).toBe(3600);
-        expect(serviceInstance.valid).toBe(true);
-        expect(serviceRegistrationCtrl.serviceInstanceModel.numValid).toBe(1);
+        expect(serviceRegistrationCtrl.activeServiceInstance).toBeDefined();
+        expect(serviceRegistrationCtrl.credentialsFormOpen).toBe(true);
       });
 
       it('should call disconnect on model on disconnect()', function () {
@@ -91,9 +77,8 @@
           expires_at: 3600
         };
 
-        $httpBackend.when('POST', '/api/service-instances/user/connect').respond(200, mockResponse);
         serviceRegistrationCtrl.connect(serviceInstance);
-        $httpBackend.flush();
+        serviceRegistrationCtrl.onConnectSuccess(mockResponse);
 
         $httpBackend.when('DELETE', '/api/service-instances/user/1').respond(200, {});
         $httpBackend.expectDELETE('/api/service-instances/user/1');
@@ -104,6 +89,12 @@
         expect(serviceInstance.expires_at).toBeUndefined();
         expect(serviceInstance.valid).toBeUndefined();
         expect(serviceRegistrationCtrl.serviceInstanceModel.numValid).toBe(0);
+      });
+
+      it('should hide credentials form flyout `onConnectCancel`', function () {
+        serviceRegistrationCtrl.credentialsFormOpen = true;
+        serviceRegistrationCtrl.onConnectCancel();
+        expect(serviceRegistrationCtrl.credentialsFormOpen).toBe(false);
       });
     });
 

--- a/src/app/view/service-registration/service-registration.html
+++ b/src/app/view/service-registration/service-registration.html
@@ -69,3 +69,10 @@
     </button>
   </div>
 </div>
+<flyout flyout-active="serviceRegistrationCtrl.credentialsFormOpen"
+  flyout-close-icon="'helion-icon helion-icon-Close'">
+  <credentials-form cnsi="serviceRegistrationCtrl.activeServiceInstance"
+    on-cancel="serviceRegistrationCtrl.onConnectCancel()"
+    on-submit="serviceRegistrationCtrl.onConnectSuccess(serviceInstance)">
+  </credentials-form>
+</flyout>

--- a/src/app/view/service-registration/service-registration.scss
+++ b/src/app/view/service-registration/service-registration.scss
@@ -1,5 +1,8 @@
+@import "credentials-form/credentials-form";
+
 .service-registration {
   display: block;
+  overflow-y: auto;
 
   &.overlay-position {
     .registration-content {

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
   <!-- inject:js -->
   <!-- endinject -->
 </head>
-<body application>
+<body application
+  ng-class="{'modal-open': (applicationCtrl.showRegistration || applicationCtrl.showClusterRegistration)}">
 </body>
 </html>


### PR DESCRIPTION
Re-adding the credentials form flyout to the service registration overlay.

Also fixed a bug with page scrolling when overlays are present.

Note: The username and password are not sent to the API server yet. Once the portal-proxy is ready, the service instance client model and API will need to be updated accordingly.
