### PR TITLE
TEAMFOUR-855: Fixes busted add app button logic

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/list.html
+++ b/src/plugins/cloud-foundry/view/applications/list/list.html
@@ -2,7 +2,7 @@
   <div class="applications-header font-semi-bold pull-left" translate>Applications</div>
   <div class="pull-right">
     <button class="btn btn-primary"
-      ng-if="applicationsListCtrl.ready && applicationsListCtrl.clusterCount > 0"
+      ng-if="applicationsListCtrl.ready && applicationsListCtrl.model.clusterCount > 0"
       translate
       ng-click="applicationsListCtrl.eventService.$emit('cf.events.START_ADD_APP_WORKFLOW')">
       add application


### PR DESCRIPTION
Doh! This fixed broken logic for hiding the "Add App" button on the app wall if there are no clusters available.
