### PR TITLE
Fix App Redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,3 @@ Tested with Browserstack
 ## License
 
 The work done has been licensed under Apache License 2.0. The license file can be found [here](LICENSE).
-

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Tested with Browserstack
 ## License
 
 The work done has been licensed under Apache License 2.0. The license file can be found [here](LICENSE).
+

--- a/src/frontend/packages/cloud-foundry/src/entity-action-builders/git-action-builder.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-action-builders/git-action-builder.ts
@@ -1,26 +1,32 @@
+import { GitSCM } from '../../../core/src/shared/data-services/scm/scm';
 import {
   EntityRequestActionConfig,
   KnownEntityActionBuilder,
   OrchestratedActionBuilderConfig,
   OrchestratedActionBuilders,
 } from '../../../store/src/entity-catalog/action-orchestrator/action-orchestrator';
-import { GitSCM } from '../../../core/src/shared/data-services/scm/scm';
-import { FetchBranchesForProject, FetchCommits } from '../actions/deploy-applications.actions';
+import { FetchBranchesForProject, FetchCommit, FetchCommits } from '../actions/deploy-applications.actions';
 import { FetchGitHubRepoInfo } from '../actions/github.actions';
 import {
   EnvVarStratosProject,
 } from '../features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service';
 
-export const gitRepoActionBuilders = {
+export interface GitRepoActionBuilders extends OrchestratedActionBuilders {
+  getRepoInfo: (
+    projectEnvVars: EnvVarStratosProject
+  ) => FetchGitHubRepoInfo;
+}
+
+export const gitRepoActionBuilders: GitRepoActionBuilders = {
   getRepoInfo: (
     projectEnvVars: EnvVarStratosProject
   ) => new FetchGitHubRepoInfo(projectEnvVars)
-} as OrchestratedActionBuilders;
+};
 
-interface GitMeta {
+export interface GitMeta {
   projectName: string;
   scm: GitSCM;
-  commitId?: string;
+  commitSha?: string;
 }
 
 export interface GitCommitActionBuildersConfig extends OrchestratedActionBuilderConfig {
@@ -28,14 +34,19 @@ export interface GitCommitActionBuildersConfig extends OrchestratedActionBuilder
   getMultiple: (commitSha: string, endpointGuid: string, projectMeta: GitMeta) => FetchCommits;
 }
 
+
+// export interface GitCommitActionBuilders extends OrchestratedActionBuilders {
+//   get: KnownEntityActionBuilder<GitMeta>;
+//   getMultiple: (commitSha: string, endpointGuid: string, projectMeta: GitMeta) => FetchCommits;
+// }
 export interface GitCommitActionBuilders extends OrchestratedActionBuilders {
-  get: KnownEntityActionBuilder<GitMeta>;
+  get: (guid: string, endpointGuid: string, gitMetadata: GitMeta) => FetchCommit;
   getMultiple: (commitSha: string, endpointGuid: string, projectMeta: GitMeta) => FetchCommits;
 }
 
 export const gitCommitActionBuilders: GitCommitActionBuildersConfig = {
   get: new EntityRequestActionConfig<KnownEntityActionBuilder<GitMeta>>(
-    (id, endpointGuid, meta) => meta.scm.getCommitApiUrl(meta.projectName, meta.commitId),
+    (id, endpointGuid, meta) => meta.scm.getCommitApiUrl(meta.projectName, meta.commitSha),
     {
       externalRequest: true
     }
@@ -56,5 +67,5 @@ export const gitBranchActionBuilders: GitBranchActionBuilders = {
     guid: string,
     endpointGuid: string,
     meta: GitMeta
-  ) => new FetchBranchesForProject(meta.scm, guid)
+  ) => new FetchBranchesForProject(meta.scm, meta.projectName)
 };

--- a/src/frontend/packages/cloud-foundry/src/entity-action-builders/git-action-builder.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-action-builders/git-action-builder.ts
@@ -5,7 +5,7 @@ import {
   OrchestratedActionBuilderConfig,
   OrchestratedActionBuilders,
 } from '../../../store/src/entity-catalog/action-orchestrator/action-orchestrator';
-import { FetchBranchesForProject, FetchCommit, FetchCommits } from '../actions/deploy-applications.actions';
+import { FetchBranchesForProject, FetchCommits } from '../actions/deploy-applications.actions';
 import { FetchGitHubRepoInfo } from '../actions/github.actions';
 import {
   EnvVarStratosProject,
@@ -34,13 +34,8 @@ export interface GitCommitActionBuildersConfig extends OrchestratedActionBuilder
   getMultiple: (commitSha: string, endpointGuid: string, projectMeta: GitMeta) => FetchCommits;
 }
 
-
-// export interface GitCommitActionBuilders extends OrchestratedActionBuilders {
-//   get: KnownEntityActionBuilder<GitMeta>;
-//   getMultiple: (commitSha: string, endpointGuid: string, projectMeta: GitMeta) => FetchCommits;
-// }
 export interface GitCommitActionBuilders extends OrchestratedActionBuilders {
-  get: (guid: string, endpointGuid: string, gitMetadata: GitMeta) => FetchCommit;
+  get: KnownEntityActionBuilder<GitMeta>;
   getMultiple: (commitSha: string, endpointGuid: string, projectMeta: GitMeta) => FetchCommits;
 }
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-deployer.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-deployer.ts
@@ -34,6 +34,37 @@ export interface FileTransferStatus {
   fileName: string;
 }
 
+interface DeploySource {
+  type: string;
+}
+
+interface GitSCMSourceInfo extends DeploySource {
+  project: string;
+  branch: string;
+  url: string;
+  commit: string;
+  scm: string;
+}
+
+// Structure used to provide metadata about the Git Url source
+interface GitUrlSourceInfo extends DeploySource {
+  branch: string;
+  url: string;
+}
+
+// DockerImageSourceInfo - Structure used to provide metadata about the docker source
+interface DockerImageSourceInfo extends DeploySource {
+  applicationName: string;
+  dockerImage: string;
+  dockerUsername: string;
+}
+
+interface FolderSourceInfo extends DeploySource {
+  wait: boolean;
+  files: number;
+  folders: string[];
+}
+
 export class DeployApplicationDeployer {
 
   isRedeploy: string;
@@ -204,7 +235,7 @@ export class DeployApplicationDeployer {
   }
 
   sendGitSCMSourceMetadata = (appSource: DeployApplicationSource) => {
-    const gitscm = {
+    const gitscm: GitSCMSourceInfo = {
       project: appSource.gitDetails.projectName,
       branch: appSource.gitDetails.branch.name,
       type: appSource.type.group,
@@ -222,7 +253,7 @@ export class DeployApplicationDeployer {
   }
 
   sendGitUrlSourceMetadata = (appSource: DeployApplicationSource) => {
-    const gitUrl = {
+    const gitUrl: GitUrlSourceInfo = {
       url: appSource.gitDetails.projectName,
       branch: appSource.gitDetails.branch.name,
       type: appSource.type.id
@@ -237,7 +268,7 @@ export class DeployApplicationDeployer {
   }
 
   sendDockerImageMetadata = (appSource: DeployApplicationSource) => {
-    const dockerInfo = {
+    const dockerInfo: DockerImageSourceInfo = {
       applicationName: appSource.dockerDetails.applicationName,
       dockerImage: appSource.dockerDetails.dockerImage,
       dockerUsername: appSource.dockerDetails.dockerUsername,
@@ -392,7 +423,7 @@ export class DeployApplicationDeployer {
 
     this.fileTransferStatus$.next(this.fileTransferStatus);
 
-    const transferMetadata = {
+    const transferMetadata: FolderSourceInfo = {
       files: metadata.files.length,
       folders: metadata.folders,
       type: 'filefolder',

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -1,17 +1,7 @@
-<b *ngIf="canDeployType$ | async"> {{ stepperText }}</b>
+<b *ngIf="stepperText$ | async as stepperText">{{ stepperText }}</b>
 <form novalidate #sourceSelectionForm="ngForm" class="stepper-form">
   <div *ngIf="(canDeployType$ | async) === true">
     <div class="deploy-step2-form">
-      <!-- This can be flipped when we add other deploy types -->
-      <mat-form-field *ngIf="!selectedSourceType && sourceTypes.length > 1">
-        <mat-select class="reset-margin" [disabled]="isRedeploy" placeholder="Source Type" name="sourceType"
-          [(ngModel)]="sourceType" (selectionChange)="setSourceType($event.value)" required>
-          <mat-option *ngFor="let sourceType of sourceTypes" [value]="sourceType">
-            {{ sourceType.name }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-      <p *ngIf="!selectedSourceType && sourceType && sourceType.helpText"> {{sourceType.helpText}} </p>
       <div *ngIf="(sourceType$ | async) as sourceType">
         <app-deploy-application-fs #fsChooser [hideTitle]='true'
           *ngIf="sourceType.id === DEPLOY_TYPES_IDS.FILE || sourceType.id === DEPLOY_TYPES_IDS.FOLDER"
@@ -62,7 +52,8 @@
                 </mat-option>
               </mat-select>
             </mat-form-field>
-            <div *ngIf="isRedeploy && commitInfo" class="deploy-step2-form__project-info-group">
+            <div *ngIf="isRedeploy && commitInfo"
+              class="deploy-step2-form__project-info-group deploy-step2-form__commit">
               <div>
                 <img src="{{commitInfo.author.avatar_url}}">
               </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -75,7 +75,7 @@ export class DeployApplicationStep2Component
   sourceTypes: SourceType[];
   public DEPLOY_TYPES_IDS = DEPLOY_TYPES_IDS;
   sourceType$: Observable<SourceType>;
-  INITIAL_SOURCE_TYPE = 0; // GitHub by default
+  INITIAL_SOURCE_TYPE = 0; // Fall back to GitHub, for cases where there's no type in store (refresh) or url (removed & nav)
   validate: Observable<boolean>;
 
   stepperText$: Observable<string>;

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -8,6 +8,7 @@ import {
   combineLatest,
   Observable,
   of as observableOf,
+  of,
   Subscription,
   timer as observableTimer,
 } from 'rxjs';
@@ -29,7 +30,6 @@ import {
 
 import {
   FetchBranchesForProject,
-  FetchCommit,
   ProjectDoesntExist,
   SaveAppDetails,
   SetAppSourceDetails,
@@ -55,11 +55,9 @@ import { GitBranch } from '../../../../../../cloud-foundry/src/store/types/githu
 import { StepOnNextFunction } from '../../../../../../core/src/shared/components/stepper/step/step.component';
 import { GitSCM } from '../../../../../../core/src/shared/data-services/scm/scm';
 import { GitSCMService, GitSCMType } from '../../../../../../core/src/shared/data-services/scm/scm.service';
-import { entityCatalog } from '../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { EntityServiceFactory } from '../../../../../../store/src/entity-service-factory.service';
 import { PaginationMonitorFactory } from '../../../../../../store/src/monitors/pagination-monitor.factory';
 import { getPaginationObservables } from '../../../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
-import { EntityInfo } from '../../../../../../store/src/types/api.types';
 import { CF_ENDPOINT_TYPE, CFEntityConfig } from '../../../../cf-types';
 import { ApplicationDeploySourceTypes, DEPLOY_TYPES_IDS } from '../deploy-application-steps.types';
 
@@ -80,7 +78,7 @@ export class DeployApplicationStep2Component
   INITIAL_SOURCE_TYPE = 0; // GitHub by default
   validate: Observable<boolean>;
 
-  stepperText = 'Please specify the source';
+  stepperText$: Observable<string>;
 
   // Observables for source types
   sourceTypeGithub$: Observable<boolean>;
@@ -125,8 +123,6 @@ export class DeployApplicationStep2Component
 
   @ViewChild('fsChooser', { static: false }) fsChooser;
 
-  public selectedSourceType: SourceType = null;
-
   ngOnDestroy() {
     this.subscriptions.forEach(p => p.unsubscribe());
     if (this.commitSubscription) {
@@ -137,17 +133,13 @@ export class DeployApplicationStep2Component
   constructor(
     private entityServiceFactory: EntityServiceFactory,
     private store: Store<CFAppState>,
-    route: ActivatedRoute,
+    private route: ActivatedRoute,
     private paginationMonitorFactory: PaginationMonitorFactory,
     private scmService: GitSCMService,
     private httpClient: HttpClient,
     private appDeploySourceTypes: ApplicationDeploySourceTypes
   ) {
     this.sourceTypes = appDeploySourceTypes.getTypes();
-    this.selectedSourceType = appDeploySourceTypes.getAutoSelectedType(route);
-    if (this.selectedSourceType) {
-      this.stepperText = this.selectedSourceType.helpText;
-    }
   }
 
   onNext: StepOnNextFunction = () => {
@@ -156,7 +148,8 @@ export class DeployApplicationStep2Component
       this.store.dispatch(new SaveAppDetails({
         projectName: this.repository,
         branch: this.repositoryBranch,
-        url: this.scm.getCloneURL(this.repository)
+        url: this.scm.getCloneURL(this.repository),
+        commit: this.isRedeploy ? this.commitInfo.sha : undefined
       }, null));
     } else if (this.sourceType.id === DEPLOY_TYPES_IDS.GIT_URL) {
       this.store.dispatch(new SaveAppDetails({
@@ -176,11 +169,14 @@ export class DeployApplicationStep2Component
   }
 
   ngOnInit() {
-    if (this.isRedeploy) {
-      this.stepperText = 'Review source details';
-    }
-
-    this.sourceType$ = this.store.select(selectSourceType);
+    this.sourceType$ = combineLatest(
+      of(this.appDeploySourceTypes.getAutoSelectedType(this.route)),
+      this.store.select(selectSourceType),
+      of(this.sourceTypes[this.INITIAL_SOURCE_TYPE])
+    ).pipe(
+      map(([sourceFromStore, sourceFromParam, sourceDefault]) => sourceFromParam || sourceFromStore || sourceDefault),
+      filter(sourceType => !!sourceType),
+    );
 
     this.sourceTypeGithub$ = this.sourceType$.pipe(
       filter(type => type && !!type.id),
@@ -192,14 +188,12 @@ export class DeployApplicationStep2Component
       map(type => type.id === DEPLOY_TYPES_IDS.FOLDER || type.id === DEPLOY_TYPES_IDS.FILE)
     );
 
-    const setInitialSourceType$ = this.store.select(selectSourceType).pipe(
-      filter(p => !p),
+
+    const setInitialSourceType$ = this.sourceType$.pipe(
       first(),
-      tap(p => {
-        this.setSourceType(this.selectedSourceType || this.sourceTypes[this.INITIAL_SOURCE_TYPE]);
-        if (this.selectedSourceType) {
-          this.sourceType = this.selectedSourceType;
-        }
+      tap(sourceType => {
+        this.setSourceType(sourceType);
+        this.sourceType = sourceType;
       })
     );
 
@@ -216,6 +210,13 @@ export class DeployApplicationStep2Component
       switchMap(([cfGuid, sourceType]) => this.appDeploySourceTypes.canDeployType(cfGuid, sourceType.id)),
       publishReplay(1),
       refCount()
+    );
+
+    this.stepperText$ = this.canDeployType$.pipe(
+      switchMap(canDeployType => canDeployType ?
+        this.isRedeploy ? of('Review source details') : this.sourceType$.pipe(map(st => st.helpText)) :
+        of(null)
+      )
     );
 
     this.subscriptions.push(setInitialSourceType$.subscribe());
@@ -295,27 +296,31 @@ export class DeployApplicationStep2Component
         const branch = branches.find(b => b.name === name);
         if (branch && !!projectInfo && branch.projectId === projectInfo.full_name) {
           this.store.dispatch(new SetBranch(branch));
-          const commitSha = commit || branch.commit.sha;
-          const entityID = projectInfo.full_name + '-' + commitSha;
-          const gitCommitEntity = entityCatalog.getEntity(CF_ENDPOINT_TYPE, gitCommitEntityType);
-          const fetchCommitActionBuilder = gitCommitEntity.actionOrchestrator.getActionBuilder('get');
-          const fetchCommitAction = fetchCommitActionBuilder(null, null, {
-            scm: this.scm,
-            projectName: projectInfo.full_name,
-            commitId: commitSha
-          }) as FetchCommit;
-          const commitEntityService = this.entityServiceFactory.create<EntityInfo>(
-            entityID,
-            fetchCommitAction
-          );
 
-          if (this.commitSubscription) {
-            this.commitSubscription.unsubscribe();
+
+          if (this.isRedeploy) {
+            const commitSha = commit || branch.commit.sha;
+            // This method to create entity id's should be standardised....
+            const repoEntityID = `${this.scm.getType()}-${projectInfo.full_name}`;
+            const commitEntityID = `${repoEntityID}-${commitSha}`;
+            const commitEntityService = this.entityServiceFactory.create<GitCommit>(
+              {
+                endpointType: CF_ENDPOINT_TYPE,
+                entityType: gitCommitEntityType,
+                actionMetadata: { projectName: projectInfo.full_name, scm: this.scm, commitSha },
+                entityGuid: commitEntityID,
+              }
+            );
+
+            if (this.commitSubscription) {
+              this.commitSubscription.unsubscribe();
+            }
+            this.commitSubscription = commitEntityService.waitForEntity$.pipe(
+              first(),
+              map(p => p.entity),
+              tap(p => this.commitInfo = p),
+            ).subscribe();
           }
-          this.commitSubscription = commitEntityService.waitForEntity$.pipe(
-            map(p => p.entity.entity),
-            tap(p => this.commitInfo = p)
-          ).subscribe();
         }
       })
     );

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-steps.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-steps.types.ts
@@ -95,7 +95,7 @@ export class ApplicationDeploySourceTypes {
 
   getAutoSelectedType(activatedRoute: ActivatedRoute): SourceType {
     const typeId = activatedRoute.snapshot.queryParams[AUTO_SELECT_DEPLOY_TYPE_URL_PARAM];
-    return this.getTypes().find(source => source.id === typeId);
+    return typeId ? this.getTypes().find(source => source.id === typeId) : null;
   }
 
   canDeployType(cfId: string, sourceId: string): Observable<boolean> {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
@@ -3,18 +3,22 @@
 </app-page-header>
 
 <app-steppers cancel="/applications">
+  <!-- Select the cf/org/space -->
   <app-step *ngIf="!appGuid" [title]="'Cloud Foundry'" [valid]="step1.validate | async" [onNext]="onNext"
     [blocked]="cfOrgSpaceService.isLoading$ | async">
     <app-create-application-step1 [isRedeploy]="isRedeploy" #step1></app-create-application-step1>
   </app-step>
+  <!-- Select the configuration for the source previously selected -->
   <app-step [title]="'Source'" [valid]="step2.validate | async" [onNext]="step2.onNext">
     <app-deploy-application-step2 [isRedeploy]="isRedeploy" #step2></app-deploy-application-step2>
   </app-step>
+  <!-- Select the commit if source type is git -->
   <app-step [hidden]="appGuid || !(step2.sourceTypeGithub$ | async)" [title]="'Source Config'"
     [valid]="step2_1.validate | async" [skip]="skipConfig$ | async" [onLeave]="step2_1.onLeave"
     [onEnter]="step2_1.onEnter" [onNext]="step2_1.onNext">
     <app-deploy-application-step2-1 #step2_1></app-deploy-application-step2-1>
   </app-step>
+  <!-- Upload the source if source type is folder/archive  -->
   <app-step [hidden]="isRedeploy || !(step2.sourceTypeNeedsUpload$ | async)" title="Source Upload"
     [valid]="step2_2.valid$ | async" [skip]="step2_2.skip$ | async" [onLeave]="step2_2.onLeave"
     [onEnter]="step2_2.onEnter" [onNext]="step2_2.onNext">

--- a/src/frontend/packages/cloud-foundry/src/store/effects/deploy-app.effects.ts
+++ b/src/frontend/packages/cloud-foundry/src/store/effects/deploy-app.effects.ts
@@ -6,6 +6,7 @@ import { of as observableOf } from 'rxjs';
 import { catchError, filter, map, mergeMap, switchMap, withLatestFrom } from 'rxjs/operators';
 
 import { LoggerService } from '../../../../core/src/core/logger.service';
+import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
 import { NormalizedResponse } from '../../../../store/src/types/api.types';
 import { PaginatedAction } from '../../../../store/src/types/pagination.types';
 import {
@@ -29,10 +30,9 @@ import {
 } from '../../actions/deploy-applications.actions';
 import { CFAppState } from '../../cf-app-state';
 import { gitBranchesEntityType, gitCommitEntityType } from '../../cf-entity-types';
+import { CF_ENDPOINT_TYPE } from '../../cf-types';
 import { selectDeployAppState } from '../selectors/deploy-application.selector';
 import { GitCommit } from '../types/git.types';
-import { entityCatalog } from '../../../../store/src/entity-catalog/entity-catalog.service';
-import { CF_ENDPOINT_TYPE } from '../../cf-types';
 
 function parseHttpPipeError(res: any, logger: LoggerService): { message?: string } {
   if (!res.status) {
@@ -96,10 +96,10 @@ export class DeployAppEffects {
       return action.scm.getBranches(this.httpClient, action.projectName).pipe(
         mergeMap(branches => {
           const entityKey = entityCatalog.getEntity(apiAction).entityKey;
-          const mappedData = {
+          const mappedData: NormalizedResponse = {
             entities: { [entityKey]: {} },
             result: []
-          } as NormalizedResponse;
+          };
 
           const scmType = action.scm.getType();
           branches.forEach(b => {

--- a/src/frontend/packages/cloud-foundry/src/store/types/deploy-application.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/store/types/deploy-application.types.ts
@@ -1,6 +1,6 @@
 import { ITileGraphic } from '../../../../core/src/shared/components/tile/tile-selector.types';
 import { NewAppCFDetails } from './create-application.types';
-import { GitBranch, GitCommit } from './git.types';
+import { GitBranch } from './git.types';
 
 export interface SourceType {
   name: string;
@@ -67,7 +67,7 @@ export interface DockerAppDetails {
 export interface GitAppDetails {
   projectName: string;
   branch: GitBranch;
-  commit?: GitCommit;
+  commit?: string;
   branchName?: string;
   url?: string;
 }

--- a/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-data-source.ts
@@ -1,12 +1,12 @@
 import { Store } from '@ngrx/store';
 import { of as observableOf } from 'rxjs';
 
-import { CF_ENDPOINT_TYPE } from '../../../../../../../cloud-foundry/src/cf-types';
 import { CFAppState } from '../../../../../../../cloud-foundry/src/cf-app-state';
 import { CFEntitySchema } from '../../../../../../../cloud-foundry/src/cf-entity-schema-types';
 import { gitCommitEntityType } from '../../../../../../../cloud-foundry/src/cf-entity-types';
+import { CF_ENDPOINT_TYPE } from '../../../../../../../cloud-foundry/src/cf-types';
+import { GitMeta } from '../../../../../../../cloud-foundry/src/entity-action-builders/git-action-builder';
 import { GitCommit } from '../../../../../../../cloud-foundry/src/store/types/git.types';
-import { PaginatedAction } from '../../../../../../../store/src/types/pagination.types';
 import { entityCatalog } from '../../../../../../../store/src/entity-catalog/entity-catalog.service';
 import { GitSCM } from '../../../../data-services/scm/scm';
 import { ListDataSource } from '../../data-sources-controllers/list-data-source';
@@ -32,11 +32,12 @@ export class GithubCommitsDataSource extends ListDataSource<GitCommit> {
   ) {
     const gitCommitEntity = entityCatalog.getEntity(CF_ENDPOINT_TYPE, gitCommitEntityType);
     const fetchCommitActionBuilder = gitCommitEntity.actionOrchestrator.getActionBuilder('getMultiple');
-    const fetchCommitAction = fetchCommitActionBuilder(sha, null, {
+    const gitMeta: GitMeta = {
       scm,
       projectName,
-      commitId: sha
-    }) as PaginatedAction;
+      commitSha: sha
+    };
+    const fetchCommitAction = fetchCommitActionBuilder(sha, null, gitMeta);
     const action = fetchCommitAction;
     const paginationKey = action.paginationKey;
     const rowsState = observableOf(commitSha ? {

--- a/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
@@ -5,7 +5,6 @@ import * as moment from 'moment';
 import { Observable } from 'rxjs';
 import { combineLatest, filter, first, map } from 'rxjs/operators';
 
-import { CF_ENDPOINT_TYPE } from '../../../../../../../cloud-foundry/src/cf-types';
 import {
   CheckProjectExists,
   SetAppSourceDetails,
@@ -15,6 +14,7 @@ import {
 } from '../../../../../../../cloud-foundry/src/actions/deploy-applications.actions';
 import { CFAppState } from '../../../../../../../cloud-foundry/src/cf-app-state';
 import { gitBranchesEntityType, gitCommitEntityType } from '../../../../../../../cloud-foundry/src/cf-entity-types';
+import { CF_ENDPOINT_TYPE } from '../../../../../../../cloud-foundry/src/cf-types';
 import { ApplicationService } from '../../../../../../../cloud-foundry/src/features/applications/application.service';
 import { selectCfEntity } from '../../../../../../../cloud-foundry/src/store/selectors/api.selectors';
 import { GitBranch, GitCommit } from '../../../../../../../cloud-foundry/src/store/types/git.types';

--- a/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
@@ -34,7 +34,7 @@ export class GithubCommitsListConfigServiceDeploy extends GithubCommitsListConfi
           scm: appSource.type.id as GitSCMType,
           projectName: appSource.gitDetails.projectName,
           sha: appSource.gitDetails.branch.name,
-          commitSha: appSource.gitDetails.commit ? appSource.gitDetails.commit.sha : null
+          commitSha: appSource.gitDetails.commit ? appSource.gitDetails.commit : null
         } : null;
       }),
       filter(fetchDetails => !!fetchDetails && !!fetchDetails.projectName && !!fetchDetails.sha),

--- a/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/github-commits/github-commits-list-config-deploy.service.ts
@@ -33,16 +33,14 @@ export class GithubCommitsListConfigServiceDeploy extends GithubCommitsListConfi
         return (appSource.type.id === 'github' || appSource.type.id === 'gitlab') ? {
           scm: appSource.type.id as GitSCMType,
           projectName: appSource.gitDetails.projectName,
-          sha: appSource.gitDetails.branch.name,
-          commitSha: appSource.gitDetails.commit ? appSource.gitDetails.commit : null
+          sha: appSource.gitDetails.branch.name
         } : null;
       }),
       filter(fetchDetails => !!fetchDetails && !!fetchDetails.projectName && !!fetchDetails.sha),
       first()
     ).subscribe(fetchDetails => {
       const scm = scmService.getSCM(fetchDetails.scm);
-      this.dataSource = new GithubCommitsDataSource(this.store,
-        this, scm, fetchDetails.projectName, fetchDetails.sha, fetchDetails.commitSha);
+      this.dataSource = new GithubCommitsDataSource(this.store, this, scm, fetchDetails.projectName, fetchDetails.sha);
       this.initialised.next(true);
     });
   }

--- a/src/jetstream/plugins/cfapppush/types.go
+++ b/src/jetstream/plugins/cfapppush/types.go
@@ -50,10 +50,10 @@ type GitSCMSourceInfo struct {
 // Structure used to provide metadata about the Git Url source
 type GitUrlSourceInfo struct {
 	DeploySource
-	Project    string `json:"project"`
+	Project    string `json:"project"` // Not sent from client
 	Branch     string `json:"branch"`
 	Url        string `json:"url"`
-	CommitHash string `json:"commit"`
+	CommitHash string `json:"commit"` // Not sent from client
 }
 
 // DockerImageSourceInfo - Structure used to provide metadata about the docker source

--- a/src/test-e2e/application/application-deploy-e2e.spec.ts
+++ b/src/test-e2e/application/application-deploy-e2e.spec.ts
@@ -1,4 +1,4 @@
-import { browser } from 'protractor';
+import { browser, promise } from 'protractor';
 
 import { e2e } from '../e2e';
 import { CFHelpers } from '../helpers/cf-helpers';
@@ -13,6 +13,7 @@ import { ApplicationPageRoutesTab } from './po/application-page-routes.po';
 import { ApplicationPageSummaryTab } from './po/application-page-summary.po';
 import { ApplicationPageVariablesTab } from './po/application-page-variables.po';
 import { ApplicationBasePage } from './po/application-page.po';
+import { DeployApplication } from './po/deploy-app.po';
 
 let applicationE2eHelper: ApplicationE2eHelper;
 let cfHelper: CFHelpers;
@@ -299,6 +300,106 @@ describe('Application Deploy -', () => {
     confirm.waitUntilShown();
     expect(confirm.getMessage()).toBe('Are you sure you want to terminate instance 0?');
     confirm.confirm();
+  });
+
+  describe('Redeploy', () => {
+
+    let pRedeployHash: promise.Promise<string>;
+    const deployApp: DeployApplication = new DeployApplication();
+
+    it('Should reach deploy stepper from git tab', () => {
+      const appGithub = new ApplicationPageGithubTab(appDetails.cfGuid, appDetails.appGuid);
+      appGithub.goToGithubTab();
+
+
+      const pCurrentCommitRow = appGithub.commits.table.getHighlightedRow();
+      expect(pCurrentCommitRow).toBeGreaterThanOrEqual(0);
+
+      // Initial deploy should be HEAD of master, so top row
+      const pDeployedHash = appGithub.commits.table.getCell(0, 1).getText();
+
+      pRedeployHash = appGithub.commits.table.getCell(1, 1).getText();
+      expect(pRedeployHash).not.toBe(pDeployedHash);
+      pRedeployHash.then(redeployHash => {
+        expect(redeployHash).toBeDefined();
+        expect(redeployHash.length).toBe(8);
+      });
+
+      const menu = appGithub.commits.table.openRowActionMenuByIndex(1);
+      menu.waitUntilShown();
+      menu.clickItem('Deploy');
+      return deployApp.waitForChildPage('?appGuid=');
+
+    });
+
+    it('Should be source step with correct values', () => {
+      expect(deployApp.header.getTitleText()).toBe(`Redeploy`);
+
+      deployApp.stepper.getStepNames().then(steps => {
+        expect(steps.length).toBe(3);
+        expect(steps[0]).toBe('Source');
+        expect(steps[1]).toBe('Overrides (Optional)');
+        expect(steps[2]).toBe('Redeploy');
+      });
+
+      expect(deployApp.stepper.getActiveStepName()).toBe('Source');
+      expect(deployApp.stepper.canNext()).toBeTruthy();
+
+      return deployApp.stepper.getStepperForm().getFieldsMapped().then(fields => {
+        fields.forEach(field => {
+          switch (field.placeholder) {
+            case 'Project':
+              expect(field.value).toBe(testApp);
+              break;
+            case 'Branch':
+              expect(field.text).toBe('master');
+              break;
+            default:
+              fail(`Unknown field: ${field.placeholder}`);
+              break;
+          }
+        });
+        expect(deployApp.sourceStepGetRedeployCommit()).toBe(pRedeployHash);
+      });
+    });
+
+    it('Should deploy successfully', () => {
+      deployApp.stepper.next();
+
+      const overrides = deployApp.getOverridesForm();
+      overrides.waitUntilShown();
+
+      deployApp.stepper.next();
+
+      // Turn off waiting for Angular - the web socket connection is kept open which means the tests will timeout
+      // waiting for angular if we don't turn off.
+      browser.waitForAngularEnabled(false);
+
+      // Press next to deploy the app
+      deployApp.stepper.next();
+
+      // Wait for the application to be fully deployed - so we see any errors that occur
+      deployApp.waitUntilDeployed();
+
+      // Wait until app summary button can be pressed
+      deployApp.stepper.waitUntilCanNext('Go to App Summary');
+      deployApp.stepper.next();
+    });
+
+    it('Should have correct commit after deploy', () => {
+
+      const appSummary = new ApplicationPageSummaryTab(appDetails.cfGuid, appDetails.appGuid);
+      // Reload page at app summary, just in case of caching
+      appSummary.navigateTo();
+      appSummary.waitForPage();
+      appSummary.cardDeployInfo.github.waitUntilShown();
+      appSummary.cardDeployInfo.github.getValue().then(commitHash => {
+        expect(commitHash).toBeDefined();
+        expect(commitHash.length).toBe(8);
+      });
+
+      browser.waitForAngularEnabled(true);
+    });
   });
 
   afterAll(() => applicationE2eHelper.deleteApplication(null, { appName: testAppName }));

--- a/src/test-e2e/application/po/deploy-app.po.ts
+++ b/src/test-e2e/application/po/deploy-app.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element, protractor } from 'protractor';
+import { browser, by, element, promise, protractor } from 'protractor';
 
 import { FormComponent } from '../../po/form.po';
 import { ListComponent } from '../../po/list.po';
@@ -33,5 +33,9 @@ export class DeployApplication extends Page {
   public waitUntilDeployed(timeout = 120000) {
     const deployStatus = element(by.cssContainingText('.deploy-app__title', 'Deployed'));
     return browser.wait(until.presenceOf(deployStatus), timeout);
+  }
+
+  public sourceStepGetRedeployCommit(): promise.Promise<string> {
+    return element(by.css('.deploy-step2-form__commit a')).getText();
   }
 }

--- a/src/test-e2e/po/menu.po.ts
+++ b/src/test-e2e/po/menu.po.ts
@@ -1,5 +1,6 @@
-import { protractor, ElementFinder } from 'protractor/built';
-import { browser, element, by, promise } from 'protractor';
+import { by, element, promise } from 'protractor';
+import { ElementFinder } from 'protractor/built';
+
 import { Component } from './component.po';
 
 export class MenuItemMap {
@@ -10,7 +11,7 @@ export class MenuItem {
   index: number;
   label: string;
   class: string;
-  click: Function;
+  click: () => promise.Promise<void>;
   disabled: boolean;
 }
 /**
@@ -25,7 +26,7 @@ export class MenuComponent extends Component {
   getItems(): promise.Promise<MenuItem[]> {
     return this.locator.all(by.tagName('button')).map((elm, index) => {
       return {
-        index: index,
+        index,
         label: elm.getText(),
         class: elm.getAttribute('class'),
         click: elm.click,


### PR DESCRIPTION
Fixes #4185
Bugs
- Deploy Source Step - Blank step on redeploy
- Deploy Source Step - Blank commit details on deploy
- Redploy commit was ignored, always used HEAD of branch
- 404 when fetching github project in app github tab

Fixed by
- Tidy up deploy source step
- Use correct param when fetching github branches via action builder
- Ensure commit sha is correctly sent on redeploy (typing, not actually sent!)
- Fetch github commit uses new weird syntax, old action builder way not working
- Improved typing of deploy messages sent to backend

E2E
- Added redeploy test