### PR TITLE
Fix E2E tests

### DIFF
--- a/test/e2e/po/applications/application.po.js
+++ b/test/e2e/po/applications/application.po.js
@@ -88,7 +88,10 @@
   }
 
   function getTabs() {
-    return element.all(by.css('ul.application-nav.nav > li.nav-item > a'));
+    return element.all(by.css('ul.application-nav.nav > li.nav-item > a'))
+      .filter(function (elem) {
+        return elem.isDisplayed();
+      });
   }
 
   function addRoute() {

--- a/test/e2e/tests/acceptance/application.spec.js
+++ b/test/e2e/tests/acceptance/application.spec.js
@@ -52,7 +52,12 @@
     });
 
     it('Should Walk through the tabs', function () {
-      var names = ['Summary', 'Log Stream', 'Services', 'Variables', 'Versions'];
+      var names = ['Summary', 'Log Stream', 'Services', 'Variables'];
+      var hcfFromConfig = helpers.getHcfs() ? helpers.getHcfs().hcf1 : undefined;
+      if (hcfFromConfig && hcfFromConfig.supportsVersions) {
+        names.push('Versions');
+      }
+      browser.debugger();
       // Walk through each of the tabs
       application.getTabs().then(function (tabs) {
         _.each(tabs, function (tab, i) {
@@ -118,7 +123,7 @@
           var routes = table.wrap(element(by.css('.summary-routes table')));
           routes.getData(routes).then(function (rows) {
             expect(rows.length).toBe(2);
-            var columnMenu = actionMenu.wrap(routes.getItem(0,1));
+            var columnMenu = actionMenu.wrap(routes.getItem(0, 1));
             columnMenu.click();
             // Delete
             columnMenu.clickItem(1);

--- a/tools/protractor.conf.js
+++ b/tools/protractor.conf.js
@@ -90,7 +90,8 @@
               password: 'changeme'
             },
             testOrgName: 'e2e',
-            testSpaceName: 'e2e'
+            testSpaceName: 'e2e',
+            supportsVersions: false
           }
         }
       },


### PR DESCRIPTION
The `Versions` CF plugin seems to be missing from the latest SCF. Therefore, we now skip checking if the versions tab is present when running the E2E tests