### PR TITLE
Show only services with plans

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/services/manage-services/manage-services.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/application/services/manage-services/manage-services.directive.js
@@ -84,7 +84,8 @@
       this.serviceBindings = {};
 
       var serviceInstances = _.filter(this.data.app.summary.services, function (o) {
-        return o.service_plan.service.guid === that.data.service.metadata.guid;
+        return angular.isDefined(o.service_plan) &&
+          o.service_plan.service.guid === that.data.service.metadata.guid;
       });
       if (serviceInstances.length > 0) {
         [].push.apply(this.serviceInstances, serviceInstances);

--- a/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.directive.js
@@ -115,7 +115,8 @@
       var that = this;
       var serviceInstances = _.chain(this.app.summary.services)
                               .filter(function (o) {
-                                return o.service_plan.service.guid === that.service.metadata.guid;
+                                return angular.isDefined(o.service_plan) &&
+                                  o.service_plan.service.guid === that.service.metadata.guid;
                               })
                               .map('guid')
                               .value();

--- a/src/plugins/cloud-foundry/view/applications/application/services/services.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/services/services.module.js
@@ -70,7 +70,9 @@
           .then(function (services) {
             // retrieve categories and attachment data for service filtering
             var categories = [];
-            var attachedServices = _.map(summary.services, function (o) { return o.service_plan.service.guid; });
+            var attachedServices = _.chain(summary.services)
+                                    .filter(function () { return angular.isDefined(o.service_plan); })
+                                    .map(function (o) { return o.service_plan.service.guid; });
             angular.forEach(services, function (service) {
               if (attachedServices.length > 0) {
                 if (_.includes(attachedServices, service.metadata.guid)) {


### PR DESCRIPTION
Now that HCE will attach a user provided service to the app on deploy, the services tab in the app summary and create app workflow should only show services with a service plan.
