### PR TITLE
Fix transition from space summary to app summary page

### DIFF
--- a/src/frontend/packages/store/src/entity-service.ts
+++ b/src/frontend/packages/store/src/entity-service.ts
@@ -94,6 +94,9 @@ export class EntityService<T = any> {
     this.waitForEntity$ = this.entityObs$.pipe(
       filter((ent) => {
         const { entityRequestInfo, entity } = ent;
+        // Note - isEntityAvailable does not block on updating, decision taken to ensure we show entity as soon as possible.
+        // This means, in the cf world, entities will be emitted here that are still in the validation process and as such may be missing
+        // required relations
         return this.isEntityAvailable(entity, entityRequestInfo);
       }),
       publishReplay(1),

--- a/src/frontend/packages/store/src/monitors/entity-monitor.factory.service.ts
+++ b/src/frontend/packages/store/src/monitors/entity-monitor.factory.service.ts
@@ -22,8 +22,8 @@ export class EntityMonitorFactory {
     entityConfig: EntityCatalogEntityConfig,
     startWithNull = true
   ): EntityMonitor<T> {
-    const { endpointType, entityType } = entityConfig;
-    const cacheKey = id + endpointType + entityType;
+    const { endpointType, entityType, schemaKey, subType } = entityConfig;
+    const cacheKey = id + endpointType + entityType + schemaKey + subType;
     if (this.monitorCache[cacheKey]) {
       return this.monitorCache[cacheKey];
     } else {

--- a/src/frontend/packages/store/src/reducers/api-request-reducer/types.ts
+++ b/src/frontend/packages/store/src/reducers/api-request-reducer/types.ts
@@ -45,7 +45,7 @@ export const defaultDeletingActionState = {
 };
 
 export interface UpdatingSection {
-  _root_: ActionState;
+  [rootUpdatingKey]: ActionState;
   [key: string]: ActionState;
 }
 export interface RequestInfoState {
@@ -61,7 +61,7 @@ export interface RequestInfoState {
 const defaultRequestState = {
   fetching: false,
   updating: {
-    _root_: getDefaultActionState()
+    [rootUpdatingKey]: getDefaultActionState()
   },
   creating: false,
   error: false,

--- a/src/frontend/packages/store/testing/src/store-test-helper.ts
+++ b/src/frontend/packages/store/testing/src/store-test-helper.ts
@@ -250,7 +250,7 @@ function getDefaultInitialTestStoreState(): AppState<BaseEntityValues> {
         '57ab08d8-86cc-473a-8818-25d5e8d0ea23': {
           fetching: false,
           updating: {
-            _root_: {
+            [rootUpdatingKey]: {
               busy: false,
               error: false,
               message: ''

--- a/src/frontend/packages/store/testing/src/store-test-helper.ts
+++ b/src/frontend/packages/store/testing/src/store-test-helper.ts
@@ -7,7 +7,7 @@ import { AppState } from '../../src/app-state';
 import { entityCatalog } from '../../src/entity-catalog/entity-catalog';
 import { EntityCatalogEntityConfig } from '../../src/entity-catalog/entity-catalog.types';
 import { appReducers } from '../../src/reducers.module';
-import { getDefaultRequestState } from '../../src/reducers/api-request-reducer/types';
+import { getDefaultRequestState, rootUpdatingKey } from '../../src/reducers/api-request-reducer/types';
 import { getDefaultPaginationEntityState } from '../../src/reducers/pagination-reducer/pagination-reducer-reset-pagination';
 import { NormalizedResponse } from '../../src/types/api.types';
 import { SessionData, SessionDataEndpoint } from '../../src/types/auth.types';


### PR DESCRIPTION
- bug came in after entity access work (we now use the entity service factory everywhere)
- an entity service for a space with no org was cached by guid
- an entity service for a space requiring org used the space with no org cached version
- solution is to make cache id include schema key (determines with/without org)
- also tidied use of `rootUpdatingKey` and added comment regarding blocking validating entities