### PR TITLE
Cope with local uid and gid already existing in the docker image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,8 +5,19 @@ ARG GROUP_ID
 ARG USER_NAME
 
 # Run this as a normal with the specified ID
-RUN groupadd -r -g ${GROUP_ID} ${USER_NAME} && useradd -m -r -g ${USER_NAME} -u ${USER_ID} ${USER_NAME}
-USER ${USER_NAME}
+RUN user_exists=$(getent passwd ${USER_ID} | cut -d: -f1); \
+  group_exists=$(getent group ${GROUP_ID} | cut -d: -f1); \
+  if [ -z "${group_exists}" ]; then \
+    groupadd -r -g ${GROUP_ID} ${USER_NAME}; \
+    else \
+      echo "Group with gid ${GROUP_ID} already exists."; \
+    fi ;\
+    if [ -z "${user_exists}" ]; then \
+      useradd -m -r -g ${USER_NAME} -u ${USER_ID} ${USER_NAME}; \
+      else \
+        echo "User with uid ${USER_ID} already exists."; \
+      fi
+USER ${USER_ID}
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The nodejs image we use to build the UI image in docker-compose now has a user with uid 1000 and a group with gid 1000. This fix makes Docker correctly cope without corrupting local file permissions.