### PR TITLE
462 Launch App action button hide logic

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/application.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/application.module.js
@@ -200,10 +200,12 @@
 
       // TODO: This list-index mechanism is WAY fragile. Now we can't reorder the actions without re-counting indexes.
       // TODO: Why are we both conditionally hiding and conditionally disabling these appActions?  That seems ... odd.
-      this.appActions[1].hidden = newState === 'STOPPED';  // Stop
-      this.appActions[2].hidden = newState === 'STOPPED';  // Restart
-      this.appActions[3].hidden = newState === 'STARTED';  // Delete
-      this.appActions[4].hidden = newState === 'STARTED';  // Start
+      this.showOrHideLaunchApp(newState, null);
+      // Index 0 is Launch App though it's handled in it's own special method because it requires route info.
+      this.appActions[1].hidden = newState !== 'STARTED';  // Stop
+      this.appActions[2].hidden = newState !== 'STARTED';  // Restart
+      this.appActions[3].hidden = newState !== 'STOPPED';  // Delete
+      this.appActions[4].hidden = newState !== 'STOPPED';  // Start
       // Index 5 is CLI Instructions
 
       if (newState === 'STARTED' || newState === 'STOPPED') {
@@ -212,7 +214,14 @@
     },
 
     onAppRoutesChange: function (newRoutes) {
-      this.appActions[0].hidden = _.isNil(newRoutes) || newRoutes.length === 0;
+      // Launch App requires state info, so it's handled in it's own process.
+      this.showOrHideLaunchApp(null, newRoutes);
+    },
+
+    showOrHideLaunchApp: function(newState, newRoutes) {
+      var state = _.isNil(newState) ? this.model.application.summary.state : newState;
+      var routes = _.isNil(newRoutes) ? this.model.application.summary.routes : newRoutes;
+      this.appActions[0].hidden = _.isNil(routes) || routes.length === 0 || state !== 'STARTED';
     }
   });
 


### PR DESCRIPTION
Currently, the launch-app button shows up sometimes even when the app is
stopped.  I'm not entirely sure how the logic should go, but I've done
my best to clean it up.

I've combined the state based and route based hiding logic into a single
function.

Also, the other buttons are being hidden if the state = something bad.
I disagree with that.  They shoud be hidden UNLESS the state = something good.
