### PR TITLE
TEAMFOUR-1059: Application Summary: Display available application metadata when entering from the App Wall

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -56,21 +56,8 @@
     this.data = {
       applications: []
     };
-    this.application = {
-      instanceCount: 0,
-      summary: {
-        state: 'LOADING'
-      },
-      stats: {},
-      pipeline: {
-        fetching: false,
-        valid: false,
-        hceCnsi: undefined,
-        hceServiceGuid: undefined,
-        projectId: undefined
-      },
-      project: null
-    };
+
+    this.clearApplication();
     this.appStateSwitchTo = '';
     this.filterParams = {
       cnsiGuid: 'all',
@@ -85,6 +72,45 @@
   }
 
   angular.extend(Application.prototype, {
+
+    /**
+     * @function clearApplication
+     * @memberof  cloud-foundry.model.application
+     * @description Clear the cached application metadata
+     * @public
+     **/
+    clearApplication: function () {
+      this.application = {
+        instanceCount: 0,
+        summary: {
+          state: 'LOADING'
+        },
+        stats: {},
+        pipeline: {
+          fetching: false,
+          valid: false,
+          hceCnsi: undefined,
+          hceServiceGuid: undefined,
+          projectId: undefined
+        },
+        project: null
+      };
+    },
+
+    /**
+     * @function initApplicationFromSummary
+     * @memberof  cloud-foundry.model.application
+     * @param {object} appSummaryMetadata - application summary metadata
+     * @public
+     **/
+    initApplicationFromSummary: function (appSummaryMetadata) {
+      this.clearApplication();
+      this.application.summary = appSummaryMetadata.entity;
+      this.application.instances = appSummaryMetadata.instances || {};
+      this.application.instanceCount = appSummaryMetadata.instanceCount || 0;
+      this.application.state = appSummaryMetadata.state | {};
+    },
+
     /**
      * @function all
      * @memberof  cloud-foundry.model.application

--- a/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/list/gallery-view/application-gallery-card/application-gallery-card.directive.js
@@ -23,12 +23,14 @@
 
   ApplicationGalleryCardController.$inject = [
     '$state',
-    '$scope'
+    '$scope',
+    'app.model.modelManager'
   ];
 
-  function ApplicationGalleryCardController($state, $scope) {
+  function ApplicationGalleryCardController($state, $scope, modelManager) {
     var that = this;
     this.$state = $state;
+    this.modelManager = modelManager;
     this.cardData = {
       title: this.app.entity.name
     };
@@ -41,11 +43,14 @@
   }
 
   angular.extend(ApplicationGalleryCardController.prototype, {
+
     goToApp: function () {
       var guids = {
         cnsiGuid: this.cnsiGuid,
         guid: this.app.metadata.guid
       };
+      var appModel = this.modelManager.retrieve('cloud-foundry.model.application');
+      appModel.initApplicationFromSummary(this.app);
       this.$state.go('cf.applications.application.summary', guids);
     }
   });


### PR DESCRIPTION
This PR improves the UI experience when going from the app wall to an app.

Much of the metadata that we already have in the app wall for an app can be used on the app page.

This PR initializes the app metadata from the app summary metadata - this means when you view an app, you see the name straight away and you no longer see the metadata for a previous app that you might have viewed.
