### PR TITLE
TEAMFOUR-987: Allow expired HCF services to be disconnected

### DIFF
--- a/src/app/view/endpoints/clusters/tiles/cluster-tile/cluster-tile.directive.js
+++ b/src/app/view/endpoints/clusters/tiles/cluster-tile/cluster-tile.directive.js
@@ -100,7 +100,7 @@
         });
       }
 
-      if (this.service.isConnected || this.service.hasExpired ) {
+      if (this.service.isConnected || this.service.hasExpired) {
         this.actions.push({
           name: gettext('Disconnect'),
           execute: function () {


### PR DESCRIPTION
This PR fixes the action menu logic for HCF endpoints, so that you can now disconnect an expired HCF endpoint,

Without this, expired endpoints would stay and there was no way to get rid of them, other than the admin unregistering them.
