### PR TITLE
HSC-1067: Change tense of HCE pipeline event labels

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
@@ -65,7 +65,7 @@
           <thead>
           <tr>
             <th st-sort="message" translate>MESSAGE</th>
-            <th translate>RESULT</th>
+            <th translate>STATUS</th>
             <th st-sort="reason.mCreatedDate" st-sort-default="reverse" translate>TIME</th>
             <th st-sort="reason.author" translate>COMMIT AUTHOR</th>
             <th st-sort="reason.type" translate>REASON</th>

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
@@ -243,13 +243,13 @@
       // this directly in a language file, however these are auto generated.
       switch (event.type) {
         case this.eventTypes.BUILDING:
-          event.name = gettext('Build');
+          event.name = gettext('Built');
           break;
         case this.eventTypes.TESTING:
-          event.name = gettext('Test');
+          event.name = gettext('Tested');
           break;
         case this.eventTypes.DEPLOYING:
-          event.name = gettext('Deploy');
+          event.name = gettext('Deployed');
           break;
         case this.eventTypes.WATCHDOG_TERMINATED:
           event.name = gettext('Terminated');


### PR DESCRIPTION
As HCE-3234 won't be addressed this release ensure we display the pipeline
execution result as something more descriptive of actual progress. Events
are received after stage has passed, so label as past tense. Also updated
column header from 'RESULT' to 'STATUS' to reflect content of column.
