### PR TITLE
Avoid adding cnsi-list header to none portal-proxy requests

### DIFF
--- a/src/plugins/cloud-foundry/model/model.module.js
+++ b/src/plugins/cloud-foundry/model/model.module.js
@@ -29,7 +29,7 @@
     };
 
     function request(config) {
-      if (!config.url.startsWith('/pp')) {
+      if (_.isString(config.url) && !_.startsWith(config.url, '/pp')) {
         return config;
       }
 


### PR DESCRIPTION
@ongk I _think_ this might be right. Could you take a look? There's an issue when calling out to github when extra headers are attached. This will stop the interceptor adding the header for any url not starting in pp.
