### PR TITLE
Show username and account status in cluster summary

### DIFF
--- a/src/app/view/endpoints/clusters/cluster/detail/cluster-detail.html
+++ b/src/app/view/endpoints/clusters/cluster/detail/cluster-detail.html
@@ -25,8 +25,8 @@
         </div>
       <div class="col-md-7">
         <dl class="dl-horizontal">
-          <dt ng-if="clusterController.getEndpoint()" translate>CF Endpoint URL</dt>
-          <dd ng-if="clusterController.getEndpoint()">
+          <dt ng-if="clusterDetailController.initialized" translate>CF Endpoint URL</dt>
+          <dd ng-if="clusterDetailController.initialized">
             {{ clusterController.getEndpoint() }}
           </dd>
           <dt translate>CF Interactions</dt>
@@ -34,6 +34,14 @@
             <a class="btn btn-link">
               <span translate>CLI Commands</span>
             </a>
+          </dd>
+          <dt ng-if="clusterDetailController.initialized" translate>Account Username</dt>
+          <dd ng-if="clusterDetailController.initialized">
+            {{ clusterDetailController.userName }}
+          </dd>
+          <dt ng-if="clusterDetailController.initialized" translate>Account Status</dt>
+          <dd ng-if="clusterDetailController.initialized" translate>
+            {{ clusterDetailController.isAdmin ? 'administrator' : 'user' }}
           </dd>
         </dl>
       </div>

--- a/src/app/view/endpoints/clusters/cluster/detail/cluster-detail.module.js
+++ b/src/app/view/endpoints/clusters/cluster/detail/cluster-detail.module.js
@@ -65,13 +65,19 @@
     }
 
     function init() {
-
+      var organizationModel = modelManager.retrieve('cloud-foundry.model.organization');
+      var stackatoInfo = modelManager.retrieve('app.model.stackatoInfo');
+      var user = stackatoInfo.info.endpoints.hcf[that.guid].user;
+      that.isAdmin = user.admin;
+      that.userName = user.name;
       // Start watching for further model changes after parent init chain completes
       $scope.$watchCollection(function () {
         return organizationModel.organizations[that.guid];
       }, function () {
         updateFromModel();
       });
+
+      that.initialized = true;
 
       // init functions should return a promise
       return $q.resolve(that.organizations);


### PR DESCRIPTION
Trivial tweaks from Cierra.

We now show the connected user's username and account status in the cluster summary
