### PR TITLE
TEAMFOUR-951 - Delete pipeline should also delete HCE user defined service instance

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -55,7 +55,8 @@
       pipeline: {
         fetching: false,
         valid: false,
-        hceCnsi: undefined
+        hceCnsi: undefined,
+        hceServiceGuid: undefined
       }
     };
     this.appStateSwitchTo = '';
@@ -600,6 +601,7 @@
         metadata.valid = false;
         metadata.hceCnsi = undefined;
         metadata.hce_api_url = undefined;
+        metadata.hceServiceGuid = undefined;
       }
 
       if (hceServiceData) {
@@ -609,6 +611,7 @@
           // Now we need to see if the CNSI is known
           if (data && data.entity && data.entity.credentials && data.entity.credentials.hce_api_url) {
             // HCE API Endpoint
+            pipeline.hceServiceGuid = hceServiceData.guid;
             pipeline.hce_api_url = data.entity.credentials.hce_api_url;
             return that.listHceCnsis().then(function (hceEndpoints) {
               var hceInstance = _.find(hceEndpoints, function (hce) {

--- a/src/plugins/cloud-foundry/model/service/user-provided/user-provided-service-instance.model.js
+++ b/src/plugins/cloud-foundry/model/service/user-provided/user-provided-service-instance.model.js
@@ -54,6 +54,44 @@
         .then(function (response) {
           return response.data;
         });
+    },
+
+    /**
+     * @function listAllServiceBindings
+     * @memberof cloud-foundry.model.user-provided-service-instance.UserProvidedServiceInstance
+     * @description List all service bindings
+     * @param {string} cnsiGuid - the CNSI guid
+     * @param {string} guid - the user provided service instance guid
+     * @returns {promise} A promise object
+     */
+    listAllServiceBindings: function (cnsiGuid, guid) {
+      var httpConfig = {
+        headers: {
+          'x-cnap-cnsi-list': cnsiGuid,
+          'x-cnap-passthrough': 'true'
+        }
+      };
+
+      return this.userProvidedServiceInstance.ListAllServiceBindingsForUserProvidedServiceInstance(guid, {}, httpConfig);
+    },
+
+    /**
+     * @function deleteUserProvidedServiceInstance
+     * @memberof cloud-foundry.model.user-provided-service-instance.UserProvidedServiceInstance
+     * @description Delete user provided service instance
+     * @param {string} cnsiGuid - the CNSI guid
+     * @param {string} guid - the user provided service instance guid
+     * @returns {promise} A promise object
+     */
+    deleteUserProvidedServiceInstance: function (cnsiGuid, guid) {
+      var httpConfig = {
+        headers: {
+          'x-cnap-cnsi-list': cnsiGuid,
+          'x-cnap-passthrough': 'true'
+        }
+      };
+
+      return this.userProvidedServiceInstance.DeleteUserProvidedServiceInstance(guid, {}, httpConfig);
     }
   });
 

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.spec.js
@@ -3,7 +3,7 @@
 
   describe('Delivery Pipeline', function () {
 
-    var controller, $state, $stateParams, $rootScope, cnsiModel, modelManager, $httpBackend, account;
+    var controller, eventService, $interpolate, $state, $stateParams, $rootScope, cnsiModel, modelManager, $httpBackend, account;
 
     beforeEach(module('green-box-console'));
     beforeEach(module('cloud-foundry.view.applications.application.delivery-pipeline'));
@@ -20,6 +20,8 @@
 
     beforeEach(inject(function ($injector) {
       // Create the parameters required by the ctor
+      eventService = $injector.get('app.event.eventService');
+      $interpolate = $injector.get('$interpolate');
       $state = $injector.get('$state');
       $stateParams = $injector.get('$stateParams');
       modelManager = $injector.get('app.model.modelManager');
@@ -37,7 +39,7 @@
 
     function createController() {
       var ApplicationDeliveryPipelineController = $state.get('cf.applications.application.delivery-pipeline').controller;
-      controller = new ApplicationDeliveryPipelineController(modelManager, $stateParams, $rootScope.$new(), null);
+      controller = new ApplicationDeliveryPipelineController(eventService, modelManager, $interpolate, $stateParams, $rootScope.$new(), null);
       expect(controller).toBeDefined();
     }
 


### PR DESCRIPTION
When deleting a pipeline, the HCE user defined service instance is left around. This causes the delivery logs and delivery pipeline views to be blank. On successful delete, a notification appears on the top right.
