### PR TITLE
448 Fix connected styling

### DIFF
--- a/src/app/view/service-registration/service-registration.scss
+++ b/src/app/view/service-registration/service-registration.scss
@@ -23,7 +23,10 @@
   }
 
   .registration-actions {
-    min-width: 150px;
+    //min-width: 150px;
+    // For the demo, we need to keep 2 buttons worth of width.
+    // Not sure if ems are right here.
+    min-width: 29em;
   }
 
   .registration-status {


### PR DESCRIPTION
On the service registration page, if you connect an HCF cluster, the two
"add buttons" now stack which is really ugly.  Just need a min-width to
sort it all out.
