### PR TITLE
for upgrade demo, show the console version in the settings view

### DIFF
--- a/src/app/view/console-view/settings-page/settings-page.html
+++ b/src/app/view/console-view/settings-page/settings-page.html
@@ -5,12 +5,16 @@
 <div class="container registration-content col-sm-12">
   <div class="cluster-settings user-summary">
     <div class="cluster row">
-      <div class="col-md-12">User Summary</div>
+      <div class="col-md-12">Stackato Summary</div>
     </div>
     <div class="cluster row">
       <div class="col-md-6">
         <div class="cluster-info">
           <div class="cluster-properties">
+            <div class="cluster-property">
+              <div translate>Console Version</div>
+              <div>{{settingsCtrl.stackatoInfo.info.version.proxy_version}}</div>
+            </div>
             <div class="cluster-property">
               <div translate>User</div>
               <div>{{settingsCtrl.stackatoInfo.info.user.name}}</div>


### PR DESCRIPTION
We'll probably want to have some kind of 'about stackato' view eventually. This was an easy place to show the current console version for demoing upgrades later this week.
