### PR TITLE
CF Push: A better fix for the token expiry issue

### DIFF
--- a/src/jetstream/plugins/cfapppush/connection_wrapper.go
+++ b/src/jetstream/plugins/cfapppush/connection_wrapper.go
@@ -1,0 +1,53 @@
+package cfapppush
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/command"
+
+	"github.com/cloudfoundry-incubator/stratos/src/jetstream/repository/interfaces"
+)
+
+// PushConnectionWrapper can wrap a given connection allowing the wrapper to modify
+// all requests going in and out of the given connection.
+type PushConnectionWrapper struct {
+	inner       cloudcontroller.Connection
+	portalProxy interfaces.PortalProxy
+	config      *CFPushAppConfig
+	cmdConfig   command.Config
+}
+
+// Wrap an existing connection
+func (cw PushConnectionWrapper) Wrap(innerconnection cloudcontroller.Connection) cloudcontroller.Connection {
+	cw.inner = innerconnection
+	return cw
+}
+
+// Make makes an HTTP request
+func (cw PushConnectionWrapper) Make(request *cloudcontroller.Request, passedResponse *cloudcontroller.Response) error {
+	// Check to see if the token is about to expire, if it is, refresh it first
+	token, found := cw.portalProxy.GetCNSITokenRecord(cw.config.EndpointID, cw.config.UserID)
+	if found {
+		// Aways update the access token, in case someone else refreshed it
+		cw.config.AuthToken = token.AuthToken
+
+		// Check if this is about to expire in the next 30 seconds
+		expiry := token.TokenExpiry - 30
+		expTime := time.Unix(expiry, 0)
+		if expTime.Before(time.Now()) {
+			cnsiRecord, err := cw.portalProxy.GetCNSIRecord(cw.config.EndpointID)
+			if err == nil {
+				// Refresh token first - makes sure it will be valid when we do the push
+				refreshedTokenRec, err := cw.portalProxy.RefreshOAuthToken(cnsiRecord.SkipSSLValidation, cnsiRecord.GUID, cw.config.UserID, cnsiRecord.ClientId, cnsiRecord.ClientSecret, cnsiRecord.TokenEndpoint)
+				if err == nil {
+					cw.config.AuthToken = refreshedTokenRec.AuthToken
+				}
+			}
+		}
+	}
+
+	cw.cmdConfig.SetAccessToken("bearer " + cw.config.AuthToken)
+
+	return cw.inner.Make(request, passedResponse)
+}

--- a/src/jetstream/plugins/cfapppush/info.go
+++ b/src/jetstream/plugins/cfapppush/info.go
@@ -30,6 +30,7 @@ func (c *CFPushApp) setEndpointInfo(config *configv3.Config) error {
 		// Got the info we need - update the config with it
 		config.SetTargetInformation(apiEndpoint, info.APIVersion, info.AuthorizationEndpoint, info.MinCLIVersion, info.DopplerLoggingEndpoint, info.RoutingEndpoint, skipSSLValidation)
 		config.SetAccessToken("bearer " + c.config.AuthToken)
+		// Note: We do not give the refresh token to the CLI code as we do NOT want it to refresh the token
 	} else {
 		return errors.New("Did not get a CF /v2/info response")
 	}

--- a/src/jetstream/plugins/cfapppush/main.go
+++ b/src/jetstream/plugins/cfapppush/main.go
@@ -10,7 +10,6 @@ import (
 // CFAppPush is a plugin to allow applications to be pushed to Cloud Foundry from Stratos
 type CFAppPush struct {
 	portalProxy interfaces.PortalProxy
-	cfPush      CFPush
 }
 
 // Init creates a new CFAppPush


### PR DESCRIPTION
This is a better fix for token expiry during CF Push.

We now refresh the token if needed before each API request that the CF CLI code makes. We also make sure that is is always using the latest auth token, in case Stratos has refreshed the token while the push is in progress.

Also fixed a bug where we had an unnecessary singleton which could cause issues with concurrent pushes.