### PR TITLE
TEAMFOUR-776: Remove Env Vars to avoid yahoo link being there

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
@@ -81,7 +81,9 @@
           <th translate>Name</th>
           <th translate>Service</th>
           <th translate>Plan</th>
+          <!--
           <th translate>ENV.VARIABLES</th>
+          -->
         </tr>
       </thead>
       <tbody>
@@ -89,9 +91,11 @@
           <td>{{ service.name }}</td>
           <td>{{ service.service_plan.service.label }}</td>
           <td>{{ service.service_plan.name }}</td>
+          <!--
           <td>
-            <a class="icon-link" href="http://yahoo.com" target="_blank"><i class="helion-icon helion-icon-Share"></i></a>
+            <a class="icon-link" href="#" target="_blank"><i class="helion-icon helion-icon-Share"></i></a>
           </td>
+          -->
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
This fixes the issue where we have a link to yahoo.com in the UI.

I have removed (hidden) the env vars on service instances table in the app summary view.

We will revisit later, once we understand what that was supposed to do. Focusing on having a UI that could be shipped - so taking out links etcs that are not implemented.

This is trivial fix.
