### PR TITLE
TEAMFOUR-366 - Initial page load now restores context from URL on load

### DIFF
--- a/src/app/model/navigation/navigation.model.js
+++ b/src/app/model/navigation/navigation.model.js
@@ -14,15 +14,16 @@
   registerModel.$inject = [
     'app.model.modelManager',
     'app.event.eventService',
-    '$state'
+    '$state',
+    '$rootScope'
   ];
 
-  function registerModel(modelManager, eventService, $state) {
+  function registerModel(modelManager, eventService, $state, $rootScope) {
     /**
      * Register 'app.model.navigation' with the model manager service.
      * This model hosts the application's navigation tree.
      */
-    modelManager.register('app.model.navigation', new NavigationModel(eventService, $state));
+    modelManager.register('app.model.navigation', new NavigationModel(eventService, $state, $rootScope));
   }
 
   /**
@@ -32,11 +33,12 @@
    * @constructor
    * @param {app.event.eventService} eventService - the event bus service
    * @param {object} $state - ui-router $state service
+   * @param {object} $rootScope - Angular rootScope object
    * @property {app.event.eventService} eventService - the event bus service
    * @property {object} $state - ui-router $state service
    * @property {app.model.navigation} menu - the navigation model
    */
-  function NavigationModel(eventService, $state) {
+  function NavigationModel(eventService, $state, $rootScope) {
     var that = this;
     this.eventService = eventService;
     this.$state = $state;
@@ -50,6 +52,12 @@
     this.eventService.$on(this.eventService.events.REDIRECT, function (event, state) {
       that.onAutoNav(event, state);
     });
+
+    // Install state change handler to set currentState on our menu
+    $rootScope.$on('$stateChangeSuccess', function(event, toState) {
+      that.menu.currentState = toState.data.activeMenuState;
+    });
+
   }
 
   angular.extend(NavigationModel.prototype, {
@@ -83,7 +91,6 @@
      */
     onAutoNav: function (event, state) {
       this.$state.go(state);
-      this.menu.currentState = state;
     }
   });
 
@@ -107,17 +114,22 @@
      * @description Appends a new menu item into the menu list. Each menu item
      * is a sub-menu which is also of type Menu and is empty initially.
      * @param {string} name - the name/ID of the menu item
-     * @param {string} href - the href / ng-router state
+     * @param {string} href - the href / ng-router state we go to when clicking the entry.
+     *                        e.g. cf.applications.list.gallery-view
      * @param {string} text - the displayed text of the menu item
      * @param {string} icon - the icon of the menu item
+     * @param {string=} baseState - optional href / ng-router top-level base state e.g. cf.applications or cf.workspaces
+     *                              (defaults to name)
      * @returns {app.model.navigation.Menu} The navigation's Menu object
      */
-    addMenuItem: function (name, href, text, icon) {
+    addMenuItem: function (name, href, text, icon, baseState) {
       this.push({
         name: name,
         href: href,
         text: text,
         icon: icon,
+        // baseState is used to work out which menu entry is active based on any child state
+        baseState: baseState || name, // defaults to name
         items: new Menu()   // sub-menu
       });
       return this;

--- a/src/app/view/navbar/navigation/navigation.html
+++ b/src/app/view/navbar/navigation/navigation.html
@@ -1,7 +1,6 @@
 <ul class="nav navbar-nav">
   <li ng-repeat="menuItem in navigationCtrl.navigationModel.menu"
-      ng-class="{ active: navigationCtrl.navigationModel.menu.currentState === menuItem.href }"
-      ng-click="navigationCtrl.navigationModel.menu.currentState = menuItem.href">
+      ng-class="{ active: navigationCtrl.navigationModel.menu.currentState === menuItem.baseState }">
     <a ui-sref="{{ menuItem.href }}">{{ menuItem.text }}</a>
   </li>
 </ul>

--- a/src/plugins/cloud-foundry/view/applications/applications.module.js
+++ b/src/plugins/cloud-foundry/view/applications/applications.module.js
@@ -15,7 +15,10 @@
   function registerRoute($stateProvider) {
     $stateProvider.state('cf.applications', {
       url: '/applications',
-      templateUrl: 'plugins/cloud-foundry/view/applications/applications.html'
+      templateUrl: 'plugins/cloud-foundry/view/applications/applications.html',
+      data: {
+        activeMenuState: 'cf.applications'
+      }
     });
   }
 

--- a/src/plugins/cloud-foundry/view/workspaces/workspaces.module.js
+++ b/src/plugins/cloud-foundry/view/workspaces/workspaces.module.js
@@ -12,7 +12,10 @@
   function registerRoute($stateProvider) {
     $stateProvider.state('cf.workspaces', {
       url: '/workspaces',
-      templateUrl: 'plugins/cloud-foundry/view/workspaces/workspaces.html'
+      templateUrl: 'plugins/cloud-foundry/view/workspaces/workspaces.html',
+      data: {
+        activeMenuState: 'cf.workspaces'
+      }
     });
   }
 


### PR DESCRIPTION
- Allows bookmarking deep pages
- Preserves context across browserSync reloads

This installs a rootScope $stateChangeSuccess handler to set the correct currentState on menu.
We then don't need to manually set the menu.currentState in an ng-click handler on menu entries.
We then don't need to manually set the menu.currentState in autoNav()

We still redirect to the applications gallery from the login page.
