### PR TITLE
TEAMFOUR-586 - Add request interceptor for CF models

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -81,10 +81,7 @@
      **/
     usage: function (cnsiGuid, guid, options) {
       var that = this;
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
-      return this.applicationApi.GetDetailedStatsForStartedApp(guid, options, config)
+      return this.applicationApi.GetDetailedStatsForStartedApp(guid, options)
         .then(function (response) {
           that.onUsage(response.data[cnsiGuid]);
         });
@@ -141,13 +138,8 @@
      **/
     getAppVariables: function (cnsiGuid, guid) {
       var that = this;
-      var config = {
-        headers: {
-          'x-cnap-cnsi-list': cnsiGuid
-        }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
-        .GetEnvForApp(guid, {}, config)
+        .GetEnvForApp(guid)
         .then(function (response) {
           var data = response.data[cnsiGuid];
           if (data.error_code) {
@@ -172,11 +164,8 @@
      * @public
      **/
     listServiceBindings: function (cnsiGuid, guid, params) {
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
-        .ListAllServiceBindingsForApp(guid, params, config)
+        .ListAllServiceBindingsForApp(guid, params)
         .then(function (response) {
           return response.data[cnsiGuid].resources;
         });
@@ -193,13 +182,10 @@
      */
     startApp: function (cnsiGuid, guid) {
       var that = this;
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       this.appStateSwitchTo = 'STARTED';
       this.application.summary.state = 'PENDING';
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
-        .UpdateApp(guid, {state: 'STARTED'}, {}, config)
+        .UpdateApp(guid, {state: 'STARTED'})
         .then(
           function (response) {
             var data = response.data[cnsiGuid];
@@ -230,13 +216,10 @@
      */
     stopApp: function (cnsiGuid, guid) {
       var that = this;
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       this.appStateSwitchTo = 'STOPPED';
       this.application.summary.state = 'PENDING';
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
-        .UpdateApp(guid, {state: 'STOPPED'}, {}, config)
+        .UpdateApp(guid, {state: 'STOPPED'})
         .then(
           function (response) {
             var data = response.data[cnsiGuid];
@@ -304,11 +287,8 @@
      */
     update: function (cnsiGuid, guid, newAppSpec) {
       var that = this;
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       var applicationApi = this.apiManager.retrieve('cloud-foundry.api.Apps');
-      return applicationApi.UpdateApp(guid, newAppSpec, {}, config)
+      return applicationApi.UpdateApp(guid, newAppSpec)
         .then(function (response) {
           if(response.data[cnsiGuid].metadata) {
             that.getAppSummary(cnsiGuid, response.data[cnsiGuid].metadata.guid);
@@ -327,11 +307,8 @@
      * @public
      */
     deleteApp: function (cnsiGuid, guid) {
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
-        .DeleteApp(guid, {}, config);
+        .DeleteApp(guid);
     },
 
     /**
@@ -346,11 +323,8 @@
      */
     getAppStats: function (cnsiGuid, guid, params) {
       var that = this;
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
-        .GetDetailedStatsForStartedApp(guid, params, config)
+        .GetDetailedStatsForStartedApp(guid, params)
         .then(function (response) {
           var data = response.data[cnsiGuid];
           that.application.stats = angular.isDefined(data['0']) ? data['0'].stats : {};
@@ -368,11 +342,8 @@
      * @public
      */
     getEnv: function (cnsiGuid, guid, params) {
-      var config = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
-        .GetEnvForApp(guid, params, config)
+        .GetEnvForApp(guid, params)
         .then(function (response) {
           return response.data[cnsiGuid];
         });

--- a/src/plugins/cloud-foundry/model/model.module.js
+++ b/src/plugins/cloud-foundry/model/model.module.js
@@ -2,6 +2,39 @@
   'use strict';
 
   angular
-    .module('cloud-foundry.model', []);
+    .module('cloud-foundry.model', [], config);
+
+  config.$inject = [
+    '$httpProvider'
+  ];
+
+  function config($httpProvider) {
+    $httpProvider.interceptors.push(interceptor);
+  }
+
+  interceptor.$inject = [
+    '$stateParams'
+  ];
+
+  /**
+   * @name interceptor
+   * @description A $http interceptor that adds `x-cnap-cnsi-list`
+   * header to each request if the CNSI guid is present in the
+   * URL (route).
+   * @returns {object} The request function
+   */
+  function interceptor($stateParams) {
+    return {
+      request: request
+    };
+
+    function request(config) {
+      var cnsiGuid = $stateParams.cnsiGuid;
+      if (angular.isUndefined(config.headers['x-cnap-cnsi-list']) && angular.isDefined(cnsiGuid)) {
+        config.headers['x-cnap-cnsi-list'] = cnsiGuid;
+      }
+      return config;
+    }
+  }
 
 })();

--- a/src/plugins/cloud-foundry/model/route/route.model.js
+++ b/src/plugins/cloud-foundry/model/route/route.model.js
@@ -87,11 +87,8 @@
     * @public
     */
     removeAppFromRoute: function (cnsiGuid, guid, appGuid) {
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Routes')
-        .RemoveAppFromRoute(guid, appGuid, {}, httpConfig);
+        .RemoveAppFromRoute(guid, appGuid);
     },
 
     createRoute: function (cnsiGuid, routeSpec) {
@@ -116,11 +113,8 @@
     * @public
     */
     deleteRoute: function (cnsiGuid, guid, recursive) {
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Routes')
-        .DeleteRoute(guid, recursive, {}, httpConfig);
+        .DeleteRoute(guid, recursive);
     },
 
    /**
@@ -135,11 +129,8 @@
     */
     listAllAppsForRoute: function (cnsiGuid, guid, params) {
       var that = this;
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Routes')
-        .ListAllAppsForRoute(guid, params, httpConfig)
+        .ListAllAppsForRoute(guid, params)
         .then(function (response) {
           that.route.id = guid;
           that.route.apps = response.data[cnsiGuid];
@@ -158,11 +149,8 @@
     * @public
     */
     listAllAppsForRouteWithoutStore: function (cnsiGuid, guid, params) {
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Routes')
-        .ListAllAppsForRoute(guid, params, httpConfig)
+        .ListAllAppsForRoute(guid, params)
         .then(function (response) {
           return response.data[cnsiGuid].resources;
         });

--- a/src/plugins/cloud-foundry/model/service/service-binding.model.js
+++ b/src/plugins/cloud-foundry/model/service/service-binding.model.js
@@ -64,11 +64,8 @@
      * @public
      **/
     deleteServiceBinding: function (cnsiGuid, guid, params) {
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.ServiceBindings')
-        .DeleteServiceBinding(guid, params, httpConfig);
+        .DeleteServiceBinding(guid, params);
     },
 
     /**

--- a/src/plugins/cloud-foundry/model/service/service-instance.model.js
+++ b/src/plugins/cloud-foundry/model/service/service-instance.model.js
@@ -45,10 +45,7 @@
      */
     all: function (cnsiGuid, options) {
       var that = this;
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
-      return this.serviceInstanceApi.ListAllServiceInstances(options, httpConfig)
+      return this.serviceInstanceApi.ListAllServiceInstances(options)
         .then(function (response) {
           return that.onAll(response.data[cnsiGuid]);
         });

--- a/src/plugins/cloud-foundry/model/service/service.model.js
+++ b/src/plugins/cloud-foundry/model/service/service.model.js
@@ -46,10 +46,7 @@
      **/
     all: function (cnsiGuid, options) {
       var that = this;
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
-      return this.serviceApi.ListAllServices(options, httpConfig)
+      return this.serviceApi.ListAllServices(options)
         .then(function (response) {
           return that.onAll(response.data[cnsiGuid]);
         });

--- a/src/plugins/cloud-foundry/model/space/space.model.js
+++ b/src/plugins/cloud-foundry/model/space/space.model.js
@@ -61,11 +61,8 @@
     * @public
     */
     listAllSpaces: function (cnsiGuid, params) {
-      var httpConfig = {
-        headers: { 'x-cnap-cnsi-list': cnsiGuid }
-      };
       return this.apiManager.retrieve('cloud-foundry.api.Spaces')
-        .ListAllSpaces(params, httpConfig)
+        .ListAllSpaces(params)
         .then(function (response) {
           return response.data[cnsiGuid].resources;
         });

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
@@ -510,6 +510,7 @@
      * @description redefine the workflow if there is no HCE service instances registered
      */
     redefineWorkflowWithoutHce: function () {
+      this.options.subflow = 'cli';
       this.data.workflow.steps.pop();
       [].push.apply(this.data.workflow.steps, this.data.subflows.cli);
     },


### PR DESCRIPTION
Move CNSI list header to request interceptor in Cloud Foundry models. Since the CNSI guid is provided in the route in most cases, pass the CNSI in the header automatically in the request interceptor for Cloud Foundry models. In some cases, the model method allows the header to be bypassed. For example, when creating an application, the GUID is not provided in the route yet.
