### PR TITLE
TEAMFOUR-737: No apps message shown event when there are apps

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -61,6 +61,10 @@
       orgGuid: 'all',
       spaceGuid: 'all'
     };
+
+    // This state should be in the model
+    this.clusterCount = 0;
+    this.hasApps = false;
   }
 
   angular.extend(Application.prototype, {
@@ -546,6 +550,19 @@
      */
     onAll: function (response) {
       this.data.applications = response.data;
+
+      // Check the data we have and determine if we have any applications
+      this.hasApps = false;
+      if (this.clusterCount > 0 && this.data && this.data.applications) {
+        var appCount = _.reduce(this.data.applications, function (sum, app) {
+          if (!app.error && app.resources) {
+            return sum + app.resources.length;
+          } else {
+            return sum;
+          }
+        }, 0);
+        this.hasApps = appCount > 0;
+      }
     },
 
     /**

--- a/src/plugins/cloud-foundry/view/applications/list/list.html
+++ b/src/plugins/cloud-foundry/view/applications/list/list.html
@@ -9,7 +9,7 @@
   </div>
 </div>
 
-<div class="applications-filter" ng-if="applicationsListCtrl.ready && applicationsListCtrl.clusterCount > 0">
+<div class="applications-filter" ng-if="applicationsListCtrl.ready && applicationsListCtrl.model.clusterCount > 0">
   <div class="panel panel-default">
     <div class="panel-body">
       <form class="form-horizontal">
@@ -54,15 +54,15 @@
   </div>
 </div>
 
-<div class="applications-empty" ng-if="applicationsListCtrl.ready && !applicationsListCtrl.hasApps">
-  <div ng-if="applicationsListCtrl.clusterCount === 0">
+<div class="applications-empty" ng-if="applicationsListCtrl.ready && !applicationsListCtrl.model.hasApps">
+  <div ng-if="applicationsListCtrl.model.clusterCount === 0">
     <div class="helion-icon helion-icon-3x helion-icon-Cluster"></div>
     <div class="applications-msg" translate>You cannot view any applications.</div>
     <div class="applications-cta" ><a class="btn-link" href="#/endpoint" translate>
       Use the Endpoints Dashboard</a> <span translate>to fix your connections or connect to new clusters.</span>
     </div>
   </div>
-  <div ng-if="applicationsListCtrl.clusterCount > 0">
+  <div ng-if="applicationsListCtrl.model.clusterCount > 0">
     <div class="helion-icon helion-icon-3x helion-icon-Application"></div>
     <div class="applications-msg" translate>You have no applications.</div>
     <div class="applications-cta">

--- a/src/plugins/cloud-foundry/view/applications/list/list.module.js
+++ b/src/plugins/cloud-foundry/view/applications/list/list.module.js
@@ -41,7 +41,6 @@
     this.model = modelManager.retrieve('cloud-foundry.model.application');
     this.eventService = eventService;
     this.ready = false;
-    this.hasApps = false;
     this.clusters = [{label: 'All Clusters', value: 'all'}];
     this.organizations = [{label: 'All Organizations', value: 'all'}];
     this.spaces = [{label: 'All Spaces', value: 'all'}];
@@ -50,7 +49,6 @@
       orgGuid: 'all',
       spaceGuid: 'all'
     };
-    this.clusterCount = 0;
     this.userCnsiModel = modelManager.retrieve('app.model.serviceInstance.user');
     this.userCnsiModel.list().then(function () {
       that._setClusters();
@@ -78,7 +76,7 @@
                       })
                       .value();
       [].push.apply(this.clusters, clusters);
-      this.clusterCount = clusters.length;
+      this.model.clusterCount = clusters.length;
 
       if (this.model.filterParams.cnsiGuid !== 'all') {
         this.filter.cnsiGuid = this.model.filterParams.cnsiGuid;
@@ -142,18 +140,6 @@
     _getApps: function () {
       var that = this;
       this.model.all().finally(function () {
-        // Check the data we have and determine if we have any applications
-        that.hasApps = false;
-        if (that.clusterCount > 0 && that.model.data && that.model.data.applications) {
-          var appCount = _.reduce(that.model.data.applications, function (sum, app) {
-            if (!app.error && app.resources) {
-              return sum + app.resources.length;
-            } else {
-              return sum;
-            }
-          }, 0);
-          that.hasApps = appCount > 0;
-        }
         that.ready = true;
       });
     },


### PR DESCRIPTION
Fixed the issue where when you add an application to an empty cluster, the message telling yoy that you have no applications remains on screen.

Moved some state to the model - as this is refreshed when an app is added, but this did not refresh the state in the list controller.

Better to have this state on the model, so that we can update it on the onAll() handler.
