### PR TITLE
Skip Endpoint Type selection screen when only one type is available

### DIFF
--- a/test/e2e/tests/acceptance/endpoints-dashboard.spec.js
+++ b/test/e2e/tests/acceptance/endpoints-dashboard.spec.js
@@ -209,9 +209,9 @@
               endpointsPage.headerRegister()
                 .then(function () {
                   expect(registerEndpoint.isVisible().isDisplayed()).toBeTruthy();
-                  expect(registerEndpoint.getStep()).toBe(1);
+                  expect(registerEndpoint.getStep()).toBe(2);
                   registerEndpoint.closeEnabled(true);
-                  registerEndpoint.selectType(type);
+                  // registerEndpoint.selectType(type);
                 });
             });
 


### PR DESCRIPTION
When registering an endpoint, this skips the Endpoint Type selection screen when only one endpoint type is available