### PR TITLE
TEAMFOUR-358: Allow gulpfile to work when using bower link

### DIFF
--- a/tools/gulp.config.js
+++ b/tools/gulp.config.js
@@ -38,14 +38,19 @@ module.exports = function () {
     ],
 
     jsSourceFiles: [
-      paths.src + '**/*.js',
-      '!' + paths.dist + '**/*.mock.js',
-      '!' + paths.dist + '**/*.spec.js',
-      '!' + paths.src + 'lib/**/*.js'
+      paths.src + '*.js',
+      paths.src + 'app/**/*.js',
+      paths.src + 'plugins/**/*.js',
+      '!' + paths.src + 'app/**/*.mock.js',
+      '!' + paths.src + 'app/**/*.spec.js',
+      '!' + paths.src + 'plugins/**/*.mock.js',
+      '!' + paths.src + 'plugins/**/*.spec.js'
     ],
 
     scssFiles: [
-      paths.src + '**/*.scss'
+      paths.src + '*.scss',
+      paths.src + 'app/**/*.scss',
+      paths.src + 'plugins/**/*.scss'
     ],
 
     scssSourceFiles: [

--- a/tools/gulpfile.js
+++ b/tools/gulpfile.js
@@ -17,7 +17,7 @@ var concat = require('gulp-concat-util'),
   browserSyncProxy = require('proxy-middleware'),
   gutil = require('gulp-util'),
   node_url = require('url'),
-
+  vfs = require('vinyl-fs'),
   wiredep = require('wiredep').stream;
 
 var config = require('./gulp.config')();
@@ -60,10 +60,13 @@ gulp.task('copy:js', function () {
 });
 
 // Copy 'lib' folder to 'dist'
+// gulp.src does not support symlinks, so use vinyl-fs
 gulp.task('copy:lib', function () {
-  return gulp
-    .src(paths.src + 'lib/**')
-    .pipe(gulp.dest(paths.dist + 'lib/'));
+  return vfs
+    .src([
+      paths.src + 'lib/',
+      paths.src + 'lib/**/*'
+    ]).pipe(vfs.dest(paths.dist + 'lib/'));
 });
 
 // Copy 'translations' folder to 'dist'

--- a/tools/package.json
+++ b/tools/package.json
@@ -50,6 +50,7 @@
     "protractor": "^3.0.0",
     "proxy-middleware": "^0.15.0",
     "request": "2.69.0",
-    "shelljs": "^0.5.3"
+    "shelljs": "^0.5.3",
+    "vinyl-fs": "2.4.3"
   }
 }


### PR DESCRIPTION
Simpler approach than previously - doesn't move lib folder.

Uses vinylfs to copy the lib folder - this can handle symlinks, so folders linked via bower link are okay.
Narrowed watch globs to speed things up (was taking 2 minutes on my windows machine)
