### PR TITLE
TEAMFOUR-997 - Space Developers can't rename spaces

### DIFF
--- a/src/plugins/cloud-foundry/model/auth/checkers/space-access.js
+++ b/src/plugins/cloud-foundry/model/auth/checkers/space-access.js
@@ -64,7 +64,6 @@
        * @description User can delete space if:
        * 1. user is an admin
        * 2. user is the org manager
-       * 3. user is the space manager
        * @param {Object} space - space detail
        * @returns {boolean}
        */
@@ -103,7 +102,6 @@
        * 1. User is admin
        * 2. User is an Org Manager
        * 3. User is a Space Manager
-       * 4. User is a Space Developer
        * @param {Object} space - Application detail
        * @returns {boolean}
        */
@@ -118,9 +116,7 @@
         // User is Org manager
         return this.baseAccess._doesContainGuid(this.principal.userSummary.organizations.managed, space.entity.organization_guid) ||
           // User is Space manager
-          this.baseAccess._doesContainGuid(this.principal.userSummary.spaces.managed, space.metadata.guid) ||
-          // User is Space developer
-          this.baseAccess._doesContainGuid(this.principal.userSummary.spaces.all, space.metadata.guid);
+          this.baseAccess._doesContainGuid(this.principal.userSummary.spaces.managed, space.metadata.guid);
       },
 
       /**


### PR DESCRIPTION
Roles documentation has been updated (https://github.com/cloudfoundry/docs-cloudfoundry-concepts/commit/e8ad817a31148c36c1b22c65efa67d9b7f4a101b) in response to issue https://github.com/cloudfoundry/docs-cloudfoundry-concepts/issues/37

Updating the space-access checker code to reflect the change.
