### PR TITLE
HSC-1206 - Fixed unique route validation for Add route

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/summary/add-route/add-route.service.js
+++ b/src/plugins/cloud-foundry/view/applications/application/summary/add-route/add-route.service.js
@@ -103,13 +103,13 @@
             .catch(function (error) {
               // check if error is CF-RouteHostTaken indicating that the route has already been created
               if (_.isPlainObject(error) &&
-                error.error_code &&
-                error.error_code === 'CF-RouteHostTaken') {
+                error.data.error_code &&
+                error.data.error_code === 'CF-RouteHostTaken') {
                 routeExists = true;
                 hideAsyncIndicatorContent = true;
               }
-              if (error.description) {
-                dialog.context.errorMsg = error.description;
+              if (error.data.description) {
+                dialog.context.errorMsg = error.data.description;
               }
               throw error;
             });


### PR DESCRIPTION
Unique route validation was broken because the `error` object passed to the `catch` has changed. It is the `response`, rather than `response.data` 
