### PR TITLE
TEAMFOUR-799: Application scroll bar sits under the header

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -8,4 +8,5 @@ html {
 body {
   padding-top: 0;
   height: 100%;
+  overflow: hidden;
 }

--- a/src/app/view/console-view/console-view.scss
+++ b/src/app/view/console-view/console-view.scss
@@ -19,4 +19,8 @@ console-view {
       flex: 1 0 auto;
     }
   }
+
+  > .container-fluid {
+    overflow-y: auto;
+  }
 }


### PR DESCRIPTION
This is a change to the CSS to fix the issue where the header overlaps the scroll bar.

The scroll bar will now appear in the portion of the UI below the header - which stays full width. The page content and footer are included in the scrollable area.
