### PR TITLE
Fix autoscaler events page

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
@@ -196,7 +196,7 @@
           </mat-card-header>
           <mat-card-content>
             <div class="app-metadata app-metadata-table">
-              <table mat-table [dataSource]="scalingHistory.resources">
+              <table mat-table [dataSource]="scalingHistory">
                 <ng-container matColumnDef="event">
                   <th mat-header-cell *matHeaderCellDef> Event </th>
                   <td mat-cell *matCellDef="let element"> Instances scaled
@@ -218,7 +218,7 @@
                 <tr mat-header-row *matHeaderRowDef="scalingHistoryColumns"></tr>
                 <tr mat-row *matRowDef="let row; columns: scalingHistoryColumns;"></tr>
               </table>
-              <div class="autoscaler-tab-table-no-record" *ngIf="scalingHistory.resources.length == 0">
+              <div class="autoscaler-tab-table-no-record" *ngIf="scalingHistory.length == 0">
                 No events.</div>
             </div>
           </mat-card-content>

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
@@ -76,10 +76,10 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
   metricTypes: string[] = AutoscalerConstants.MetricTypes;
 
   appAutoscalerPolicyService: EntityService<APIResource<AppAutoscalerPolicyLocal>>;
-  public appAutoscalerScalingHistoryService: PaginationObservables<AppAutoscalerEvent>;
+  public appAutoscalerScalingHistoryService: PaginationObservables<APIResource<AppAutoscalerEvent>>;
   appAutoscalerPolicy$: Observable<AppAutoscalerPolicyLocal>;
   appAutoscalerPolicySafe$: Observable<AppAutoscalerPolicyLocal>;
-  appAutoscalerScalingHistory$: Observable<APIResource<AppAutoscalerEvent[]>>;
+  appAutoscalerScalingHistory$: Observable<AppAutoscalerEvent[]>;
   appAutoscalerAppMetricNames$: Observable<AppAutoscaleMetricChart[]>;
 
   public showNoPolicyMessage$: Observable<boolean>;

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
@@ -22,6 +22,10 @@ import { EntityServiceFactory } from '../../../../store/src/entity-service-facto
 import { PaginationMonitorFactory } from '../../../../store/src/monitors/pagination-monitor.factory';
 import { ActionState } from '../../../../store/src/reducers/api-request-reducer/types';
 import { getPaginationObservables } from '../../../../store/src/reducers/pagination-reducer/pagination-reducer.helper';
+import {
+  getCurrentPageRequestInfo,
+  PaginationObservables,
+} from '../../../../store/src/reducers/pagination-reducer/pagination-reducer.types';
 import { selectDeletionInfo } from '../../../../store/src/selectors/api.selectors';
 import { APIResource } from '../../../../store/src/types/api.types';
 import { fetchAutoscalerInfo, isAutoscalerEnabled } from '../../core/autoscaler-helpers/autoscaler-available';
@@ -35,9 +39,9 @@ import {
 } from '../../store/app-autoscaler.actions';
 import {
   AppAutoscaleMetricChart,
+  AppAutoscalerEvent,
   AppAutoscalerMetricData,
   AppAutoscalerPolicyLocal,
-  AppAutoscalerScalingHistory,
   AppScalingTrigger,
 } from '../../store/app-autoscaler.types';
 import { appAutoscalerAppMetricEntityType, autoscalerEntityFactory } from '../../store/autoscaler-entity-factory';
@@ -72,10 +76,10 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
   metricTypes: string[] = AutoscalerConstants.MetricTypes;
 
   appAutoscalerPolicyService: EntityService<APIResource<AppAutoscalerPolicyLocal>>;
-  public appAutoscalerScalingHistoryService: EntityService<APIResource<AppAutoscalerScalingHistory>>;
+  public appAutoscalerScalingHistoryService: PaginationObservables<AppAutoscalerEvent>;
   appAutoscalerPolicy$: Observable<AppAutoscalerPolicyLocal>;
   appAutoscalerPolicySafe$: Observable<AppAutoscalerPolicyLocal>;
-  appAutoscalerScalingHistory$: Observable<AppAutoscalerScalingHistory>;
+  appAutoscalerScalingHistory$: Observable<APIResource<AppAutoscalerEvent[]>>;
   appAutoscalerAppMetricNames$: Observable<AppAutoscaleMetricChart[]>;
 
   public showNoPolicyMessage$: Observable<boolean>;
@@ -179,15 +183,20 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
       createEntityRelationPaginationKey(applicationEntityType, this.applicationService.appGuid, 'latest'),
       this.applicationService.appGuid,
       this.applicationService.cfGuid,
-      true,
+      false,
       this.paramsHistory
     );
-    this.appAutoscalerScalingHistoryService = this.entityServiceFactory.create(
-      this.applicationService.appGuid,
-      this.scalingHistoryAction
-    );
-    this.appAutoscalerScalingHistory$ = this.appAutoscalerScalingHistoryService.entityObs$.pipe(
-      map(({ entity }) => entity && entity.entity),
+    this.appAutoscalerScalingHistoryService = getPaginationObservables({
+      store: this.store,
+      action: this.scalingHistoryAction,
+      paginationMonitor: this.paginationMonitorFactory.create(
+        this.scalingHistoryAction.paginationKey,
+        this.scalingHistoryAction,
+        true
+      ),
+    }, true);
+    this.appAutoscalerScalingHistory$ = this.appAutoscalerScalingHistoryService.entities$.pipe(
+      map(entities => entities.map(entity => entity.entity)),
       publishReplay(1),
       refCount()
     );
@@ -197,7 +206,7 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
       this.appAutoscalerPolicy$,
       this.appAutoscalerScalingHistory$
     ]).pipe(
-      map(([policy, history]) => !!policy || (!!history && history.total_results > 0)),
+      map(([policy, history]) => !!policy || (!!history && history.length > 0)),
       publishReplay(1),
       refCount()
     );
@@ -206,7 +215,7 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
       this.appAutoscalerPolicy$,
       this.appAutoscalerScalingHistory$
     ]).pipe(
-      map(([policy, history]) => !policy && (!history || history.total_results === 0)),
+      map(([policy, history]) => !policy && (!history || history.length === 0)),
       publishReplay(1),
       refCount()
     );
@@ -261,7 +270,8 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
     if (this.appAutoscalerScalingHistoryErrorSub) {
       this.appAutoscalerScalingHistoryErrorSub.unsubscribe();
     }
-    this.appAutoscalerScalingHistoryErrorSub = this.appAutoscalerScalingHistoryService.entityMonitor.entityRequest$.pipe(
+    this.appAutoscalerScalingHistoryErrorSub = this.appAutoscalerScalingHistoryService.pagination$.pipe(
+      map(pagination => getCurrentPageRequestInfo(pagination)),
       filter(request => !!request.error),
       map(request => request.message),
       distinctUntilChanged(),

--- a/src/frontend/packages/cf-autoscaler/src/store/app-autoscaler.types.ts
+++ b/src/frontend/packages/cf-autoscaler/src/store/app-autoscaler.types.ts
@@ -69,15 +69,6 @@ export interface AppAutoscalerHealth {
   };
 }
 
-export interface AppAutoscalerScalingHistory {
-  next_url: string;
-  prev_url: string;
-  page: number;
-  resources: AppAutoscalerEvent[];
-  total_pages: number;
-  total_results: number;
-}
-
 export interface AppAutoscalerEvent {
   app_id: string;
   error: string;

--- a/src/frontend/packages/cf-autoscaler/src/store/autoscaler-entity-generator.ts
+++ b/src/frontend/packages/cf-autoscaler/src/store/autoscaler-entity-generator.ts
@@ -9,12 +9,7 @@ import {
 import { IStratosEndpointDefinition } from '../../../store/src/entity-catalog/entity-catalog.types';
 import { APIResource } from '../../../store/src/types/api.types';
 import { IFavoriteMetadata } from '../../../store/src/types/user-favorites.types';
-import {
-  AppAutoscalerHealth,
-  AppAutoscalerPolicy,
-  AppAutoscalerScalingHistory,
-  AppScalingTrigger,
-} from './app-autoscaler.types';
+import { AppAutoscalerEvent, AppAutoscalerHealth, AppAutoscalerPolicy, AppScalingTrigger } from './app-autoscaler.types';
 import {
   appAutoscalerAppMetricEntityType,
   appAutoscalerCredentialEntityType,
@@ -101,7 +96,7 @@ function generateScalingEntity(endpointDefinition: IStratosEndpointDefinition) {
     schema: autoscalerEntityFactory(appAutoscalerScalingHistoryEntityType),
     endpoint: endpointDefinition
   };
-  return new StratosCatalogEntity<IFavoriteMetadata, APIResource<AppAutoscalerScalingHistory>>(definition);
+  return new StratosCatalogEntity<IFavoriteMetadata, APIResource<AppAutoscalerEvent>>(definition);
 }
 
 function generateAppMetricEntity(endpointDefinition: IStratosEndpointDefinition) {

--- a/src/frontend/packages/core/src/shared/components/list/list.component.scss
+++ b/src/frontend/packages/core/src/shared/components/list/list.component.scss
@@ -85,14 +85,6 @@
         padding: 10px 10px 10px 0;
       }
 
-      &--metrics-range {
-        padding-left: 10px;
-
-        app-metrics-range-selector {
-          padding-left: 10px;
-        }
-      }
-
       &--multi-actions {
         button {
           &:first-of-type {

--- a/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.scss
+++ b/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.scss
@@ -6,7 +6,6 @@
   display: flex;
 
   &__overlay {
-    background-color: rgba(0, 0, 0, 0);
     left: 0;
     overflow: hidden;
     position: absolute;
@@ -29,7 +28,6 @@
     }
 
     &-show {
-      background-color: rgba(0, 0, 0, .6);
       transition-delay: 0s;
       visibility: visible;
 
@@ -39,7 +37,6 @@
     }
 
     &-inner {
-      box-shadow: -4px 3px 41px -1px rgba(0, 0, 0, .36);
       padding: 50px;
       position: relative;
       transform: translateY(-100%);

--- a/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.theme.scss
+++ b/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.theme.scss
@@ -1,10 +1,18 @@
 @import '~@angular/material/theming';
 @mixin metrics-range-selector-theme($theme, $app-theme) {
   $primary: map-get($theme, primary);
+  $background-color: map-get($app-theme, app-background-color);
+  $foreground: map-get($theme, foreground);
+
   .metrics-range-selector {
     &__overlay {
+      background-color: $background-color;
+      &-show {
+        background-color: rgba($background-color, .6);
+      }
       &-inner {
-        background-color: mat-contrast($primary, 500);
+        background-color: $background-color;
+        box-shadow: -4px 3px 41px -1px rgba(0, 0, 0, .36);
       }
     }
   }

--- a/src/frontend/packages/core/src/shared/services/metrics-range-selector.service.ts
+++ b/src/frontend/packages/core/src/shared/services/metrics-range-selector.service.ts
@@ -75,7 +75,7 @@ export class MetricsRangeSelectorService {
         };
       } else {
         return {
-          timeRange: metrics.query.params && metrics.query.params.window ?
+          timeRange: metrics.query && metrics.query.params && metrics.query.params.window ?
             times.find(time => time.value === metrics.query.params.window) :
             this.getDefaultTimeRange(times)
         };


### PR DESCRIPTION
- events weren't showing due to earlier init of metrics list. fixed by adding extra checks
- access events as list when needed
- fixed custom metrics time window drop down in dark mode
- fixed position of custom metric time drop down
