### PR TITLE
HSC-1412: Fix broken add application button

### DIFF
--- a/e2e/po/applications/applications.po.js
+++ b/e2e/po/applications/applications.po.js
@@ -17,7 +17,11 @@
 
     getAddApplicationButton: getAddApplicationButton,
     addApplication: addApplication,
-    clickEndpointsDashboard: clickEndpointsDashboard
+    clickEndpointsDashboard: clickEndpointsDashboard,
+
+    appNameSearch: appNameSearch,
+    resetFilters: resetFilters,
+    getAddAppWhenNoApps: getAddAppWhenNoApps
   };
 
   function applicationGalleryCard(idx) {
@@ -59,5 +63,17 @@
 
   function clickEndpointsDashboard() {
     return element(by.css('.applications-cta a')).click();
+  }
+
+  function appNameSearch() {
+    return element(by.css('.app-actions-bar .form-group.search-field'));
+  }
+
+  function resetFilters() {
+    return element(by.css('.reset-link .btn-link')).click();
+  }
+
+  function getAddAppWhenNoApps() {
+    return element(by.css('.applications-cta .btn.btn-link'));
   }
 })();

--- a/e2e/tests/acceptance/applications.add-app.spec.js
+++ b/e2e/tests/acceptance/applications.add-app.spec.js
@@ -13,6 +13,7 @@
   var cfModel = require('../../po/models/cf-model.po');
   var proxyModel = require('../../po/models/proxy-model.po');
   var searchBox = require('../../po/widgets/input-search-box.po');
+  var inputText = require('../../po/widgets/input-text.po');
 
   describe('Applications - Add application', function () {
 
@@ -339,6 +340,24 @@
 
     it('Arrive at pipeline section of wizard', function () {
       expect(addAppWizard.getWizard().getCurrentStep().getText()).toBe('Delivery');
+      addAppWizard.getWizard().cancel();
+    });
+
+    it('Should show add application button when no applications shown on app wall', function () {
+      galleryWall.showApplications();
+      galleryWall.resetFilters();
+      galleryWall.getAddAppWhenNoApps().isPresent().then(function (present) {
+        if (!present) {
+          // Type some stuff in the search box that will result in no matching applications
+          var appNameSearchBox = inputText.wrap(galleryWall.appNameSearch());
+          appNameSearchBox.clear();
+          return appNameSearchBox.addText('zzz_not_expecting_any_apps');
+        }
+      });
+      galleryWall.getAddAppWhenNoApps().click();
+      expect(addAppWizard.isDisplayed()).toBeTruthy();
+      expect(addAppWizard.getTitle()).toBe('Add Application');
+      addAppWizard.getWizard().cancel();
     });
 
   });

--- a/src/plugins/cloud-foundry/view/applications/list/list.html
+++ b/src/plugins/cloud-foundry/view/applications/list/list.html
@@ -126,7 +126,7 @@
         <div class="helion-icon helion-icon-3x helion-icon-Application"></div>
         <div class="applications-msg" ng-bind="applicationsListCtrl.getNoAppsMessage()"></div>
         <div class="applications-cta">
-          <a class="btn btn-link" ng-click="applicationsListCtrl.eventService.$emit('cf.events.START_ADD_APP_WORKFLOW')"
+          <a class="btn btn-link" ng-click="applicationsListCtrl.addApplication()"
              translate>
             Add an application
           </a>


### PR DESCRIPTION
The add application message/link shown when there are no applications does not work.

This PR fixes this and also adds a test to the e2e acceptance tests to check that this works.