### PR TITLE
Add support for stratos buildpack verbose logging

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,8 @@ applications:
 #       CF_API_FORCE_SECURE: true
 # Turn on backend debugging
 #       LOG_LEVEL: debug
+# Turn on staging debugging in stratos-buildpack
+# STRATOS_BP_DEBUG: true #Remove line to turn off debugging
 
 # User provided services can also be used to set environment properties:
 #   env:


### PR DESCRIPTION
## Description

Add support for stratos buildpack verbose logging in manifest to troubleshoot failed staging (e.g. network proxy errors)

Depends on https://github.com/cloudfoundry/stratos-buildpack/pull/4

## Motivation and Context

Missing traces during staging

```
   Stratos Buildpack
	
   -----> Stack cflinuxfs3
   -----> Download go 1.12.4
   Failed to compile droplet: Failed to compile droplet: exit status 56
   Exit status 223
```

with traces 

```
   ++ echo '-----> Download go 1.12.4'
   ++ curl -s -L --retry 15 --retry-delay 2 https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz -o /tmp/cache/final/Downloads/go1.12.4.tar.gz
   Failed to compile droplet: Failed to compile droplet: exit status 56
```


## How Has This Been Tested?

Manually tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [x] New feature (non-breaking change which adds functionality during CF-based deployment)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message