### PR TITLE
Redefine add-app workflow when no Hce available

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
@@ -56,7 +56,6 @@
     this.eventService = eventService;
     this.appModel = modelManager.retrieve('cloud-foundry.model.application');
     this.cnsiModel = modelManager.retrieve('app.model.serviceInstance');
-    this.serviceInstanceModel = modelManager.retrieve('app.model.serviceInstance');
     this.serviceInstanceModel = modelManager.retrieve('app.model.serviceInstance.user');
     // Adding a service model for the demo.
     this.serviceModel = modelManager.retrieve('cloud-foundry.model.service');


### PR DESCRIPTION
If you do not select an HCE cluster and move to the GitHub page you get stuck. We should not let the user move forward unless they selected an HCE endpoint

The solution is: If there is no Hce service instances available / registered, the add-app flow will be simplify without pipeline subflow, as designed at https://app.frontify.com/screen/600931

Related JIRA: https://jira.hpcloud.net/browse/TEAMFOUR-472
