### PR TITLE
TEAMFOUR-1060: Scroll Position is no longer reset when navigating around the app

### DIFF
--- a/src/app/model/navigation/navigation.model.js
+++ b/src/app/model/navigation/navigation.model.js
@@ -64,9 +64,9 @@
       // Activate the correct menu entry or deactivate all menu entries if none match
       that.menu.currentState = _.get(toState, 'data.activeMenuState', '');
       // Scroll to the console-view's top after a state transition
-      var consoleView = angular.element(document).find('console-view');
-      if (consoleView[0]) {
-        consoleView[0].scrollTop = 0;
+      var consoleViewScrollPanel = angular.element(document).find('#console-view-scroll-panel');
+      if (consoleViewScrollPanel[0]) {
+        consoleViewScrollPanel[0].scrollTop = 0;
       }
     });
   }

--- a/src/app/view/console-view/console-view.html
+++ b/src/app/view/console-view/console-view.html
@@ -1,4 +1,4 @@
-<div class="container-fluid">
+<div class="container-fluid" id="console-view-scroll-panel">
   <div class="content clearfix" ui-view></div>
   <page-footer class="bleeding"></page-footer>
 </div>


### PR DESCRIPTION
Fixes annoying regression where the scroll position is not reset on navigating.

Caused by the scroll bar being moved off of the top-level console-view element.
