### PR TITLE
THTEAMFOUR-1049: Refine padding/margins/style on Application Summary tab

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/application.scss
+++ b/src/plugins/cloud-foundry/view/applications/application/application.scss
@@ -4,7 +4,6 @@
         'summary/summary',
         'log-stream/log-stream',
         'variables/variables',
-        'versions/versions',
         'notification-targets/notification-target';
 
 .application-action-col {


### PR DESCRIPTION
This PR changes one style sheet to improve the layout on the App Summary Tab.

It:
- Reduces some of the padding at the top of the page
- Reduces the padding in the top panel
- Makes the size of the action menu (when the screen is narrower) to be consistent with other UI sizing
- Improves the tab margin - placing it on the right, rather than the left, so when the screen shrinks, the extra rows of tabs are aligned on the left
- Moves some top padding for the tabs bar to the tabs, so that when this wraps, there is better spacing between the rows of tabs
