### PR TITLE
Fix for endpoint count being wrong - we are double counting

### DIFF
--- a/src/app/view/service-registration/service-registration.directive.js
+++ b/src/app/view/service-registration/service-registration.directive.js
@@ -150,12 +150,10 @@
         // Only for an HCF service, get the auth model
         if (serviceInstance.cnsi_type === 'hcf') {
           that.authModel.initializeForEndpoint(serviceInstance.guid, true).then(function () {
-            that.userCnsiModel.numValid += 1;
             that.credentialsFormOpen = false;
             that.activeServiceInstance = null;
           });
         } else {
-          that.userCnsiModel.numValid += 1;
           that.credentialsFormOpen = false;
           that.activeServiceInstance = null;
         }


### PR DESCRIPTION
We were adding 1 each time - the underlying user instance model was correctly re-calculating - so we ended up counting twice.
