### PR TITLE
update kubernetes deploy doc to reference uaa.endpoint

### DIFF
--- a/deploy/kubernetes/console/README.md
+++ b/deploy/kubernetes/console/README.md
@@ -283,10 +283,7 @@ UAA configuration can be specified by providing the following configuration.
 Create a yaml file with the content below and and update according to your environment and save to a file called `uaa-config.yaml`.
 ```
 uaa:
-  url: https://uaa.cf-dev.io:2793
-  protocol: https://
-  port: 2793
-  host: uaa.cf-dev.io
+  endpoint: https://uaa.cf-dev.io:2793
   consoleClient:  cf
   consoleClientSecret: 
   consoleAdminIdentifier: cloud_controller.admin 

--- a/deploy/kubernetes/console/README.md
+++ b/deploy/kubernetes/console/README.md
@@ -20,9 +20,9 @@ helm repo add stratos https://cloudfoundry.github.io/stratos
 Check the repository was successfully added by searching for the `console`, for example:
 
 ```
-helm search console
+helm search repo console
 NAME               	CHART VERSION   APP VERSION	DESCRIPTION                                  
-stratos/console    	3.1.0           3.1.0      	A Helm chart for deploying Stratos UI Console
+stratos/console    	3.2.0           3.2.0      	A Helm chart for deploying Stratos UI Console
 ```
 
 > Note: Version numbers will depend on the version of Stratos available from the Helm repository


### PR DESCRIPTION
note: I didn't follow the contributing guidelines yet, I'll fix it up after work hours today

noticed that in this commit which updates the stratos console uaa configuration to be simpler and leverage "uaa.endpoint" that the README was using an example referencing "uaa.url" (which I don't think is a param reference? could be wrong?) and still including uaa.port, uaa.host, etc., though it appears that was all replaced by `uaa.endpoint`. would appreciate if someone double-checked this, apologies if I'm dead wrong.

additionally:
- bumps chart ref to 3.2.0
- bumps helm search command for helm3, which is `helm repo search console`

thanks for the time