### PR TITLE
HSC-1119: Cached data was being swallowed

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/list.module.js
+++ b/src/plugins/cloud-foundry/view/applications/list/list.module.js
@@ -215,10 +215,11 @@
       this.paginationProperties.total = 0;
 
       return this.model.resetPagination()
-        .then(function () {
+        .then(function (cacheData) {
           // Only in the success case is the pagination model set correctly. If the call is rejected pagination is
           // likely to be undefined
           that.paginationProperties.total = that.model.pagination.totalPage;
+          return cacheData;
         })
         .finally(function () {
           that.loading = false;


### PR DESCRIPTION
Straight forward PR fixes regression introduced where cached data was not used resulting in another API call being made.
