### PR TITLE
Fix local de-pagination

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/actions/app-metadata.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/app-metadata.actions.ts
@@ -1,15 +1,11 @@
+import { HttpRequest } from '@angular/common/http';
+
 import { PaginatedAction } from '../../../store/src/types/pagination.types';
 import { ICFAction, RequestEntityLocation } from '../../../store/src/types/request.types';
 import { cfEntityFactory } from '../cf-entity-factory';
-import {
-  appEnvVarsEntityType,
-  applicationEntityType,
-  appStatsEntityType,
-  appSummaryEntityType,
-} from '../cf-entity-types';
+import { appEnvVarsEntityType, applicationEntityType, appStatsEntityType, appSummaryEntityType } from '../cf-entity-types';
 import { createEntityRelationPaginationKey } from '../entity-relations/entity-relations.types';
 import { CFStartAction } from './cf-action.types';
-import { HttpRequest } from '@angular/common/http';
 
 export enum AppMetadataTypes {
   STATS,
@@ -67,7 +63,7 @@ export class GetAppEnvVarsAction extends CFStartAction implements PaginatedActio
     '[App Metadata] EnvVars success',
     '[App Metadata] EnvVars failed',
   ];
-  flattenPagination: false;
+  flattenPagination = false;
   initialParams = {
     'order-direction': 'desc',
     'order-direction-field': 'name',

--- a/src/frontend/packages/core/src/shared/components/list/list.component.html
+++ b/src/frontend/packages/core/src/shared/components/list/list.component.html
@@ -196,8 +196,8 @@
     <ng-template #defaultNoEntriesMaxedResults>
       <mat-card class="list-component__default-no-entries">
         <mat-card-content>
-          <div class="no-rows">{{config.text?.maxedResults || 'There are too many results. Please use the filters to
-            reduce the number of results.'}}</div>
+          <div class="no-rows">{{config.text?.maxedResults || 'There are too many results. If available please use the
+            filters to reduce the number of results.'}}</div>
         </mat-card-content>
       </mat-card>
     </ng-template>

--- a/src/frontend/packages/store/src/entity-request-pipeline/pagination-request-base-handlers/pagination-iterator.pipe.ts
+++ b/src/frontend/packages/store/src/entity-request-pipeline/pagination-request-base-handlers/pagination-iterator.pipe.ts
@@ -2,8 +2,8 @@ import { HttpRequest } from '@angular/common/http';
 import { combineLatest, Observable, of, range } from 'rxjs';
 import { map, mergeMap, reduce } from 'rxjs/operators';
 
-import { entityCatalog } from '../../entity-catalog/entity-catalog.service';
 import { UpdatePaginationMaxedState } from '../../actions/pagination.actions';
+import { entityCatalog } from '../../entity-catalog/entity-catalog.service';
 import { PaginatedAction } from '../../types/pagination.types';
 import {
   ActionDispatcher,
@@ -116,7 +116,7 @@ export class PaginationPageIterator<R = any, E = any> {
           this.getValidNumber(totalPages),
           this.getValidNumber(totalResults)
         ).pipe(
-          map(([initialRequestResponse]) => [initialRequestResponse]),
+          map(([initialRequestResponse, othersResponse]) => [initialRequestResponse, ...othersResponse]),
           map(responsePages => this.reducePages(responsePages)),
         );
       })


### PR DESCRIPTION
- Local lists were failing to show all results after the first page
- We were correctly going out and fetching additional pages
- However results of later pages were being ignored
- Bug came in via https://github.com/cloudfoundry/stratos/commit/9408c87857fe211a3ab31d6c91990ebe2783e5b1
- Test by reducing actions `results-per-page` value to small number
- Have tested effect on page size & maxed lists
- Raised by Hillary Jeffrey in Slack
