### PR TITLE
Fix local auth session timeout

### DIFF
--- a/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.ts
+++ b/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.ts
@@ -19,21 +19,22 @@ export class LogOutDialogComponent implements OnInit, OnDestroy {
     private store: Store<GeneralEntityAppState>) { }
 
   private autoLogout: Subscription;
-  public countDown: number;
-  public countdownTotal: number;
+  private countDown: number;
+  private countdownTotal: number;
   public percentage = 0;
 
   ngOnInit() {
     const updateInterval = 500;
-    this.countdownTotal = this.countDown = this.data.expiryDate - Date.now();
+    this.countdownTotal = this.calcCountdown();
     this.autoLogout = interval(updateInterval)
       .pipe(
         tap(() => {
+          // Recalculate this every time, as `interval` slows down when tab not focused
+          this.countDown = this.calcCountdown();
           if (this.countDown <= 0) {
             this.autoLogout.unsubscribe();
             this.store.dispatch(new Logout());
           } else {
-            this.countDown -= updateInterval;
             this.percentage = ((this.countdownTotal - this.countDown) / this.countdownTotal) * 100;
           }
         })
@@ -43,5 +44,9 @@ export class LogOutDialogComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.percentage = 0;
     this.autoLogout.unsubscribe();
+  }
+
+  private calcCountdown(): number {
+    return this.data.expiryDate - Date.now();
   }
 }

--- a/src/frontend/packages/core/src/core/page-visible.ts
+++ b/src/frontend/packages/core/src/core/page-visible.ts
@@ -17,6 +17,7 @@ class VisibilityStatusConstant {
 export class PageVisible {
   private hidden: string;
   private visibilityState: string;
+  // private visibilityChanged: string;
 
   constructor(@Inject(DOCUMENT) private document: Document) {
     this.defineBrowserSupport();
@@ -30,6 +31,20 @@ export class PageVisible {
     return VisibilityStatusConstant.HIDDEN === this.getVisibilityState() || this.isHidden();
   }
 
+  // nowVisible(): Observable<any> {
+  //   return this.getVisibility().pipe(
+  //     startWith(false),
+  //     pairwise(),
+  //     filter(([oldV, newV]) => oldV === false && newV === true)
+  //   );
+  // }
+
+  // getVisibility(): Observable<boolean> {
+  //   return fromEvent(document, this.visibilityChanged).pipe(
+  //     map(() => this.isPageVisible())
+  //   );
+  // }
+
   private isHidden(): boolean {
     return document[this.hidden];
   }
@@ -42,12 +57,15 @@ export class PageVisible {
     if (typeof document[HiddenKeyConstant.DEFAULT] !== 'undefined') { // Opera 12.10 and Firefox 18 and later support
       this.hidden = HiddenKeyConstant.DEFAULT;
       this.visibilityState = 'visibilityState';
+      // this.visibilityChanged = 'visibilitychange';
     } else if (typeof document[HiddenKeyConstant.MS] !== 'undefined') {
       this.hidden = HiddenKeyConstant.MS;
       this.visibilityState = 'msVisibilityState';
+      // this.visibilityChanged = 'msvisibilitychange';
     } else if (typeof document[HiddenKeyConstant.WEB_KIT] !== 'undefined') {
       this.hidden = HiddenKeyConstant.WEB_KIT;
       this.visibilityState = 'webkitVisibilityState';
+      // this.visibilityChanged = 'webkitvisibilitychange';
     }
   }
 }

--- a/src/frontend/packages/core/src/logged-in.service.ts
+++ b/src/frontend/packages/core/src/logged-in.service.ts
@@ -95,7 +95,7 @@ export class LoggedInService {
             this.store.select(selectDashboardState),
             this.store.select(s => s.auth)
           ),
-          tap(([i, dashboardState, authState]) => {
+          tap(([, dashboardState, authState]) => {
             this.ngZone.run(() => {
               this._checkSession(dashboardState, authState);
             });

--- a/src/frontend/packages/store/src/effects/auth.effects.ts
+++ b/src/frontend/packages/store/src/effects/auth.effects.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
@@ -28,9 +28,9 @@ import {
 import { HydrateDashboardStateAction } from '../actions/dashboard-actions';
 import { GET_ENDPOINTS_SUCCESS, GetAllEndpointsSuccess } from '../actions/endpoint.actions';
 import { GetSystemInfo } from '../actions/system.actions';
+import { DispatchOnlyAppState } from '../app-state';
 import { getDashboardStateSessionId } from '../helpers/store-helpers';
 import { SessionData } from '../types/auth.types';
-import { DispatchOnlyAppState } from '../app-state';
 
 const SETUP_HEADER = 'stratos-setup-required';
 const UPGRADE_HEADER = 'retry-after';
@@ -50,8 +50,6 @@ export class AuthEffect {
   @Effect() loginRequest$ = this.actions$.pipe(
     ofType<Login>(LOGIN),
     switchMap(({ username, password }) => {
-      const encoder = new BrowserStandardEncoder();
-      const headers = new HttpHeaders();
       const params = new HttpParams({
         encoder: new BrowserStandardEncoder(),
         fromObject: {
@@ -59,9 +57,10 @@ export class AuthEffect {
           password
         }
       });
+      const headers = {
+        'x-cap-request-date': (Math.floor(Date.now() / 1000)).toString()
+      };
 
-      headers.set('Content-Type', 'application/x-www-form-urlencoded');
-      headers.set('x-cap-request-date', (Math.floor(Date.now() / 1000)).toString());
       return this.http.post('/pp/v1/auth/login/uaa', params, {
         headers,
       }).pipe(
@@ -72,8 +71,10 @@ export class AuthEffect {
   @Effect() verifyAuth$ = this.actions$.pipe(
     ofType<VerifySession>(VERIFY_SESSION),
     switchMap(action => {
-      const headers = new HttpHeaders();
-      headers.set('x-cap-request-date', (Math.floor(Date.now() / 1000)).toString());
+      const headers = {
+        'x-cap-request-date': (Math.floor(Date.now() / 1000)).toString()
+      };
+
       return this.http.get<SessionData>('/pp/v1/auth/session/verify', {
         headers,
         observe: 'response',

--- a/src/frontend/packages/store/src/effects/endpoint.effects.ts
+++ b/src/frontend/packages/store/src/effects/endpoint.effects.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
@@ -274,11 +274,8 @@ export class EndpointsEffect {
     errorMessageHandler?: (e: any) => string,
   ) {
     const endpointEntityKey = entityCatalogue.getEntityKey(apiAction);
-    const headers = new HttpHeaders();
-    headers.set('Content-Type', 'application/x-www-form-urlencoded');
     this.store.dispatch(new StartRequestAction(apiAction, apiActionType));
     return this.http.post(url, body || {}, {
-      headers,
       params
     }).pipe(
       mergeMap((endpoint: EndpointModel) => {

--- a/src/jetstream/authuaa.go
+++ b/src/jetstream/authuaa.go
@@ -151,11 +151,6 @@ func (a *uaaAuth) VerifySession(c echo.Context, sessionUser string, sessionExpir
 		if err = a.p.setSessionValues(c, sessionValues); err != nil {
 			return err
 		}
-	} else {
-		// Still need to extend the expires_on of the Session
-		if err = a.p.setSessionValues(c, nil); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/src/jetstream/session.go
+++ b/src/jetstream/session.go
@@ -16,7 +16,6 @@ import (
 
 const (
 
-
 	// XSRFTokenHeader - XSRF Token Header name
 	XSRFTokenHeader = "X-Xsrf-Token"
 	// XSRFTokenSessionName - XSRF Token Session name
@@ -32,12 +31,7 @@ const (
 	jetstreamSessionName              = "console-session"
 	jetStreamSessionContextKey        = "jetstream-session"
 	jetStreamSessionContextUpdatedKey = "jetstream-session-updated"
-
 )
-
-
-
-
 
 // SessionValueNotFound - Error returned when a requested key was not found in the session
 type SessionValueNotFound struct {
@@ -254,6 +248,11 @@ func (p *portalProxy) verifySession(c echo.Context) error {
 
 	} else {
 
+		// Still need to extend the expires_on of the Session (set session will save session, in save we update `expires_on`)
+		if err = p.setSessionValues(c, nil); err != nil {
+			return err
+		}
+
 		err = p.handleSessionExpiryHeader(c)
 		if err != nil {
 			return err
@@ -272,6 +271,6 @@ func (p *portalProxy) verifySession(c echo.Context) error {
 			return err
 		}
 	}
-	
+
 	return err
 }


### PR DESCRIPTION
- With local auth enabled, in some cases, the automatic timeout would cause the client to spam the verify request
- This was caused by the verify request not updating the session expired date
- Also fixed ang8 upgrade issue where header information was not sent... such as `x-cap-request-date` (I don't _think_ this was needed for the fix though)
- blocked on https://github.com/cloudfoundry/stratos/pull/4026