### PR TITLE
462 restart app actions showing while app stopped

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/application.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/application.module.js
@@ -198,9 +198,13 @@
         appAction.disabled = that.isPending;
       });
 
-      this.appActions[1].hidden = newState === 'STOPPED';
-      this.appActions[3].hidden = newState === 'STARTED';
-      this.appActions[4].hidden = newState === 'STARTED';
+      // TODO: This list-index mechanism is WAY fragile. Now we can't reorder the actions without re-counting indexes.
+      // TODO: Why are we both conditionally hiding and conditionally disabling these appActions?  That seems ... odd.
+      this.appActions[1].hidden = newState === 'STOPPED';  // Stop
+      this.appActions[2].hidden = newState === 'STOPPED';  // Restart
+      this.appActions[3].hidden = newState === 'STARTED';  // Delete
+      this.appActions[4].hidden = newState === 'STARTED';  // Start
+      // Index 5 is CLI Instructions
 
       if (newState === 'STARTED' || newState === 'STOPPED') {
         this.init();


### PR DESCRIPTION
According to
https://wiki.hpcloud.net/display/iaas/App+Lifecycle+State+Diagram
the app-action "restart" should not be showing while the app is stopped.

Also added some comments to help clarify the table indexing.

Also added some TODOs because there's strangeness afoot.
