### PR TITLE
HSC-1373: Deliver logs search builds fix

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
+++ b/src/plugins/cloud-foundry/view/applications/application/delivery-logs/delivery-logs.html
@@ -64,9 +64,9 @@
 
       <div ng-if="appDelLogsCtrl.displayedExecutions.length < 1"
            class="panel panel-default">
-        <div class="panel-body" translate>
-          <span ng-if="appDelLogsCtrl.parsedHceModel.pipelineExecutions.length">No builds found</span>
-          <span ng-if="!appDelLogsCtrl.parsedHceModel.pipelineExecutions.length">You have no builds</span>
+        <div class="panel-body">
+          <span ng-if="appDelLogsCtrl.parsedHceModel.pipelineExecutions.length" translate>No builds found</span>
+          <span ng-if="!appDelLogsCtrl.parsedHceModel.pipelineExecutions.length" translate>You have no builds</span>
         </div>
       </div>
 


### PR DESCRIPTION
- Show the search dialog if there are builds to search over (instead of if there are any in the filtered list)
- Show different text in the 'no builds' box depending on if there are zero initial builds or builds are filtered to zero