### PR TITLE
HSC-1126: Update Delivery Logs for HCE event changes

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
@@ -109,12 +109,15 @@
 
     eventTypes: {
       // Required to determine 'Last Build|Last Test|Last Deploy' summary at top of page
-      BUILDING: 'Building',
-      TESTING: 'Testing',
-      DEPLOYING: 'Deploying',
+      BUILDING: 'buildingstarted',
+      BUILT: 'building',
+      TESTING: 'testingstarted',
+      TESTED: 'testing',
+      DEPLOYING: 'deployingstarted',
+      DEPLOYED: 'deploying',
       // Require to know if the execution has finished (execution state is not trustworthy)
       WATCHDOG_TERMINATED: 'watchdog',
-      PIPELINE_COMPLETED: 'pipeline_completed'
+      PIPELINE_COMPLETED: 'pipelinecompleted'
     },
 
     eventStates: {
@@ -140,7 +143,16 @@
       });
 
       var pipeline = that.model.application.pipeline;
-      this.views.viewExecution.open(rawExecution, this.eventsPerExecution[execution.id], pipeline.hceCnsi.guid);
+
+      // Do not show the 'started' style events and 'completed' event
+      var filteredEvents = _.filter(this.eventsPerExecution[execution.id], function (event) {
+        return event.type !== that.eventTypes.BUILDING &&
+          event.type !== that.eventTypes.TESTING &&
+          event.type !== that.eventTypes.DEPLOYING &&
+          event.type !== that.eventTypes.PIPELINE_COMPLETED;
+      });
+
+      this.views.viewExecution.open(rawExecution, filteredEvents, pipeline.hceCnsi.guid);
     },
 
     viewEventForExecution: function (execution) {
@@ -238,18 +250,34 @@
         event.durationString = gettext('Unknown');
       }
 
-      // Update event name such that they are set before the table filter is applied. Note the change in tense for
-      // building, testing and deploying (we get these events after they've actually finished). It would be good to do
-      // this directly in a language file, however these are auto generated.
+      // This is used as a key in a number of places. Sanitise to make viable.
+      event.type = _.replace(event.type, ' ', '').toLowerCase();
+
+      // The event name needs to be massaged into two forms
+      // - event.name will be the title and used without tense. this is used in slide outs and their titles
+      // - event.resultLabel will be the value shown in the main executions table as the 'status' and should show tense
+      // It would be good to do this directly in a language file, however these are auto generated.
       switch (event.type) {
         case this.eventTypes.BUILDING:
-          event.name = gettext('Built');
+          event.name = gettext('Building');
+          break;
+        case this.eventTypes.BUILT:
+          event.name = gettext('Build');
+          event.resultLabel = gettext('Built');
           break;
         case this.eventTypes.TESTING:
-          event.name = gettext('Tested');
+          event.name = gettext('Testing');
+          break;
+        case this.eventTypes.TESTED:
+          event.name = gettext('Test');
+          event.resultLabel = gettext('Tested');
           break;
         case this.eventTypes.DEPLOYING:
-          event.name = gettext('Deployed');
+          event.name = gettext('Deploying');
+          break;
+        case this.eventTypes.DEPLOYED:
+          event.name = gettext('Deploy');
+          event.resultLabel = gettext('Deployed');
           break;
         case this.eventTypes.WATCHDOG_TERMINATED:
           event.name = gettext('Terminated');
@@ -258,6 +286,7 @@
           event.name = gettext('Completed');
           break;
       }
+      event.resultLabel = event.resultLabel || event.name;
 
       this.determineLatestEvent(event);
     },
@@ -268,7 +297,7 @@
      * @param {object} event - HCE event
      */
     determineLatestEvent: function (event) {
-      var type = event.type.toLowerCase();
+      var type = event.type;
       if (!this.last[type] ||
         event.state === this.eventStates.SUCCEEDED && event.id > this.last[type].id) {
         this.last[type] = event;
@@ -314,7 +343,7 @@
       var result = {
         completed: hasCompleted,
         state: hasCompleted ? event.state : this.eventStates.RUNNING,
-        label: event.name
+        label: event.resultLabel
       };
 
       // Override the label for this specific case. This is the real 'result' of the execution

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.spec.js
@@ -388,6 +388,7 @@
           };
           controller.parseEvent(event);
           expect(event.name).toBeDefined();
+          expect(event.resultLabel).toBeDefined();
         });
       });
     });
@@ -525,15 +526,16 @@
             created_date: moment().format()
           }
         };
-        var event = {
+        var parsedEvent = {
           name: 'event name',
+          resultLabel: 'result label',
           artifact_id: 'artifact id'
         };
-        var events = [event];
+        var events = [parsedEvent];
         controller.parseExecution(execution, events);
         expect(execution.result).toBeDefined();
         expect(execution.result.state).toBeDefined();
-        expect(execution.result.label).toEqual(event.name);
+        expect(execution.result.label).toEqual(parsedEvent.resultLabel);
       });
     });
 
@@ -580,20 +582,20 @@
         var event = {
           type: controller.eventTypes.TESTING,
           state: controller.eventStates.FAILED,
-          name: 'label'
+          resultLabel: 'label'
         };
         var res = controller.determineExecutionResult(event);
-        expect(res.label).toEqual(event.name);
+        expect(res.label).toEqual(event.resultLabel);
         expect(res.state).toEqual(event.state);
       });
 
       it('execution still running', function () {
         var event = {
           type: controller.eventTypes.TESTING,
-          name: 'label'
+          resultLabel: 'label'
         };
         var res = controller.determineExecutionResult(event);
-        expect(res.label).toEqual(event.name);
+        expect(res.label).toEqual(event.resultLabel);
         expect(res.state).toEqual(controller.eventStates.RUNNING);
       });
 
@@ -604,14 +606,17 @@
           var event = {
             type: type,
             state: origState,
-            name: 'Name'
+            resultLabel: 'Name'
           };
           var state = controller.determineExecutionResult(event);
           switch (type) {
             case controller.eventTypes.BUILDING:
+            case controller.eventTypes.BUILT:
             case controller.eventTypes.TESTING:
+            case controller.eventTypes.TESTED:
             case controller.eventTypes.DEPLOYING:
-              expect(state.label).toEqual(event.name);
+            case controller.eventTypes.DEPLOYED:
+              expect(state.label).toEqual(event.resultLabel);
               expect(state.state).toEqual(controller.eventStates.RUNNING);
               break;
             case controller.eventTypes.PIPELINE_COMPLETED:
@@ -620,7 +625,7 @@
               break;
             case controller.eventTypes.WATCHDOG_TERMINATED:
               expect(state.state).toEqual(origState);
-              expect(state.label).toEqual(event.name);
+              expect(state.label).toEqual(event.resultLabel);
               break;
             default:
               fail('Unknown event type: ' + type);


### PR DESCRIPTION
- Show new 'started' style events as the 'status' of an execution in the executions table
- Do not show the new events elsewhere
- Ensure the tense of the event names are correct (agnostic everywhere except execution table)
