### PR TITLE
Ignore many many lint warnings and errors in plugins/cloud-foundry/api/hcf

### DIFF
--- a/tools/gulpfile.js
+++ b/tools/gulpfile.js
@@ -122,7 +122,8 @@ gulp.task('lint', function () {
   return gulp
     .src([
       paths.src + '**/*.js',
-      '!' + paths.src + 'lib/**/*.js'
+      '!' + paths.src + 'lib/**/*.js',
+      '!' + paths.src + 'plugins/cloud-foundry/api/hcf/**/*.js'
     ])
     .pipe(eslint())
     .pipe(eslint.format())


### PR DESCRIPTION
Auto generated files causing lots of lint issues. Ignore these for now
