### PR TITLE
TEAMFOUR-1014 - Enable polling in delivery logs and pipeline views

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/application.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/application.module.js
@@ -307,10 +307,16 @@
           .then(function (response) {
             var project = response.data;
             if (!_.isNil(project)) {
-              return that.hceModel.getVcs(that.hceCnsi.guid, project.vcs_id)
-                .then(function () {
-                  that.model.application.project = project;
-                });
+              // Don't need to fetch VCS data every time if project hasn't changed
+              if (_.isNil(that.model.application.project) ||
+                  that.model.application.project.id !== project.id) {
+                return that.hceModel.getVcs(that.hceCnsi.guid, project.vcs_id)
+                  .then(function () {
+                    that.model.application.project = project;
+                  });
+              } else {
+                that.model.application.project = project;
+              }
             } else {
               that.model.application.project = null;
             }

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
@@ -72,10 +72,9 @@
           </tr>
           </thead>
           <tbody>
-          <tr
-            ng-repeat="execution in appDelLogsCtrl.displayedExecutions">
+          <tr ng-repeat="execution in appDelLogsCtrl.displayedExecutions">
             <td><a href="" ng-click="appDelLogsCtrl.viewExecution(execution)">{{ execution.message }}</a></td>
-            <td ng-if="!execution.result" class="row result-col">
+            <td ng-if="!execution.result" class="row result-col"></td>
             <td ng-if="execution.result" class="row result-col" id="build-result-col">
               <div ng-switch="execution.result.state" class="pull-left">
                 <span ng-switch-when="succeeded" class="helion-icon helion-icon-Active_S text-primary"></span>

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.js
@@ -146,6 +146,14 @@
         that.project = null;
       }
     });
+
+    this.$scope.$watch(function () {
+      return that.model.application.project;
+    }, function (newProject, oldProject) {
+      if (!_.isNil(oldProject) && newProject.id === oldProject.id) {
+        that.getPipelineData();
+      }
+    });
   }
 
   angular.extend(ApplicationDeliveryPipelineController.prototype, {


### PR DESCRIPTION
The delivery logs and delivery pipeline views weren't getting updated with the polling in the application details page. This should fix that issue.

One way to test: trigger a build from delivery logs and you should see the status updating.
