### PR TITLE
HSC-1062 - Hide rollback action for non-developers

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/versions/versions.html
+++ b/src/plugins/cloud-foundry/view/applications/application/versions/versions.html
@@ -9,7 +9,9 @@
     <span translate>Versions</span>
   </div>
 
-  <div ng-if="applicationVersionsCtrl.hasVersions()" id="app-version-info-message" class="app-version-info welcome-message panel panel-default">
+  <div ng-if="applicationVersionsCtrl.hasVersions() && !applicationVersionsCtrl.disableRollbackAction"
+       id="app-version-info-message"
+       class="app-version-info welcome-message panel panel-default">
     <span class="helion-icon helion-icon-Information"></span>
     <span translate>You will need to restart the application after rolling back to a previous version.</span>
   </div>

--- a/src/plugins/cloud-foundry/view/applications/application/versions/versions.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/versions/versions.module.js
@@ -96,6 +96,8 @@
         authModel.resources.application,
         authModel.actions.update,
         that.appModel.application.summary.space_guid);
+
+      return that.$q.resolve();
     }
 
     utilsService.chainStateResolve('cf.applications.application.versions', $state, init);


### PR DESCRIPTION
Only admins and Space Developers can execute the rollback action in the versions tab. This action is now hidden to all other users.

Note: To simplify review, add the `?w=1` option to the URL to hide white space differences. The HTML file contained some CRLF line terminators.
