### PR TITLE
TEAMFOUR-828: Delivery pipeline setup message flickers

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -552,9 +552,13 @@
         return svc.name === hceServiceLink;
       });
 
-      pipeline.valid = false;
-      pipeline.hceCnsi = undefined;
-      pipeline.hce_api_url = undefined;
+      function clearDeliveryPipelineMetadata(metadata) {
+        metadata.fetching = false;
+        metadata.valid = false;
+        metadata.hceCnsi = undefined;
+        metadata.hce_api_url = undefined;
+      }
+
       if (hceServiceData) {
         // Go fetch the service metadata
         return hcfUserProvidedServiceInstanceModel.getUserProvidedServiceInstance(that.cnsiGuid, hceServiceData.guid)
@@ -570,15 +574,18 @@
               });
               pipeline.hceCnsi = hceInstance;
               pipeline.valid = angular.isDefined(hceInstance);
+              pipeline.fetching = false;
               return pipeline;
             });
+          } else {
+            clearDeliveryPipelineMetadata(pipeline);
           }
         })
-        .finally(function () {
-          pipeline.fetching = false;
+        .catch(function () {
+          clearDeliveryPipelineMetadata(pipeline);
         });
       } else {
-        pipeline.fetching = false;
+        clearDeliveryPipelineMetadata(pipeline);
         return that.$q.when(pipeline);
       }
     },


### PR DESCRIPTION
This fixes the issue on the delivery logs and pipeline views where the message would flicker.

The fix is to not nuke the pipeline data - this was causing the flicker.

We now update the existing object appropriately.
