### PR TITLE
TEAMFOUR-516 - Update the GitHub OAuth URL reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .idea
-**/.*/*
-**/.*.*
 npm-debug.log
 phantomjsdriver.log
 node_modules

--- a/src/plugins/github/view/github-authentication/githut-authentication.directive.js
+++ b/src/plugins/github/view/github-authentication/githut-authentication.directive.js
@@ -38,7 +38,7 @@
 
   angular.extend(GithubAuthenticationController.prototype, {
     openAuthWindow: function () {
-      var win = this.$window.open('/api/gh/auth', '_blank');
+      var win = this.$window.open('/pp/v1/github/oauth/auth', '_blank');
       win.focus();
     }
   });


### PR DESCRIPTION
Update the GitHub OAuth URl, now that we have the portal proxy handling GH OAuth.

Fixed the .gitignore - everything in this project is hidden from me without the updated .gitignore.

Do we wnt this stored in an env var?

We need to coordinate this change with the changes required in the portal-proxy and stratos-deploy, so DO NOT MERGE until we reach agreement and merge all at the same time.

@woodm1979 
