### PR TITLE
TEAMFOUR-901: Instance count on gallery card is misleading

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.directive.js
@@ -22,14 +22,22 @@
   }
 
   ApplicationGalleryCardController.$inject = [
-    '$state'
+    '$state',
+    '$scope'
   ];
 
-  function ApplicationGalleryCardController($state) {
+  function ApplicationGalleryCardController($state, $scope) {
+    var that = this;
     this.$state = $state;
     this.cardData = {
       title: this.app.entity.name
     };
+
+    $scope.$watch(function () {
+      return that.app.entity.state;
+    }, function () {
+      that.canShowStats = that.app.entity.state === 'STARTED';
+    });
   }
 
   angular.extend(ApplicationGalleryCardController.prototype, {

--- a/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.html
+++ b/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.html
@@ -7,10 +7,13 @@
     </dt>
     <dd></dd>
     <dt translate>Instances</dt>
-    <dd>{{ applicationGalleryCardCtrl.app.entity.instances }}</dd>
+    <dd ng-if="applicationGalleryCardCtrl.canShowStats">{{ applicationGalleryCardCtrl.app.instanceCount }} / {{ applicationGalleryCardCtrl.app.entity.instances }}</dd>
+    <dd ng-if="!applicationGalleryCardCtrl.canShowStats">0 / {{ applicationGalleryCardCtrl.app.entity.instances }}</dd>
     <dt translate>Disk Quota</dt>
-    <dd>{{ applicationGalleryCardCtrl.app.entity.disk_quota | mbToHumanSize }}</dd>
-    <dt translate>Memory</dt>
-    <dd>{{ applicationGalleryCardCtrl.app.entity.memory | mbToHumanSize }}</dd>
+    <dd ng-if="applicationGalleryCardCtrl.canShowStats">{{ applicationGalleryCardCtrl.app.entity.disk_quota | mbToHumanSize }}</dd>
+    <dd ng-if="!applicationGalleryCardCtrl.canShowStats">-</dd>
+    <dt translate>Memory Quota</dt>
+    <dd ng-if="applicationGalleryCardCtrl.canShowStats">{{ applicationGalleryCardCtrl.app.entity.memory | mbToHumanSize }}</dd>
+    <dd ng-if="!applicationGalleryCardCtrl.canShowStats">-</dd>
   </dl>
 </gallery-card>


### PR DESCRIPTION
This is a first fix for the reported issue about instance count being wrong.

On the gallery card it incorrectly shows the instance limit, not the running count - this PR fixes that.

Apps not with an app_state that is not STARTED will report an instance count of 0 - since no instances are running in these cases.
