### PR TITLE
Use new Cookie name + access /userinfo

### DIFF
--- a/src/app/api/account/account.api.js
+++ b/src/app/api/account/account.api.js
@@ -42,6 +42,7 @@
     this.$httpParamSerializer = $httpParamSerializer;
     this.$q = $q;
     this.$cookies = $cookies;
+    this.sessionName = 'stackato-console-session';
   }
 
   angular.extend(AccountApi.prototype, {
@@ -83,13 +84,19 @@
      * @public
      */
     verifySession: function () {
-      if (this.$cookies.get('portal-session')) {
+      if (this.$cookies.get(this.sessionName)) {
         return this.$http.get('/pp/v1/auth/session/verify');
       }
-      return this.$q(function (resolve, reject) {
-        reject({});
-      });
+      return this.$q.reject(this.sessionName + ' cookie missing!');
+    },
+
+    userInfo: function () {
+      if (this.$cookies.get(this.sessionName)) {
+        return this.$http.get('/pp/v1/userinfo');
+      }
+      return this.$q.reject(this.sessionName + ' cookie missing!');
     }
+
   });
 
 })();

--- a/src/app/model/account/account.model.js
+++ b/src/app/model/account/account.model.js
@@ -155,7 +155,8 @@
      * @private
      */
     onLoggedOut: function () {
-      this.$cookies.remove('portal-session');
+      var sessionName = this.apiManager.retrieve('app.api.account').sessionName;
+      this.$cookies.remove(sessionName);
       this.loggedIn = false;
       delete this.data;
     }


### PR DESCRIPTION
The session nmae was updated in portal proxy, we must use the new name.
Also added service for getting the userInfo
