### PR TITLE
TEAMFOUR-980: Fix footer links

### DIFF
--- a/src/app/view/page-footer/page-footer.directive.js
+++ b/src/app/view/page-footer/page-footer.directive.js
@@ -19,25 +19,8 @@
    */
   function pageFooter(path) {
     return {
-      templateUrl: path + 'view/page-footer/page-footer.html',
-      controller: FooterController,
-      controllerAs: 'footerCtrl'
+      templateUrl: path + 'view/page-footer/page-footer.html'
     };
   }
 
-  FooterController.$inject = [];
-
-  /**
-   * @namespace app.view.pageFooter
-   * @memberof app.view
-   * @name FooterController
-   * @description Controller for the footer - provides footer links
-   * @constructor
-   */
-  function FooterController() {
-    this.links = {
-      privacy: gettext('https://www.hpe.com/us/en/legal/privacy.html'),
-      terms: gettext('http://docs.hpcloud.com/permalink/helion-openstack/3.0/eula')
-    };
-  }
 })();

--- a/src/app/view/page-footer/page-footer.html
+++ b/src/app/view/page-footer/page-footer.html
@@ -7,6 +7,6 @@
 </div>
 
 <ul class="links">
-  <li><a rel="noopener noreferrer" target="_blank" href="{{ footerCtrl.links.terms }}" translate>Terms of use</a></li>
-  <li><a rel="noopener noreferrer" target="_blank" href="{{ footerCtrl.links.privacy }}" translate>Privacy</a></li>
+  <li><a rel="noopener noreferrer" target="_blank" href="{{ 'http://docs.hpcloud.com/permalink/helion-openstack/3.0/eula' | translate }}" translate>Terms of use</a></li>
+  <li><a rel="noopener noreferrer" target="_blank" href="{{ 'https://www.hpe.com/us/en/legal/privacy.html' | translate }}" translate>Privacy</a></li>
 </ul>


### PR DESCRIPTION
This PR fixes the broken footer links:
- Remove Report a bug link
- Other two links use URls provided by a controller - allows them to be localised
- Updated version number to remove the 'v' in front of 4.0
