### PR TITLE
TEAMFOUR-1009: Optimize API calls on initial Endpoints Dashboard page

### DIFF
--- a/src/app/view/endpoints/dashboard/endpoints-dashboard.html
+++ b/src/app/view/endpoints/dashboard/endpoints-dashboard.html
@@ -35,9 +35,9 @@
       </div>
     </div>
 
-    <service-tile service-instances="endpointsDashboardCtrl.serviceInstances" service-type="hcf"
+    <service-tile use-cached-data="true" service-instances="endpointsDashboardCtrl.serviceInstances" service-type="hcf"
                   class="endpoint-tile col-md-4 col-sm-1"></service-tile>
-    <service-tile service-instances="endpointsDashboardCtrl.serviceInstances" service-type="hce"
+    <service-tile use-cached-data="true" service-instances="endpointsDashboardCtrl.serviceInstances" service-type="hce"
                   class="endpoint-tile col-md-4 col-sm-1"></service-tile>
   </div>
 </div>

--- a/src/app/view/endpoints/dashboard/endpoints-dashboard.module.js
+++ b/src/app/view/endpoints/dashboard/endpoints-dashboard.module.js
@@ -55,12 +55,12 @@
     if (this.serviceInstanceModel.serviceInstances > 0) {
       // serviceInstanceModel has previously been updated
       // to decrease load time, we will use that data.
+      // we will still refresh the data asyncronously and the UI will update to relect and changes
       this.listPromiseResolved = true;
       _updateLocalServiceInstances();
     }
     // Show welcome message only if no endpoints are registered
     this.showWelcomeMessage = this.serviceInstanceModel.serviceInstances.length === 0;
-    this.serviceInstanceModel.list();
     this.$q = $q;
 
     _updateEndpoints();

--- a/src/app/view/endpoints/dashboard/tiles/service-tile.directive.js
+++ b/src/app/view/endpoints/dashboard/tiles/service-tile.directive.js
@@ -9,7 +9,8 @@
     return {
       scope: {
         serviceType: '@',
-        serviceInstances: '=?'
+        serviceInstances: '=?',
+        useCachedData: '=?'
       },
       controller: ServiceTileController,
       controllerAs: 'serviceTileCtrl',
@@ -44,6 +45,7 @@
     this.modelManager = modelManager;
     this.serviceInstanceModel = modelManager.retrieve('app.model.serviceInstance');
     this.serviceType = $scope.serviceType;
+    this.useCachedData = $scope.useCachedData;
     this.userServiceInstanceModel = modelManager.retrieve('app.model.serviceInstance.user');
     this.currentUserAccount = modelManager.retrieve('app.model.account');
     this.$state = $state;
@@ -69,6 +71,11 @@
       .then(function () {
         $scope.$watchCollection(function () {
           return that.serviceInstanceModel.serviceInstances;
+        }, function () {
+          that._updateInstances();
+        });
+        $scope.$watchCollection(function () {
+          return that.userServiceInstanceModel.serviceInstances;
         }, function () {
           that._updateInstances();
         });
@@ -177,12 +184,12 @@
 
     _listServiceInstances: function () {
       var that = this;
-      return this.$q.all([this.serviceInstanceModel.list(), this.userServiceInstanceModel.list()])
-        .then(function () {
-          return that._updateInstances();
-        }).then(function () {
-          that.resolvedPromise = true;
-        });
+      var promise = this.useCachedData ? this.$q.when(true) : this.$q.all([this.serviceInstanceModel.list(), this.userServiceInstanceModel.list()]);
+      return promise.then(function () {
+        return that._updateInstances();
+      }).then(function () {
+        that.resolvedPromise = true;
+      });
     },
 
     _updateChart: function () {


### PR DESCRIPTION
This PR improves the initial load time of the endpoints dashboard.

The service tiles can now be told to use cached data - previously we would fetch data in the controller and then in both tiles.

With this change, the number of call is optimized.
