### PR TITLE
Use hce_pipeline_id to get project

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -61,7 +61,8 @@
         fetching: false,
         valid: false,
         hceCnsi: undefined,
-        hceServiceGuid: undefined
+        hceServiceGuid: undefined,
+        projectId: undefined
       },
       project: null
     };
@@ -610,6 +611,7 @@
         metadata.hceCnsi = undefined;
         metadata.hce_api_url = undefined;
         metadata.hceServiceGuid = undefined;
+        metadata.projectId = undefined;
       }
 
       if (hceServiceData) {
@@ -621,6 +623,7 @@
               // HCE API Endpoint
               pipeline.hceServiceGuid = hceServiceData.guid;
               pipeline.hce_api_url = data.entity.credentials.hce_api_url;
+              pipeline.projectId = _.toNumber(data.entity.credentials.hce_pipeline_id);
               return that.listHceCnsis().then(function (hceEndpoints) {
                 var hceInstance = _.find(hceEndpoints, function (hce) {
                   var url = hce.info ? hce.info.api_public_uri : hce.api_endpoint.Scheme + '://' + hce.api_endpoint.Host;

--- a/src/plugins/cloud-foundry/model/hce/hce.model.js
+++ b/src/plugins/cloud-foundry/model/hce/hce.model.js
@@ -42,7 +42,7 @@
       buildContainers: [],
       deploymentTargets: [],
       imageRegistries: [],
-      projects: {},
+      projects: [],
       pipelineExecutions: [],
       vcsInstances: [],
       vcsTypes: [],
@@ -304,12 +304,14 @@
      * @function getProject
      * @memberof cloud-foundry.model.hce.HceModel
      * @description Get project by name
-     * @param {string} name - the project name
+     * @param {string} guid - the HCE instance GUID
+     * @param {number} projectId - the HCE project ID
      * @returns {promise} A promise object
      * @public
      */
-    getProject: function (name) {
-      return this.data.projects[name];
+    getProject: function (guid, projectId) {
+      return this.apiManager.retrieve('cloud-foundry.api.HceProjectApi')
+        .getProject(guid, projectId, {}, this.hceProxyPassthroughConfig);
     },
 
     /**
@@ -590,7 +592,7 @@
      */
     onGetProjects: function (response) {
       var projects = response.data;
-      this.data.projects = _.keyBy(projects, 'name') || {};
+      this.data.projects = projects;
       return projects;
     },
 

--- a/src/plugins/cloud-foundry/view/applications/application/application.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/application.module.js
@@ -275,9 +275,9 @@
       var that = this;
       if (pipeline && pipeline.valid) {
         this.hceCnsi = pipeline.hceCnsi;
-        this.hceModel.getProjects(this.hceCnsi.guid)
-          .then(function () {
-            that.model.application.project = that.hceModel.getProject(that.model.application.summary.name);
+        this.hceModel.getProject(this.hceCnsi.guid, pipeline.projectId)
+          .then(function (response) {
+            that.model.application.project = response.data;
 
             if (angular.isDefined(that.model.application.project)) {
               // TODO (kdomico): Fix once vcs_id is returned - TEAMFOUR-946

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/notifications/add-notifications-target.service.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/notifications/add-notifications-target.service.js
@@ -50,7 +50,7 @@
     this.model = modelManager.retrieve('cloud-foundry.model.application');
     this.hceNotificationApi = apiManager.retrieve('cloud-foundry.api.HceNotificationApi');
     this.hceModel = modelManager.retrieve('cloud-foundry.model.hce');
-    this.project = this.hceModel.getProject(this.model.application.summary.name);
+    this.project = this.model.application.project;
     this.cnsiModel = modelManager.retrieve('app.model.serviceInstance');
     this.$uibModalInstance = $uibModalInstance;
     this.hceCnsi = that.model.application.pipeline.hceCnsi;


### PR DESCRIPTION
There was a breaking change when the project name was change to be <app-name>-<app-guid>. This PR should now correctly fetch the project for an app that has a linked HCE pipeline.
