### PR TITLE
HSC-1258: More precise durations for build events

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.js
@@ -243,11 +243,17 @@
       event.mEndDate = event.end_date ? moment(event.end_date) : undefined;
 
       if (!event.duration && (event.start_date && event.end_date)) {
-        event.duration = moment(event.start_date).diff(event.end_date);
+        // Duration should be a positive integer
+        event.duration = moment(event.end_date).diff(event.start_date);
       }
 
       if (angular.isDefined(event.duration)) {
-        event.durationString = moment.duration(event.duration, 'ms').humanize();
+        // We're not interested in showing time to the ms, so 'round' to nearest second
+        if (event.duration < 1000) {
+          event.durationString = gettext('Less than a second');
+        } else {
+          event.durationString = moment.duration(event.duration, 'ms').format('h[h] m[m] s[s]');
+        }
       } else {
         event.durationString = gettext('Unknown');
       }

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.module.spec.js
@@ -362,19 +362,20 @@
         expect(event.mEndDate).toBeDefined();
         expect(event.duration).toBeDefined();
         expect(event.durationString).toBeDefined();
-        expect(event.durationString).not.toEqual('Unknown');
+        expect(event.durationString).toEqual('Less than a second');
         expect(event.name).toBeDefined();
       });
 
       it('Populated event - calculate duration', function () {
         var event = {
-          start_date: moment().subtract(100, 's').format(),
+          start_date: moment().subtract(1, 'm').format(),
           end_date: moment().format()
         };
         controller.parseEvent(event);
         expect(event.mEndDate).toBeDefined();
         expect(event.duration).toBeDefined();
         expect(event.durationString).toBeDefined();
+        expect(event.durationString).not.toEqual('Less than a second');
         expect(event.durationString).not.toEqual('Unknown');
       });
 

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/event.html
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/event.html
@@ -6,9 +6,7 @@
       <span ng-if="!detailViewCtrl.context.event.start_date" translate>Unknown</span>
     </div>
     <div class="row col-md-4">
-      <span translate>Duration: </span>
-      <span ng-if="detailViewCtrl.context.event.duration < 1000" translate>Less than a second</span>
-      <span ng-if="detailViewCtrl.context.event.duration >= 1000"> {{ detailViewCtrl.duration }}</span>
+      <span translate>Duration: </span> {{ detailViewCtrl.context.event.durationString }}
     </div>
   </div>
   <div ng-if="detailViewCtrl.log === null" class="message-box message-box-no-bg">

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/event.service.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/event.service.js
@@ -41,7 +41,6 @@
     '$log',
     'context',
     'content',
-    'moment',
     'app.model.modelManager'
   ];
 
@@ -52,14 +51,13 @@
    * @param {object} $log - the Angular $log service
    * @param {object} context - parameter object passed in to DetailView
    * @param {object} content - configuration object passed in to DetailView
-   * @param {object} moment - the moment timezone component
    * @param {app.model.modelManager} modelManager - the Model management service
    * @property {object} context - parameter object passed in to DetailView
    * @property {object} content - configuration object passed in to DetailView
    * @property {object} log - The log / artifact associated with the event
    * @property {string} duration - The duration of the event
    */
-  function EventDetailViewController($timeout, $log, context, content, moment, modelManager) {
+  function EventDetailViewController($timeout, $log, context, content, modelManager) {
     var vm = this;
     vm.context = context;
     vm.content = content;
@@ -88,11 +86,6 @@
           }
         });
     }, 400);
-
-    // The design shows this as a human readible but vague 'a few seconds' ago. Moment humanize matches this.
-    // Need to loop back and understand the requirement (only show this for a few seconds/show something more accurate
-    // for longer durations/etc)
-    vm.duration = moment.duration(event.duration, 'ms').humanize();
   }
 
 })();

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/event.service.spec.js
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/event.service.spec.js
@@ -2,7 +2,7 @@
   'use strict';
 
   describe('variables manager service', function () {
-    var $controller, modelManager, dialogContext, promise, $httpBackend, $timeout, $log, moment, $q;
+    var $controller, modelManager, dialogContext, promise, $httpBackend, $timeout, $log, $q;
 
     var artifactId = 123;
     var guid = 321;
@@ -28,7 +28,6 @@
 
       $timeout = _$timeout_;
       $log = _$log_;
-      moment = $injector.get('moment');
       modelManager = $injector.get('app.model.modelManager');
 
       var viewEvent = $injector.get('viewEventDetailView');
@@ -46,7 +45,7 @@
       describe("open", function () {
         it("Plumbing", function () {
           /* eslint-disable */
-          new $controller($timeout, $log, dialogContext, undefined, moment, modelManager);
+          new $controller($timeout, $log, dialogContext, undefined, modelManager);
           /* eslint-enable */
           expect(dialogContext.guid).toEqual(guid);
           expect(dialogContext.event).toEqual(event);
@@ -58,10 +57,9 @@
       var controller;
 
       beforeEach(function () {
-        controller = new $controller($timeout, $log, dialogContext, undefined, moment, modelManager);
+        controller = new $controller($timeout, $log, dialogContext, undefined, modelManager);
         expect(controller).toBeDefined();
         expect(controller.log).toBeNull();
-        expect(controller.duration).toBe('a few seconds');
       });
 
       it('Fetch fails', function () {

--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/execution.html
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/details/execution.html
@@ -34,9 +34,7 @@
         </td>
         <td></td>
         <td class="row result-col" ng-if="typeof(event.durationString) !== 'undefined'">
-          <span translate>Duration: </span>
-          <span ng-if="event.duration < 1000" translate>Less than a second</span>
-          <span ng-if="event.duration >= 1000"> {{ event.durationString }}</span>
+          <span translate>Duration: </span> {{ event.durationString }}
         </td>
         <td class="row result-col" ng-if="typeof(event.durationString) === 'undefined'"></td>
         <td ng-switch="event.state == 'succeeded' || event.state == 'failed'" class="event-view">


### PR DESCRIPTION
- Use more precise duration strings on execution and event slide outs
- Determine event duration string in a single place
- Fix diff for case HCE event duration is missing (not sure this is possible though..)
