### PR TITLE
HSC-1132: Instance display shows stats for only the first instance

### DIFF
--- a/src/plugins/cloud-foundry/model/application/application.model.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.js
@@ -115,15 +115,6 @@
       this.application.state = appSummaryMetadata.state || {};
 
       if (this.application.instances) {
-
-        /* eslint-disable no-warning-comments */
-        // TODO (HSC-1132): Instance display shows stats for only the first instance
-        /* eslint-enable no-warning-comments */
-        var keys = Object.keys(this.application.instances);
-        if (keys && keys.length) {
-          this.application.stats = this.application.instances[keys[0]].stats;
-        }
-
         var running = _.filter(this.application.instances, {state: 'RUNNING'});
         this.application.summary.running_instances = running.length;
       }
@@ -168,7 +159,7 @@
       _.each(apps, function (app) {
         if (app.entity.state === 'STARTED') {
           // We need more information
-          tasks.push(that.returnAppStats(cnsiGuid, app.metadata.guid, null, true).then(function (stats) {
+          tasks.push(that.returnAppStats(cnsiGuid, app.metadata.guid, null).then(function (stats) {
             app.instances = stats.data;
             app.instanceCount = _.keys(app.instances).length;
             app.state = that.appStateService.get(app.entity, app.instances);
@@ -650,7 +641,7 @@
      */
     getAppStats: function (cnsiGuid, guid, params, noCache) {
       var that = this;
-      return that.returnAppStats(cnsiGuid, guid, params, noCache).then(function (response) {
+      return that.returnAppStats(cnsiGuid, guid, params).then(function (response) {
         if (!noCache) {
           var data = response.data;
           // Stats for all instances
@@ -668,22 +659,13 @@
      * @param {string} cnsiGuid - The GUID of the cloud-foundry server.
      * @param {string} guid - the app guid
      * @param {object} params - options for getting the stats of an app
-     * @param {boolean} noCache - Do not cache fetched data
      * @returns {promise} A promise object
      * @public
      */
-    returnAppStats: function (cnsiGuid, guid, params, noCache) {
-      var that = this;
+    returnAppStats: function (cnsiGuid, guid, params) {
       return this.apiManager.retrieve('cloud-foundry.api.Apps')
         .GetDetailedStatsForStartedApp(guid, params, this.modelUtils.makeHttpConfig(cnsiGuid))
         .then(function (response) {
-          if (!noCache) {
-            var data = response.data;
-            /* eslint-disable no-warning-comments */
-            // TODO (HSC-1132): Instance display shows stats for only the first instance
-            /* eslint-enable no-warning-comments */
-            that.application.stats = angular.isDefined(data['0']) ? data['0'].stats : {};
-          }
           return response;
         });
     },

--- a/src/plugins/cloud-foundry/model/application/application.model.spec.js
+++ b/src/plugins/cloud-foundry/model/application/application.model.spec.js
@@ -135,7 +135,6 @@
       applicationModel.getAppStats('guid', guid, params);
       $httpBackend.flush();
       expect(GetDetailedStatsForStartedApp.response['200'].body['0'].state).toBe('RUNNING');
-      expect(applicationModel.application.stats.usage.disk).toBe(66392064);
     });
   });
 

--- a/src/plugins/cloud-foundry/view/applications/application/application.scss
+++ b/src/plugins/cloud-foundry/view/applications/application/application.scss
@@ -55,18 +55,6 @@
 .application-details {
   padding-top: $hpe-unit-space;
   padding-bottom: $hpe-unit-space;
-
-  .summary {
-    .percent-gauge {
-      padding: 0;
-    }
-
-    .data-body dl.dl-horizontal {
-      dt:last-of-type, dd:last-of-type {
-        margin-bottom: 0;
-      }
-    }
-  }
 }
 
 .application-nav.nav.nav-tabs > li {

--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
@@ -11,31 +11,19 @@
     <div class="col-md-6">
       <dl class="dl-horizontal">
 
-        <dd>
-          <percent-gauge title="{{ 'Memory Utilization' | translate }}"
-                         value="{{ appCtrl.model.application.stats.usage.mem / appCtrl.model.application.stats.mem_quota }}"
-                         value-text="{{ [appCtrl.model.application.stats.usage.mem, appCtrl.model.application.stats.mem_quota] | usageBytes:0 }}" />
-        </dd>
-
-        <dd>
-          <percent-gauge mode="instance"
-                         title="{{ 'Instances' | translate }}"
-                         value="{{ appCtrl.model.application.summary.running_instances / appCtrl.model.application.summary.instances }}"
-                         value-text="{{ appCtrl.model.application.summary.running_instances }} / {{ appCtrl.model.application.summary.instances }}" />
-        </dd>
-
-        <dd>
-          <percent-gauge title="{{ 'Disk Utilization' | translate }}"
-                         value="{{ appCtrl.model.application.stats.usage.disk / appCtrl.model.application.stats.disk_quota }}"
-                         value-text="{{ [appCtrl.model.application.stats.usage.disk, appCtrl.model.application.stats.disk_quota] | usageBytes }}" />
-        </dd>
-
         <dt translate>STATE</dt>
         <dd class="pull-right app-status-block">
           <div ng-if="appCtrl.ready">
-          <span class="app-status helion-icon {{ appCtrl.model.application.state.indicator | appStateIcon }}"></span>
-          <span class="app-status">{{ appCtrl.model.application.state.label }}</span>
+            <span class="app-status helion-icon {{ appCtrl.model.application.state.indicator | appStateIcon }}"></span>
+            <span class="app-status">{{ appCtrl.model.application.state.label }}</span>
           </div>
+        </dd>
+
+        <dt class="app-instance-title" translate>INSTANCES</dt>
+        <dd>
+          <percent-gauge mode="instance"
+                         value="{{ appCtrl.model.application.summary.running_instances / appCtrl.model.application.summary.instances }}"
+                         value-text="{{ appCtrl.model.application.summary.running_instances }} / {{ appCtrl.model.application.summary.instances }}" />
         </dd>
 
         <dt translate>MODIFIED</dt>
@@ -43,6 +31,16 @@
           {{ appCtrl.model.application.summary.package_updated_at | date : 'M/d/yy h:mm:ss a'}}
         </dd>
         <dd class="pull-right" ng-if="!appCtrl.model.application.summary.package_updated_at">-</dd>
+
+        <dt translate>MEMORY QUOTA</dt>
+        <dd class="pull-right">
+          {{ applicationSummaryCtrl.utils.mbToHumanSize(appCtrl.model.application.summary.memory)}}
+        </dd>
+
+        <dt translate>DISK QUOTA</dt>
+        <dd class="pull-right">
+          {{ applicationSummaryCtrl.utils.mbToHumanSize(appCtrl.model.application.summary.disk_quota)}}
+        </dd>
 
       </dl>
     </div>
@@ -57,9 +55,18 @@
              rel="noopener noreferrer">{{ appCtrl.appBuildPack }}</a>
         </dd>
 
-        <dt translate>ENDPOINT</dt>
+        <dt translate>ENDPOINT URL</dt>
         <dd class="pull-right">
           {{ applicationSummaryCtrl.getEndpoint() }}
+        </dd>
+
+        <dt translate>ENDPOINT</dt>
+        <dd class="pull-right">
+          <a class="btn btn-link" ui-sref="endpoint.clusters.cluster.detail.organizations({
+                  guid: applicationSummaryCtrl.cnsiGuid
+          })">
+            {{ applicationSummaryCtrl.userCnsiModel.serviceInstances[applicationSummaryCtrl.cnsiGuid].name }}
+          </a>
         </dd>
 
         <dt translate>ORGANIZATION</dt>
@@ -67,7 +74,7 @@
           <a class="btn btn-link" ui-sref="endpoint.clusters.cluster.organization.detail.spaces({
                   guid: applicationSummaryCtrl.cnsiGuid,
                   organization: applicationSummaryCtrl.model.application.organization.metadata.guid,
-          })" translate>
+          })">
             {{ appCtrl.model.application.organization.entity.name }}
           </a>
         </dd>
@@ -78,12 +85,103 @@
                   guid: applicationSummaryCtrl.cnsiGuid,
                   organization: applicationSummaryCtrl.model.application.organization.metadata.guid,
                   space: applicationSummaryCtrl.model.application.space.metadata.guid
-          })" translate>
+          })">
             {{ appCtrl.model.application.space.entity.name }}
           </a>
         </dd>
       </dl>
     </div>
+  </div>
+</div>
+
+<div class="summary-instances">
+  <div class="action-header">
+    <span translate>Instances</span>
+    <!--
+    <a class="btn btn-link">
+      <i class="helion-icon helion-icon-Right_Arrow"></i>
+      <span translate>Add instances</span>
+    </a>
+    -->
+  </div>
+  <div class="panel panel-default">
+    <div class="panel-body" ng-if="appCtrl.model.application.summary.running_instances === 0" translate>
+      This application has no running instances.
+    </div>
+    <table class="table" ng-if="appCtrl.model.application.summary.running_instances > 0" >
+      <thead>
+      <tr>
+        <th translate>Index</th>
+        <th translate>Status</th>
+        <th translate>Memory</th>
+        <th translate>Disk</th>
+        <th translate>Uptime</th>
+        <!--<th></th>-->
+      </tr>
+      </tr>
+      </thead>
+      <tbody>
+      <tr ng-repeat="instance in appCtrl.model.application.instances" ng-show="$index < applicationSummaryCtrl.instanceViewLimit">
+        <td>{{ $index }}</td>
+        <td>{{ instance.state }}</td>
+        <td class="instance-percent-gauge">
+          <percent-gauge value="{{ instance.stats.usage.mem / instance.stats.mem_quota }}"
+                         value-text="{{ [instance.stats.usage.mem, instance.stats.mem_quota] | usageBytes:0 }}"/>
+        </td>
+        <td class="instance-percent-gauge">
+          <percent-gauge value="{{ instance.stats.usage.disk / instance.stats.disk_quota }}"
+                         value-text="{{ [instance.stats.usage.disk, instance.stats.disk_quota] | usageBytes }}" />
+        </td>
+        <td class="instance-uptime-td">{{ applicationSummaryCtrl.formatUptime(instance.stats.uptime) }}</td>
+        <!--<td></td>-->
+      </tr>
+      </tbody>
+      <tfoot ng-show="applicationSummaryCtrl.instanceViewLimit < appCtrl.model.application.instanceCount">
+      <tr>
+        <td colspan="4" class="text-center">
+          <a ng-click="applicationSummaryCtrl.instanceViewLimit = appCtrl.model.application.instanceCount">
+            <span translate>Show All</span> ({{appCtrl.model.application.instanceCount}})
+          </a>
+        </td>
+      </tr>
+      </tfoot>
+    </table>
+  </div>
+</div>
+
+<div>
+  <div class="action-header">
+    <span translate>Routes</span>
+    <a class="btn btn-link" ng-click="applicationSummaryCtrl.showAddRouteForm()" ng-hide="!appCtrl.ready || applicationSummaryCtrl.hideAddRoutes">
+      <i class="helion-icon helion-icon-Right_Arrow" ></i>
+      <span translate>Add route</span>
+    </a>
+  </div>
+  <div class="panel panel-default">
+    <div class="panel-body"
+         ng-if="!appCtrl.model.application.summary.routes.length" translate>
+      You have no routes.
+    </div>
+    <table class="table table-actionable"
+           ng-if="appCtrl.model.application.summary.routes.length" >
+      <thead>
+      <tr>
+        <th translate>Route</th>
+        <th translate>Actions</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr ng-repeat="route in appCtrl.model.application.summary.routes track by applicationSummaryCtrl.routesService.getRouteId(route)">
+        <td>{{ applicationSummaryCtrl.routesService.getRouteId(route) }}</td>
+        <td>
+          <actions-menu actions="applicationSummaryCtrl.routesActionMenu"
+                        action-target="route"
+                        menu-position="actions-menu-right"
+                        menu-icon="helion-icon helion-icon-More"></actions-menu>
+        </td>
+      </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 
@@ -129,83 +227,3 @@
   </div>
 </div>
 
-<div>
-  <div class="action-header">
-    <span translate>Routes</span>
-    <a class="btn btn-link" ng-click="applicationSummaryCtrl.showAddRouteForm()" ng-hide="!appCtrl.ready || applicationSummaryCtrl.hideAddRoutes">
-      <i class="helion-icon helion-icon-Right_Arrow" ></i>
-      <span translate>Add route</span>
-    </a>
-  </div>
-  <div class="panel panel-default">
-    <div class="panel-body"
-      ng-if="!appCtrl.model.application.summary.routes.length" translate>
-      You have no routes.
-    </div>
-    <table class="table table-actionable"
-      ng-if="appCtrl.model.application.summary.routes.length" >
-      <thead>
-        <tr>
-          <th translate>Route</th>
-          <th translate>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr ng-repeat="route in appCtrl.model.application.summary.routes track by applicationSummaryCtrl.routesService.getRouteId(route)">
-          <td>{{ applicationSummaryCtrl.routesService.getRouteId(route) }}</td>
-          <td>
-            <actions-menu actions="applicationSummaryCtrl.routesActionMenu"
-                            action-target="route"
-                            menu-position="actions-menu-right"
-                            menu-icon="helion-icon helion-icon-More"></actions-menu>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-<div>
-  <div class="action-header">
-    <span translate>Instances</span>
-    <!--
-    <a class="btn btn-link">
-      <i class="helion-icon helion-icon-Right_Arrow"></i>
-      <span translate>Add instances</span>
-    </a>
-    -->
-  </div>
-  <div class="panel panel-default">
-    <div class="panel-body" ng-if="appCtrl.model.application.summary.running_instances === 0" translate>
-      This application has no running instances.
-    </div>
-    <table class="table" ng-if="appCtrl.model.application.summary.running_instances > 0" >
-      <thead>
-        <tr>
-          <th translate>Index</th>
-          <th translate>Status</th>
-          <th translate>Uptime</th>
-          <th></th>
-        </tr>
-      </tr>
-      </thead>
-      <tbody>
-        <tr ng-repeat="instance in appCtrl.model.application.instances" ng-show="$index < applicationSummaryCtrl.instanceViewLimit">
-          <td>{{ $index }}</td>
-          <td>{{ instance.state }}</td>
-          <td>{{ applicationSummaryCtrl.formatUptime(instance.stats.uptime) }}</td>
-          <td></td>
-        </tr>
-      </tbody>
-      <tfoot ng-show="applicationSummaryCtrl.instanceViewLimit < appCtrl.model.application.instanceCount">
-      <tr>
-        <td colspan="4" class="text-center">
-          <a ng-click="applicationSummaryCtrl.instanceViewLimit = appCtrl.model.application.instanceCount">
-            <span translate>Show All</span> ({{appCtrl.model.application.instanceCount}})
-          </a>
-        </td>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>

--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.module.js
@@ -51,7 +51,6 @@
    * @property {helion.framework.widgets.dialog.confirm} confirmDialog - the confirm dialog service
    * @property {app.model.utilsService} utils - the utils service
    */
-//  function ApplicationSummaryController($state, $log, $q, modelManager, $stateParams, addRoutesService, editAppService, utils,
   function ApplicationSummaryController($state, $stateParams, $log, $q, $scope, modelManager, addRoutesService, editAppService, utils,
                                         routesService) {
 
@@ -178,7 +177,7 @@
     /**
      * @function formatUptime
      * @description format an uptime in seconds into a days, hours, minutes, seconds string
-     * @param {number} uptime in seconsd
+     * @param {number} uptime in seconds
      * @returns {string} formatted uptime string
      */
     formatUptime: function (uptime) {
@@ -186,7 +185,7 @@
         return '-';
       }
       if (uptime === 0) {
-        return '0 ' + gettext('seconds');
+        return '0' + gettext('s');
       }
       var days = Math.floor(uptime / 86400);
       uptime = uptime % 86400;
@@ -199,16 +198,16 @@
         if (count === 0) {
           return '';
         } else if (count === 1) {
-          return count + ' ' + single + ' ';
+          return count + single + ' ';
         } else {
-          return count + ' ' + plural + ' ';
+          return count + plural + ' ';
         }
       }
 
-      return (formatPart(days, gettext('day'), gettext('days')) +
-      formatPart(hours, gettext('hour'), gettext('hours')) +
-      formatPart(minutes, gettext('minute'), gettext('minutes')) +
-      formatPart(seconds, gettext('second'), gettext('seconds'))).trim();
+      return (formatPart(days, gettext('d'), gettext('d')) +
+      formatPart(hours, gettext('h'), gettext('h')) +
+      formatPart(minutes, gettext('m'), gettext('m')) +
+      formatPart(seconds, gettext('s'), gettext('s'))).trim();
     }
   });
 

--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.module.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.module.spec.js
@@ -72,25 +72,25 @@
       });
 
       it('formats 0 correctly', function () {
-        expect($controller.formatUptime(0)).toBe('0 seconds');
+        expect($controller.formatUptime(0)).toBe('0s');
       });
 
       it('formats 1 correctly', function () {
-        expect($controller.formatUptime(1)).toBe('1 second');
+        expect($controller.formatUptime(1)).toBe('1s');
       });
 
       it('formats day uptime correctly', function () {
-        expect($controller.formatUptime(86400)).toBe('1 day');
-        expect($controller.formatUptime(172800)).toBe('2 days');
+        expect($controller.formatUptime(86400)).toBe('1d');
+        expect($controller.formatUptime(172800)).toBe('2d');
       });
 
       it('formats mixed uptime correctly', function () {
-        expect($controller.formatUptime(3661)).toBe('1 hour 1 minute 1 second');
-        expect($controller.formatUptime(3665)).toBe('1 hour 1 minute 5 seconds');
-        expect($controller.formatUptime(7200)).toBe('2 hours');
-        expect($controller.formatUptime(7320)).toBe('2 hours 2 minutes');
-        expect($controller.formatUptime(172800 + 7321)).toBe('2 days 2 hours 2 minutes 1 second');
-        expect($controller.formatUptime(172800 + 7327)).toBe('2 days 2 hours 2 minutes 7 seconds');
+        expect($controller.formatUptime(3661)).toBe('1h 1m 1s');
+        expect($controller.formatUptime(3665)).toBe('1h 1m 5s');
+        expect($controller.formatUptime(7200)).toBe('2h');
+        expect($controller.formatUptime(7320)).toBe('2h 2m');
+        expect($controller.formatUptime(172800 + 7321)).toBe('2d 2h 2m 1s');
+        expect($controller.formatUptime(172800 + 7327)).toBe('2d 2h 2m 7s');
       });
 
     });

--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.scss
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.scss
@@ -10,9 +10,19 @@
   .summary .data-body {
     padding: $hpe-unit-space * .75 $hpe-unit-space;
 
-    .dl-horizontal > * {
-      margin-bottom: $hpe-unit-space * .5;
-      margin-left: auto;
+    .dl-horizontal {
+
+      & > * {
+        margin-bottom: $hpe-unit-space * .5;
+        margin-left: auto;
+      }
+
+      @media (min-width: 992px) {
+        // Remove extra margin at bottom of lists (except for when lists are stacked)
+        dt:last-of-type, dd:last-of-type {
+          margin-bottom: 0;
+        }
+      }
     }
 
     dd {
@@ -35,6 +45,10 @@
         display: table-cell;
         line-height: normal;
       }
+
+      .percent-gauge {
+        padding: 0;
+      }
     }
 
     .app-status-block {
@@ -44,6 +58,21 @@
         margin-left: 0;
         margin-right: 2px;
       }
+    }
+
+    .app-instance-title {
+      margin-bottom: 0;
+    }
+  }
+
+  .summary-instances {
+
+    .instance-percent-gauge {
+      padding: 7px 14px;
+    }
+
+    .instance-uptime-td {
+      min-width: 120px;
     }
   }
 }


### PR DESCRIPTION
- Removes stats for first instance in app summary
- Add instance stats to instance table
- re-arrange order of items in app summary
- re-arrange order of items in app page
- add endpoint link in app summary
- show shortened instance up-time string
- fix bottom margin in app summary when window width shrinks
