### PR TITLE
HSC-1275: Ensure org/space pages show cluster actions when page is sm + xs

### DIFF
--- a/src/app/view/endpoints/clusters/cluster/organization/detail/cluster-organization-detail.html
+++ b/src/app/view/endpoints/clusters/cluster/organization/detail/cluster-organization-detail.html
@@ -1,8 +1,8 @@
-<div ng-if="!clusterOrgDetailController.organization().details" class="cluster-loading col-md-9 col-sm-12">
+<div ng-if="!clusterOrgDetailController.organization().details" class="cluster-loading col-md-9 col-sm-11 col-xs-11">
   <bounce-spinner classes="bounce-spinner-sm"></bounce-spinner>
 </div>
 
-<div ng-if="clusterOrgDetailController.organization().details" class="cluster-detail col-md-9 col-sm-12">
+<div ng-if="clusterOrgDetailController.organization().details" class="cluster-detail col-md-9 col-sm-11 col-xs-11">
   <h3>Organization : {{ clusterOrgDetailController.organization().details.org.entity.name }}</h3>
   <organization-summary-tile
     cluster-guid="clusterOrgDetailController.clusterGuid"
@@ -24,4 +24,4 @@
   </ul>
   <ui-view></ui-view>
 </div>
-<cluster-actions></cluster-actions>
+<cluster-actions class="col-md-3 col-sm-1 col-xs-1"></cluster-actions>

--- a/src/app/view/endpoints/clusters/cluster/organization/space/detail/cluster-space-detail.html
+++ b/src/app/view/endpoints/clusters/cluster/organization/space/detail/cluster-space-detail.html
@@ -1,8 +1,8 @@
-<div ng-if="!clusterSpaceController.stateInitialised" class="cluster-loading col-md-9 col-sm-12">
+<div ng-if="!clusterSpaceController.stateInitialised" class="cluster-loading col-md-9 col-sm-11 col-xs-11">
   <bounce-spinner classes="bounce-spinner-sm"></bounce-spinner>
 </div>
 
-<div ng-if="clusterSpaceController.stateInitialised" class="cluster-detail col-md-9 col-sm-12">
+<div ng-if="clusterSpaceController.stateInitialised" class="cluster-detail col-md-9 col-sm-11 col-xs-11">
   <h3>Space : {{ clusterSpaceController.space().details.space.entity.name }}</h3>
   <space-summary-tile ng-if="clusterSpaceController.space()"
                       cluster-guid="clusterSpaceController.clusterGuid"
@@ -33,4 +33,4 @@
   </ul>
   <ui-view></ui-view>
 </div>
-<cluster-actions></cluster-actions>
+<cluster-actions class="col-md-3 col-sm-1 col-xs-1"></cluster-actions>


### PR DESCRIPTION
Org + Space endpoint pages now correctly show the cluster actions mini-menu
when page width is shrunk to sm/xs size
