### PR TITLE
Fix 'View App' when there are no attached routes

### DIFF
--- a/components/cloud-foundry/src/view/applications/application/application.module.js
+++ b/components/cloud-foundry/src/view/applications/application/application.module.js
@@ -423,7 +423,8 @@
       } else {
         var hideAction = true;
         if (id === 'launch') {
-          hideAction = false;
+          // isActionHidden is called on update. Ensure we check routes are ok here as well as in onAppRoutesChange
+          hideAction = !_.get(this.model.application.summary.routes, 'length');
         } else {
           // Check permissions
           if (id === 'delete' ? _.get(this.model.application.pipeline, 'forbidden') : false) {


### PR DESCRIPTION
This looks like a very old regression. See current node-env app for app that is running and has no routes.