### PR TITLE
Pin PhantomJs

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -48,7 +48,7 @@
     "karma-phantomjs-launcher": "^1.0.1",
     "karma-wiredep": "1.0.1",
     "minimatch": "^3.0.2",
-    "phantomjs-prebuilt": "^2.1.0",
+    "phantomjs-prebuilt": "2.1.11",
     "prompt": "^0.2.14",
     "protractor": "^3.0.0",
     "q": "^1.4.1",


### PR DESCRIPTION
Pinning the version of phantomjs-built to 2.1.11 until 2.1.12 is fixed for Linux
