### PR TITLE
check sso whitelist in more places

### DIFF
--- a/src/jetstream/authuaa.go
+++ b/src/jetstream/authuaa.go
@@ -435,14 +435,11 @@ func (p *portalProxy) RefreshUAAToken(userGUID string) (t interfaces.TokenRecord
 // We use a single callback so this can be whitelisted in the client
 func (p *portalProxy) ssoLoginToUAA(c echo.Context) error {
 	state := c.QueryParam("state")
-	if len(state) == 0 {
-		err := interfaces.NewHTTPShadowError(
-			http.StatusUnauthorized,
-			"SSO Login: State parameter missing",
-			"SSO Login: State parameter missing")
-		return err
-	}
 
+	stateErr := validateSSORedirectState(state, p.Config.SSOWhiteList)
+	if stateErr != nil {
+		return stateErr
+	}
 	// We use the same callback URL for both UAA and endpoint login
 	// Check if it is an endpoint login and dens to the right handler
 	endpointGUID := c.QueryParam("guid")
@@ -466,13 +463,6 @@ func (p *portalProxy) ssoLoginToUAA(c echo.Context) error {
 		state = fmt.Sprintf("%s/login?SSO_Message=%s", state, url.QueryEscape(msg))
 	}
 
-	if !safeSSORedirectState(state, p.Config.SSOWhiteList) {
-		err := interfaces.NewHTTPShadowError(
-			http.StatusUnauthorized,
-			"SSO Login: Disallowed redirect state",
-			"SSO Login: Disallowed redirect state")
-		return err
-	}
 
 	return c.Redirect(http.StatusTemporaryRedirect, state)
 }
@@ -527,15 +517,25 @@ func (p *portalProxy) initSSOlogin(c echo.Context) error {
 	}
 
 	state := c.QueryParam("state")
+	stateErr := validateSSORedirectState(state, p.Config.SSOWhiteList)
+	if stateErr != nil {
+		return stateErr
+	}
+
+	redirectURL := fmt.Sprintf("%s/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s", p.Config.ConsoleConfig.AuthorizationEndpoint, p.Config.ConsoleConfig.ConsoleClient, url.QueryEscape(getSSORedirectURI(state, state, "")))
+	c.Redirect(http.StatusTemporaryRedirect, redirectURL)
+	return nil
+}
+
+func validateSSORedirectState(state string, whiteListStr string) error {
 	if len(state) == 0 {
 		err := interfaces.NewHTTPShadowError(
 			http.StatusUnauthorized,
-			"SSO Login: Redirect state parameter missing",
-			"SSO Login: Redirect state parameter missing")
+			"SSO Login: State parameter missing",
+			"SSO Login: State parameter missing")
 		return err
 	}
-
-	if !safeSSORedirectState(state, p.Config.SSOWhiteList) {
+	if !safeSSORedirectState(state,whiteListStr) {
 		err := interfaces.NewHTTPShadowError(
 			http.StatusUnauthorized,
 			"SSO Login: Disallowed redirect state",
@@ -543,8 +543,6 @@ func (p *portalProxy) initSSOlogin(c echo.Context) error {
 		return err
 	}
 
-	redirectURL := fmt.Sprintf("%s/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s", p.Config.ConsoleConfig.AuthorizationEndpoint, p.Config.ConsoleConfig.ConsoleClient, url.QueryEscape(getSSORedirectURI(state, state, "")))
-	c.Redirect(http.StatusTemporaryRedirect, redirectURL)
 	return nil
 }
 

--- a/src/jetstream/authuaa.go
+++ b/src/jetstream/authuaa.go
@@ -466,6 +466,14 @@ func (p *portalProxy) ssoLoginToUAA(c echo.Context) error {
 		state = fmt.Sprintf("%s/login?SSO_Message=%s", state, url.QueryEscape(msg))
 	}
 
+	if !safeSSORedirectState(state, p.Config.SSOWhiteList) {
+		err := interfaces.NewHTTPShadowError(
+			http.StatusUnauthorized,
+			"SSO Login: Disallowed redirect state",
+			"SSO Login: Disallowed redirect state")
+		return err
+	}
+
 	return c.Redirect(http.StatusTemporaryRedirect, state)
 }
 


### PR DESCRIPTION
Check SSO whitelist in more of the SSO workflow

## Description
Applies open SSO redirect checks to more of the SSO flow

## Motivation and Context
closes open redirect on `/pp/v1/auth/sso_login_callback`

## How Has This Been Tested?
Tested manually against a running instance.
with `SSO_WHITELIST=${MY_DOMAIN}/*`
```
[jetstream](sso-whitelist)$ curl -s -w "%{http_code}" https://${MY_DOMAIN}/pp/v1/auth/sso_login_callback?state=https%3A%2F%2Fexample.com
{"error":"SSO Login: Disallowed redirect state"}401
[jetstream](sso-whitelist)$ curl -s -w "%{http_code}" https://${MY_DOMAIN}/pp/v1/auth/sso_login_callback?state=https%3A%2F%2F${MY_DOMAIN}
307
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message