### PR TITLE
TEAMFOUR-996 - Remove trigger build at end of create app flow

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
@@ -529,9 +529,6 @@
       },
 
       finishWorkflow: function () {
-        if (this.options.subflow === 'pipeline') {
-          this.triggerPipeline();
-        }
         this.notify();
         this.addingApplication = false;
       }

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-pipeline-workflow/add-pipeline-workflow.module.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-pipeline-workflow/add-pipeline-workflow.module.js
@@ -340,21 +340,6 @@
         return name;
       },
 
-      triggerPipeline: function () {
-        var that = this;
-        var githubModel = this.modelManager.retrieve('github.model');
-        var hceModel = this.modelManager.retrieve('cloud-foundry.model.hce');
-        var githubOptions = this._getVcsHeaders();
-
-        githubModel.getBranch(this.userInput.repo.full_name, this.userInput.branch, githubOptions)
-          .then(function (response) {
-            var branch = response.data;
-            hceModel.triggerPipelineExecution(that.userInput.hceCnsi.guid,
-                                              that.userInput.projectId,
-                                              branch.commit.sha);
-          });
-      },
-
       _getVcsHeaders: function () {
         var githubOptions = {};
         if (this.userInput.source) {

--- a/src/plugins/cloud-foundry/view/applications/workflows/add-pipeline-workflow/deploy.html
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-pipeline-workflow/deploy.html
@@ -1,8 +1,8 @@
 <h4 translate>Deploy App</h4>
 <div class="deploy-alert alert alert-info alert-no-bg alert-bordered">
-  <p translate>In order to deploy your app, you must make a code change.</p>
+  <p translate>In order to deploy your app, you must make a code change or trigger the delivery pipeline manually from your application's <b>Delivery Logs</b> view.</p>
 </div>
-<p translate>You must update the manifest.yml file in your source code repository, this will automatically trigger the delivery pipeline. You can <strong>copy & paste</strong> the code below into the manifest.yml file in your repository. Cloud Foundry uses the manifest file to set the application's name and route. Since the application and its route has been created for you, please ensure that the name, host and domain of your manifest file matches the example below. If the application name and route is not correct in the manifest file, two applications and routes will get created.</p>
+<p translate>To automatically trigger the delivery pipeline, update the manifest.yml file in your source code repository. You can <b>copy & paste</b> the code below into the manifest.yml file in your repository. Cloud Foundry uses the manifest file to set the application's name and route. Since the application and its route has been created for you, please ensure that the name, host and domain of your manifest file matches the example below. If the application name and route is not correct in the manifest file, two applications and routes will get created.</p>
 <div class="row">
   <div class="col-sm-12 col-md-12">
     <code-block>---


### PR DESCRIPTION
We will no longer trigger a build at the end of the create app workflow. Added verbiage to deploy step to let the user know to make a change in the source code or trigger manually from Delivery Logs.
