### PR TITLE
Fix issue where app wall filters were only semi cleared after being reset

### DIFF
--- a/components/cloud-foundry/src/view/applications/list/list.module.js
+++ b/components/cloud-foundry/src/view/applications/list/list.module.js
@@ -253,6 +253,9 @@
             }
           });
       } else {
+        // Ensure any previous values are wiped
+        that.model.filterParams.orgGuid = 'all';
+        that.filter.orgGuid = that.model.filterParams.orgGuid;
         return this.$q.resolve();
       }
     },
@@ -290,6 +293,9 @@
             }
           });
       } else {
+        // Ensure any previous values are wiped
+        that.model.filterParams.spaceGuid = 'all';
+        that.filter.spaceGuid = that.model.filterParams.spaceGuid;
         return this.$q.resolve();
       }
     },

--- a/components/cloud-foundry/test/unit/view/applications/list/list.module.spec.js
+++ b/components/cloud-foundry/test/unit/view/applications/list/list.module.spec.js
@@ -438,7 +438,8 @@
           appModel.filterParams.spaceGuid = 'junk3';
 
           setUp();
-          $httpBackend.flush();
+          // Kick of a digest, we only make a call when we have a valid org
+          $scope.$digest();
 
           check(allFilterValue, 3, allFilterValue, 1, allFilterValue, 1);
         });
@@ -448,6 +449,7 @@
           appModel.filterParams.cnsiGuid = 'junk1';
 
           setUp();
+          // Kick of a digest, we only make a call when we have a valid org
           $scope.$digest();
 
           check(allFilterValue, 3, allFilterValue, 1, allFilterValue, 1);
@@ -459,6 +461,7 @@
           appModel.filterParams.orgGuid = 'junk2';
 
           setUp();
+          // Kick of a digest, we only make a call when we have a valid org
           $scope.$digest();
 
           check(cnsiGuid, 3, allFilterValue, 3, allFilterValue, 1);


### PR DESCRIPTION
Bug was...
- 1 cf, in app wall select cluster, org and space
- Add a second cf and return to app wall
- Filters all showed as being reset while under the hood old filter was
still being applied.