### PR TITLE
HSC-1134 - Secure our cookie

### DIFF
--- a/src/app/api/account/account.api.js
+++ b/src/app/api/account/account.api.js
@@ -42,7 +42,6 @@
     this.$httpParamSerializer = $httpParamSerializer;
     this.$q = $q;
     this.$cookies = $cookies;
-    this.sessionName = 'stackato-console-session';
   }
 
   angular.extend(AccountApi.prototype, {
@@ -84,28 +83,11 @@
      * @public
      */
     verifySession: function () {
-      if (this.$cookies.get(this.sessionName)) {
-        return this.$http.get('/pp/v1/auth/session/verify');
-      }
-      return this.$q.reject(this.sessionName + ' cookie missing!');
-    },
-
-    /**
-     * @function hasSessionCookie
-     * @memberof app.api.account.AccountApi
-     * @description Check if the user has a session cookie
-     * @returns {boolean} Indicates if a session cookie exists
-     * @public
-     */
-    hasSessionCookie: function () {
-      return this.$cookies.get(this.sessionName);
+      return this.$http.get('/pp/v1/auth/session/verify');
     },
 
     userInfo: function () {
-      if (this.$cookies.get(this.sessionName)) {
-        return this.$http.get('/pp/v1/userinfo');
-      }
-      return this.$q.reject(this.sessionName + ' cookie missing!');
+      return this.$http.get('/pp/v1/userinfo');
     }
 
   });

--- a/src/app/api/stackato-info.service.js
+++ b/src/app/api/stackato-info.service.js
@@ -9,24 +9,17 @@
     .factory('stackatoInfoService', StackatoInfoService);
 
   StackatoInfoService.$inject = [
-    '$q',
-    '$cookies',
-    '$http',
-    'app.api.apiManager'
+    '$http'
   ];
 
   /**
    * @memberof app
    * @name app.stackatoInfoService
    * @description User information service provider
-   * @param {object} $q - the angular $q service
-   * @param {object} $cookies - the angular $cookies service
    * @param {object} $http - the $http service
-   * @param {object} apiManager - API Manager used to fetch session details
    * @returns {object} The user info service
    */
-  function StackatoInfoService($q, $cookies, $http, apiManager) {
-    var sessionName = apiManager.retrieve('app.api.account').sessionName;
+  function StackatoInfoService($http) {
     return {
       /**
        * @function stackatoInfo
@@ -35,10 +28,7 @@
        * @returns {promise} A promise object
        */
       stackatoInfo: function () {
-        if ($cookies.get(sessionName)) {
-          return $http.get('/pp/v1/stackato/info');
-        }
-        return $q.reject(sessionName + ' cookie missing!');
+        return $http.get('/pp/v1/stackato/info');
       },
 
       /**

--- a/src/app/model/account/account.model.js
+++ b/src/app/model/account/account.model.js
@@ -88,18 +88,6 @@
     },
 
     /**
-     * @function hasSessionCookie
-     * @memberof app.model.account.Account
-     * @description Check if the user has a session cookie
-     * @returns {boolean} Indicates if a session cookie exists
-     * @public
-     */
-    hasSessionCookie: function () {
-      var accountApi = this.apiManager.retrieve('app.api.account');
-      return accountApi.hasSessionCookie();
-    },
-
-    /**
      * @function verifySession
      * @memberof app.model.account.Account
      * @description verify if current session
@@ -160,8 +148,6 @@
      * @private
      */
     onLoggedOut: function () {
-      var sessionName = this.apiManager.retrieve('app.api.account').sessionName;
-      this.$cookies.remove(sessionName);
       this.loggedIn = false;
       delete this.accountData;
     }

--- a/src/app/view/application.directive.js
+++ b/src/app/view/application.directive.js
@@ -102,13 +102,7 @@
      */
     verifySessionOrCheckUpgrade: function () {
       var that = this;
-      var api = this.modelManager.retrieve('app.model.account');
-      var infoApi = this.modelManager.retrieve('app.model.stackatoInfo');
-      // We need to make an API call to see if an upgrade is in progress
-      // If we have a session cookie, we will make a verifySession call anyway, so use that
-      // Otherwise, we need to make some call - so we use the version api to get the basic version metadata
-      var check = api.hasSessionCookie() ? this.verifySession() : infoApi.stackatoInfo.version();
-      check.catch(function (response) {
+      this.verifySession().catch(function (response) {
         // We only care about 503 - use upgrade service to determine if this is an upgrade
         if (that.upgradeCheck.isUpgrading(response)) {
           // Upgrade service will cause the upgrade page to be displayed to the user

--- a/src/app/view/application.directive.spec.js
+++ b/src/app/view/application.directive.spec.js
@@ -114,11 +114,14 @@
         applicationCtrl.loggedIn = false;
         $httpBackend.when('POST', '/pp/v1/auth/login/uaa').respond(200, {account: 'dev', scope: 'foo'});
         $httpBackend.when('GET', '/pp/v1/cnsis').respond(200, []);
+        $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, {});
         $httpBackend.when('GET', '/app/view/console-error/console-error.html').respond(200, []);
+
         $httpBackend.expectPOST('/pp/v1/auth/login/uaa');
-        $httpBackend.expectGET('/pp/v1/cnsis');
         // No endpoints are set up, so we should go to error page
         $httpBackend.expectGET('/app/view/console-error/console-error.html');
+        $httpBackend.expectGET('/pp/v1/cnsis/registered').respond(200, []);
+
         applicationCtrl.login('dev', 'dev');
         $httpBackend.flush();
         expect(applicationCtrl.loggedIn).toBe(true);
@@ -131,10 +134,13 @@
         applicationCtrl.loggedIn = false;
         $httpBackend.when('POST', '/pp/v1/auth/login/uaa').respond(200, { account: 'admin', scope: 'ucp.admin' });
         $httpBackend.when('GET', '/pp/v1/cnsis').respond(200, []);
+        $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, {});
         $httpBackend.when('GET', '/app/view/console-error/console-error.html').respond(200, []);
         $httpBackend.when('GET', '/pp/v1/cnsis/registered').respond(200, []);
+
         $httpBackend.expectPOST('/pp/v1/auth/login/uaa');
         $httpBackend.expectGET('/pp/v1/cnsis');
+
         // No endpoints are set up - but admin user - so will not go to error page
         applicationCtrl.login('admin', 'admin');
         $httpBackend.flush();
@@ -151,6 +157,8 @@
           { guid: 'service', cnsi_type: 'hcf', name: 'test', api_endpoint: testAptEndpoint }
         ]);
         $httpBackend.when('GET', '/pp/v1/cnsis/registered').respond(200, []);
+        $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, {});
+
         $httpBackend.expectPOST('/pp/v1/auth/login/uaa');
         $httpBackend.expectGET('/pp/v1/cnsis');
         applicationCtrl.login('dev', 'dev');
@@ -241,6 +249,7 @@
         it('should go to endpoints dashboard if cluster count === 0', function () {
           $httpBackend.when('GET', '/pp/v1/cnsis')
             .respond(200, []);
+          $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, []);
           $httpBackend.when('GET', '/pp/v1/cnsis/registered').respond(200, []);
 
           applicationCtrl.login('admin', 'admin');
@@ -258,6 +267,7 @@
           ];
           $httpBackend.when('GET', '/pp/v1/cnsis')
             .respond(200, responseData);
+          $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, []);
           $httpBackend.when('GET', '/pp/v1/cnsis/registered').respond(200, []);
 
           applicationCtrl.login('admin', 'admin');
@@ -279,6 +289,7 @@
 
         it('should show service instance registration if we dot not have registered services', function () {
           $httpBackend.when('GET', '/pp/v1/cnsis').respond(200, []);
+          $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, []);
           $httpBackend.when('GET', '/pp/v1/cnsis/registered').respond(200, []);
 
           applicationCtrl.login('dev', 'dev');
@@ -291,6 +302,7 @@
         it('should not show service instance registration if we have registered services', function () {
           var future = 50000 + (new Date()).getTime() / 1000;
 
+          $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, []);
           $httpBackend.when('GET', '/pp/v1/cnsis/registered').respond(200, [
             { account: 'test', token_expiry: future, guid: 'service', cnsi_type: 'hcf', name: 'test', api_endpoint: testAptEndpoint }
           ]);

--- a/src/app/view/endpoints/clusters/tiles/cluster-tiles.module.spec.js
+++ b/src/app/view/endpoints/clusters/tiles/cluster-tiles.module.spec.js
@@ -121,6 +121,7 @@
           userServiceInstanceModel.serviceInstances = {};
           return $q.when(userServiceInstanceModel.serviceInstances);
         });
+        spyOn(stackatoInfo, 'getStackatoInfo').and.returnValue($q.resolve());
 
         createCluster();
         // updateClusterList should have been called as part of creation.
@@ -201,6 +202,7 @@
     describe('refreshClusterModel', function () {
 
       it('Calls fail', function () {
+        spyOn(stackatoInfo, 'getStackatoInfo').and.returnValue($q.reject());
         spyOn(serviceInstanceModel, 'list').and.returnValue($q.reject());
         spyOn(userServiceInstanceModel, 'list').and.returnValue($q.reject());
         createCluster();
@@ -263,15 +265,16 @@
 
     describe('disconnect', function () {
       beforeEach(function () {
+        spyOn(stackatoInfo, 'getStackatoInfo').and.returnValue($q.resolve());
         createCluster();
       });
 
       it('success', function () {
+        spyOn(clusterTilesCtrl, 'refreshClusterModel').and.returnValue($q.resolve());
         spyOn(userServiceInstanceModel, 'disconnect').and.callFake(function (guid) {
           expect(guid).toEqual(hcfUserService.guid);
           return $q.when();
         });
-        spyOn(clusterTilesCtrl, 'refreshClusterModel').and.returnValue($q.resolve());
         clusterTilesCtrl.disconnect(hcfUserService.guid);
         $scope.$digest();
         expect(userServiceInstanceModel.disconnect).toHaveBeenCalled();
@@ -293,6 +296,7 @@
 
     describe('register', function () {
       beforeEach(function () {
+        spyOn(stackatoInfo, 'getStackatoInfo').and.returnValue($q.resolve());
         createCluster();
         spyOn(authModel, 'initializeForEndpoint').and.callFake(angular.noop);
       });
@@ -318,6 +322,7 @@
 
     describe('unregister', function () {
       beforeEach(function () {
+        spyOn(stackatoInfo, 'getStackatoInfo').and.returnValue($q.resolve());
         createCluster();
       });
 

--- a/src/app/view/service-registration/service-registration.directive.spec.js
+++ b/src/app/view/service-registration/service-registration.directive.spec.js
@@ -81,6 +81,7 @@
 
         var data = { cnsi_guid: 'cnsi_guid' };
         $httpBackend.expectPOST('/pp/v1/auth/logout/cnsi', $httpParamSerializer(data)).respond(200, '');
+        $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, {});
 
         var serviceInstance = { guid: 'cnsi_guid', account: 'defined', token_expiry: 'defined', valid: 'defined' };
         expect(serviceInstance.account).toBeDefined();

--- a/src/app/view/util/upgrade/upgrade.service.spec.js
+++ b/src/app/view/util/upgrade/upgrade.service.spec.js
@@ -86,8 +86,8 @@
       }));
 
       it('should show login page when no upgrade is in progress', function () {
-        $httpBackend.when('GET', '/pp/v1/version').respond(200, {});
-        $httpBackend.expectGET('/pp/v1/version');
+        $httpBackend.when('GET', '/pp/v1/auth/session/verify').respond(401, null);
+        $httpBackend.expectGET('/pp/v1/auth/session/verify');
         $timeout.flush();
         $httpBackend.flush();
         expect(applicationCtrl.ready).toBe(true);
@@ -99,8 +99,8 @@
       });
 
       it('should show upgrade page when an upgrade is in progress', function () {
-        $httpBackend.when('GET', '/pp/v1/version').respond(503, {}, {'Retry-After': 300});
-        $httpBackend.expectGET('/pp/v1/version');
+        $httpBackend.when('GET', '/pp/v1/auth/session/verify').respond(503, null, {'Retry-After': 300});
+        $httpBackend.expectGET('/pp/v1/auth/session/verify');
         $httpBackend.when('GET', '/app/view/console-error/console-error.html').respond(200, []);
         $httpBackend.expectGET('/app/view/console-error/console-error.html');
         $timeout.flush();
@@ -178,6 +178,7 @@
         beforeEach(function () {
           applicationCtrl.loggedIn = false;
           $httpBackend.when('POST', '/pp/v1/auth/login/uaa').respond(200, { account: 'dev', scope: 'foo' });
+          $httpBackend.when('GET', '/pp/v1/stackato/info').respond(200, {});
           $httpBackend.when('GET', '/pp/v1/cnsis').respond(200, [
             { guid: 'service', cnsi_type: 'hcf', name: 'test', api_endpoint: testAptEndpoint }
           ]);


### PR DESCRIPTION
This is needed before we can merge https://github.com/hpcloud/portal-proxy/pull/120 which is a security requirement.
Also this does not _require_ https://github.com/hpcloud/portal-proxy/pull/120 so should be merged first or at the same time.

This allows the UI to function with HttpOnly cookies. No loss of functionality should occur.
