### PR TITLE
Fix attached not showing up on add service in add-app workflow

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.html
+++ b/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.html
@@ -22,7 +22,7 @@
       menu-position="actions-menu-right">
     </actions-menu>
     <div class="service-added font-semi-bold text-uppercase"
-      ng-if="serviceCardCtrl.allowAddOnly && serviceCardCtrl.numAdded > 0">
+      ng-if="serviceCardCtrl.allowAddOnly && serviceCardCtrl.numAttached > 0">
       {{ serviceCardCtrl.numAttached }} <span translate>Attached</span>
     </div>
     <button class="btn btn-sm btn-link"


### PR DESCRIPTION
When adding service in the create app workflow, the "X Attached" text isn't showing up correctly. This PR fixes that issue.
