### PR TITLE
Fixed cluster actions position after visibility change

### DIFF
--- a/src/app/view/endpoints/clusters/cluster/cluster.scss
+++ b/src/app/view/endpoints/clusters/cluster/cluster.scss
@@ -34,6 +34,11 @@
     height: $hpe-unit-space;
   }
 
+  .cluster-loading {
+    margin: 72px auto;
+    text-align: center;
+  }
+
   .cluster-detail {
 
     padding-left: $hpe-unit-space;

--- a/src/app/view/endpoints/clusters/cluster/detail/cluster-detail-organizations.html
+++ b/src/app/view/endpoints/clusters/cluster/detail/cluster-detail-organizations.html
@@ -1,7 +1,7 @@
-<div ng-if="clusterDetailController.organizations === null" class="message-box message-box-no-bg">
+<div ng-if="clusterDetailController.organizations === null" class="cluster-loading col-md-9 col-sm-12">
   <bounce-spinner classes="bounce-spinner-sm"></bounce-spinner>
 </div>
-<div ng-if="clusterDetailController.organizations === false" class="message-box message-box-no-bg">
+<div ng-if="clusterDetailController.organizations === false" class="cluster-loading col-md-9 col-sm-12">
   <div translate>An error occurred retrieving organizations</div>
 </div>
 <div class="cluster-gallery-card-container" ng-if="clusterDetailController.organizations">

--- a/src/app/view/endpoints/clusters/cluster/organization/detail/cluster-organization-detail.html
+++ b/src/app/view/endpoints/clusters/cluster/organization/detail/cluster-organization-detail.html
@@ -1,4 +1,4 @@
-<div ng-if="!clusterOrgDetailController.organization().details" class="message-box message-box-no-bg">
+<div ng-if="!clusterOrgDetailController.organization().details" class="cluster-loading col-md-9 col-sm-12">
   <bounce-spinner classes="bounce-spinner-sm"></bounce-spinner>
 </div>
 

--- a/src/app/view/endpoints/clusters/cluster/organization/space/detail/cluster-space-detail.html
+++ b/src/app/view/endpoints/clusters/cluster/organization/space/detail/cluster-space-detail.html
@@ -1,4 +1,4 @@
-<div ng-if="!clusterSpaceController.space()" class="message-box message-box-no-bg">
+<div ng-if="!clusterSpaceController.space()" class="cluster-loading col-md-9 col-sm-12">
   <bounce-spinner classes="bounce-spinner-sm"></bounce-spinner>
 </div>
 


### PR DESCRIPTION
In a previous commit I broke the position of the generic cluster actions whilst loading the org + space screens. Here's the fix.
