### PR TITLE
HSC-1010: support WebSocket over TLS

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/log-stream/log-stream.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/log-stream/log-stream.module.js
@@ -39,7 +39,9 @@
    */
   function ApplicationLogStreamController(base64, modelManager, $stateParams, $location, $log) {
     this.model = modelManager.retrieve('cloud-foundry.model.application');
-    this.websocketUrl = 'ws://' + $location.host() + '/pp/v1/' +
+
+    var protocol = $location.protocol() === 'https' ? 'wss' : 'ws';
+    this.websocketUrl = protocol + '://' + $location.host() + ':' + $location.port() + '/pp/v1/' +
       $stateParams.cnsiGuid + '/apps/' + $stateParams.guid + '/stream';
 
     this.autoScrollOn = true; // auto-scroll by default


### PR DESCRIPTION
Unfortunately with this it now doesn't work through gulp because of the port. Trying to get gulp with browser-sync to proxy WS requests took me a whole day and I failed because of various bugs.
I tried with http-proxy-middleware which was the most promising library but it failed
See mainly: https://github.com/chimurai/http-proxy-middleware/issues/15
