### PR TITLE
Add pointer cursor to clickable tile

### DIFF
--- a/src/app/view/endpoints/dashboard/tiles/service-tile.scss
+++ b/src/app/view/endpoints/dashboard/tiles/service-tile.scss
@@ -1,5 +1,4 @@
 .service-tile {
-  
   &.card.panel .service-chart-panel {
     padding: $hpe-unit-space  $hpe-unit-space * .5;
   }


### PR DESCRIPTION
Endpoint tile is clickable therefore should have a pointer cursor, rather than a normal cursor.
