### PR TITLE
462 app card labels

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.html
+++ b/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.html
@@ -13,11 +13,11 @@
         </bounce-spinner>
       </span>
     </dd>
-    <dt translate>Instances</dt>
+    <dt translate>Instance Quota</dt>
     <dd>{{applicationGalleryCardCtrl.app.entity.instances}}</dd>
     <dt translate>Disk Quota</dt>
     <dd>{{applicationGalleryCardCtrl.app.entity.disk_quota}}</dd>
-    <dt translate>Memory Utilization</dt>
+    <dt translate>Memory Quota</dt>
     <dd>{{applicationGalleryCardCtrl.app.entity.memory}} MB</dd>
   </dl>
 </gallery-card>


### PR DESCRIPTION
Demo-testers don't like the labels or data that we're showing on the
cards.  "instances" and "memory usage" are not actually correct, since
when an app is shutdown, those numbers don't drop to 0.  Technically,
these are quotas anyway, so let's label them as such.
