### PR TITLE
TEAMFOUR-749: Login Page: Busy indicator remains

### DIFF
--- a/src/app/event/event.service.js
+++ b/src/app/event/event.service.js
@@ -4,6 +4,7 @@
   var events = {
     LOGIN               : 'LOGIN',
     LOGIN_FAILED        : 'LOGIN_FAILED',
+    LOGIN_TIMEOUT       : 'LOGIN_TIMEOUT',
     LOGOUT              : 'LOGOUT',
     HTTP_401            : 'HTTP_401',
     HTTP_403            : 'HTTP_403',

--- a/src/app/view/application.directive.js
+++ b/src/app/view/application.directive.js
@@ -202,6 +202,7 @@
     onLoginFailed: function (response) {
       if (response.status === -1) {
         // handle the case when the server never responds
+        this.eventService.$emit(this.eventService.events.LOGIN_TIMEOUT);
         this.serverFailedToRespond = true;
         this.serverErrorOnLogin = false;
         this.failedLogin = false;

--- a/src/app/view/login-page/login-form/login-form.directive.js
+++ b/src/app/view/login-page/login-form/login-form.directive.js
@@ -55,6 +55,9 @@
     this.eventService.$on(this.eventService.events.LOGIN_FAILED, function () {
       that.clearPassword();
     });
+    this.eventService.$on(this.eventService.events.LOGIN_TIMEOUT, function () {
+      that.clearPassword();
+    });
     this.eventService.$on(this.eventService.events.HTTP_5XX_ON_LOGIN, function () {
       that.clearPassword();
     });


### PR DESCRIPTION
Fixed issue where the "authenticating" message and spinner stay stuck on the page if the server does not respond.

Small fix to ensure an event is sent in this case and that the login form then listens for this event and removes the spinner and message.
