### PR TITLE
DO NOT MERGE THIS IS A TEST

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
@@ -74,7 +74,7 @@
           <tbody>
           <tr ng-repeat="execution in appDelLogsCtrl.displayedExecutions">
             <td><a href="" ng-click="appDelLogsCtrl.viewExecution(execution)">{{ execution.message }}</a></td>
-            <td ng-if="!execution.result" class="row result-col"></td>
+            <td ng-if="!execution.result" class="row result-col"><div class="pull-left"><spinner></spinner></div></td>
             <td ng-if="execution.result" class="row result-col" id="build-result-col">
               <div ng-switch="execution.result.state" class="pull-left">
                 <span ng-switch-when="succeeded" class="helion-icon helion-icon-Active_S text-primary"></span>


### PR DESCRIPTION
It can take up to a minute for HCE to report a 'building' event for a new
execution. During this time the delivery logs build status cell is empty.
This change ensures that for builds without a status we show a spinner.