### PR TITLE
Make the world debian-jessie

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,6 @@
-FROM node:4.2.3
+FROM nodesource/jessie:4.2
+
+ENV NODE_ENV="development"
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,6 @@
-FROM node:4.2.3
+FROM nodesource/jessie:4.2
+
+ENV NODE_ENV="development"
 
 RUN apt-get update && \
     apt-get install -y openjdk-7-jre-headless && \


### PR DESCRIPTION
We can reduce our total images footprint by consolidating to the same
base OSes for all of our docker containers.

As it turns out, the postgres and golang images are both based on
debian-jessie, so that's the natural choice for the others.
