### PR TITLE
TEAMFOUR-302 - Fix browser back/forward buttons

### DIFF
--- a/src/plugins/cloud-foundry/view/view.module.js
+++ b/src/plugins/cloud-foundry/view/view.module.js
@@ -14,7 +14,7 @@
 
   function registerRoute($stateProvider) {
     $stateProvider.state('cf', {
-      url: 'cf',
+      url: '/cf',
       templateUrl: 'plugins/cloud-foundry/view/view.html'
     });
   }


### PR DESCRIPTION
ui router got confused by the missing leading slash '/' in the base state URL. We can now use the back and forward buttons of the browser.
