### PR TITLE
HSC-1216 - Use localized date format

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/summary.html
@@ -30,7 +30,7 @@
 
         <dt translate>MODIFIED</dt>
         <dd class="pull-right" ng-if="appCtrl.model.application.summary.package_updated_at">
-          {{ appCtrl.model.application.summary.package_updated_at | date : 'M/d/yy h:mm:ss a'}}
+          {{ appCtrl.model.application.summary.package_updated_at | amDateFormat: 'L - LTS' }}
         </dd>
         <dd class="pull-right" ng-if="!appCtrl.model.application.summary.package_updated_at">-</dd>
 

--- a/src/plugins/cloud-foundry/view/applications/application/versions/versions.html
+++ b/src/plugins/cloud-foundry/view/applications/application/versions/versions.html
@@ -31,7 +31,7 @@
       </thead>
       <tbody>
         <tr ng-repeat="v in applicationVersionsCtrl.versions">
-          <td>{{ v.created_at | date : 'M/d/yy h:mm:ss a' }}</span></td>
+          <td>{{ v.created_at | amDateFormat: 'L - LTS' }}</span></td>
           <td>{{ v.guid }}</td>
           <td>
             <a class="btn-link" ng-click="applicationVersionsCtrl.rollback(v)"


### PR DESCRIPTION
I searched the code base and only found these two instances.
The other instance in log stream module uses the CF date format which I think we should not change:
var timeStamp = coloredLog(moment(msStamp).format('YYYY-MM-DD HH:mm:ss'), 'blue');
