### PR TITLE
TEAMFOUR-883 - Fixed timer leak in App Summary page & flickering stats values

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -84,22 +84,6 @@
     all: function (guid, options, sync) {
       var that = this;
 
-      /* Reset application data
-       so that Summary page doesn't
-       show stale information */
-      this.application = {
-        instanceCount: 0,
-        summary: {
-          state: 'LOADING'
-        },
-        stats: {},
-        pipeline: {
-          fetching: false,
-          valid: false,
-          hceCnsi: undefined
-        }
-      };
-
       var cnsis = [];
       if (this.filterParams.cnsiGuid === 'all') {
         cnsis = _.chain(this.serviceInstanceModel.serviceInstances)

--- a/src/plugins/cloud-foundry/view/applications/application/application.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/application.module.js
@@ -140,7 +140,6 @@
     ];
 
     $scope.$watch(function () {
-
       return that.model.application.summary.state;
     }, function (newState) {
       that.onAppStateChange(newState);
@@ -149,7 +148,6 @@
     $scope.$watch(function () {
       return that.model.application.summary.routes;
     }, function (newRoutes) {
-
       that.onAppRoutesChange(newRoutes);
     });
 
@@ -195,13 +193,9 @@
     startUpdate: function () {
       var that = this;
       if (!this.scheduledUpdate) {
-        console.log('Starting Update for', that.id);
         this.scheduledUpdate = this.$interval(function () {
           that.update();
-          console.log('Running Update for', that.id);
         }, this.UPDATE_INTERVAL);
-        console.log('Starting Update for', that.id, this.scheduledUpdate);
-
       }
     },
 
@@ -211,14 +205,9 @@
      * @public
      */
     stopUpdate: function () {
-      console.log('Cancelling for: ', this.id);
       if (this.scheduledUpdate) {
-        console.log('About to cancel: ', this.id);
         this.$interval.cancel(this.scheduledUpdate);
-        console.log('Cancelled for: ', this.id);
         delete this.scheduledUpdate;
-      }  else {
-        console.log('nothing to do', this.id);
       }
     },
 


### PR DESCRIPTION
Addresses a couple issues in the App Summary page.
1. Application stats data values constantly change when a user enters the page from the Application Wall.
2. Fixed a timer leak, that caused App summary page to flicker between information about different apps.
