### PR TITLE
Update test identity endpoint

### DIFF
--- a/e2e/login-page.spec.js
+++ b/e2e/login-page.spec.js
@@ -106,7 +106,7 @@ fdescribe('Login Page', function () {
     });
 
     it('should allow log in with correct credentials', function () {
-      loginPage.enterLogin('admin@cnap.local', 'cnapadmin');
+      loginPage.enterLogin('hsctestadmin', 'hsctestadmin');
 
       expect(loginPage.loginButton().isEnabled()).toBeTruthy();
 

--- a/e2e/po/login-page.po.js
+++ b/e2e/po/login-page.po.js
@@ -2,8 +2,8 @@
 
 // Login page helpers
 var helpers = require('./helpers.po');
-var adminUser = browser.params.adminUser || 'admin@cnap.local';
-var adminPassword = browser.params.adminPassword || 'cnapadmin';
+var adminUser = browser.params.adminUser || 'hsctestadmin';
+var adminPassword = browser.params.adminPassword || 'hsctestadmin';
 
 module.exports = {
 


### PR DESCRIPTION
Moving the identity endpoint for dev and test from https://ident.helion.space to https://identity.hsctest.stacktest.io. Should be merged with https://github.com/hpcloud/stratos-deploy/pull/112.
