### PR TITLE
Only show 1 decimal precision if it is useful (non-zero)

### DIFF
--- a/src/app/utils/utils.service.js
+++ b/src/app/utils/utils.service.js
@@ -51,7 +51,7 @@
       if (sizeMb > 1024) {
         return precisionIfUseful(sizeMb / 1024) + ' GB';
       }
-      return sizeMb + ' MB';
+      return precisionIfUseful(sizeMb) + ' MB';
     }
 
     function sizeUtilization(sizeMbUsed, sizeMbTotal) {


### PR DESCRIPTION
If the value is an integer, no point showing the decimal
