### PR TITLE
Add missing feature flag descriptions

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/components/components.module.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/components.module.ts
@@ -175,6 +175,7 @@ import { SelectServiceComponent } from './select-service/select-service.componen
 import { ServiceIconComponent } from './service-icon/service-icon.component';
 import { ServicePlanPriceComponent } from './service-plan-price/service-plan-price.component';
 import { ServicePlanPublicComponent } from './service-plan-public/service-plan-public.component';
+import { TableCellFeatureFlagDescriptionComponent } from './list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component';
 
 // tslint:disable:max-line-length
 // tslint:enable:max-line-length
@@ -187,6 +188,7 @@ const cfListTableCells: Type<TableCellCustom<any>>[] = [
   CfOrgPermissionCellComponent,
   CfSpacePermissionCellComponent,
   TableCellFeatureFlagStateComponent,
+  TableCellFeatureFlagDescriptionComponent,
   TableCellConfirmOrgSpaceComponent,
   TableCellSelectOrgComponent,
   TableCellAppStatusComponent,
@@ -283,7 +285,8 @@ const cfListCards: Type<CardCell<any>>[] = [
     EventMetadataComponent,
     ...cfListTableCells,
     ...cfListCards,
-    ServiceInstanceLastOpComponent
+    ServiceInstanceLastOpComponent,
+    TableCellFeatureFlagDescriptionComponent
   ],
   exports: [
     ServiceIconComponent,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/cf-feature-flags-data-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/cf-feature-flags-data-source.ts
@@ -22,11 +22,13 @@ export const FeatureFlagDescriptions = {
   set_roles_by_username: 'Org Managers and Space Managers can add roles by username',
   unset_roles_by_username: 'Org Managers and Space Managers can remove roles by username',
   task_creation: 'Space Developers can create tasks on their application. This feature is under development',
-  env_var_visibility: ' All users can view environment variables',
+  env_var_visibility: 'All users can view environment variables',
   space_scoped_private_broker_creation: 'Space Developers can create space-scoped private service brokers',
   space_developer_env_var_visibility:
     'Space Developers can view their v2 environment variables. Org Managers and Space Managers can view their v3 environment variables',
-  service_instance_sharing: 'Org and Space Managers can allow service instances to be shared across different spaces.'
+  service_instance_sharing: 'Org and Space Managers can allow service instances to be shared across different spaces.',
+  hide_marketplace_from_unauthenticated_users: 'Service offerings available in the marketplace will be hidden from unauthenticated users',
+  resource_matching: 'Any user can create resource matches'
 };
 export class CfFeatureFlagsDataSource extends ListDataSource<IFeatureFlag> {
   static nameColumnId = 'name';

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/cf-feature-flags-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/cf-feature-flags-list-config.service.ts
@@ -8,8 +8,9 @@ import { IListFilter, ListViewTypes } from '../../../../../../../core/src/shared
 import { ListView } from '../../../../../../../store/src/actions/list.actions';
 import { ActiveRouteCfOrgSpace } from '../../../../../features/cloud-foundry/cf-page.types';
 import { BaseCfListConfig } from '../base-cf/base-cf-list-config';
-import { CfFeatureFlagsDataSource, FeatureFlagDescriptions } from './cf-feature-flags-data-source';
+import { CfFeatureFlagsDataSource } from './cf-feature-flags-data-source';
 import { TableCellFeatureFlagStateComponent } from './table-cell-feature-flag-state/table-cell-feature-flag-state.component';
+import { TableCellFeatureFlagDescriptionComponent } from './table-cell-feature-flag-description/table-cell-feature-flag-description.component';
 
 @Injectable()
 export class CfFeatureFlagsListConfigService extends BaseCfListConfig<IFeatureFlag> {
@@ -48,9 +49,7 @@ export class CfFeatureFlagsListConfigService extends BaseCfListConfig<IFeatureFl
     {
       columnId: CfFeatureFlagsDataSource.descriptionColumnId,
       headerCell: () => 'Description',
-      cellDefinition: {
-        getValue: (row) => FeatureFlagDescriptions[row.name]
-      },
+      cellComponent: TableCellFeatureFlagDescriptionComponent,
       class: 'table-column-select',
       cellFlex: '4'
     },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="FeatureFlagDescriptions[row.name]; else noDescription">{{ FeatureFlagDescriptions[row.name] }}</div>
+<div *ngIf="description; else noDescription">{{ description }}</div>
 <ng-template #noDescription>
   See <a target="_blank" noopener noreferrer href="https://v3-apidocs.cloudfoundry.org/index.html#list-of-feature-flags">Feature Flag reference</a>
 </ng-template>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="FeatureFlagDescriptions[row.name]; else noDescription">{{ FeatureFlagDescriptions[row.name] }}</div>
+<ng-template #noDescription>
+  See <a target="_blank" noopener noreferrer href="https://v3-apidocs.cloudfoundry.org/index.html#list-of-feature-flags">Feature Flag reference</a>
+</ng-template>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableCellFeatureFlagDescriptionComponent } from './table-cell-feature-flag-description.component';
+
+describe('TableCellFeatureFlagDescriptionComponent', () => {
+  let component: TableCellFeatureFlagDescriptionComponent;
+  let fixture: ComponentFixture<TableCellFeatureFlagDescriptionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableCellFeatureFlagDescriptionComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableCellFeatureFlagDescriptionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { TableCellCustom } from 'frontend/packages/core/src/shared/components/list/list.types';
+import { IFeatureFlag } from 'frontend/packages/core/src/core/cf-api.types';
+import { FeatureFlagDescriptions } from '../cf-feature-flags-data-source';
+
+@Component({
+  selector: 'app-table-cell-feature-flag-description',
+  templateUrl: './table-cell-feature-flag-description.component.html',
+  styleUrls: ['./table-cell-feature-flag-description.component.scss']
+})
+export class TableCellFeatureFlagDescriptionComponent extends TableCellCustom<IFeatureFlag> {
+  @Input() row: IFeatureFlag;
+
+  FeatureFlagDescriptions = FeatureFlagDescriptions;
+}

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.ts
@@ -9,7 +9,13 @@ import { FeatureFlagDescriptions } from '../cf-feature-flags-data-source';
   styleUrls: ['./table-cell-feature-flag-description.component.scss']
 })
 export class TableCellFeatureFlagDescriptionComponent extends TableCellCustom<IFeatureFlag> {
-  @Input() row: IFeatureFlag;
 
-  FeatureFlagDescriptions = FeatureFlagDescriptions;
+  description: string;
+
+  @Input()
+  set row(row: IFeatureFlag) {
+    this.description = row ? FeatureFlagDescriptions[row.name] : null;
+  }
+
 }
+


### PR DESCRIPTION
Fixes #4188 

This PR:

- Adds descriptions for missing feature flags
- Uses a link to the CF docs if a feature flag does not have a description