### PR TITLE
Fix display of Space Roles in Org User list and other associated fixes

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
@@ -10,16 +10,16 @@ import { createEntityRelationPaginationKey } from '../../../../cloud-foundry/src
 import { ApplicationMonitorService } from '../../../../cloud-foundry/src/features/applications/application-monitor.service';
 import { ApplicationService } from '../../../../cloud-foundry/src/features/applications/application.service';
 import { getGuids } from '../../../../cloud-foundry/src/features/applications/application/application-base.component';
-import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
-import { EntityService } from '../../../../store/src/entity-service';
-import { EntityServiceFactory } from '../../../../store/src/entity-service-factory.service';
 import { StratosTab, StratosTabType } from '../../../../core/src/core/extension/extension-service';
 import { safeUnsubscribe } from '../../../../core/src/core/utils.service';
 import { ConfirmationDialogConfig } from '../../../../core/src/shared/components/confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../../core/src/shared/components/confirmation-dialog.service';
-import { PaginationMonitorFactory } from '../../../../store/src/monitors/pagination-monitor.factory';
 import { RouterNav } from '../../../../store/src/actions/router.actions';
 import { AppState } from '../../../../store/src/app-state';
+import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
+import { EntityService } from '../../../../store/src/entity-service';
+import { EntityServiceFactory } from '../../../../store/src/entity-service-factory.service';
+import { PaginationMonitorFactory } from '../../../../store/src/monitors/pagination-monitor.factory';
 import { ActionState } from '../../../../store/src/reducers/api-request-reducer/types';
 import { getPaginationObservables } from '../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { selectDeletionInfo } from '../../../../store/src/selectors/api.selectors';
@@ -195,7 +195,8 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
       action,
       paginationMonitor: this.paginationMonitorFactory.create(
         action.paginationKey,
-        autoscalerEntityFactory(appAutoscalerAppMetricEntityType)
+        autoscalerEntityFactory(appAutoscalerAppMetricEntityType),
+        false
       )
     }, false).entities$;
   }

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.ts
@@ -5,8 +5,8 @@ import { filter } from 'rxjs/operators';
 
 import { ApplicationService } from '../../../../../../cloud-foundry/src/features/applications/application.service';
 import { CardCell, IListRowCell } from '../../../../../../core/src/shared/components/list/list.types';
-import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { AppState } from '../../../../../../store/src/app-state';
+import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../../store/src/types/api.types';
 import { AutoscalerConstants, buildLegendData } from '../../../../core/autoscaler-helpers/autoscaler-util';
@@ -111,7 +111,8 @@ export class AppAutoscalerMetricChartCardComponent extends CardCell<APIResource<
       action,
       paginationMonitor: this.paginationMonitorFactory.create(
         action.paginationKey,
-        autoscalerEntityFactory(appAutoscalerAppMetricEntityType)
+        autoscalerEntityFactory(appAutoscalerAppMetricEntityType),
+        false
       )
     }, false).entities$.pipe(
       filter(entities => !!entities)

--- a/src/frontend/packages/cloud-foundry/src/cf-entity-schema-types.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-entity-schema-types.ts
@@ -1,7 +1,6 @@
 import { Schema, schema } from 'normalizr';
 
 import { EntitySchema } from '../../store/src/helpers/entity-schema';
-import { CF_ENDPOINT_TYPE } from './cf-types';
 import {
   applicationEntityType,
   cfUserEntityType,
@@ -17,6 +16,7 @@ import {
   spaceEntityType,
   stackEntityType,
 } from './cf-entity-types';
+import { CF_ENDPOINT_TYPE } from './cf-types';
 import { getAPIResourceGuid } from './store/selectors/api.selectors';
 
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.ts
@@ -4,7 +4,6 @@ import { Store } from '@ngrx/store';
 import { combineLatest, Observable, ReplaySubject } from 'rxjs';
 import { filter, first, map, pairwise, shareReplay, startWith, switchMap, tap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../cf-types';
 import { DeleteUserProvidedInstance } from '../../../../../cloud-foundry/src/actions/user-provided-service.actions';
 import {
   applicationEntityType,
@@ -14,7 +13,6 @@ import {
 } from '../../../../../cloud-foundry/src/cf-entity-types';
 import { IServiceBinding } from '../../../../../core/src/core/cf-api-svc.types';
 import { IApp, IRoute } from '../../../../../core/src/core/cf-api.types';
-import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
 import {
   AppMonitorComponentTypes,
 } from '../../../../../core/src/shared/components/app-action-monitor-icon/app-action-monitor-icon.component';
@@ -22,14 +20,16 @@ import {
   DataFunctionDefinition,
 } from '../../../../../core/src/shared/components/list/data-sources-controllers/list-data-source';
 import { ITableColumn } from '../../../../../core/src/shared/components/list/list-table/table.types';
+import { RouterNav } from '../../../../../store/src/actions/router.actions';
+import { GeneralEntityAppState } from '../../../../../store/src/app-state';
+import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
 import { EntityMonitor } from '../../../../../store/src/monitors/entity-monitor';
 import { EntityMonitorFactory } from '../../../../../store/src/monitors/entity-monitor.factory.service';
 import { PaginationMonitor } from '../../../../../store/src/monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
-import { RouterNav } from '../../../../../store/src/actions/router.actions';
-import { GeneralEntityAppState } from '../../../../../store/src/app-state';
 import { APIResource } from '../../../../../store/src/types/api.types';
 import { PaginatedAction } from '../../../../../store/src/types/pagination.types';
+import { CF_ENDPOINT_TYPE } from '../../../cf-types';
 import {
   CfAppRoutesListConfigService,
 } from '../../../shared/components/list/list-types/app-route/cf-app-routes-list-config.service';
@@ -249,9 +249,14 @@ export class ApplicationDeleteComponent<T> {
 
     const instanceMonitor = this.paginationMonitorFactory.create<APIResource<IServiceBinding>>(
       instancePaginationKey,
-      instanceAction.entity[0]
+      instanceAction.entity[0],
+      instanceAction.flattenPagination
     );
-    const routeMonitor = this.paginationMonitorFactory.create<APIResource<IRoute>>(routesPaginationKey, routesAction.entity[0]);
+    const routeMonitor = this.paginationMonitorFactory.create<APIResource<IRoute>>(
+      routesPaginationKey,
+      routesAction.entity[0],
+      routesAction.flattenPagination
+    );
     return {
       fetch: () => {
         this.store.dispatch(instanceAction);

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/delete-app-instances/app-delete-instances-routes-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/delete-app-instances/app-delete-instances-routes-list-config.service.ts
@@ -4,7 +4,6 @@ import { Store } from '@ngrx/store';
 import { Observable, of as observableOf } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { FetchAllServiceBindings } from '../../../../../../cloud-foundry/src/actions/service-bindings.actions';
 import { CFAppState } from '../../../../../../cloud-foundry/src/cf-app-state';
 import { serviceBindingEntityType, serviceEntityType } from '../../../../../../cloud-foundry/src/cf-entity-types';
@@ -13,17 +12,18 @@ import {
 } from '../../../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import { IServiceBinding } from '../../../../../../core/src/core/cf-api-svc.types';
 import { CurrentUserPermissionsService } from '../../../../../../core/src/core/current-user-permissions.service';
-import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { RowState } from '../../../../../../core/src/shared/components/list/data-sources-controllers/list-data-source-types';
 import { ListViewTypes } from '../../../../../../core/src/shared/components/list/list.component.types';
+import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
-import { QParam } from '../../../../shared/q-param';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../../store/src/types/api.types';
+import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import {
   AppServiceBindingListConfigService,
 } from '../../../../shared/components/list/list-types/app-sevice-bindings/app-service-binding-list-config.service';
 import { ServiceActionHelperService } from '../../../../shared/data-services/service-action-helper.service';
+import { QParam } from '../../../../shared/q-param';
 import { ApplicationService } from '../../application.service';
 
 @Injectable()
@@ -81,7 +81,8 @@ export class AppDeleteServiceInstancesListConfigService extends AppServiceBindin
           action,
           paginationMonitor: this.paginationMonitorFactory.create(
             action.paginationKey,
-            catalogEntity.getSchema()
+            catalogEntity.getSchema(),
+            false
           )
         });
         this.obsCache[serviceBinding.entity.service_instance_guid] = pagObs.pagination$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
@@ -3,7 +3,6 @@ import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { combineLatest, filter, first, map, publishReplay, refCount, startWith, switchMap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE, CFEntityConfig } from '../../cf-types';
 import { AppMetadataTypes } from '../../../../cloud-foundry/src/actions/app-metadata.actions';
 import {
   GetApplication,
@@ -26,14 +25,14 @@ import {
   stackEntityType,
 } from '../../../../cloud-foundry/src/cf-entity-types';
 import { IApp, IAppSummary, IDomain, IOrganization, ISpace } from '../../../../core/src/core/cf-api.types';
-import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
-import { EntityService } from '../../../../store/src/entity-service';
-import { EntityServiceFactory } from '../../../../store/src/entity-service-factory.service';
 import {
   ApplicationStateData,
   ApplicationStateService,
 } from '../../../../core/src/shared/components/application-state/application-state.service';
 import { APP_GUID, CF_GUID } from '../../../../core/src/shared/entity.tokens';
+import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
+import { EntityService } from '../../../../store/src/entity-service';
+import { EntityServiceFactory } from '../../../../store/src/entity-service-factory.service';
 import { EntityMonitorFactory } from '../../../../store/src/monitors/entity-monitor.factory.service';
 import { PaginationMonitor } from '../../../../store/src/monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../../../store/src/monitors/pagination-monitor.factory';
@@ -48,6 +47,7 @@ import { endpointEntitiesSelector } from '../../../../store/src/selectors/endpoi
 import { APIResource, EntityInfo } from '../../../../store/src/types/api.types';
 import { PaginatedAction, PaginationEntityState } from '../../../../store/src/types/pagination.types';
 import { cfEntityFactory } from '../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE, CFEntityConfig } from '../../cf-types';
 import { createEntityRelationKey } from '../../entity-relations/entity-relations.types';
 import { AppStat } from '../../store/types/app-metadata.types';
 import {
@@ -153,7 +153,8 @@ export class ApplicationService {
     const paginationMonitor = new PaginationMonitor(
       store,
       dummyAction.paginationKey,
-      dummyAction
+      dummyAction,
+      dummyAction.flattenPagination
     );
     return paginationMonitor.currentPage$.pipe(
       map(appInstancesPages => {
@@ -228,7 +229,8 @@ export class ApplicationService {
       action,
       paginationMonitor: this.paginationMonitorFactory.create(
         action.paginationKey,
-        new CFEntityConfig(appStatsEntityType)
+        new CFEntityConfig(appStatsEntityType),
+        action.flattenPagination
       )
     }, true);
     // This will fail to fetch the app stats if the current app is not running but we're
@@ -272,7 +274,8 @@ export class ApplicationService {
         const domainsAction = new GetAllOrganizationDomains(org.metadata.guid, this.cfGuid);
         const paginationMonitor = this.paginationMonitorFactory.create(
           domainsAction.paginationKey,
-          domainsAction
+          domainsAction,
+          domainsAction.flattenPagination
         );
         return getPaginationObservables<APIResource<IDomain>>(
           {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
-import { CF_ENDPOINT_TYPE } from '../../../../../../cf-types';
 import { CFAppState } from '../../../../../../../../cloud-foundry/src/cf-app-state';
 import { appEnvVarsEntityType } from '../../../../../../../../cloud-foundry/src/cf-entity-types';
 import { OverrideAppDetails } from '../../../../../../../../cloud-foundry/src/store/types/deploy-application.types';
@@ -13,6 +12,7 @@ import {
 } from '../../../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../../../../store/src/types/api.types';
 import { PaginatedAction } from '../../../../../../../../store/src/types/pagination.types';
+import { CF_ENDPOINT_TYPE } from '../../../../../../cf-types';
 
 
 export interface EnvVarStratosProject {
@@ -49,7 +49,8 @@ export class ApplicationEnvVarsHelper {
       action,
       paginationMonitor: this.paginationMonitorFactory.create(
         action.paginationKey,
-        catalogEntity.getSchema()
+        catalogEntity.getSchema(),
+        action.flattenPagination
       )
     }, true);
   }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.ts
@@ -6,7 +6,6 @@ import { Store } from '@ngrx/store';
 import { combineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
 import { filter, first, map, share, startWith, switchMap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { SaveAppOverrides } from '../../../../../../cloud-foundry/src/actions/deploy-applications.actions';
 import { GetAllOrganizationDomains } from '../../../../../../cloud-foundry/src/actions/organization.actions';
 import { CFAppState } from '../../../../../../cloud-foundry/src/cf-app-state';
@@ -18,11 +17,12 @@ import {
 } from '../../../../../../cloud-foundry/src/store/selectors/deploy-application.selector';
 import { OverrideAppDetails, SourceType } from '../../../../../../cloud-foundry/src/store/types/deploy-application.types';
 import { IDomain } from '../../../../../../core/src/core/cf-api.types';
-import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
+import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../../store/src/types/api.types';
+import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import {
   ApplicationEnvVarsHelper,
 } from '../../application/application-tabs-base/tabs/build-tab/application-env-vars.service';
@@ -138,7 +138,8 @@ export class DeployApplicationOptionsStepComponent implements OnInit, OnDestroy 
             action,
             paginationMonitor: this.paginationMonitorFactory.create(
               action.paginationKey,
-              action
+              action,
+              action.flattenPagination
             )
           },
           true
@@ -161,6 +162,7 @@ export class DeployApplicationOptionsStepComponent implements OnInit, OnDestroy 
             paginationMonitor: this.paginationMonitorFactory.create(
               action.paginationKey,
               action,
+              action.flattenPagination
             )
           },
           true

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -27,7 +27,6 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE, CFEntityConfig } from '../../../../cf-types';
 import {
   FetchBranchesForProject,
   FetchCommit,
@@ -53,14 +52,15 @@ import {
 } from '../../../../../../cloud-foundry/src/store/types/deploy-application.types';
 import { GitCommit, GitRepo } from '../../../../../../cloud-foundry/src/store/types/git.types';
 import { GitBranch } from '../../../../../../cloud-foundry/src/store/types/github.types';
-import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
-import { EntityServiceFactory } from '../../../../../../store/src/entity-service-factory.service';
 import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
 import { GitSCM } from '../../../../../../core/src/shared/data-services/scm/scm';
 import { GitSCMService, GitSCMType } from '../../../../../../core/src/shared/data-services/scm/scm.service';
+import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
+import { EntityServiceFactory } from '../../../../../../store/src/entity-service-factory.service';
 import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { EntityInfo } from '../../../../../../store/src/types/api.types';
+import { CF_ENDPOINT_TYPE, CFEntityConfig } from '../../../../cf-types';
 import { ApplicationDeploySourceTypes, DEPLOY_TYPES_IDS } from '../deploy-application-steps.types';
 
 @Component({
@@ -265,7 +265,8 @@ export class DeployApplicationStep2Component
               action: fetchBranchesAction,
               paginationMonitor: this.paginationMonitorFactory.create(
                 fetchBranchesAction.paginationKey,
-                new CFEntityConfig(gitBranchesEntityType)
+                new CFEntityConfig(gitBranchesEntityType),
+                false
               )
             },
             true

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/add-edit-space-step-base.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/add-edit-space-step-base.ts
@@ -2,9 +2,8 @@ import { AbstractControl, ValidatorFn } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
-import { filter, map, tap } from 'rxjs/operators';
+import { filter, first, map, tap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE, CFEntityConfig } from '../../cf-types';
 import { CFAppState } from '../../../../cloud-foundry/src/cf-app-state';
 import {
   organizationEntityType,
@@ -13,15 +12,16 @@ import {
 } from '../../../../cloud-foundry/src/cf-entity-types';
 import { createEntityRelationPaginationKey } from '../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import { ISpaceQuotaDefinition } from '../../../../core/src/core/cf-api.types';
+import { StepOnNextResult } from '../../../../core/src/shared/components/stepper/step/step.component';
+import { getPaginationKey } from '../../../../store/src/actions/pagination.actions';
 import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
 import { IEntityMetadata } from '../../../../store/src/entity-catalog/entity-catalog.types';
-import { StepOnNextResult } from '../../../../core/src/shared/components/stepper/step/step.component';
 import { PaginationMonitorFactory } from '../../../../store/src/monitors/pagination-monitor.factory';
-import { getPaginationKey } from '../../../../store/src/actions/pagination.actions';
 import { getPaginationObservables } from '../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../store/src/types/api.types';
 import { PaginatedAction } from '../../../../store/src/types/pagination.types';
 import { cfEntityFactory } from '../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE, CFEntityConfig } from '../../cf-types';
 import { SpaceQuotaDefinitionActionBuilders } from '../../entity-action-builders/space-quota.action-builders';
 import { ActiveRouteCfOrgSpace } from './cf-page.types';
 
@@ -43,25 +43,26 @@ export class AddEditSpaceStepBase {
   ) {
     this.cfGuid = activeRouteCfOrgSpace.cfGuid;
     this.orgGuid = activeRouteCfOrgSpace.orgGuid;
-    const paginationKey = getPaginationKey('cf-space', this.orgGuid);
+    const paginationKey = getPaginationKey(organizationEntityType, this.orgGuid);
     const spaceEntity = entityCatalog.getEntity(CF_ENDPOINT_TYPE, spaceEntityType);
     const getAllSpaceActionBuilder = spaceEntity.actionOrchestrator.getActionBuilder('getAllInOrganization');
     const action = getAllSpaceActionBuilder(this.orgGuid, this.cfGuid, paginationKey) as PaginatedAction;
-
     this.allSpacesInOrg$ = getPaginationObservables<APIResource, CFAppState>(
       {
         store: this.store,
         action,
         paginationMonitor: this.paginationMonitorFactory.create(
           action.paginationKey,
-          new CFEntityConfig(spaceEntityType)
+          new CFEntityConfig(spaceEntityType),
+          action.flattenPagination
         )
       },
       true
     ).entities$.pipe(
-      filter(o => !!o),
-      map(o => o.map(org => org.entity.name)),
-      tap((o) => this.allSpacesInOrg = o)
+      filter(spaces => !!spaces),
+      map(spaces => spaces.map(space => space.entity.name)),
+      tap(spaceNames => this.allSpacesInOrg = spaceNames),
+      first(),
     );
     this.fetchSpacesSubscription = this.allSpacesInOrg$.subscribe();
 
@@ -79,12 +80,14 @@ export class AddEditSpaceStepBase {
         action: getAllInOrganization as PaginatedAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           quotaPaginationKey,
-          cfEntityFactory(spaceQuotaEntityType)
+          cfEntityFactory(spaceQuotaEntityType),
+          getAllInOrganization.flattenPagination
         )
       },
       true
     ).entities$.pipe(
       filter(o => !!o),
+      first()
     );
 
     this.hasSpaceQuotas$ = this.quotaDefinitions$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/add-organization/create-organization-step/create-organization-step.component.ts
@@ -5,7 +5,6 @@ import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { CreateOrganization } from '../../../../../../cloud-foundry/src/actions/organization.actions';
 import { CFAppState } from '../../../../../../cloud-foundry/src/cf-app-state';
 import { organizationEntityType, quotaDefinitionEntityType } from '../../../../../../cloud-foundry/src/cf-entity-types';
@@ -14,14 +13,15 @@ import {
 } from '../../../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import { selectCfRequestInfo } from '../../../../../../cloud-foundry/src/store/selectors/api.selectors';
 import { IOrganization, IOrgQuotaDefinition } from '../../../../../../core/src/core/cf-api.types';
+import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
 import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { IEntityMetadata } from '../../../../../../store/src/entity-catalog/entity-catalog.types';
-import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
-import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { endpointSchemaKey } from '../../../../../../store/src/helpers/entity-factory';
+import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../../store/src/types/api.types';
 import { cfEntityFactory } from '../../../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { QuotaDefinitionActionBuilder } from '../../../../entity-action-builders/quota-definition.action-builders';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 
@@ -66,7 +66,8 @@ export class CreateOrganizationStepComponent implements OnInit, OnDestroy {
         action,
         paginationMonitor: this.paginationMonitorFactory.create(
           action.paginationKey,
-          entityCatalog.getEntity(CF_ENDPOINT_TYPE, organizationEntityType).getSchema()
+          entityCatalog.getEntity(CF_ENDPOINT_TYPE, organizationEntityType).getSchema(),
+          action.flattenPagination
         )
       },
       true
@@ -89,7 +90,8 @@ export class CreateOrganizationStepComponent implements OnInit, OnDestroy {
         action: getQuotaDefinitionsAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           quotaPaginationKey,
-          cfEntityFactory(quotaDefinitionEntityType)
+          cfEntityFactory(quotaDefinitionEntityType),
+          action.flattenPagination
         )
       },
       true

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/add-space/create-space-step/create-space-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/add-space/create-space-step/create-space-step.component.ts
@@ -8,9 +8,9 @@ import { filter } from 'rxjs/operators';
 import { CFAppState } from '../../../../../../cloud-foundry/src/cf-app-state';
 import { spaceEntityType } from '../../../../../../cloud-foundry/src/cf-entity-types';
 import { selectCfRequestInfo } from '../../../../../../cloud-foundry/src/store/selectors/api.selectors';
+import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
 import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { IEntityMetadata } from '../../../../../../store/src/entity-catalog/entity-catalog.types';
-import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
 import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { SpaceActionBuilders } from '../../../../entity-action-builders/space.action-builders';
@@ -66,8 +66,9 @@ export class CreateSpaceStepComponent extends AddEditSpaceStepBase implements On
     }));
   }
 
-  validateNameTaken = (spaceName: string = null) =>
-    this.allSpacesInOrg ? this.allSpacesInOrg.indexOf(spaceName || this.spaceName.value) === -1 : true
+  validateNameTaken = (spaceName: string = null) => {
+    return this.allSpacesInOrg ? this.allSpacesInOrg.indexOf(spaceName || this.spaceName.value) === -1 : true;
+  }
 
   validate = () => !!this.createSpaceForm && this.createSpaceForm.valid;
 

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/cf.helpers.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/cf.helpers.ts
@@ -340,7 +340,8 @@ export function fetchTotalResults(
     action: newAction,
     paginationMonitor: paginationMonitorFactory.create(
       newAction.paginationKey,
-      cfEntityFactory(newAction.entityType)
+      cfEntityFactory(newAction.entityType),
+      newAction.flattenPagination
     )
   });
   // Ensure the request is made by sub'ing to the entities observable

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/edit-organization/edit-organization-step/edit-organization-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/edit-organization/edit-organization-step/edit-organization-step.component.ts
@@ -4,7 +4,6 @@ import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 import { filter, map, take, tap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { UpdateOrganization } from '../../../../../../cloud-foundry/src/actions/organization.actions';
 import { CFAppState } from '../../../../../../cloud-foundry/src/cf-app-state';
 import { organizationEntityType, quotaDefinitionEntityType } from '../../../../../../cloud-foundry/src/cf-entity-types';
@@ -12,16 +11,17 @@ import {
   createEntityRelationPaginationKey,
 } from '../../../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import { IOrganization, IOrgQuotaDefinition } from '../../../../../../core/src/core/cf-api.types';
-import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
-import { IEntityMetadata } from '../../../../../../store/src/entity-catalog/entity-catalog.types';
 import { safeUnsubscribe } from '../../../../../../core/src/core/utils.service';
 import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
-import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
+import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
+import { IEntityMetadata } from '../../../../../../store/src/entity-catalog/entity-catalog.types';
 import { endpointSchemaKey } from '../../../../../../store/src/helpers/entity-factory';
+import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { selectRequestInfo } from '../../../../../../store/src/selectors/api.selectors';
 import { APIResource } from '../../../../../../store/src/types/api.types';
 import { cfEntityFactory } from '../../../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { QuotaDefinitionActionBuilder } from '../../../../entity-action-builders/quota-definition.action-builders';
 import { getActiveRouteCfOrgSpaceProvider } from '../../cf.helpers';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
@@ -102,7 +102,8 @@ export class EditOrganizationStepComponent implements OnInit, OnDestroy {
         action,
         paginationMonitor: this.paginationMonitorFactory.create(
           action.paginationKey,
-          cfEntityFactory(organizationEntityType)
+          cfEntityFactory(organizationEntityType),
+          action.flattenPagination
         )
       },
       true
@@ -126,7 +127,8 @@ export class EditOrganizationStepComponent implements OnInit, OnDestroy {
         action: getQuotaDefinitionsAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           quotaPaginationKey,
-          cfEntityFactory(quotaDefinitionEntityType)
+          cfEntityFactory(quotaDefinitionEntityType),
+          action.flattenPagination
         )
       },
       true

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/services/cloud-foundry-endpoint.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/services/cloud-foundry-endpoint.service.ts
@@ -22,15 +22,14 @@ import {
 import { CfApplicationState } from '../../../../../cloud-foundry/src/store/types/application.types';
 import { IApp, ICfV2Info, IOrganization, ISpace } from '../../../../../core/src/core/cf-api.types';
 import { EndpointsService } from '../../../../../core/src/core/endpoints.service';
-import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
-import { EntityService } from '../../../../../store/src/entity-service';
-import { EntityServiceFactory } from '../../../../../store/src/entity-service-factory.service';
-import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 import { MetricQueryType } from '../../../../../core/src/shared/services/metrics-range-selector.types';
 import { GetAllEndpoints } from '../../../../../store/src/actions/endpoint.actions';
 import { MetricQueryConfig } from '../../../../../store/src/actions/metrics.actions';
+import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
+import { EntityService } from '../../../../../store/src/entity-service';
+import { EntityServiceFactory } from '../../../../../store/src/entity-service-factory.service';
 import { endpointSchemaKey } from '../../../../../store/src/helpers/entity-factory';
-import { QParam, QParamJoiners } from '../../../shared/q-param';
+import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 import {
   getPaginationObservables,
   PaginationObservables,
@@ -39,11 +38,12 @@ import { APIResource, EntityInfo } from '../../../../../store/src/types/api.type
 import { IMetrics } from '../../../../../store/src/types/base-metric.types';
 import { EndpointModel, EndpointUser } from '../../../../../store/src/types/endpoint.types';
 import { PaginatedAction } from '../../../../../store/src/types/pagination.types';
-import { CF_ENDPOINT_TYPE } from '../../../cf-types';
 import { FetchCFCellMetricsPaginatedAction } from '../../../actions/cf-metrics.actions';
 import { cfEntityFactory } from '../../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE } from '../../../cf-types';
 import { CfInfoDefinitionActionBuilders } from '../../../entity-action-builders/cf-info.action-builders';
 import { CfUserService } from '../../../shared/data-services/cf-user.service';
+import { QParam, QParamJoiners } from '../../../shared/q-param';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { fetchTotalResults } from '../cf.helpers';
 
@@ -168,7 +168,8 @@ export class CloudFoundryEndpointService {
       action: this.getAllOrgsAction,
       paginationMonitor: this.pmf.create(
         this.getAllOrgsAction.paginationKey,
-        cfEntityFactory(organizationEntityType)
+        cfEntityFactory(organizationEntityType),
+        this.getAllOrgsAction.flattenPagination
       )
     }, true).entities$;
 
@@ -182,7 +183,11 @@ export class CloudFoundryEndpointService {
   }
 
   constructAppObs() {
-    const appPaginationMonitor = this.pmf.create(this.getAllAppsAction.paginationKey, this.getAllAppsAction);
+    const appPaginationMonitor = this.pmf.create(
+      this.getAllAppsAction.paginationKey,
+      this.getAllAppsAction,
+      this.getAllAppsAction.flattenPagination
+    );
     this.appsPagObs = getPaginationObservables<APIResource<IApp>>({
       store: this.store,
       action: this.getAllAppsAction,
@@ -243,7 +248,8 @@ export class CloudFoundryEndpointService {
         action,
         paginationMonitor: this.pmf.create(
           action.paginationKey,
-          cfEntityFactory(domainEntityType)
+          cfEntityFactory(domainEntityType),
+          action.flattenPagination
         )
       },
       true
@@ -278,7 +284,8 @@ export class CloudFoundryEndpointService {
           action,
           paginationMonitor: this.paginationMonitorFactory.create(
             action.paginationKey,
-            action
+            action,
+            false
           )
         }).entities$.pipe(
           filter(entities => !!entities && !!entities.length),

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/services/cloud-foundry-organization.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/services/cloud-foundry-organization.service.ts
@@ -24,19 +24,19 @@ import {
   ISpaceQuotaDefinition,
 } from '../../../../../core/src/core/cf-api.types';
 import { getEntityFlattenedList, getStartedAppInstanceCount } from '../../../../../core/src/core/cf.helpers';
-import { EntityServiceFactory } from '../../../../../store/src/entity-service-factory.service';
-import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 import {
   CloudFoundryUserProvidedServicesService,
 } from '../../../../../core/src/shared/services/cloud-foundry-user-provided-services.service';
+import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
+import { EntityServiceFactory } from '../../../../../store/src/entity-service-factory.service';
+import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 import { APIResource, EntityInfo } from '../../../../../store/src/types/api.types';
+import { CF_ENDPOINT_TYPE } from '../../../cf-types';
 import { createEntityRelationKey } from '../../../entity-relations/entity-relations.types';
 import { CfUserService } from '../../../shared/data-services/cf-user.service';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { getOrgRolesString } from '../cf.helpers';
 import { CloudFoundryEndpointService } from './cloud-foundry-endpoint.service';
-import { CF_ENDPOINT_TYPE } from '../../../cf-types';
-import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
 
 export const createOrgQuotaDefinition = (): IOrgQuotaDefinition => ({
   memory_limit: -1,
@@ -133,7 +133,7 @@ export class CloudFoundryOrganizationService {
         }
         const orgEntity = entityCatalog.getEntity(CF_ENDPOINT_TYPE, organizationEntityType);
         const getOrgActionBuilder = orgEntity.actionOrchestrator.getActionBuilder('get');
-        const getOrgAction = getOrgActionBuilder(this.orgGuid, this.cfGuid, relations);
+        const getOrgAction = getOrgActionBuilder(this.orgGuid, this.cfGuid, { includeRelations: relations });
         const orgEntityService = this.entityServiceFactory.create<APIResource<IOrganization>>(
           this.orgGuid,
           getOrgAction

--- a/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/users/manage-users/cf-roles.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cloud-foundry/users/manage-users/cf-roles.service.ts
@@ -20,9 +20,10 @@ import {
 import { IOrganization, ISpace } from '../../../../../../core/src/core/cf-api.types';
 import { CurrentUserPermissionsChecker } from '../../../../../../core/src/core/current-user-permissions.checker';
 import { CurrentUserPermissionsService } from '../../../../../../core/src/core/current-user-permissions.service';
+import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { EntityServiceFactory } from '../../../../../../store/src/entity-service-factory.service';
-import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { endpointSchemaKey } from '../../../../../../store/src/helpers/entity-factory';
+import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import {
   selectUsersRolesCf,
@@ -30,17 +31,16 @@ import {
   selectUsersRolesRoles,
 } from '../../../../../../store/src/selectors/users-roles.selector';
 import { APIResource, EntityInfo } from '../../../../../../store/src/types/api.types';
+import { UsersRolesSetChanges } from '../../../../actions/users-roles.actions';
 import { CFAppState } from '../../../../cf-app-state';
 import { cfEntityFactory } from '../../../../cf-entity-factory';
 import { organizationEntityType, spaceEntityType } from '../../../../cf-entity-types';
+import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
 import { CfUserService } from '../../../../shared/data-services/cf-user.service';
 import { createDefaultOrgRoles, createDefaultSpaceRoles } from '../../../../store/reducers/users-roles.reducer';
 import { CfUser, IUserPermissionInOrg, UserRoleInOrg, UserRoleInSpace } from '../../../../store/types/user.types';
 import { CfRoleChange, CfUserRolesSelected } from '../../../../store/types/users-roles.types';
 import { canUpdateOrgSpaceRoles } from '../../cf.helpers';
-import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
-import { CF_ENDPOINT_TYPE } from '../../../../cf-types';
-import { UsersRolesSetChanges } from '../../../../actions/users-roles.actions';
 
 @Injectable()
 export class CfRolesService {
@@ -267,7 +267,8 @@ export class CfRolesService {
         action: getAllOrganizationsAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
-          cfEntityFactory(organizationEntityType)
+          cfEntityFactory(organizationEntityType),
+          getAllOrganizationsAction.flattenPagination
         ),
       },
         true

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/services-helper.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/services-helper.ts
@@ -89,7 +89,7 @@ export const getServiceInstancesInCf = (cfGuid: string, store: Store<CFAppState>
   return getPaginationObservables<APIResource<IServiceInstance>>({
     store,
     action,
-    paginationMonitor: paginationMonitorFactory.create(paginationKey, action)
+    paginationMonitor: paginationMonitorFactory.create(paginationKey, action, action.flattenPagination)
   }, true).entities$;
 };
 
@@ -150,7 +150,11 @@ export const getServicePlans = (
         return getPaginationObservables<APIResource<IServicePlan>>({
           store,
           action: getServicePlansAction,
-          paginationMonitor: paginationMonitorFactory.create(getServicePlansAction.paginationKey, cfEntityFactory(servicePlanEntityType))
+          paginationMonitor: paginationMonitorFactory.create(
+            getServicePlansAction.paginationKey,
+            cfEntityFactory(servicePlanEntityType),
+            getServicePlansAction.flattenPagination
+          )
         }, true)
           .entities$.pipe(share(), first());
       }

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/services.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/services.service.ts
@@ -91,7 +91,8 @@ export class ServicesService {
         action: getServicePlanVisibilitiesAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
-          cfEntityFactory(servicePlanVisibilityEntityType)
+          cfEntityFactory(servicePlanVisibilityEntityType),
+          getServicePlanVisibilitiesAction.flattenPagination
         )
       },
       true
@@ -112,7 +113,8 @@ export class ServicesService {
         action: getServiceBrokersAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
-          cfEntityFactory(serviceBrokerEntityType)
+          cfEntityFactory(serviceBrokerEntityType),
+          getServiceBrokersAction.flattenPagination
         )
       },
       true

--- a/src/frontend/packages/cloud-foundry/src/features/services/services/services-wall.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services/services-wall.service.ts
@@ -11,8 +11,8 @@ import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagi
 import { getPaginationObservables } from '../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../store/src/types/api.types';
 import { PaginatedAction } from '../../../../../store/src/types/pagination.types';
-import { CF_ENDPOINT_TYPE } from '../../../cf-types';
 import { cfEntityFactory } from '../../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE } from '../../../cf-types';
 import { createEntityRelationPaginationKey } from '../../../entity-relations/entity-relations.types';
 
 @Injectable()
@@ -37,7 +37,8 @@ export class ServicesWallService {
         action: getServicesAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
-          cfEntityFactory(serviceEntityType)
+          cfEntityFactory(serviceEntityType),
+          getServicesAction.flattenPagination
         )
       },
       true
@@ -67,7 +68,8 @@ export class ServicesWallService {
         action: getAllServicesForSpaceAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
-          cfEntityFactory(serviceEntityType)
+          cfEntityFactory(serviceEntityType),
+          getAllServicesForSpaceAction.flattenPagination
         )
       },
       true

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -172,7 +172,8 @@ export class AddServiceInstanceComponent implements OnDestroy, AfterContentInit 
           action: getAllAppsInSpaceAction,
           paginationMonitor: this.paginationMonitorFactory.create(
             paginationKey,
-            cfEntityFactory(applicationEntityType)
+            cfEntityFactory(applicationEntityType),
+            getAllAppsInSpaceAction.flattenPagination
           )
         }, true).entities$;
       }),

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/create-service-instance-helper.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/create-service-instance-helper.service.ts
@@ -4,7 +4,10 @@ import { Observable } from 'rxjs';
 import { filter, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
 
 import { CFAppState } from '../../../../../cloud-foundry/src/cf-app-state';
-import { serviceInstancesEntityType, servicePlanVisibilityEntityType } from '../../../../../cloud-foundry/src/cf-entity-types';
+import {
+  serviceInstancesEntityType,
+  servicePlanVisibilityEntityType,
+} from '../../../../../cloud-foundry/src/cf-entity-types';
 import { createEntityRelationPaginationKey } from '../../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import {
   IService,
@@ -21,7 +24,12 @@ import { getPaginationObservables } from '../../../../../store/src/reducers/pagi
 import { APIResource } from '../../../../../store/src/types/api.types';
 import { cfEntityFactory } from '../../../cf-entity-factory';
 import { CF_ENDPOINT_TYPE } from '../../../cf-types';
-import { getCfService, getServiceBroker, getServiceName, getServicePlans } from '../../../features/service-catalog/services-helper';
+import {
+  getCfService,
+  getServiceBroker,
+  getServiceName,
+  getServicePlans,
+} from '../../../features/service-catalog/services-helper';
 import { QParam, QParamJoiners } from '../../q-param';
 
 export class CreateServiceInstanceHelper {
@@ -69,7 +77,8 @@ export class CreateServiceInstanceHelper {
         action: getServicePlanVisibilitiesAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           paginationKey,
-          cfEntityFactory(servicePlanVisibilityEntityType)
+          cfEntityFactory(servicePlanVisibilityEntityType),
+          getServicePlanVisibilitiesAction.flattenPagination
         )
       },
       true
@@ -196,7 +205,8 @@ export class CreateServiceInstanceHelper {
       action,
       paginationMonitor: this.paginationMonitorFactory.create(
         paginationKey,
-        cfEntityFactory(serviceInstancesEntityType)
+        cfEntityFactory(serviceInstancesEntityType),
+        action.flattenPagination
       )
     }, true)
       .entities$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/cf-routes-data-source-base.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/cf-routes-data-source-base.ts
@@ -2,11 +2,9 @@ import { Store } from '@ngrx/store';
 import { combineLatest, Observable, Subscription } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../../../cf-types';
 import { CFAppState } from '../../../../../../../cloud-foundry/src/cf-app-state';
 import { routeEntityType } from '../../../../../../../cloud-foundry/src/cf-entity-types';
 import { IRoute } from '../../../../../../../core/src/core/cf-api.types';
-import { entityCatalog } from '../../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { safeUnsubscribe } from '../../../../../../../core/src/core/utils.service';
 import {
   ListPaginationMultiFilterChange,
@@ -16,13 +14,15 @@ import {
   TableRowStateManager,
 } from '../../../../../../../core/src/shared/components/list/list-table/table-row/table-row-state-manager';
 import { IListConfig } from '../../../../../../../core/src/shared/components/list/list.component.types';
+import { entityCatalog } from '../../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { PaginationMonitor } from '../../../../../../../store/src/monitors/pagination-monitor';
-import { CFListDataSource } from '../../../../cf-list-data-source';
 import { APIResource } from '../../../../../../../store/src/types/api.types';
 import { PaginatedAction, PaginationParam } from '../../../../../../../store/src/types/pagination.types';
 import { cfEntityFactory } from '../../../../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE } from '../../../../../cf-types';
 import { getRoute, isTCPRoute } from '../../../../../features/applications/routes/routes.helper';
 import { cfOrgSpaceFilter, getRowMetadata } from '../../../../../features/cloud-foundry/cf.helpers';
+import { CFListDataSource } from '../../../../cf-list-data-source';
 import { createCfOrSpaceMultipleFilterFn } from '../../../../data-services/cf-org-space-service.service';
 
 export interface ListCfRoute extends IRoute {
@@ -57,7 +57,12 @@ export abstract class CfRoutesDataSourceBase extends CFListDataSource<APIResourc
     appGuid?: string,
     genericRouteState = true
   ) {
-    const { rowsState, sub } = CfRoutesDataSourceBase.createRowState(store, action.paginationKey, genericRouteState);
+    const { rowsState, sub } = CfRoutesDataSourceBase.createRowState(
+      store,
+      action.paginationKey,
+      genericRouteState,
+      action.flattenPagination
+    );
 
     super({
       store,
@@ -111,9 +116,13 @@ export abstract class CfRoutesDataSourceBase extends CFListDataSource<APIResourc
   /**
    * Create a row state manager that will set the route row state to busy/blocked/deleting etc
    */
-  private static createRowState(store, paginationKey, genericRouteState: boolean): { rowsState: Observable<RowsState>, sub: Subscription } {
+  private static createRowState(
+    store,
+    paginationKey,
+    genericRouteState: boolean,
+    isLocal: boolean): { rowsState: Observable<RowsState>, sub: Subscription } {
     if (genericRouteState) {
-      const { rowStateManager, sub } = CfRoutesDataSourceBase.getRowStateManager(store, paginationKey);
+      const { rowStateManager, sub } = CfRoutesDataSourceBase.getRowStateManager(store, paginationKey, isLocal);
       return {
         rowsState: rowStateManager.observable,
         sub
@@ -126,7 +135,7 @@ export abstract class CfRoutesDataSourceBase extends CFListDataSource<APIResourc
     }
   }
 
-  private static getRowStateManager(store: Store<CFAppState>, paginationKey: string): {
+  private static getRowStateManager(store: Store<CFAppState>, paginationKey: string, isLocal: boolean): {
     rowStateManager: TableRowStateManager,
     sub: Subscription
   } {
@@ -137,7 +146,8 @@ export abstract class CfRoutesDataSourceBase extends CFListDataSource<APIResourc
       {
         entityType: routeEntityType,
         endpointType: CF_ENDPOINT_TYPE
-      }
+      },
+      isLocal
     );
 
     const sub = this.setUpManager(

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-select-users/cf-select-users-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-select-users/cf-select-users-list-config.service.ts
@@ -17,10 +17,10 @@ import {
   ListRowSateHelper,
   ListRowStateSetUpManager,
 } from '../../../../../../../core/src/shared/components/list/list.helper';
+import { ListView } from '../../../../../../../store/src/actions/list.actions';
 import { EntityMonitorFactory } from '../../../../../../../store/src/monitors/entity-monitor.factory.service';
 import { PaginationMonitor } from '../../../../../../../store/src/monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../../../../../../store/src/monitors/pagination-monitor.factory';
-import { ListView } from '../../../../../../../store/src/actions/list.actions';
 import { APIResource } from '../../../../../../../store/src/types/api.types';
 import { PaginatedAction } from '../../../../../../../store/src/types/pagination.types';
 import { ActiveRouteCfOrgSpace } from '../../../../../features/cloud-foundry/cf-page.types';
@@ -108,7 +108,8 @@ export class CfSelectUsersListConfigService implements IListConfig<APIResource<C
       this.entityMonitorFactory,
       action.paginationKey,
       action,
-      this.cfUserRowStateSetUpManager.bind(this)
+      this.cfUserRowStateSetUpManager.bind(this),
+      action.flattenPagination
     );
     this.dataSource = new CfSelectUsersDataSourceService(this.cfGuid, this.store, action, this, rowStateManager, () => {
       sub.unsubscribe();

--- a/src/frontend/packages/cloud-foundry/src/shared/components/running-instances/running-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/running-instances/running-instances.component.ts
@@ -25,7 +25,8 @@ export class RunningInstancesComponent implements OnInit {
     const dummyAction = new GetAppStatsAction(this.appGuid, this.cfGuid);
     const paginationMonitor = this.paginationMonitorFactory.create<AppStat>(
       dummyAction.paginationKey,
-      dummyAction
+      dummyAction,
+      dummyAction.flattenPagination
     );
     this.runningInstances$ = paginationMonitor.currentPage$.pipe(
       map(appInstancesPages => {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/select-service/select-service.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/select-service/select-service.component.ts
@@ -57,7 +57,7 @@ export class SelectServiceComponent implements OnDestroy, AfterContentInit {
     this.isFetching$ = cfSpaceGuid$.pipe(
       switchMap(([cfGuid, spaceGuid]) => {
         const paginationKey = this.servicesWallService.getSpaceServicePagKey(cfGuid, spaceGuid);
-        const paginationMonitor = this.paginationMonitorFactory.create(paginationKey, schema);
+        const paginationMonitor = this.paginationMonitorFactory.create(paginationKey, schema, false);
         return paginationMonitor.fetchingCurrentPage$;
       }),
       tap(fetching => {

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.ts
@@ -18,7 +18,6 @@ import { CFAppState } from '../../../../cloud-foundry/src/cf-app-state';
 import { organizationEntityType, spaceEntityType } from '../../../../cloud-foundry/src/cf-entity-types';
 import { createEntityRelationKey } from '../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import { IOrganization, ISpace } from '../../../../core/src/core/cf-api.types';
-import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
 import { safeUnsubscribe } from '../../../../core/src/core/utils.service';
 import {
   ListPaginationMultiFilterChange,
@@ -26,9 +25,9 @@ import {
 import {
   valueOrCommonFalsy,
 } from '../../../../core/src/shared/components/list/data-sources-controllers/list-pagination-controller';
-import { PaginationMonitorFactory } from '../../../../store/src/monitors/pagination-monitor.factory';
 import { ResetPagination, SetParams } from '../../../../store/src/actions/pagination.actions';
-import { QParam, QParamJoiners } from '../q-param';
+import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
+import { PaginationMonitorFactory } from '../../../../store/src/monitors/pagination-monitor.factory';
 import {
   getCurrentPageRequestInfo,
   getPaginationObservables,
@@ -37,8 +36,9 @@ import { selectPaginationState } from '../../../../store/src/selectors/paginatio
 import { APIResource } from '../../../../store/src/types/api.types';
 import { EndpointModel } from '../../../../store/src/types/endpoint.types';
 import { PaginatedAction, PaginationParam } from '../../../../store/src/types/pagination.types';
-import { CF_ENDPOINT_TYPE } from '../../cf-types';
 import { cfEntityFactory } from '../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE } from '../../cf-types';
+import { QParam, QParamJoiners } from '../q-param';
 
 export function spreadPaginationParams(params: PaginationParam): PaginationParam {
   return {
@@ -212,7 +212,8 @@ export class CfOrgSpaceDataService implements OnDestroy {
       action: this.paginationAction,
       paginationMonitor: this.paginationMonitorFactory.create(
         this.paginationAction.paginationKey,
-        cfEntityFactory(this.paginationAction.entityType)
+        cfEntityFactory(this.paginationAction.entityType),
+        this.paginationAction.flattenPagination
       )
     }, true);
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-user.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-user.service.ts
@@ -26,8 +26,8 @@ import {
 } from '../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../store/src/types/api.types';
 import { PaginatedAction } from '../../../../store/src/types/pagination.types';
-import { CF_ENDPOINT_TYPE } from '../../cf-types';
 import { cfEntityFactory } from '../../cf-entity-factory';
+import { CF_ENDPOINT_TYPE } from '../../cf-types';
 import { ActiveRouteCfOrgSpace } from '../../features/cloud-foundry/cf-page.types';
 import {
   fetchTotalResults,
@@ -296,7 +296,8 @@ export class CfUserService {
                 action: allUsersAction,
                 paginationMonitor: this.paginationMonitorFactory.create(
                   allUsersAction.paginationKey,
-                  cfEntityFactory(cfUserEntityType)
+                  cfEntityFactory(cfUserEntityType),
+                  allUsersAction.flattenPagination
                 )
               }))
             );

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.ts
@@ -22,7 +22,7 @@ export class CloudFoundryService {
     store: Store<CFAppState>
   ) {
 
-    this.cfEndpointsMonitor = new PaginationMonitor(store, endpointListKey, endpointEntitySchema);
+    this.cfEndpointsMonitor = new PaginationMonitor(store, endpointListKey, endpointEntitySchema, false);
 
     this.cFEndpoints$ = this.cfEndpointsMonitor.currentPage$.pipe(
       map(endpoints => endpoints.filter(e => e.cnsi_type === 'cf'))

--- a/src/frontend/packages/core/src/features/cloud-foundry/cf-cell.helpers.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/cf-cell.helpers.ts
@@ -50,7 +50,8 @@ export class CfCellHelper {
       action,
       paginationMonitor: this.paginationMonitorFactory.create(
         action.paginationKey,
-        new CFEntityConfig(action.entityType)
+        new CFEntityConfig(action.entityType),
+        false
       )
     }).entities$.pipe(
       filter(entities => !!entities && !!entities.length),

--- a/src/frontend/packages/core/src/features/cloud-foundry/quota-definition-form/quota-definition-form.component.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/quota-definition-form/quota-definition-form.component.ts
@@ -5,20 +5,22 @@ import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../../../cloud-foundry/src/cf-types';
 import { CFAppState } from '../../../../../cloud-foundry/src/cf-app-state';
 import { cfEntityFactory } from '../../../../../cloud-foundry/src/cf-entity-factory';
 import { quotaDefinitionEntityType } from '../../../../../cloud-foundry/src/cf-entity-types';
+import { CF_ENDPOINT_TYPE } from '../../../../../cloud-foundry/src/cf-types';
+import {
+  QuotaDefinitionActionBuilder,
+} from '../../../../../cloud-foundry/src/entity-action-builders/quota-definition.action-builders';
 import { createEntityRelationPaginationKey } from '../../../../../cloud-foundry/src/entity-relations/entity-relations.types';
+import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
+import { IEntityMetadata } from '../../../../../store/src/entity-catalog/entity-catalog.types';
 import { endpointSchemaKey } from '../../../../../store/src/helpers/entity-factory';
+import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../store/src/types/api.types';
 import { IQuotaDefinition } from '../../../core/cf-api.types';
-import { entityCatalog } from '../../../../../store/src/entity-catalog/entity-catalog.service';
 import { safeUnsubscribe } from '../../../core/utils.service';
-import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
-import { IEntityMetadata } from '../../../../../store/src/entity-catalog/entity-catalog.types';
-import { QuotaDefinitionActionBuilder } from '../../../../../cloud-foundry/src/entity-action-builders/quota-definition.action-builders';
 
 export interface QuotaFormValues {
   name: string;
@@ -91,7 +93,8 @@ export class QuotaDefinitionFormComponent implements OnInit, OnDestroy {
         action: getQuotaDefinitionsAction,
         paginationMonitor: this.paginationMonitorFactory.create(
           quotaPaginationKey,
-          cfEntityFactory(quotaDefinitionEntityType)
+          cfEntityFactory(quotaDefinitionEntityType),
+          getQuotaDefinitionsAction.flattenPagination
         )
       },
       true

--- a/src/frontend/packages/core/src/features/cloud-foundry/space-quota-definition-form/space-quota-definition-form.component.ts
+++ b/src/frontend/packages/core/src/features/cloud-foundry/space-quota-definition-form/space-quota-definition-form.component.ts
@@ -11,11 +11,11 @@ import { spaceQuotaEntityType } from '../../../../../cloud-foundry/src/cf-entity
 import { createEntityRelationPaginationKey } from '../../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import { AppState } from '../../../../../store/src/app-state';
 import { endpointSchemaKey } from '../../../../../store/src/helpers/entity-factory';
+import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
 import { APIResource } from '../../../../../store/src/types/api.types';
 import { IQuotaDefinition } from '../../../core/cf-api.types';
 import { safeUnsubscribe } from '../../../core/utils.service';
-import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 
 
 @Component({
@@ -66,13 +66,15 @@ export class SpaceQuotaDefinitionFormComponent implements OnInit, OnDestroy {
 
   fetchQuotasDefinitions() {
     const spaceQuotaPaginationKey = createEntityRelationPaginationKey(endpointSchemaKey, this.cfGuid);
+    const action = new GetOrganizationSpaceQuotaDefinitions(spaceQuotaPaginationKey, this.orgGuid, this.cfGuid);
     this.spaceQuotaDefinitions$ = getPaginationObservables<APIResource>(
       {
         store: this.store,
-        action: new GetOrganizationSpaceQuotaDefinitions(spaceQuotaPaginationKey, this.orgGuid, this.cfGuid),
+        action,
         paginationMonitor: this.paginationMonitorFactory.create(
           spaceQuotaPaginationKey,
-          cfEntityFactory(spaceQuotaEntityType)
+          cfEntityFactory(spaceQuotaEntityType),
+          action.flattenPagination
         )
       },
       true

--- a/src/frontend/packages/core/src/features/metrics/services/metrics-service.ts
+++ b/src/frontend/packages/core/src/features/metrics/services/metrics-service.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, publishReplay, refCount } from 'rxjs/operators';
 
-import { APIResource, EntityInfo } from '../../../../../store/src/types/api.types';
-import { endpointListKey, EndpointModel } from '../../../../../store/src/types/endpoint.types';
 import { PaginationMonitor } from '../../../../../store/src/monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
-import { getFullEndpointApiUrl } from '../../endpoints/endpoint-helpers';
+import { APIResource, EntityInfo } from '../../../../../store/src/types/api.types';
+import { endpointListKey, EndpointModel } from '../../../../../store/src/types/endpoint.types';
 import { endpointEntitySchema } from '../../../base-entity-schemas';
+import { getFullEndpointApiUrl } from '../../endpoints/endpoint-helpers';
 
 export interface MetricsEndpointProvider {
   provider: EndpointModel;
@@ -27,7 +27,8 @@ export class MetricsService {
   ) {
     this.endpointsMonitor = this.paginationMonitorFactory.create(
       endpointListKey,
-      endpointEntitySchema
+      endpointEntitySchema,
+      true
     );
 
     this.setupObservables();

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
@@ -6,12 +6,12 @@ import { CFAppState } from '../../../../../../../cloud-foundry/src/cf-app-state'
 import { GetAllEndpoints } from '../../../../../../../store/src/actions/endpoint.actions';
 import { CreatePagination } from '../../../../../../../store/src/actions/pagination.actions';
 import { endpointSchemaKey } from '../../../../../../../store/src/helpers/entity-factory';
-import { endpointEntitiesSelector } from '../../../../../../../store/src/selectors/endpoint.selectors';
-import { EndpointModel } from '../../../../../../../store/src/types/endpoint.types';
-import { endpointEntitySchema } from '../../../../../base-entity-schemas';
 import { EntityMonitorFactory } from '../../../../../../../store/src/monitors/entity-monitor.factory.service';
 import { InternalEventMonitorFactory } from '../../../../../../../store/src/monitors/internal-event-monitor.factory';
 import { PaginationMonitorFactory } from '../../../../../../../store/src/monitors/pagination-monitor.factory';
+import { endpointEntitiesSelector } from '../../../../../../../store/src/selectors/endpoint.selectors';
+import { EndpointModel } from '../../../../../../../store/src/types/endpoint.types';
+import { endpointEntitySchema } from '../../../../../base-entity-schemas';
 import { DataFunctionDefinition, ListDataSource } from '../../data-sources-controllers/list-data-source';
 import { RowsState } from '../../data-sources-controllers/list-data-source-types';
 import { TableRowStateManager } from '../../list-table/table-row/table-row-state-manager';
@@ -57,7 +57,8 @@ export class BaseEndpointsDataSource extends ListDataSource<EndpointModel> {
       entityMonitorFactory,
       GetAllEndpoints.storeKey,
       action,
-      EndpointRowStateSetUpManager
+      EndpointRowStateSetUpManager,
+      false
     );
     const eventSub = BaseEndpointsDataSource.monitorEvents(internalEventMonitorFactory, rowStateManager, store);
     const config = BaseEndpointsDataSource.getEndpointConfig(

--- a/src/frontend/packages/core/src/shared/components/list/list.helper.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list.helper.ts
@@ -1,10 +1,10 @@
 import { Subscription } from 'rxjs';
 
+import { EntityCatalogEntityConfig } from '../../../../../store/src/entity-catalog/entity-catalog.types';
 import { EntityMonitorFactory } from '../../../../../store/src/monitors/entity-monitor.factory.service';
 import { PaginationMonitor } from '../../../../../store/src/monitors/pagination-monitor';
 import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
 import { TableRowStateManager } from './list-table/table-row/table-row-state-manager';
-import { EntityCatalogEntityConfig } from '../../../../../store/src/entity-catalog/entity-catalog.types';
 
 export type ListRowStateSetUpManager = (
   paginationMonitor: PaginationMonitor<any>,
@@ -18,12 +18,14 @@ export class ListRowSateHelper<T extends { guid: string }> {
     entityMonitorFactory: EntityMonitorFactory,
     paginationKey: string,
     entityConfig: EntityCatalogEntityConfig,
-    setup: ListRowStateSetUpManager
+    setup: ListRowStateSetUpManager,
+    isLocal: boolean
   ) {
     const rowStateManager = new TableRowStateManager();
     const paginationMonitor = paginationMonitorFactory.create<T>(
       paginationKey,
-      entityConfig
+      entityConfig,
+      isLocal
     );
 
     const sub = setup(

--- a/src/frontend/packages/core/src/shared/services/cloud-foundry-user-provided-services.service.ts
+++ b/src/frontend/packages/core/src/shared/services/cloud-foundry-user-provided-services.service.ts
@@ -71,7 +71,8 @@ export class CloudFoundryUserProvidedServicesService {
       action,
       paginationMonitor: this.paginationMonitorFactory.create(
         action.paginationKey,
-        action
+        action,
+        action.flattenPagination
       )
     });
     return combineLatest([

--- a/src/frontend/packages/store/src/monitors/pagination-monitor.factory.ts
+++ b/src/frontend/packages/store/src/monitors/pagination-monitor.factory.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
+import { AppState } from '../app-state';
 import { entityCatalog } from '../entity-catalog/entity-catalog.service';
 import { EntityCatalogEntityConfig } from '../entity-catalog/entity-catalog.types';
 import { PaginationMonitor } from './pagination-monitor';
-import { AppState } from '../app-state';
 
 @Injectable()
 export class PaginationMonitorFactory {
@@ -17,7 +17,8 @@ export class PaginationMonitorFactory {
 
   public create<T = any>(
     paginationKey: string,
-    entityConfig: EntityCatalogEntityConfig
+    entityConfig: EntityCatalogEntityConfig,
+    isLocal: boolean
   ) {
     const { endpointType, entityType } = entityConfig;
     const catalogEntity = entityCatalog.getEntity(endpointType, entityType);
@@ -31,7 +32,8 @@ export class PaginationMonitorFactory {
       const monitor = new PaginationMonitor<T>(
         this.store,
         paginationKey,
-        entityConfig
+        entityConfig,
+        isLocal
       );
       this.monitorCache[cacheKey] = monitor;
       return monitor;


### PR DESCRIPTION
- Fix display of Space roles in Org user table
  - Fixes #4131
  - Ensure fetch org action builder passes in entity relations correctly
  - This change exposed a number of other issues also fixed in this PR
- Fix PaginationMonitorFactory Cacheing
  - PaginationMonitorFactory creates obs for collections of an entities
  - First request will result in new obs, subsequent requests will then use it also
  - On first use everything is fine, problem occurs if 
     - obs chain has no remaining subscribers
     - changes to underlying collection occurs which are not passed through obs chain
     - new subscriber to obs chain does not get this but the stale one from when the previous subscriber was listening
     - more details in code
- Ensure isLocal is correctly set in PaginationMonitorFactory
  - The bulk of the edits 
- Fixes in AddEditSpaceStepBase given above
  - ensure we look for org spaces in the correct place
  - unsub from fetch org spaces obs once we have a response