### PR TITLE
TEAMFOUR-476 - Set HCE instance by default in add app flow

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
@@ -422,6 +422,7 @@
         if (hceCnsis.length > 0) {
           var hceOptions = _.map(hceCnsis, function (o) { return { label: o.api_endpoint.Host, value: o }; });
           [].push.apply(that.options.hceCnsis, hceOptions);
+          that.userInput.hceCnsi = hceOptions[0].value;
         }
       });
     },


### PR DESCRIPTION
In the "Delivery" step, if pipeline is selected, set the first HCE instance by default
