### PR TITLE
TEAMFOUR-973: Handle long token refresh during v2/info in app wall

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/list.module.js
+++ b/src/plugins/cloud-foundry/view/applications/list/list.module.js
@@ -41,7 +41,7 @@
     this.model = modelManager.retrieve('cloud-foundry.model.application');
     this.eventService = eventService;
     this.ready = false;
-    this.loading = false;
+    this.loading = true;
     this.currentPage = 1;
     this.clusters = [{label: 'All Endpoints', value: 'all'}];
     this.organizations = [{label: 'All Organizations', value: 'all'}];


### PR DESCRIPTION
Ensure that the bounce spinner shows from the start. This covers the case
where the user service model list() takes a while (recently seen as over
a minute for unavailable hcf's)
