### PR TITLE
Reduce the number of times we update app stats on sort

### DIFF
--- a/src/plugins/cloud-foundry/view/applications/list/app-sort/app-sort.directive.js
+++ b/src/plugins/cloud-foundry/view/applications/list/app-sort/app-sort.directive.js
@@ -52,29 +52,28 @@
     // Used to toggle display of sort action buttons when screen width is too small
     this.showSortActions = true;
 
-    // If currentSortOption is updated update filteredApplications
+    // If currentSortOption and sort order change update filteredApplications
     $scope.$watch(function () {
-      return that.model.currentSortOption;
-    }, function () {
-      that.sortFilteredApplications();
-    });
-
-    // If sort order is updated, update filteredApplications
-    $scope.$watch(function () {
-      return that.model.sortAscending;
-    }, function () {
-      that.sortFilteredApplications();
-    });
-
-    // In case user applied a filter, resort filteredApplications
-    $scope.$watchCollection(function () {
-      return that.model.filteredApplications;
-    }, function () {
-      if (that.updatingFilteredApplications) {
+      // Combine this into one watch so changes in the same digest only kick off one update
+      return that.model.currentSortOption + that.model.sortAscending;
+    }, function (newVal, oldVal) {
+      if (newVal === oldVal) {
         return;
       }
       that.sortFilteredApplications();
     });
+
+    // In case user applied a filter update filteredApplications
+    $scope.$watch(function () {
+      return that.model.filteredApplications.length;
+    }, function (newVal, oldVal) {
+      if (newVal === oldVal || that.updatingFilteredApplications) {
+        return;
+      }
+      that.sortFilteredApplications();
+    });
+
+    that.sortFilteredApplications();
   }
 
   angular.extend(ApplicationsSortingController.prototype, {


### PR DESCRIPTION
- app-sort will update filtered collection then call app model loadPage
- loadPage will make 1 call to stats per app (that's passed a certain status)
- this change reduces the number of times we call loadPage to 1 per sort change

See https://jira.hpcloud.net/browse/HSC-1406 for reducing the stats call per loadPage