### PR TITLE
Add CF binding on HCE project create

### DIFF
--- a/src/plugins/cloud-foundry/api/hce/HceProjectApi.js
+++ b/src/plugins/cloud-foundry/api/hce/HceProjectApi.js
@@ -99,6 +99,42 @@
     },
 
     /**
+     * @name createCfBinding
+     * @description Creates a binding in CF between a CF application and an HCE project.
+     * @param {string} guid - the HCE instance GUID
+     * @param {!number} projectId - The project id.
+     * @param {object} data - the request body
+     * @param {object} params - the query parameters
+     * @param {object} httpConfigOptions - additional config options
+     * @returns {promise} A resolved/rejected promise
+     */
+    createCfBinding: function (guid, projectId, data, params, httpConfigOptions) {
+      var path = this.baseUrl + '/projects/{project_id}/bindings/cloudfoundry'
+        .replace('{' + 'project_id' + '}', projectId);
+      var headers = {
+        'x-cnap-cnsi-list': guid
+      };
+
+      var config = {
+        method: 'POST',
+        url: path,
+        params: params || {},
+        data: data,
+        headers: headers
+      };
+
+      angular.forEach(httpConfigOptions, function (optionConfig, option) {
+        if (option === 'headers') {
+          angular.extend(config[option], optionConfig);
+        } else {
+          config[option] = optionConfig;
+        }
+      });
+
+      return this.$http(config);
+    },
+
+    /**
      * @name createProject
      * @description Create a new project.
      * @param {string} guid - the HCE instance GUID

--- a/src/plugins/cloud-foundry/api/hce/HceUserApi.js
+++ b/src/plugins/cloud-foundry/api/hce/HceUserApi.js
@@ -31,49 +31,15 @@
 
   angular.extend(HceUserApi.prototype, {
     /**
-     * @name getAuthenticatedUser
+     * @name getUser
      * @description Get the HCE currently authenticated user.
      * @param {string} guid - the HCE instance GUID
      * @param {object} params - the query parameters
      * @param {object} httpConfigOptions - additional config options
      * @returns {promise} A resolved/rejected promise
      */
-    getAuthenticatedUser: function (guid, params, httpConfigOptions) {
+    getUser: function (guid, params, httpConfigOptions) {
       var path = this.baseUrl + '/users';
-      var headers = {
-        'x-cnap-cnsi-list': guid
-      };
-
-      var config = {
-        method: 'GET',
-        url: path,
-        params: params || {},
-        headers: headers
-      };
-
-      angular.forEach(httpConfigOptions, function (optionConfig, option) {
-        if (option === 'headers') {
-          angular.extend(config[option], optionConfig);
-        } else {
-          config[option] = optionConfig;
-        }
-      });
-
-      return this.$http(config);
-    },
-
-    /**
-     * @name getUser
-     * @description Get the specified user.
-     * @param {string} guid - the HCE instance GUID
-     * @param {!number} userId - User id.
-     * @param {object} params - the query parameters
-     * @param {object} httpConfigOptions - additional config options
-     * @returns {promise} A resolved/rejected promise
-     */
-    getUser: function (guid, userId, params, httpConfigOptions) {
-      var path = this.baseUrl + '/users/{user_id}'
-        .replace('{' + 'user_id' + '}', userId);
       var headers = {
         'x-cnap-cnsi-list': guid
       };
@@ -108,6 +74,40 @@
     getUserByUaaId: function (guid, uaaId, params, httpConfigOptions) {
       var path = this.baseUrl + '/users/uaa/{uaa_id}'
         .replace('{' + 'uaa_id' + '}', uaaId);
+      var headers = {
+        'x-cnap-cnsi-list': guid
+      };
+
+      var config = {
+        method: 'GET',
+        url: path,
+        params: params || {},
+        headers: headers
+      };
+
+      angular.forEach(httpConfigOptions, function (optionConfig, option) {
+        if (option === 'headers') {
+          angular.extend(config[option], optionConfig);
+        } else {
+          config[option] = optionConfig;
+        }
+      });
+
+      return this.$http(config);
+    },
+
+    /**
+     * @name getUser_1
+     * @description Get the specified user.
+     * @param {string} guid - the HCE instance GUID
+     * @param {!number} userId - User id.
+     * @param {object} params - the query parameters
+     * @param {object} httpConfigOptions - additional config options
+     * @returns {promise} A resolved/rejected promise
+     */
+    getUser_1: function (guid, userId, params, httpConfigOptions) {
+      var path = this.baseUrl + '/users/{user_id}'
+        .replace('{' + 'user_id' + '}', userId);
       var headers = {
         'x-cnap-cnsi-list': guid
       };

--- a/src/plugins/cloud-foundry/model/hce/hce.model.js
+++ b/src/plugins/cloud-foundry/model/hce/hce.model.js
@@ -436,6 +436,21 @@
     },
 
     /**
+     * @function createCfBinding
+     * @memberof cloud-foundry.model.hce.HceModel
+     * @description Create a Cloud Foundry service instance binding to the application
+     * @param {string} guid - the HCE instance GUID
+     * @param {string} projectId - the project ID
+     * @param {string} appGuid - the application GUID
+     * @returns {promise} A promise object
+     * @public
+     */
+    createCfBinding: function (guid, projectId, appGuid) {
+      return this.apiManager.retrieve('cloud-foundry.api.HceProjectApi')
+        .createCfBinding(guid, projectId, {cf_app_guid: appGuid}, {}, this.hceProxyPassthroughConfig);
+    },
+
+    /**
      * @function createProject
      * @memberof cloud-foundry.model.hce.HceModel
      * @description Create a new project


### PR DESCRIPTION
After creating a project, the UI needs to make another call to add the CF service instance binding to the application and project. HCE has provided an endpoint to add that binding.

Waiting on an HCE release that will include the endpoint to create binding.
