### PR TITLE
show database version on setting page

### DIFF
--- a/src/app/view/console-view/settings-page/settings-page.html
+++ b/src/app/view/console-view/settings-page/settings-page.html
@@ -16,6 +16,10 @@
               <div>{{settingsCtrl.stackatoInfo.info.version.proxy_version}}</div>
             </div>
             <div class="cluster-property">
+              <div translate>Database Version</div>
+              <div>{{settingsCtrl.stackatoInfo.info.version.database_version}}</div>
+            </div>
+            <div class="cluster-property">
               <div translate>User</div>
               <div>{{settingsCtrl.stackatoInfo.info.user.name}}</div>
             </div>


### PR DESCRIPTION
Displays the database version below the console version on the settings page.
