### PR TITLE
Ensure we filter out maxed results for local lists

### DIFF
--- a/src/frontend/packages/store/src/monitors/pagination-monitor.ts
+++ b/src/frontend/packages/store/src/monitors/pagination-monitor.ts
@@ -239,6 +239,7 @@ export class PaginationMonitor<T = any, Y extends AppState = GeneralEntityAppSta
       distinctUntilChanged(),
       // Improve efficiency
       observeOn(asapScheduler),
+      filter(pagination => this.hasPage(pagination) && !LocalPaginationHelpers.isPaginationMaxed(pagination)),
       combineLatestOperator(entityObservable$),
       withLatestFrom(allEntitiesObservable$),
       map(([[pagination], allEntities]) => {


### PR DESCRIPTION
- fixes #4237
- When apps collection is fetched and exceeds maxed allowed count certain pagination monitor observables were still firing with the partial collection of apps
- This led to components who expect an apps list to show as if we had the full apps list (like count and memory), specifically space cards & summary
- This was caused by a correction to the pagination monitor to use 'local' monitor observables instead of the incorrect non-local ones
- The new correct observable used did not have a filter for maxed results, so emitted the bad data

Steps to reproduce
- Create a new space
- Create a running app in that space
- View the space summary page and ensure the app count and memory used stats are correct and shown
- Create another 600 apps in the same space (this number can be reduced by setting a lower stratos env var `UI_LIST_MAX_SIZE` or helm `console.ui.listMaxSize` though not lower than 100)
- View the space summary, no memory stat should show

