### PR TITLE
Tiny fix for css issue with cropped app state names on app wall

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/gallery-view/gallery-view.scss
+++ b/src/plugins/cloud-foundry/view/applications/list/gallery-view/gallery-view.scss
@@ -29,6 +29,7 @@ $gallery-card-layout-steps: 4;
     align-items: center;
     font-size: 18px;
     font-weight: 500;
+    width: 100%;
     color: $dove-gray2;
     &>span {
       text-transform: capitalize;


### PR DESCRIPTION
One-liner fix for cropped state names
