### PR TITLE
This PR uses another way to exclude tests. Currently it only one test…

### DIFF
--- a/e2e/dev/applications.delivery-logs.spec.js
+++ b/e2e/dev/applications.delivery-logs.spec.js
@@ -7,90 +7,90 @@ var galleryPage = require('../po/applications.po');
 var deliveryLogs = require('../po/applications.deliver-log.po');
 
 var Q = require('../../tools/node_modules/q');
-
-describe('Application - Delivery Logs', function () {
-
-  function testPopulatedString(string) {
-    expect(string).toEqual(jasmine.any(String));
-    expect(string.length).toBeGreaterThan(0);
-  }
-
-  beforeAll(function () {
-    browser.driver.wait(resetTo.devWorkflow(false))
-      .then(function () {
-        helpers.setBrowserNormal();
-        helpers.loadApp();
-        loginPage.login('dev', 'dev');
-        galleryPage.showApplications();
-        galleryPage.showApplicationDetails(0);
-        galleryPage.showDeliveryLogs();
-      });
-  });
-
-  it('should show application delivery logs URL', function () {
-    var reg = new RegExp('http:\/\/' + helpers.getHost() + '\/#\/cf\/applications\/[0-9a-z-]*\/delivery-logs');
-    expect(browser.getCurrentUrl()).toMatch(reg);
-  });
-
-  it('summary values should be populated', function (done) {
-
-    function validateEntry(entry) {
-      testPopulatedString(entry.label);
-      testPopulatedString(entry.values.link);
-      testPopulatedString(entry.values.time);
-    }
-
-    deliveryLogs.getSummaryCount()
-      .then(function (count) {
-        var summaries = [];
-        for (var i = 0; i < count; i++) {
-          summaries.push(deliveryLogs.getSummaryAt(i));
-        }
-        return Q.all(summaries);
-      })
-      .then(function (res) {
-        for (var i = 0; i < res.length; i++) {
-          validateEntry(res[i]);
-        }
-        done();
-      })
-      .catch(function (error) {
-        fail(error);
-        done();
-      });
-
-  });
-
-  it('build data populated', function (done) {
-    deliveryLogs.getBuildsRowText(1)
-      .then(function (text) {
-        for (var i = 0; i < text.length; i++) {
-          testPopulatedString(text[i]);
-        }
-        done();
-      })
-      .catch(function (error) {
-        fail(error);
-        done();
-      });
-  });
-
-  it('basic search', function (done) {
-    deliveryLogs.getBuildsCount()
-      .then(function (count) {
-        expect(count).not.toBe(1);
-        return deliveryLogs.searchBuilds('Deploying');
-      })
-      .then(function () {
-        return deliveryLogs.getBuildsCount();
-      })
-      .then(function (count) {
-        expect(count).toBe(1);
-        done();
-      })
-      .catch(function (error) {
-        fail(error);
-        done();
-      });
-  });
-});
+//
+//describe('Application - Delivery Logs', function () {
+//
+//  function testPopulatedString(string) {
+//    expect(string).toEqual(jasmine.any(String));
+//    expect(string.length).toBeGreaterThan(0);
+//  }
+//
+//  beforeAll(function () {
+//    browser.driver.wait(resetTo.devWorkflow(false))
+//      .then(function () {
+//        helpers.setBrowserNormal();
+//        helpers.loadApp();
+//        loginPage.login('dev', 'dev');
+//        galleryPage.showApplications();
+//        galleryPage.showApplicationDetails(0);
+//        galleryPage.showDeliveryLogs();
+//      });
+//  });
+//
+//  it('should show application delivery logs URL', function () {
+//    var reg = new RegExp('http:\/\/' + helpers.getHost() + '\/#\/cf\/applications\/[0-9a-z-]*\/delivery-logs');
+//    expect(browser.getCurrentUrl()).toMatch(reg);
+//  });
+//
+//  it('summary values should be populated', function (done) {
+//
+//    function validateEntry(entry) {
+//      testPopulatedString(entry.label);
+//      testPopulatedString(entry.values.link);
+//      testPopulatedString(entry.values.time);
+//    }
+//
+//    deliveryLogs.getSummaryCount()
+//      .then(function (count) {
+//        var summaries = [];
+//        for (var i = 0; i < count; i++) {
+//          summaries.push(deliveryLogs.getSummaryAt(i));
+//        }
+//        return Q.all(summaries);
+//      })
+//      .then(function (res) {
+//        for (var i = 0; i < res.length; i++) {
+//          validateEntry(res[i]);
+//        }
+//        done();
+//      })
+//      .catch(function (error) {
+//        fail(error);
+//        done();
+//      });
+//
+//  });
+//
+//  it('build data populated', function (done) {
+//    deliveryLogs.getBuildsRowText(1)
+//      .then(function (text) {
+//        for (var i = 0; i < text.length; i++) {
+//          testPopulatedString(text[i]);
+//        }
+//        done();
+//      })
+//      .catch(function (error) {
+//        fail(error);
+//        done();
+//      });
+//  });
+//
+//  it('basic search', function (done) {
+//    deliveryLogs.getBuildsCount()
+//      .then(function (count) {
+//        expect(count).not.toBe(1);
+//        return deliveryLogs.searchBuilds('Deploying');
+//      })
+//      .then(function () {
+//        return deliveryLogs.getBuildsCount();
+//      })
+//      .then(function (count) {
+//        expect(count).toBe(1);
+//        done();
+//      })
+//      .catch(function (error) {
+//        fail(error);
+//        done();
+//      });
+//  });
+//});

--- a/e2e/dev/applications.gallery.spec.js
+++ b/e2e/dev/applications.gallery.spec.js
@@ -5,26 +5,26 @@ var resetTo = require('../po/resets.po');
 var loginPage = require('../po/login-page.po');
 var galleryPage = require('../po/applications.po');
 
-describe('Applications - Gallery View', function () {
-  beforeAll(function () {
-    browser.driver.wait(resetTo.devWorkflow(false))
-      .then(function () {
-        helpers.setBrowserNormal();
-        helpers.loadApp();
-        loginPage.login('dev', 'dev');
-      });
-  });
-
-  it('should show applications as cards', function () {
-    galleryPage.showApplications();
-    expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/list/gallery-view');
-    expect(galleryPage.applicationGalleryCards().isDisplayed()).toBeTruthy();
-  });
-
-  describe('on card click', function () {
-    it('should show application details', function () {
-      galleryPage.showApplicationDetails(0);
-      expect(browser.getCurrentUrl()).toMatch(/summary$/);
-    });
-  });
-});
+//describe('Applications - Gallery View', function () {
+//  beforeAll(function () {
+//    browser.driver.wait(resetTo.devWorkflow(false))
+//      .then(function () {
+//        helpers.setBrowserNormal();
+//        helpers.loadApp();
+//        loginPage.login('dev', 'dev');
+//      });
+//  });
+//
+//  it('should show applications as cards', function () {
+//    galleryPage.showApplications();
+//    expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/list/gallery-view');
+//    expect(galleryPage.applicationGalleryCards().isDisplayed()).toBeTruthy();
+//  });
+//
+//  describe('on card click', function () {
+//    it('should show application details', function () {
+//      galleryPage.showApplicationDetails(0);
+//      expect(browser.getCurrentUrl()).toMatch(/summary$/);
+//    });
+//  });
+//});

--- a/e2e/dev/applications.services.spec.js
+++ b/e2e/dev/applications.services.spec.js
@@ -5,34 +5,34 @@ var resetTo = require('../po/resets.po');
 var loginPage = require('../po/login-page.po');
 var galleryPage = require('../po/applications.po');
 
-describe('Application - Services', function () {
-  beforeAll(function () {
-    browser.driver.wait(resetTo.devWorkflow(false))
-      .then(function () {
-        helpers.setBrowserNormal();
-        helpers.loadApp();
-        loginPage.login('dev', 'dev');
-        galleryPage.showApplications();
-        galleryPage.showApplicationDetails(0);
-        galleryPage.showServices();
-      });
-  });
-
-  it('should show application services URL', function () {
-    expect(browser.getCurrentUrl()).toMatch(/services$/);
-  });
-
-  it('should show render multiple service panels', function () {
-    expect(galleryPage.servicePanelsAddServiceButtons().count()).toBeGreaterThan(0);
-  });
-
-  describe('and you click on "Add Service"', function () {
-    beforeAll(function () {
-      galleryPage.showServiceDetails(0);
-    });
-
-    it('shows the service preview panel', function () {
-      expect(galleryPage.applicationServiceFlyout().isDisplayed()).toBe(true);
-    });
-  });
-});
+//describe('Application - Services', function () {
+//  beforeAll(function () {
+//    browser.driver.wait(resetTo.devWorkflow(false))
+//      .then(function () {
+//        helpers.setBrowserNormal();
+//        helpers.loadApp();
+//        loginPage.login('dev', 'dev');
+//        galleryPage.showApplications();
+//        galleryPage.showApplicationDetails(0);
+//        galleryPage.showServices();
+//      });
+//  });
+//
+//  it('should show application services URL', function () {
+//    expect(browser.getCurrentUrl()).toMatch(/services$/);
+//  });
+//
+//  it('should show render multiple service panels', function () {
+//    expect(galleryPage.servicePanelsAddServiceButtons().count()).toBeGreaterThan(0);
+//  });
+//
+//  describe('and you click on "Add Service"', function () {
+//    beforeAll(function () {
+//      galleryPage.showServiceDetails(0);
+//    });
+//
+//    it('shows the service preview panel', function () {
+//      expect(galleryPage.applicationServiceFlyout().isDisplayed()).toBe(true);
+//    });
+//  });
+//});

--- a/e2e/dev/service-instance-registration.spec.js
+++ b/e2e/dev/service-instance-registration.spec.js
@@ -6,123 +6,123 @@ var navbar = require('../po/navbar.po');
 var loginPage = require('../po/login-page.po');
 var registration = require('../po/service-instance-registration.po');
 
-describe('Service Instance Registration', function () {
-  beforeAll(function () {
-    browser.driver.wait(resetTo.devWorkflow(true))
-      .then(function () {
-        helpers.setBrowserNormal();
-        helpers.loadApp();
-        loginPage.login('dev', 'dev');
-      });
-  });
-
-  describe('service instances table', function () {
-    it('should be displayed', function () {
-      expect(registration.registrationOverlay().isDisplayed()).toBeTruthy();
-    });
-
-    it('should show at least one service instance', function () {
-      var serviceInstancesTable = registration.serviceInstancesTable();
-      expect(helpers.getTableRows(serviceInstancesTable).count()).toBeGreaterThan(0);
-    });
-
-    it('should show `Connect` link for each service instance', function () {
-      var serviceInstancesTable = registration.serviceInstancesTable();
-      var serviceInstanceRows = helpers.getTableRows(serviceInstancesTable);
-      for (var i = 0; i < serviceInstanceRows.count(); i++) {
-        expect(registration.connectLink(i).isDisplayed()).toBeTruthy();
-      }
-    });
-
-    it('should have the `Done` button disabled initially', function () {
-      expect(registration.doneButton().isEnabled()).toBeFalsy();
-    });
-  });
-
-  describe('service instance `Connect` clicked', function () {
-    beforeAll(function () {
-      registration.connect(0);
-    });
-
-    it('should open the credentials form', function () {
-      expect(registration.credentialsForm().isDisplayed()).toBeTruthy();
-    });
-
-    it('should show the cluster name and URL as readonly in the credentials form', function () {
-      var serviceInstancesTable = registration.serviceInstancesTable();
-      var name = helpers.getTableCellAt(serviceInstancesTable, 0, 1).getText();
-      var url = helpers.getTableCellAt(serviceInstancesTable, 0, 2).getText();
-
-      var fields = registration.credentialsFormFields();
-      expect(fields.get(0).getAttribute('value')).toBe(name);
-      expect(fields.get(1).getAttribute('value')).toBe(url);
-      expect(fields.get(2).getAttribute('value')).toBe('');
-      expect(fields.get(3).getAttribute('value')).toBe('');
-    });
-
-    it('should disable register button if username and password are blank', function () {
-      expect(registration.registerButton().isEnabled()).toBeFalsy();
-    });
-
-    it('should enable register button if username and password are not blank', function () {
-      registration.fillCredentialsForm('username', 'password');
-      expect(registration.registerButton().isEnabled()).toBeTruthy();
-    });
-
-    it('should update service instance data on register', function () {
-      registration.registerServiceInstance();
-
-      var serviceInstancesTable = registration.serviceInstancesTable();
-      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 3).getText()).not.toBe('');
-      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 4).getText()).not.toBe('');
-      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 5).getText()).toBe('DISCONNECT');
-      expect(registration.serviceInstanceStatus(0, 'helion-icon-Active_L').isDisplayed()).toBeTruthy();
-    });
-
-    it('should show `1 CLUSTER REGISTERED` next to `Done` button', function () {
-      expect(registration.registrationNotification().getText()).toBe('1 CLUSTER REGISTERED');
-    });
-
-    it('should enable `Done` button', function () {
-      expect(registration.doneButton().isEnabled()).toBeTruthy();
-    });
-  });
-
-  describe('service instance `Disconnect`', function () {
-    it('should update row in table when disconnected', function () {
-      var serviceInstancesTable = registration.serviceInstancesTable();
-      registration.disconnect(0);
-
-      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 3).getText()).toBe('');
-      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 4).getText()).toBe('');
-      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 5).getText()).toBe('CONNECT');
-    });
-
-    it('should disable `Done` button if no service instances registered', function () {
-      expect(registration.doneButton().isEnabled()).toBeFalsy();
-    });
-  });
-
-  describe('service instance - complete registration', function () {
-    beforeAll(function () {
-      registration.connect(0);
-    });
-
-    it('should show applications view when `Done` clicked', function () {
-      registration.fillCredentialsForm('username', 'password');
-      registration.registerServiceInstance();
-      registration.completeRegistration();
-
-      expect(registration.registrationOverlay().isPresent()).toBeFalsy();
-      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/list/gallery-view');
-    });
-
-    it('should go directly to applications view on logout and login', function () {
-      navbar.logout();
-      loginPage.login('dev', 'dev');
-
-      expect(registration.registrationOverlay().isPresent()).toBeFalsy();
-      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/list/gallery-view');
-    });
-  });
-});
+//describe('Service Instance Registration', function () {
+//  beforeAll(function () {
+//    browser.driver.wait(resetTo.devWorkflow(true))
+//      .then(function () {
+//        helpers.setBrowserNormal();
+//        helpers.loadApp();
+//        loginPage.login('dev', 'dev');
+//      });
+//  });
+//
+//  describe('service instances table', function () {
+//    it('should be displayed', function () {
+//      expect(registration.registrationOverlay().isDisplayed()).toBeTruthy();
+//    });
+//
+//    it('should show at least one service instance', function () {
+//      var serviceInstancesTable = registration.serviceInstancesTable();
+//      expect(helpers.getTableRows(serviceInstancesTable).count()).toBeGreaterThan(0);
+//    });
+//
+//    it('should show `Connect` link for each service instance', function () {
+//      var serviceInstancesTable = registration.serviceInstancesTable();
+//      var serviceInstanceRows = helpers.getTableRows(serviceInstancesTable);
+//      for (var i = 0; i < serviceInstanceRows.count(); i++) {
+//        expect(registration.connectLink(i).isDisplayed()).toBeTruthy();
+//      }
+//    });
+//
+//    it('should have the `Done` button disabled initially', function () {
+//      expect(registration.doneButton().isEnabled()).toBeFalsy();
+//    });
+//  });
+//
+//  describe('service instance `Connect` clicked', function () {
+//    beforeAll(function () {
+//      registration.connect(0);
+//    });
+//
+//    it('should open the credentials form', function () {
+//      expect(registration.credentialsForm().isDisplayed()).toBeTruthy();
+//    });
+//
+//    it('should show the cluster name and URL as readonly in the credentials form', function () {
+//      var serviceInstancesTable = registration.serviceInstancesTable();
+//      var name = helpers.getTableCellAt(serviceInstancesTable, 0, 1).getText();
+//      var url = helpers.getTableCellAt(serviceInstancesTable, 0, 2).getText();
+//
+//      var fields = registration.credentialsFormFields();
+//      expect(fields.get(0).getAttribute('value')).toBe(name);
+//      expect(fields.get(1).getAttribute('value')).toBe(url);
+//      expect(fields.get(2).getAttribute('value')).toBe('');
+//      expect(fields.get(3).getAttribute('value')).toBe('');
+//    });
+//
+//    it('should disable register button if username and password are blank', function () {
+//      expect(registration.registerButton().isEnabled()).toBeFalsy();
+//    });
+//
+//    it('should enable register button if username and password are not blank', function () {
+//      registration.fillCredentialsForm('username', 'password');
+//      expect(registration.registerButton().isEnabled()).toBeTruthy();
+//    });
+//
+//    it('should update service instance data on register', function () {
+//      registration.registerServiceInstance();
+//
+//      var serviceInstancesTable = registration.serviceInstancesTable();
+//      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 3).getText()).not.toBe('');
+//      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 4).getText()).not.toBe('');
+//      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 5).getText()).toBe('DISCONNECT');
+//      expect(registration.serviceInstanceStatus(0, 'helion-icon-Active_L').isDisplayed()).toBeTruthy();
+//    });
+//
+//    it('should show `1 CLUSTER REGISTERED` next to `Done` button', function () {
+//      expect(registration.registrationNotification().getText()).toBe('1 CLUSTER REGISTERED');
+//    });
+//
+//    it('should enable `Done` button', function () {
+//      expect(registration.doneButton().isEnabled()).toBeTruthy();
+//    });
+//  });
+//
+//  describe('service instance `Disconnect`', function () {
+//    it('should update row in table when disconnected', function () {
+//      var serviceInstancesTable = registration.serviceInstancesTable();
+//      registration.disconnect(0);
+//
+//      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 3).getText()).toBe('');
+//      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 4).getText()).toBe('');
+//      expect(helpers.getTableCellAt(serviceInstancesTable, 0, 5).getText()).toBe('CONNECT');
+//    });
+//
+//    it('should disable `Done` button if no service instances registered', function () {
+//      expect(registration.doneButton().isEnabled()).toBeFalsy();
+//    });
+//  });
+//
+//  describe('service instance - complete registration', function () {
+//    beforeAll(function () {
+//      registration.connect(0);
+//    });
+//
+//    it('should show applications view when `Done` clicked', function () {
+//      registration.fillCredentialsForm('username', 'password');
+//      registration.registerServiceInstance();
+//      registration.completeRegistration();
+//
+//      expect(registration.registrationOverlay().isPresent()).toBeFalsy();
+//      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/list/gallery-view');
+//    });
+//
+//    it('should go directly to applications view on logout and login', function () {
+//      navbar.logout();
+//      loginPage.login('dev', 'dev');
+//
+//      expect(registration.registrationOverlay().isPresent()).toBeFalsy();
+//      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/list/gallery-view');
+//    });
+//  });
+//});

--- a/e2e/endpoints/endpoints-dashboard.spec.js
+++ b/e2e/endpoints/endpoints-dashboard.spec.js
@@ -5,72 +5,72 @@ var resetTo = require('../po/resets.po');
 var loginPage = require('../po/login-page.po');
 var endpointsDashboardPage = require('../po/endpoints-dashboard.po.js');
 
-describe('Endpoints Dashboard', function () {
-
-  describe('No clusters', function () {
-
-    beforeAll(function () {
-      browser.driver.wait(resetTo.zeroClusterAdminWorkflow())
-        .then(function () {
-          helpers.setBrowserNormal();
-          helpers.loadApp();
-          loginPage.loginAsAdmin();
-        });
-    });
-
-    it('should show welcome endpoints page', function () {
-      endpointsDashboardPage.showEndpoints();
-      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/endpoints-dashboard');
-      expect(endpointsDashboardPage.welcomeMessage().isDisplayed()).toBeTruthy();
-      expect(endpointsDashboardPage.registerCloudFoundryTile().isDisplayed()).toBeTruthy();
-      expect(endpointsDashboardPage.registerCodeEngineTile().isDisplayed()).toBeTruthy();
-    });
-
-    it('should show add cluster form flyout when btn is pressed', function () {
-      endpointsDashboardPage.showEndpoints();
-      endpointsDashboardPage.clickAddClusterInWelcomeMessage('hcf');
-      expect(endpointsDashboardPage.getAddClusterForm().isDisplayed()).toBeTruthy();
-    });
-
-    it('should show add cluster form detail view when btn is pressed', function () {
-      endpointsDashboardPage.showEndpoints();
-      endpointsDashboardPage.clickAddClusterInWelcomeMessage('hce');
-      expect(endpointsDashboardPage.getAddEndpointFlyout().isDisplayed()).toBeTruthy();
-    });
-
-    it('should show add cluster form detail view when tile btn is pressed', function () {
-      endpointsDashboardPage.showEndpoints();
-      endpointsDashboardPage.clickAddClusterInTille('hcf');
-      expect(endpointsDashboardPage.getAddClusterForm().isDisplayed()).toBeTruthy();
-    });
-
-    it('should show add cluster form detail view when tile btn is pressed', function () {
-      endpointsDashboardPage.showEndpoints();
-      endpointsDashboardPage.clickAddClusterInTille('hce');
-      expect(endpointsDashboardPage.getAddEndpointFlyout().isDisplayed()).toBeTruthy();
-    });
-
-  });
-
-  describe('With clusters', function () {
-
-    beforeAll(function () {
-      browser.driver.wait(resetTo.nClustersAdminWorkflow())
-        .then(function () {
-          helpers.setBrowserNormal();
-          helpers.loadApp();
-          loginPage.loginAsAdmin();
-        });
-    });
-
-    it('should show welcome endpoints page', function () {
-      endpointsDashboardPage.showEndpoints();
-      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/endpoints-dashboard');
-      expect(endpointsDashboardPage.welcomeMessage().isDisplayed()).toBeFalsy();
-      expect(endpointsDashboardPage.registerCloudFoundryTile().isDisplayed()).toBeFalsy();
-      expect(endpointsDashboardPage.registerCodeEngineTile().isDisplayed()).toBeFalsy();
-    });
-
-  });
-
-});
+//describe('Endpoints Dashboard', function () {
+//
+//  describe('No clusters', function () {
+//
+//    beforeAll(function () {
+//      browser.driver.wait(resetTo.zeroClusterAdminWorkflow())
+//        .then(function () {
+//          helpers.setBrowserNormal();
+//          helpers.loadApp();
+//          loginPage.loginAsAdmin();
+//        });
+//    });
+//
+//    it('should show welcome endpoints page', function () {
+//      endpointsDashboardPage.showEndpoints();
+//      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/endpoints-dashboard');
+//      expect(endpointsDashboardPage.welcomeMessage().isDisplayed()).toBeTruthy();
+//      expect(endpointsDashboardPage.registerCloudFoundryTile().isDisplayed()).toBeTruthy();
+//      expect(endpointsDashboardPage.registerCodeEngineTile().isDisplayed()).toBeTruthy();
+//    });
+//
+//    it('should show add cluster form flyout when btn is pressed', function () {
+//      endpointsDashboardPage.showEndpoints();
+//      endpointsDashboardPage.clickAddClusterInWelcomeMessage('hcf');
+//      expect(endpointsDashboardPage.getAddClusterForm().isDisplayed()).toBeTruthy();
+//    });
+//
+//    it('should show add cluster form detail view when btn is pressed', function () {
+//      endpointsDashboardPage.showEndpoints();
+//      endpointsDashboardPage.clickAddClusterInWelcomeMessage('hce');
+//      expect(endpointsDashboardPage.getAddEndpointFlyout().isDisplayed()).toBeTruthy();
+//    });
+//
+//    it('should show add cluster form detail view when tile btn is pressed', function () {
+//      endpointsDashboardPage.showEndpoints();
+//      endpointsDashboardPage.clickAddClusterInTille('hcf');
+//      expect(endpointsDashboardPage.getAddClusterForm().isDisplayed()).toBeTruthy();
+//    });
+//
+//    it('should show add cluster form detail view when tile btn is pressed', function () {
+//      endpointsDashboardPage.showEndpoints();
+//      endpointsDashboardPage.clickAddClusterInTille('hce');
+//      expect(endpointsDashboardPage.getAddEndpointFlyout().isDisplayed()).toBeTruthy();
+//    });
+//
+//  });
+//
+//  describe('With clusters', function () {
+//
+//    beforeAll(function () {
+//      browser.driver.wait(resetTo.nClustersAdminWorkflow())
+//        .then(function () {
+//          helpers.setBrowserNormal();
+//          helpers.loadApp();
+//          loginPage.loginAsAdmin();
+//        });
+//    });
+//
+//    it('should show welcome endpoints page', function () {
+//      endpointsDashboardPage.showEndpoints();
+//      expect(browser.getCurrentUrl()).toBe('http://' + helpers.getHost() + '/#/cf/applications/endpoints-dashboard');
+//      expect(endpointsDashboardPage.welcomeMessage().isDisplayed()).toBeFalsy();
+//      expect(endpointsDashboardPage.registerCloudFoundryTile().isDisplayed()).toBeFalsy();
+//      expect(endpointsDashboardPage.registerCodeEngineTile().isDisplayed()).toBeFalsy();
+//    });
+//
+//  });
+//
+//});

--- a/e2e/login-page.spec.js
+++ b/e2e/login-page.spec.js
@@ -3,7 +3,7 @@
 var helpers = require('./po/helpers.po');
 var loginPage = require('./po/login-page.po');
 
-fdescribe('Login Page', function () {
+describe('Login Page', function () {
   beforeAll(function () {
     helpers.setBrowserNormal();
     helpers.loadApp();


### PR DESCRIPTION
Currently only one test suite are included by marked with `fdescribe` and all other e2e tests are automatically excluded by this mark. This makes adding new tests in other files impossible. 

This PR removes the `f` letter from the enabled test suite and comments out all the other disabled tests.

We cannot use `xdescribe` to exclude those tests, since it still take very long time to get them ignored by the test runner.
