### PR TITLE
Fix for App Deploy does not support .yaml file extension for manifest

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs-utils.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs-utils.ts
@@ -4,7 +4,8 @@ import { DeployApplicationFSScanner, FileScannerInfo } from './deploy-applicatio
 
 export const CF_IGNORE_FILE = '.cfignore';
 export const CF_DEFAULT_IGNORES = '.cfignore\n_darcs\n.DS_Store\n.git\n.gitignore\n.hg\n.svn\n';
-export const CF_MANIFEST_FILE = 'manifest.yml';
+export const CF_MANIFEST_FILE_YML = 'manifest.yml';
+export const CF_MANIFEST_FILE_YAML = 'manifest.yaml';
 
 export class DeployApplicationFsUtils {
 
@@ -37,7 +38,8 @@ export class DeployApplicationFsUtils {
           cfIgnoreFile = item;
         }
 
-        if (filePath.length === 2 && filePath[1] === CF_MANIFEST_FILE) {
+        // Support either manifest.yml or manifest.yaml
+        if (filePath.length === 2 && (filePath[1] === CF_MANIFEST_FILE_YML || filePath[1] === CF_MANIFEST_FILE_YAML)) {
           manifestFile = item;
         }
       }

--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -548,11 +548,30 @@ func getCommit(cloneDetails CloneDetails, clientWebSocket *websocket.Conn, tempD
 
 }
 
+// Check if file exists
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
 // This assumes manifest lives in the root of the app
 func fetchManifest(repoPath string, stratosProject StratosProject, clientWebSocket *websocket.Conn) (Applications, error) {
 
 	var manifest Applications
-	manifestPath := fmt.Sprintf("%s/manifest.yml", repoPath)
+
+	// Can be either manifest.yml or manifest.yaml
+	manifestPath := filepath.Join(repoPath, "manifest.yml")
+	if !fileExists(manifestPath) {
+		manifestPath = filepath.Join(repoPath, "manifest.yaml")
+		if !fileExists(manifestPath) {
+			return manifest, fmt.Errorf("Can not find manifest file")
+		}
+	}
+
+	// Read the manifest
 	data, err := ioutil.ReadFile(manifestPath)
 	if err != nil {
 		log.Warnf("Failed to read manifest in path %s", manifestPath)

--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -166,6 +166,8 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	// Source fetched - read manifest
 	manifest, manifestFile, err := fetchManifest(appDir, stratosProject, clientWebSocket)
 	if err != nil {
+		log.Warnf("Failed to find manifest file: %s", err)
+		sendErrorMessage(clientWebSocket, err, CLOSE_FAILURE)
 		return err
 	}
 
@@ -184,6 +186,7 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	pushConfig, err := cfAppPush.getConfigData(echoContext, cnsiGUID, orgGUID, spaceGUID, spaceName, orgName, clientWebSocket)
 	if err != nil {
 		log.Warnf("Failed to initialise config due to error %+v", err)
+		sendErrorMessage(clientWebSocket, err, CLOSE_FAILURE)
 		return err
 	}
 

--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -164,7 +164,7 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	stratosProject.DeployOverrides = overrides
 
 	// Source fetched - read manifest
-	manifest, err := fetchManifest(appDir, stratosProject, clientWebSocket)
+	manifest, manifestFile, err := fetchManifest(appDir, stratosProject, clientWebSocket)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	var repo = deps.RepoLocator.GetApplicationRepository()
 	cfAppPush.cfPush.PatchApplicationRepository(NewRepositoryIntercept(repo, cfAppPush, clientWebSocket))
 
-	err = cfAppPush.cfPush.Init(appDir, appDir+"/manifest.yml", overrides)
+	err = cfAppPush.cfPush.Init(appDir, manifestFile, overrides)
 	if err != nil {
 		log.Warnf("Failed to parse due to: %+v", err)
 		sendErrorMessage(clientWebSocket, err, CLOSE_FAILURE)
@@ -558,7 +558,7 @@ func fileExists(filename string) bool {
 }
 
 // This assumes manifest lives in the root of the app
-func fetchManifest(repoPath string, stratosProject StratosProject, clientWebSocket *websocket.Conn) (Applications, error) {
+func fetchManifest(repoPath string, stratosProject StratosProject, clientWebSocket *websocket.Conn) (Applications, string, error) {
 
 	var manifest Applications
 
@@ -567,7 +567,7 @@ func fetchManifest(repoPath string, stratosProject StratosProject, clientWebSock
 	if !fileExists(manifestPath) {
 		manifestPath = filepath.Join(repoPath, "manifest.yaml")
 		if !fileExists(manifestPath) {
-			return manifest, fmt.Errorf("Can not find manifest file")
+			return manifest, manifestPath, fmt.Errorf("Can not find manifest file")
 		}
 	}
 
@@ -576,14 +576,14 @@ func fetchManifest(repoPath string, stratosProject StratosProject, clientWebSock
 	if err != nil {
 		log.Warnf("Failed to read manifest in path %s", manifestPath)
 		sendErrorMessage(clientWebSocket, err, CLOSE_NO_MANIFEST)
-		return manifest, err
+		return manifest, manifestPath, err
 	}
 
 	err = yaml.Unmarshal(data, &manifest)
 	if err != nil {
 		log.Warnf("Failed to unmarshall manifest in path %s", manifestPath)
 		sendErrorMessage(clientWebSocket, err, CLOSE_INVALID_MANIFEST)
-		return manifest, err
+		return manifest, manifestPath, err
 	}
 
 	marshalledJSON, _ := json.Marshal(stratosProject)
@@ -603,12 +603,12 @@ func fetchManifest(repoPath string, stratosProject StratosProject, clientWebSock
 		if err != nil {
 			log.Warnf("Failed to marshall manifest in path %v", manifest)
 			sendErrorMessage(clientWebSocket, err, CLOSE_FAILURE)
-			return manifest, err
+			return manifest, manifestPath, err
 		}
 		ioutil.WriteFile(manifestPath, marshalledYaml, 0600)
 	}
 
-	return manifest, nil
+	return manifest, manifestPath, nil
 }
 
 func (sw *SocketWriter) Write(data []byte) (int, error) {


### PR DESCRIPTION
Fixes #4142 

This PR updates the backend and frontend so that it now correctly accepts either a .yml or .yaml file extension for the manifest file.