### PR TITLE
TEAMFOUR-557: Replace divs with code-block widget

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/services/service-instance/env-variables.html
+++ b/src/plugins/cloud-foundry/view/applications/services/service-instance/env-variables.html
@@ -1,5 +1,3 @@
 <div class="env-variables">
-  <div class="hpe-copy hpe-copy-dark">
-    <pre class="hpe-pre-dark">{{ detailViewCtrl.context.variables | json }}</pre>
-  </div>
+  <code-block>{{ detailViewCtrl.context.variables | json }}</code-block>
 </div>

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/cli-subflow/deploy.html
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/cli-subflow/deploy.html
@@ -5,9 +5,7 @@
 <p translate>2. Add a manifest.yml to your source code or update your existing one by <strong>copying & pasting</strong> the code below. Cloud Foundry uses the manifest file to set the application's name and route. Since the application and its route has been created for you, please ensure that the name, host and domain of your manifest file matches the example below. If the application name and route is not correct in the manifest file, two applications and routes will get created.</p>
 <div class="row">
   <div class="col-sm-12 col-md-12">
-    <div class="hpe-copy hpe-copy-dark">
-      <pre class="hpe-pre-dark">
----
+    <code-block>---
 <span class="text-primary" translate># We have created a temporary app in the gallery</span>
 <span class="text-primary" translate># We have created a delivery pipeline</span>
 applications:
@@ -17,8 +15,7 @@ applications:
   domain: {{ wizardCtrl.options.userInput.domain.entity.name }}<span ng-if="wizardCtrl.options.userInput.services.length > 0">
   <span class="text-primary" translate># We have provisioned and bound services</span>
   services:<span ng-repeat="service in wizardCtrl.options.userInput.services">
-  - {{ service.name }}</span></pre>
-    </div>
+  - {{ service.name }}</span></code-block>
   </div>
 </div>
 <p translate>3. Using the CLI, target your Cloud Foundry endpoint, login, and push to the endpoint.</p>

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-pipeline-workflow/deploy.html
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-pipeline-workflow/deploy.html
@@ -5,9 +5,7 @@
 <p translate>You must update the manifest.yml file in your source code repository, this will automatically trigger the delivery pipeline. You can <strong>copy & paste</strong> the code below into the manifest.yml file in your repository. Cloud Foundry uses the manifest file to set the application's name and route. Since the application and its route has been created for you, please ensure that the name, host and domain of your manifest file matches the example below. If the application name and route is not correct in the manifest file, two applications and routes will get created.</p>
 <div class="row">
   <div class="col-sm-12 col-md-12">
-    <div class="hpe-copy hpe-copy-dark">
-      <pre class="hpe-pre-dark">
----
+    <code-block>---
 <span class="text-primary" translate># We have created a temporary app in the gallery</span>
 <span class="text-primary" translate># We have created a delivery pipeline</span>
 applications:
@@ -17,7 +15,6 @@ applications:
   domain: {{ wizardCtrl.options.userInput.domain.entity.name }}<span ng-if="wizardCtrl.options.userInput.services.length > 0">
   <span class="text-primary" translate># We have provisioned and bound services</span>
   services:<span ng-repeat="service in wizardCtrl.options.userInput.services">
-  - {{ service.name }}</span></pre>
-    </div>
+  - {{ service.name }}</span></code-block>
   </div>
 </div>

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/acknowledge.html
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-service-workflow/acknowledge.html
@@ -5,11 +5,8 @@
   <h4 translate>Add to Manifest</h4>
   <div class="row">
     <div class="col-sm-12 col-md-12">
-      <div class="hpe-copy hpe-copy-dark">
-        <pre class="hpe-pre-dark">
-services:
-- {{ wizardCtrl.options.serviceInstance.entity.name }}</span></pre>
-      </div>
+      <code-block>services:
+- {{ wizardCtrl.options.serviceInstance.entity.name }}</code-block>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR wires in the code-block widget in all of the places where we current use a div structure.

The old way showed a copy to clipboard icon that did not work.

The code-block widget supports copy to clipboard when allowed by the browser.
