### PR TITLE
TEAMFOUR-525 - Create and continue button should be grayed

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
@@ -46,6 +46,7 @@
    * @property {object} organizationModel - the organization model
    * @property {object} data - a data bag
    * @property {object} userInput - user's input about new application
+   * @property {object} error - error map
    */
   function AddAppWorkflowController(modelManager, eventService, $scope, $q) {
     var that = this;
@@ -70,6 +71,7 @@
     });
 
     this.userInput = {};
+    this.errors = {};
 
     $scope.$watch(function () {
       return that.userInput.serviceInstance;
@@ -114,6 +116,7 @@
         imageRegistry: null,
         projectId: null
       };
+      this.errors = {};
 
       this.data.workflow = {
         allowJump: false,
@@ -126,7 +129,7 @@
           {
             title: gettext('Name'),
             templateUrl: path + 'name.html',
-            form: 'application-name-form',
+            formName: 'application-name-form',
             nextBtnText: gettext('Create and continue'),
             cancelBtnText: gettext('Cancel'),
             onNext: function () {
@@ -157,6 +160,7 @@
             ready: true,
             title: gettext('Select Source'),
             templateUrl: path + 'pipeline-subflow/select-source.html',
+            formName: 'application-source-form',
             nextBtnText: gettext('Next'),
             onNext: function () {
               // TODO (kdomico): Get or create fake HCE user until HCE API is complete
@@ -179,6 +183,7 @@
             ready: true,
             title: gettext('Select Repository'),
             templateUrl: path + 'pipeline-subflow/select-repository.html',
+            formName: 'application-repo-form',
             nextBtnText: gettext('Next'),
             onNext: function () {
               that.getPipelineDetailsData();
@@ -212,6 +217,7 @@
             ready: true,
             title: gettext('Pipeline Details'),
             templateUrl: path + 'pipeline-subflow/pipeline-details.html',
+            formName: 'application-pipeline-details-form',
             nextBtnText: gettext('Create pipeline'),
             onNext: function () {
               that.hceModel.getDeploymentTargets(that.userInput.hceCnsi.guid).then(function () {
@@ -237,12 +243,14 @@
             ready: true,
             title: gettext('Notifications'),
             templateUrl: path + 'pipeline-subflow/notifications.html',
+            formName: 'application-pipeline-notification-form',
             nextBtnText: gettext('Skip')
           },
           {
             ready: true,
             title: gettext('Deploy App'),
             templateUrl: path + 'pipeline-subflow/deploy.html',
+            formName: 'application-pipeline-deploy-form',
             nextBtnText: gettext('Finished code change'),
             isLastStep: true
           }
@@ -252,6 +260,7 @@
             ready: true,
             title: gettext('Deploy'),
             templateUrl: path + 'cli-subflow/deploy.html',
+            formName: 'application-cli-deploy-form',
             nextBtnText: gettext('Finished with code change'),
             isLastStep: true
           }
@@ -261,6 +270,7 @@
       this.options = {
         workflow: that.data.workflow,
         userInput: this.userInput,
+        errors: this.errors,
         subflow: 'pipeline',
         serviceInstances: [],
         // Adding the demo's service model to options.

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/name.html
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/name.html
@@ -1,73 +1,84 @@
-<h4 class="step-title" translate>Name your application and select deploy location</h4>
+<h4 class="step-title" translate>Name your application and select deploy location.</h4>
+
 <p translate>
   Create a unique name for your application. The name you create will be reserved even if you exit.
 </p>
 
 <form>
-  <div class="form-group" focusable-input>
+  <div class="form-group form-group-large"
+    ng-class="{'has-error' : wizardCtrl.options.errors.dupAppName}"
+    focusable-input>
     <label class="control-label"
       for="add-app-workflow-application-name" required translate>
       Application name
     </label>
+    <span class="control-message" translate>
+      This name already exists. Choose a new one.
+    </span>
     <input ng-model="wizardCtrl.options.userInput.name" type="text" class="form-control"
       id="add-app-workflow-application-name" required autofocus>
   </div>
 
   <p class="control-label" translate><br>Select deploy location</p>
 
-  <div class="form-group">
-    <label class="control-label" translate>Cluster</label>
+  <div class="form-group form-group-large">
+    <label class="control-label" required translate>Cluster</label>
     <select-input
       arrow-icon="helion-icon helion-icon-Up_tab helion-icon-r180"
       ng-model="wizardCtrl.options.userInput.serviceInstance"
       input-options="wizardCtrl.options.serviceInstances"
       placeholder="{{'Select Cluster' | translate}}"
-      tabindex="0">
+      tabindex="0" required>
     </select-input>
   </div>
 
-  <div class="form-group">
-    <label class="control-label" translate>Organization</label>
+  <div class="form-group form-group-large">
+    <label class="control-label" required translate>Organization</label>
     <select-input
       arrow-icon="helion-icon helion-icon-Up_tab helion-icon-r180"
       ng-model="wizardCtrl.options.userInput.organization"
       input-options="wizardCtrl.options.organizations"
       placeholder="{{'Select Organization' | translate}}"
-      tabindex="0">
+      tabindex="0" required>
     </select-input>
   </div>
 
 
-  <div class="form-group">
-    <label class="control-label" translate>Space</label>
+  <div class="form-group form-group-large">
+    <label class="control-label" required translate>Space</label>
     <select-input
       arrow-icon="helion-icon helion-icon-Up_tab helion-icon-r180"
       ng-model="wizardCtrl.options.userInput.space"
       input-options="wizardCtrl.options.spaces"
       placeholder="{{'Select Space' | translate}}"
-      tabindex="0">
+      tabindex="0" required>
     </select-input>
   </div>
 
   <p class="control-label" translate><br>Create a route</p>
 
-  <div class="form-group" focusable-input>
+  <div class="form-group form-group-large"
+    ng-class="{'has-error' : wizardCtrl.options.errors.dupRouteName}"
+    focusable-input>
     <label class="control-label"
       for="add-app-workflow-application-name" required translate>
       Host
     </label>
+    <span class="control-message" translate>
+      A route with this name already exists. Choose a new one.
+    </span>
     <input ng-model="wizardCtrl.options.userInput.host" type="text" class="form-control"
       id="add-app-workflow-application-host" required>
   </div>
 
-  <div class="form-group">
-    <label class="control-label" translate>Domain</label>
+  <div class="form-group form-group-large">
+    <label class="control-label" required translate>Domain</label>
     <select-input
       arrow-icon="helion-icon helion-icon-Up_tab helion-icon-r180"
       ng-model="wizardCtrl.options.userInput.domain"
       input-options="wizardCtrl.options.domains"
       placeholder="{{'Select Domain' | translate}}"
-      tabindex="0">
+      tabindex="0" required>
     </select-input>
   </div>
 


### PR DESCRIPTION
Create and continue button on add-app workflow should be grayed out before required field are not provided.

JIRA: https://jira.hpcloud.net/browse/TEAMFOUR-525

This PR enables static validation for input fields in Name step of add-app workflow. Async name uniqueness validation need more API support which is missing atm.

Depends on https://github.com/hpcloud/helion-ui-framework/pull/72
