### PR TITLE
Add a 'no users' style message to base cluster users tab

### DIFF
--- a/src/app/view/endpoints/clusters/cluster/detail/users/cluster-detail-users.html
+++ b/src/app/view/endpoints/clusters/cluster/detail/users/cluster-detail-users.html
@@ -1,7 +1,13 @@
 <div ng-if="!clusterUsersController.stateInitialised" class="message-box message-box-no-bg">
   <bounce-spinner classes="bounce-spinner-sm"></bounce-spinner>
 </div>
-<div ng-if="clusterUsersController.stateInitialised"
+<div ng-if="clusterUsersController.stateInitialised && clusterUsersController.users.length === 0"
+     class="panel panel-default cluster-empty-list">
+  <div class="panel-body" translate>
+    There are no visible users
+  </div>
+</div>
+<div ng-if="clusterUsersController.stateInitialised && clusterUsersController.users.length > 0"
      class="cluster-users-table"
      st-table="clusterUsersController.visibleUsers"
      st-safe-src="clusterUsersController.users">


### PR DESCRIPTION
- We fetch roles via orgs. If the user is not an org_user of any org they will see no users.
- Add a simple message to avoid showing an ugly empty table
- Not needed at space level (only org_user is needed to view roles)