### PR TITLE
448 HCE clusters can't connect

### DIFF
--- a/src/app/view/service-registration/service-registration.html
+++ b/src/app/view/service-registration/service-registration.html
@@ -53,13 +53,15 @@
             <td>{{serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].account}}</td>
             <td>{{serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].token_expiry | secondsToMs | amDateFormat:'MMM D YYYY, h:mm:ss a'}}</td>
             <td class="text-right">
-              <a class="btn btn-link btn-sm" ng-if="!serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid"
-                ng-click="serviceRegistrationCtrl.connect(cnsi)">
-                <span ng-if="serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid === false" translate>Reconnect</span>
-                <span ng-if="serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid === undefined" translate>Connect</span>
-              </a>
-              <a class="btn btn-link btn-sm" ng-if="serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid"
-                ng-click="serviceRegistrationCtrl.disconnect(cnsi)" translate>Disconnect</a>
+              <span ng-if="cnsi.cnsi_type === 'hcf'">  <!-- Remove this span-wrapper once HCE clusters have correct auth. -->
+                <a class="btn btn-link btn-sm" ng-if="!serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid"
+                  ng-click="serviceRegistrationCtrl.connect(cnsi)">
+                  <span ng-if="serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid === false" translate>Reconnect</span>
+                  <span ng-if="serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid === undefined" translate>Connect</span>
+                </a>
+                <a class="btn btn-link btn-sm" ng-if="serviceRegistrationCtrl.userCnsiModel.serviceInstances[cnsi.guid].valid"
+                  ng-click="serviceRegistrationCtrl.disconnect(cnsi)" translate>Disconnect</a>
+              </span>
               <a class="btn btn-link btn-sm"
                  translate
                  ng-click="serviceRegistrationCtrl.cnsiModel.remove(cnsi)">


### PR DESCRIPTION
Since HCE clusters can't currently connect (because they don't really
have an auth mechanism that works the way HCF cluster's auth does) we
should remove the "connect" action for them.  At a later date, when they
can "connect" we can revert this code.
