### PR TITLE
HSC-1086: App wall fails to display apps if a HCF is down

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.js
@@ -81,11 +81,9 @@
     };
 
     // Fetch HCE service metadata so that we can show the appropriate message
-    this.userCnsiModel.list().finally(function () {
-      that.hceServices.available = _.filter(that.cnsiModel.serviceInstances, {cnsi_type: 'hce'}).length;
-      that.hceServices.valid = _.filter(that.userCnsiModel.serviceInstances, {cnsi_type: 'hce', valid: true}).length;
-      that.hceServices.fetching = false;
-    });
+    that.hceServices.available = _.filter(that.cnsiModel.serviceInstances, {cnsi_type: 'hce'}).length;
+    that.hceServices.valid = _.filter(that.userCnsiModel.serviceInstances, {cnsi_type: 'hce', valid: true}).length;
+    that.hceServices.fetching = false;
 
     this.notificationTargetActions = [
       {

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-pipeline/delivery-pipeline.module.spec.js
@@ -3,7 +3,8 @@
 
   describe('Delivery Pipeline', function () {
 
-    var controller, eventService, $interpolate, $state, $stateParams, $rootScope, cnsiModel, modelManager, $httpBackend, account;
+    var controller, eventService, $interpolate, $state, $stateParams, $rootScope, cnsiModel, userCnsiModel,
+      modelManager, $httpBackend, account;
 
     beforeEach(module('green-box-console'));
     beforeEach(module('cloud-foundry.view.applications.application.delivery-pipeline'));
@@ -34,6 +35,7 @@
       var model = modelManager.retrieve('cloud-foundry.model.application');
       _.set(model, 'application', application);
       cnsiModel = modelManager.retrieve('app.model.serviceInstance');
+      userCnsiModel = modelManager.retrieve('app.model.serviceInstance.user');
       account = modelManager.retrieve('app.model.account');
     }));
 
@@ -51,11 +53,8 @@
 
     describe('Check HCE status', function () {
       it('Non-admin user with no services', function () {
-        $httpBackend.whenGET('/pp/v1/cnsis/registered').respond(200, []);
-        $httpBackend.expectGET('/pp/v1/cnsis/registered');
         account.data = {isAdmin: false};
         createController();
-        $httpBackend.flush();
         expect(controller.hceServices.fetching).toBe(false);
         expect(controller.hceServices.valid).toBe(0);
         expect(controller.hceServices.available).toBe(0);
@@ -63,11 +62,8 @@
       });
 
       it('Admin user with no services', function () {
-        $httpBackend.whenGET('/pp/v1/cnsis/registered').respond(200, []);
-        $httpBackend.expectGET('/pp/v1/cnsis/registered');
         account.data = {isAdmin: true};
         createController();
-        $httpBackend.flush();
         expect(controller.hceServices.fetching).toBe(false);
         expect(controller.hceServices.valid).toBe(0);
         expect(controller.hceServices.available).toBe(0);
@@ -75,19 +71,14 @@
       });
 
       it('User with valid services', function () {
-        $httpBackend.whenGET('/pp/v1/cnsis/registered').respond(200, [
-          {
+        _.set(userCnsiModel, 'serviceInstances', {
+          guid: {
             cnsi_type: 'hce',
             valid: true
           }
-        ]);
-        $httpBackend.expectGET('/pp/v1/cnsis/registered');
-        $httpBackend.whenGET('/pp/v1/proxy/info').respond(200, []);
-        $httpBackend.expectGET('/pp/v1/proxy/info');
-
+        });
         account.data = {isAdmin: true};
         createController();
-        $httpBackend.flush();
         expect(controller.hceServices.fetching).toBe(false);
         expect(controller.hceServices.valid).toBe(1);
         expect(controller.hceServices.available).toBe(0);
@@ -95,30 +86,26 @@
       });
 
       it('User with available and valid services', function () {
-        $httpBackend.whenGET('/pp/v1/cnsis').respond(200, [
-          {
+        _.set(cnsiModel, 'serviceInstances', {
+          guid_1: {
+            cnsi_type: 'hce'
+          },
+          guid_2: {
+            cnsi_type: 'hce'
+          }
+        });
+        _.set(userCnsiModel, 'serviceInstances', {
+          guid_1: {
             cnsi_type: 'hce',
             valid: true
           },
-          {
+          guid_2: {
             cnsi_type: 'hce',
-            valid: true
+            valid: false
           }
-        ]);
-        $httpBackend.expectGET('/pp/v1/cnsis');
-        cnsiModel.list();
-        $httpBackend.whenGET('/pp/v1/cnsis/registered').respond(200, [
-          {
-            cnsi_type: 'hce',
-            valid: true
-          }
-        ]);
-        $httpBackend.expectGET('/pp/v1/cnsis/registered');
-        $httpBackend.whenGET('/pp/v1/proxy/info').respond(200, []);
-        $httpBackend.expectGET('/pp/v1/proxy/info');
+        });
         account.data = {isAdmin: true};
         createController();
-        $httpBackend.flush();
         expect(controller.hceServices.fetching).toBe(false);
         expect(controller.hceServices.valid).toBe(1);
         expect(controller.hceServices.available).toBe(2);

--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.module.js
@@ -63,7 +63,6 @@
     this.cnsiGuid = $stateParams.cnsiGuid;
     this.addRoutesService = addRoutesService;
     this.editAppService = editAppService;
-    this.userCnsiModel.list();
     this.utils = utils;
     this.$log = $log;
     this.$q = $q;

--- a/src/plugins/cloud-foundry/view/applications/applications.module.js
+++ b/src/plugins/cloud-foundry/view/applications/applications.module.js
@@ -48,6 +48,7 @@
    */
   function ApplicationsController($q, $state, utils, modelManager, eventService, loggedInService) {
 
+    var userCnsiModel = modelManager.retrieve('app.model.serviceInstance.user');
     var authService = modelManager.retrieve('cloud-foundry.model.auth');
 
     var initialized = $q.defer();
@@ -57,7 +58,11 @@
     }
 
     function init() {
-      return initialized.promise.then(function () {
+      return initialized.promise
+      .then(function () {
+        return userCnsiModel.list();
+      })
+      .then(function () {
         return authService.initialize();
       });
     }

--- a/src/plugins/cloud-foundry/view/applications/list/list.module.js
+++ b/src/plugins/cloud-foundry/view/applications/list/list.module.js
@@ -85,20 +85,18 @@
     };
 
     function init() {
-      return that.userCnsiModel.list().then(function () {
-        that._setClusters();
-        that._setOrgs();
-        that._setSpaces();
-        that._reload();
-        var serviceInstances = _.values(that.userCnsiModel.serviceInstances);
-        for (var i = 0; i < serviceInstances.length; i++) {
-          var cluster = serviceInstances[i];
-          if (that.authModel.doesUserHaveRole(cluster.guid, that.authModel.roles.space_developer)) {
-            that.isSpaceDeveloper = true;
-            break;
-          }
+      that._setClusters();
+      that._setOrgs();
+      that._setSpaces();
+      that._reload();
+      var serviceInstances = _.values(that.userCnsiModel.serviceInstances);
+      for (var i = 0; i < serviceInstances.length; i++) {
+        var cluster = serviceInstances[i];
+        if (that.authModel.doesUserHaveRole(cluster.guid, that.authModel.roles.space_developer)) {
+          that.isSpaceDeveloper = true;
+          break;
         }
-      });
+      }
     }
 
     utils.chainStateResolve('cf.applications.list', $state, init);


### PR DESCRIPTION
Problem - App wall took ~3 minutes to load. This was due to a number of
requests hitting the down instance, all took 21 seconds to fail. These
calls consisted of fetching feature flags, user services list calls and multiple
app calls to services which were down

This commit contains the following changes...
- Load user service instances in a core part of the applications section
- Remove other places further up the state stack where user services were being requested
- Load feature flags/init permissions only for services that are valid
- Apps wall now does not contact invalid services
- Apps wall now uses pass through where relevant and handles failed responses
