### PR TITLE
TEAMFOUR-639 - Add detach service confirmation modal

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/services/manage-services/manage-services.directive.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/services/manage-services/manage-services.directive.spec.js
@@ -151,12 +151,8 @@
       });
 
       describe('detach', function () {
-        var DeleteServiceBinding;
-
         beforeEach(function () {
           var bindingGuid = 'binding_123';
-          var mockBindingsApi = mock.cloudFoundryAPI.ServiceBindings;
-          DeleteServiceBinding = mockBindingsApi.DeleteServiceBinding(bindingGuid);
 
           manageServicesCtrl.modal = {
             dismiss: angular.noop
@@ -183,54 +179,12 @@
           spyOn(manageServicesCtrl.appModel, 'getAppSummary');
         });
 
-        it('should remove serving binding on success', function () {
-          spyOn(manageServicesCtrl.modal, 'dismiss');
-
-          $httpBackend.whenDELETE(DeleteServiceBinding.url)
-            .respond(200, DeleteServiceBinding.response['200'].body);
+        it('should show detach confirmation dialog', function () {
+          spyOn(manageServicesCtrl, 'confirmDialog');
 
           var instance = manageServicesCtrl.serviceInstances[0];
-          manageServicesCtrl.detach(instance).then(function () {
-            expect(manageServicesCtrl.serviceInstances.length).toBe(1);
-            expect(manageServicesCtrl.appModel.getAppSummary).toHaveBeenCalled();
-            expect(manageServicesCtrl.modal.dismiss).not.toHaveBeenCalled();
-          });
-
-          $httpBackend.flush();
-        });
-
-        it('should dismiss modal if no bindings left', function () {
-          manageServicesCtrl.serviceInstances.pop();
-
-          spyOn(manageServicesCtrl.modal, 'dismiss');
-
-          $httpBackend.whenDELETE(DeleteServiceBinding.url)
-            .respond(200, DeleteServiceBinding.response['200'].body);
-
-          var instance = manageServicesCtrl.serviceInstances[0];
-          manageServicesCtrl.detach(instance).then(function () {
-            expect(manageServicesCtrl.serviceInstances.length).toBe(0);
-            expect(manageServicesCtrl.appModel.getAppSummary).toHaveBeenCalled();
-            expect(manageServicesCtrl.modal.dismiss).toHaveBeenCalled();
-          });
-
-          $httpBackend.flush();
-        });
-
-        it('should not remove serving binding on failure', function () {
-          spyOn(manageServicesCtrl.modal, 'dismiss');
-
-          $httpBackend.whenDELETE(DeleteServiceBinding.url)
-            .respond(200, DeleteServiceBinding.response['500'].body);
-
-          var instance = manageServicesCtrl.serviceInstances[0];
-          manageServicesCtrl.detach(instance).then(function () {
-            expect(manageServicesCtrl.serviceInstances.length).toBe(2);
-            expect(manageServicesCtrl.appModel.getAppSummary).not.toHaveBeenCalled();
-            expect(manageServicesCtrl.modal.dismiss).not.toHaveBeenCalled();
-          });
-
-          $httpBackend.flush();
+          manageServicesCtrl.detach(instance);
+          expect(manageServicesCtrl.confirmDialog).toHaveBeenCalled();
         });
       });
 

--- a/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.directive.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.directive.spec.js
@@ -31,6 +31,7 @@
         }
       };
       $scope.service = {
+        entity: { label: 'Service' },
         metadata: { guid: '67229bc6-8fc9-4fe1-b8bc-8790cdae5334' }
       };
 
@@ -130,32 +131,17 @@
       });
 
       describe('detach', function () {
-        it('should delete service binding if only one attached', function () {
-          spyOn(serviceCardCtrl.appModel, 'getAppSummary').and.callThrough();
-
-          var guid = '571b283b-97f9-41e3-abc7-81792ee34e40';
-          var DeleteServiceBinding = mockBindingsApi.DeleteServiceBinding(guid);
-          $httpBackend.whenDELETE(DeleteServiceBinding.url)
-            .respond(200, DeleteServiceBinding.response['200'].body);
-
-          var appGuid = '6e23689c-2844-4ebf-ab69-e52ab3439f6b';
-          var mockAppsApi = mock.cloudFoundryAPI.Apps;
-          var GetAppSummary = mockAppsApi.GetAppSummary(appGuid);
-          $httpBackend.whenGET(GetAppSummary.url)
-            .respond(200, GetAppSummary.response['200'].body);
-
-          serviceCardCtrl.detach().then(function () {
-            expect(serviceCardCtrl.appModel.getAppSummary).toHaveBeenCalled();
-          });
-
-          $httpBackend.flush();
+        it('should show detach confirmation dialog on click', function () {
+          spyOn(serviceCardCtrl, 'confirmDialog');
+          serviceCardCtrl.detach();
+          expect(serviceCardCtrl.confirmDialog).toHaveBeenCalled();
         });
 
-        it('should not delete service binding if none attached', function () {
-          spyOn(serviceCardCtrl.appModel, 'getAppSummary').and.callThrough();
+        it('should not show detach confirmation dialog on click if no services attached', function () {
+          spyOn(serviceCardCtrl, 'confirmDialog');
           serviceCardCtrl.serviceBindings.length = 0;
           serviceCardCtrl.detach();
-          expect(serviceCardCtrl.appModel.getAppSummary).not.toHaveBeenCalled();
+          expect(serviceCardCtrl.confirmDialog).not.toHaveBeenCalled();
         });
       });
 

--- a/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.html
+++ b/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.html
@@ -1,8 +1,8 @@
 <div class="service-text">
   <i class="helion-icon helion-icon-3x helion-icon-Service_business service-icon"></i>
   <div>
-    <h4 class="font-semi-bold">{{ ::serviceCardCtrl.service.entity.label }}</h4>
-    <p>{{ ::serviceCardCtrl.service.entity.description }}</p>
+    <h4 class="font-semi-bold">{{ serviceCardCtrl.service.entity.extra.displayName || serviceCardCtrl.service.entity.label }}</h4>
+    <p>{{ serviceCardCtrl.service.entity.extra.longDescription || serviceCardCtrl.service.entity.description }}</p>
   </div>
 </div>
 <div class="service-metadata">

--- a/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.scss
+++ b/src/plugins/cloud-foundry/view/applications/application/services/service-card/service-card.scss
@@ -11,6 +11,7 @@ service-card {
   .service-text {
     display: flex;
     flex-grow: 1;
+    max-width: 50%;
 
     h4 {
       margin-top: 0;

--- a/src/plugins/cloud-foundry/view/applications/application/services/services.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/services/services.module.js
@@ -87,6 +87,11 @@
                                               function (o) {return { label: o, value: { categories: o }, lower: o.toLowerCase() }; });
                 categories = _.unionBy(categories, serviceCategories, 'lower');
               }
+
+              // Parse service entity extra data JSON string
+              if (!_.isNil(service.entity.extra) && angular.isString(service.entity.extra)) {
+                service.entity.extra = angular.fromJson(service.entity.extra);
+              }
             });
 
             that.services.length = 0;

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
@@ -180,10 +180,15 @@
                     // retrieve categories that user can filter services by
                     var categories = [];
                     angular.forEach(services, function (service) {
-                      if (angular.isObject(service.entity.extra) && angular.isDefined(service.entity.extra.categories)) {
-                        var serviceCategories = _.map(service.entity.extra.categories,
-                                                      function (o) {return { label: o, value: { categories: o }, lower: o.toLowerCase() }; });
-                        categories = _.unionBy(categories, serviceCategories, 'lower');
+                      // Parse service entity extra data JSON string
+                      if (!_.isNil(service.entity.extra) && angular.isString(service.entity.extra)) {
+                        service.entity.extra = angular.fromJson(service.entity.extra);
+
+                        if (angular.isDefined(service.entity.extra.categories)) {
+                          var serviceCategories = _.map(service.entity.extra.categories,
+                                                        function (o) {return { label: o, value: { categories: o }, lower: o.toLowerCase() }; });
+                          categories = _.unionBy(categories, serviceCategories, 'lower');
+                        }
                       }
                     });
                     categories = _.sortBy(categories, 'lower');

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/add-service-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/add-service-workflow.directive.js
@@ -89,6 +89,12 @@
      */
     reset: function (config) {
       var that = this;
+
+      // Parse service entity extra data JSON string
+      if (!_.isNil(config.service.entity.extra) && angular.isString(config.service.entity.extra)) {
+        config.service.entity.extra = angular.fromJson(config.service.entity.extra);
+      }
+
       this.data = {
         app: config.app,
         service: config.service,
@@ -143,6 +149,7 @@
       this.options = {
         errors: this.errors,
         userInput: this.userInput,
+        service: this.data.service,
         workflow: this.data.workflow,
 
         instances: [],

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/add-service-workflow.directive.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/add-service-workflow.directive.spec.js
@@ -24,6 +24,7 @@
       spyOn(addServiceWorkflowCtrl, 'startWorkflow').and.callThrough();
 
       mockService = {
+        entity: { extra: '{"displayName":"Service","longDescription":"Service description"}' },
         metadata: { guid: 'b2728c78-1057-4021-9c84-d2158f8f20df' }
       };
 

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/instance.html
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/instance.html
@@ -2,8 +2,8 @@
   <div class="service-description col-sm-12">
     <i class="helion-icon helion-icon-3x helion-icon-Service_business service-icon"></i>
     <div>
-      <h4 class="font-semi-bold">{{ wizardCtrl.options.service.entity.label }}</h4>
-      <p>{{ wizardCtrl.options.service.entity.description }}</p>
+      <h4 class="font-semi-bold">{{ wizardCtrl.options.service.entity.extra.displayName || wizardCtrl.options.service.entity.label }}</h4>
+      <p>{{ wizardCtrl.options.service.entity.extra.longDescription || wizardCtrl.options.service.entity.description }}</p>
     </div>
   </div>
 


### PR DESCRIPTION
Added a confirmation modal for detaching services from an application. The service description now should correct get `displayName` and `longDescription` from the `extra` parameter.

For some reason, the `extra` parameter for each service is sent as a string so it needs to be parsed on the client side.
