### PR TITLE
TEAMFOUR-746: Remove font-awesome

### DIFF
--- a/src/index.tmpl.scss
+++ b/src/index.tmpl.scss
@@ -1,5 +1,4 @@
-// Font paths
-$fa-font-path               : "lib/font-awesome/fonts";
+// Page header and footer settings
 
 $page-header-height         : 96px !default;
 $page-footer-height         : 176px !default;

--- a/tools/bower.json
+++ b/tools/bower.json
@@ -18,7 +18,6 @@
     "angular-gettext": "~2.2.0",
     "angular-sanitize": "~1.4.9",
     "angular-ui-router": "~0.2.17",
-    "font-awesome": "~4.5.0",
     "helion-ui-framework": "../../helion-ui-framework#master",
     "lodash": "~4.0.1",
     "moment": "~2.10.6",


### PR DESCRIPTION
I removed font awesome - we do not use it and this simplifies the OSRB for the Console.

I tested locally and could not see any icons missing.

I did a search through the code base and could not find any references to "fa-".
