### PR TITLE
Ensure we don't loop between events and error page

### DIFF
--- a/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.html
+++ b/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.html
@@ -3,7 +3,7 @@
     <h1>Recent Endpoint Errors</h1>
     <div class="page-header-right">
       <span>
-        <button mat-icon-button matTooltip="Close" [routerLink]="back$ | async">
+        <button mat-icon-button matTooltip="Close" [routerLink]="back$ | async" [queryParams]="backParams$ | async">
           <mat-icon>close</mat-icon>
         </button>
       </span>

--- a/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.ts
+++ b/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.ts
@@ -8,13 +8,14 @@ import { first, map, withLatestFrom } from 'rxjs/operators';
 import { SendClearEndpointEventsAction } from '../../../../../store/src/actions/internal-events.actions';
 import { AppState } from '../../../../../store/src/app-state';
 import { endpointSchemaKey } from '../../../../../store/src/helpers/entity-factory';
+import { EntityMonitor } from '../../../../../store/src/monitors/entity-monitor';
+import { InternalEventMonitorFactory } from '../../../../../store/src/monitors/internal-event-monitor.factory';
 import { EndpointModel } from '../../../../../store/src/types/endpoint.types';
 import { InternalEventState } from '../../../../../store/src/types/internal-events.types';
 import { getPreviousRoutingState } from '../../../../../store/src/types/routing.type';
 import { endpointEntitySchema } from '../../../base-entity-schemas';
-import { EntityMonitor } from '../../../../../store/src/monitors/entity-monitor';
-import { InternalEventMonitorFactory } from '../../../../../store/src/monitors/internal-event-monitor.factory';
 import { StratosStatus } from '../../../shared/shared.types';
+import { eventReturnUrlParam } from '../../event-page/events-page/events-page.component';
 
 @Component({
   selector: 'app-error-page',
@@ -23,6 +24,7 @@ import { StratosStatus } from '../../../shared/shared.types';
 })
 export class ErrorPageComponent implements OnInit {
   public back$: Observable<string>;
+  public backParams$: Observable<object>;
   public errorDetails$: Observable<{ endpoint: EndpointModel; errors: InternalEventState[]; }>;
   public icon = StratosStatus.ERROR;
   public jsonDownloadHref$: Observable<SafeUrl>;
@@ -67,6 +69,17 @@ export class ErrorPageComponent implements OnInit {
   ) {
     this.back$ = store.select(getPreviousRoutingState).pipe(first()).pipe(
       map(previousState => previousState && previousState.url !== '/login' ? previousState.url.split('?')[0] : '/home')
+    );
+
+    this.backParams$ = this.back$.pipe(
+      map(urlBack => {
+        // If we've come from the events page ensure we pass it back it's param
+        const overrideReturnUrl = this.activatedRoute.snapshot.queryParams[eventReturnUrlParam];
+        return urlBack && urlBack.startsWith('/events') ? {
+          [eventReturnUrlParam]: overrideReturnUrl || null
+        } : {};
+      }),
+      first()
     );
   }
 }

--- a/src/frontend/packages/core/src/features/event-page/events-page/events-page.component.html
+++ b/src/frontend/packages/core/src/features/event-page/events-page/events-page.component.html
@@ -29,7 +29,7 @@
         </app-stateful-icon>
         <span class="event-page__event-message">{{event.message}}</span>
         <button class="event-page__event-row-button" *ngIf="event.link" color="primary" mat-flat-button
-          [routerLink]="event.link">View</button>
+          [routerLink]="event.link" [queryParams]="createQueryParams(event.link) | async">View</button>
         <button class="event-page__event-row-button" *ngIf="event.read" color="primary" mat-flat-button
           (click)="updateReadState(event, false)">Mark as unread</button>
         <button class="event-page__event-row-button" *ngIf="!event.read" color="primary" mat-flat-button


### PR DESCRIPTION
- Previously could get stuck in a loop Page --> Events --> Errors --> Events --> Errors
- We always went to the previous stack in the events and error page
- Now ensure we track where we came from, so when returning to events we break the loop
- fixes #4202
