### PR TITLE
Cancel debounced call to update events after leaving the view

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
@@ -98,6 +98,16 @@
       promise = $q.when({});
     }
 
+    that.debouncedUpdateVisibleExecutions = _.debounce(function(visibleExecutions) {
+      that.updateVisibleExecutions(visibleExecutions);
+    }, 500);
+
+    $scope.$on("$destroy", function(){
+      if (that.debouncedUpdateVisibleExecutions) {
+        that.debouncedUpdateVisibleExecutions.cancel();
+      }
+    });
+
     promise
       .then(function (project) {
         that.project = project;
@@ -204,9 +214,7 @@
       }
       that.execWatch = that.$scope.$watch(function() {
         return that.displayedExecutions;
-      }, _.debounce(function(visibleExecutions) {
-        that.updateVisibleExecutions(visibleExecutions);
-      }, 500));
+      }, that.debouncedUpdateVisibleExecutions);
 
       var promise;
       if (this.haveBackend) {


### PR DESCRIPTION
As spotted by @sean-sq-chen in https://github.com/hpcloud/stratos-ui/pull/395, the debounced call was not being cancelled after leaving the delivery-logs view.
