### PR TITLE
TEAMFOUR-768: Don't show add app button on app wall .. 

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/list.html
+++ b/src/plugins/cloud-foundry/view/applications/list/list.html
@@ -2,6 +2,7 @@
   <div class="applications-header font-semi-bold pull-left" translate>Applications</div>
   <div class="pull-right">
     <button class="btn btn-primary"
+      ng-if="applicationsListCtrl.ready && applicationsListCtrl.clusterCount > 0"
       translate
       ng-click="applicationsListCtrl.eventService.$emit('cf.events.START_ADD_APP_WORKFLOW')">
       add application


### PR DESCRIPTION
if there are no connected clusters

This is a trivial fix that hides the add app button when there are no clusters connected - since you can't add an app in this situation.
