### PR TITLE
TEAMFOUR-979: gulp dev: Changed proxying mechanism to allow this to go via a web proxy

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -51,9 +51,8 @@
     "phantomjs-prebuilt": "^2.1.0",
     "prompt": "^0.2.14",
     "protractor": "^3.0.0",
-    "proxy-middleware": "^0.15.0",
     "q": "^1.4.1",
-    "request": "2.69.0",
+    "request": "^2.69.0",
     "shelljs": "^0.5.3"
   }
 }


### PR DESCRIPTION
Allows you to use gulp dev with external portal proxies when behind the firewall
