### PR TITLE
959 - Handle orgs with no spaces in add application wizard

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/workflows/add-app-workflow/add-app-workflow.directive.js
@@ -104,10 +104,12 @@
         $scope.$watch(function () {
           return that.userInput.serviceInstance;
         }, function (serviceInstance) {
+          that.userInput.organization = null;
+          that.userInput.space = null;
           if (serviceInstance) {
             that.getOrganizations();
             that.getDomains().then(function () {
-              that.userInput.domain = that.options.domains[0].value;
+              that.userInput.domain = that.options.domains[0] && that.options.domains[0].value;
             });
           }
         });
@@ -115,6 +117,7 @@
         $scope.$watch(function () {
           return that.userInput.organization;
         }, function (organization) {
+          that.userInput.space = null;
           if (organization) {
             that.getSpacesForOrganization(organization.metadata.guid);
           }


### PR DESCRIPTION
Checking if a org has spaces defined for all the orgs before user select the org can be every expensive for very little benefit for the user. We should probably just do not auto-select the first if it doesn't exist.
