### PR TITLE
TEAMFOUR-824: Fix unit tests

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
@@ -134,7 +134,7 @@
     },
 
     viewExecution: function (execution) {
-      var that= this;
+      var that = this;
       var rawExecution = _.find(this.hceModel.data.pipelineExecutions, function (o) {
         return o.id === execution.id;
       });

--- a/tools/package.json
+++ b/tools/package.json
@@ -45,7 +45,7 @@
     "karma-coverage": "^0.5.3",
     "karma-jasmine": "^0.3.6",
     "karma-ng-html2js-preprocessor": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.2.3",
+    "karma-phantomjs-launcher": "^1.0.1",
     "karma-wiredep": "1.0.1",
     "minimatch": "^3.0.2",
     "phantomjs-prebuilt": "^2.1.0",


### PR DESCRIPTION
This fixes the broken unit tests on master - caused by my HCE refactor.

I had to update the version of PhantomJS to fix an issue where it crashes due to memory links. This is a known issue that the newer version has resolved.
