### PR TITLE
451 route path is undefined

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/application.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/application.module.js
@@ -73,7 +73,7 @@
           var routes = that.model.application.summary.routes;
           if (routes.length) {
             var route = routes[0];
-            var path = typeof route.path !== typeof undefined ? '/' + route.path : '';
+            var path = angular.isUndefined(route.path) ? '/' + route.path : '';
             var url = 'http://' + route.host + '.' + route.domain.name + path;
             that.$window.open(url, '_blank');
           }


### PR DESCRIPTION
Currently, if the route.path is undefined, then launching the app will
return an error.  The url ends up as http://blah.com/undefined .  The
trailing "undefined" should not be there.
