### PR TITLE
App Deploy: Tidy up UI

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -59,6 +59,14 @@
         <app-card-app-uptime></app-card-app-uptime>
       </app-tile>
     </app-tile-group>
+    <app-tile-group *ngIf="appSvc.app.entity.staging_failed_description as errorMsg">
+      <app-tile>
+        <mat-card class="summary__staging-error">
+          <mat-icon class="text-warning">warning</mat-icon>
+          <div>{{ errorMsg }}</div>
+        </mat-card>
+      </app-tile>
+    </app-tile-group>
     <app-tile-group>
       <app-tile>
         <mat-card>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.scss
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.scss
@@ -29,6 +29,14 @@
       justify-content: flex-end;
     }
   }
+  &__staging-error {
+    align-items: center;
+    display: flex;
+
+    mat-icon {
+      margin-right: 8px;
+    }
+  }
 }
 
 .app-metadata {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.html
@@ -1,4 +1,4 @@
-<div class="deploy-app">
+<div class="deploy-app" *ngIf="showOverlay$ | async">
   <div class="deploy-app__title">{{ deployer ? deployer.streamTitle : 'Pending' }}</div>
   <mat-progress-spinner *ngIf="deployer && deployer.deploying" diameter="20" mode="indeterminate">
   </mat-progress-spinner>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.scss
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.scss
@@ -1,4 +1,5 @@
 :host {
+  position: relative;
   height: 100%;
   width: 100%;
 }
@@ -6,8 +7,11 @@
 .deploy-app {
   display: flex;
   height: 43px;
+  opacity: 0.9;
   padding: 12px;
+  position: absolute;
   width: 100%;
+  z-index: 1;
   &__title {
     flex: 1;
     font-weight: 600;
@@ -17,7 +21,7 @@
   }
   &__log {
     display: flex;
-    height: calc(100% - 43px);
+    height: 100%;
   }
 }
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.scss
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.scss
@@ -1,13 +1,13 @@
 :host {
-  position: relative;
   height: 100%;
+  position: relative;
   width: 100%;
 }
 
 .deploy-app {
   display: flex;
   height: 43px;
-  opacity: 0.9;
+  opacity: .9;
   padding: 12px;
   position: absolute;
   width: 100%;

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
@@ -25,7 +25,7 @@
     <app-deploy-application-options-step #step4></app-deploy-application-options-step>
   </app-step>
   <app-step [title]="deployButtonText" [valid]="step3.valid$ | async" [canClose]="step3.closeable$ | async"
-    disablePrevious=true cancelButtonText="Close" [onEnter]="step3.onEnter" [onNext]="step3.onNext"
+    disablePrevious=true cancelButtonText="Close" [onEnter]="step3.onEnter" [onNext]="step3.onNext" [blocked]="step3.busy"
     finishButtonText="Go to App Summary">
     <app-deploy-application-step3 [appGuid]="appGuid" #step3></app-deploy-application-step3>
   </app-step>

--- a/src/frontend/packages/core/sass/mat-desktop.scss
+++ b/src/frontend/packages/core/sass/mat-desktop.scss
@@ -50,4 +50,18 @@ $desktop-toggle-button-item-height: $desktop-menu-item-height - 2px;
     // need to make font size bigger so that it is scaled back down to reasonable size by the exiting css transform
     font-size: 16px;
   }
+
+  // Drop down options
+  .mat-option {
+    font-size: $desktop-font-size;
+    height: $desktop-menu-item-height;
+    line-height: $desktop-menu-item-height;
+  }
+
+  // Stepper control
+  .steppers__headers {
+    flex: 0 0 56px;
+    font-size: $desktop-font-size;
+    height: 56px;
+  }
 }

--- a/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
@@ -25,7 +25,7 @@ export class GithubCommitsListConfigServiceDeploy extends GithubCommitsListConfi
       headerCell: () => '',
       cellComponent: TableCellRadioComponent,
       class: 'table-column-select',
-      cellFlex: '1'
+      cellFlex: '0 0 60px'
     });
 
     this.store.select<DeployApplicationSource>(selectApplicationSource).pipe(
@@ -44,6 +44,15 @@ export class GithubCommitsListConfigServiceDeploy extends GithubCommitsListConfi
       this.dataSource = new GithubCommitsDataSource(this.store,
         this, scm, fetchDetails.projectName, fetchDetails.sha, fetchDetails.commitSha);
       this.initialised.next(true);
+
+      // Auto-select first commit - wait for page to load, select first item if present
+      this.dataSource.page$.pipe(
+        first()
+      ).subscribe(rs => {
+        if (rs && rs.length > 0) {
+          this.dataSource.selectedRowToggle(rs[0], false);
+        }
+      });
     });
   }
 }

--- a/src/frontend/packages/core/src/shared/components/log-viewer/log-viewer.component.scss
+++ b/src/frontend/packages/core/src/shared/components/log-viewer/log-viewer.component.scss
@@ -34,7 +34,7 @@
   border-style: solid;
   border-width: 1px;
   font-family: 'Source Code Pro', monospace;
-  font-size: 11.25pt;
+  font-size: 10pt;
   height: 100%;
   line-height: 20px;
   overflow-x: hidden;

--- a/src/test-e2e/application/application-deploy-helper.ts
+++ b/src/test-e2e/application/application-deploy-helper.ts
@@ -182,7 +182,8 @@ export function createApplicationDeployTests(type = CREATE_APP_DEPLOY_TEST_TYPE.
       const commits = deployApp.getCommitList();
       expect(commits.getHeaderText()).toBe('Select a commit');
 
-      expect(deployApp.stepper.canNext()).toBeFalsy();
+      // The first commit should be auto-selected
+      expect(deployApp.stepper.canNext()).toBeTruthy();
 
       commits.getTableData().then(data => {
         expect(data.length).toBeGreaterThan(0);


### PR DESCRIPTION
This PR:

- Adds a card for the staging error message if the app failed staging
- Improves the deploy log step by integrating the status message over the log and moving the spinner into the stepper header. This gives more room for the log view.
- Fixes desktop sizing for auto-complete drop-downs
- Reduces the height of the stepper header on desktop to give more space for content
- Fixes width of radio button column on the select commit step to be 60px which is what we use elsewhere
- Auto-selects the first commit on the commit selection step
- Reduces the font size of the log control