### PR TITLE
Use custom nginx config when deploying in Kubernetes

### DIFF
--- a/containers/nginx/Dockerfile.k8s
+++ b/containers/nginx/Dockerfile.k8s
@@ -1,0 +1,7 @@
+FROM nginx
+RUN mkdir -p /usr/share/doc/stackato
+COPY ./LICENSE.txt /usr/share/doc/stackato/LICENSE.txt
+COPY ./conf/nginx.k8s.conf /etc/nginx/nginx.conf
+COPY ./dist/ /usr/share/nginx/html
+EXPOSE 80 443
+CMD [ "nginx", "-g", "daemon off;" ]

--- a/containers/nginx/conf/nginx.k8s.conf
+++ b/containers/nginx/conf/nginx.k8s.conf
@@ -1,0 +1,75 @@
+worker_processes 2;
+
+events {
+    worker_connections              4096;
+    use                             epoll;
+}
+
+http {
+
+    upstream portalproxy {
+        least_conn;
+        server                      localhost:3003;
+        keepalive                   32;
+    }
+
+    add_header                      X-Frame-Options DENY;
+
+    include                         mime.types;
+    default_type                    application/octet-stream;
+    keepalive_timeout               70;
+    proxy_read_timeout              200;
+    sendfile                        off;
+    tcp_nopush                      on;
+    tcp_nodelay                     on;
+    gzip                            on;
+    gzip_min_length                 1000;
+    gzip_proxied                    any;
+    gzip_types                      text/plain text/html text/css text/xml
+                                    application/x-javascript application/xml
+                                    application/atom+xml text/javascript;
+
+    proxy_next_upstream             error;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
+
+    ssl_session_cache               shared:SSL:10m;
+    ssl_session_timeout             10m;
+
+    server {
+        listen                      80;
+        return                      301 https://$host$request_uri;
+    }
+
+    server {
+        listen                      443 ssl;
+
+        ssl_certificate             /etc/secrets/console-cert;
+        ssl_certificate_key         /etc/secrets/console-cert-key;
+        ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers                 HIGH:!aNULL:!MD5;
+
+        client_max_body_size        50M;
+
+        location /pp/ {
+            proxy_pass_header       Server;
+            proxy_set_header        Host $http_host;
+            proxy_redirect          off;
+            proxy_set_header        X-Real-IP $remote_addr;
+            proxy_set_header        X-Scheme $scheme;
+            proxy_pass              https://portalproxy/;
+            proxy_intercept_errors  on;
+            proxy_http_version      1.1;
+            proxy_set_header        Upgrade $http_upgrade;
+            proxy_set_header        Connection $connection_upgrade;
+        }
+
+        location / {
+            root                    /usr/share/nginx/html;
+            add_header Cache-Control no-cache;
+        }
+    }
+}


### PR DESCRIPTION
The kubernetes deployment in https://github.com/hpcloud/stratos-deploy/pull/133 deploy the UI and portal-proxy containers in a single pod. Therefore the address for the portal-proxy is different.