### PR TITLE
TEAMFOUR-771: Fix gulp watch being broken and issue with is-utf8 package

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -36,7 +36,6 @@
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.7",
-    "is-utf8": "^0.2.1",
     "jasmine-core": "^2.4.1",
     "jsdoc": "^3.4.0",
     "karma": "^0.13.19",
@@ -53,6 +52,6 @@
     "q": "^1.4.1",
     "request": "2.69.0",
     "shelljs": "^0.5.3",
-    "vinyl-fs": "2.4.3"
+    "vinyl-fs": "^0.3.0"
   }
 }


### PR DESCRIPTION
fix for gulp watch being broken

fix is to ensure we use same version of vinyl-fs as gulp does. This removes the need to force is-utf8 to be installed as well - provision.sh will work out the box without having to do a second npm install.
