### PR TITLE
Ensure the correct key is used for metacard favourite info

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/cf-favorites-helpers.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-favorites-helpers.ts
@@ -5,12 +5,12 @@ import { CfAPIResource } from './store/types/cf-api.types';
 
 export function getFavoriteFromCfEntity<T extends IEntityMetadata = IEntityMetadata>(
   entity,
-  entityKey: string,
+  entityType: string,
   favoritesConfigMapper: FavoritesConfigMapper
 ): UserFavorite<T> {
   if (isCfEntity(entity as CfAPIResource)) {
     return favoritesConfigMapper.getFavoriteFromEntity<T>(
-      entityKey,
+      entityType,
       'cf',
       entity.entity.cfGuid,
       entity

--- a/src/frontend/packages/core/src/core/user-favorite-helpers.ts
+++ b/src/frontend/packages/core/src/core/user-favorite-helpers.ts
@@ -10,14 +10,14 @@ export function isEndpointTypeFavorite(favorite: UserFavorite<IFavoriteMetadata>
 // Uses the endpoint definition to get the helper that can look up an entitty
 export function getFavoriteFromEntity<T extends IEntityMetadata = IEntityMetadata>(
   entity,
-  entityKey: string,
+  entityType: string,
   favoritesConfigMapper: FavoritesConfigMapper,
-  entityType: string
+  endpointType: string
 ): UserFavorite<T> {
   // Use entity catalog to get favorite for the given endpoint type
-  const endpoint = entityCatalog.getEndpoint(entityType);
+  const endpoint = entityCatalog.getEndpoint(endpointType);
   if (endpoint && endpoint.definition && endpoint.definition.favoriteFromEntity) {
-    return endpoint.definition.favoriteFromEntity(entity, entityKey, favoritesConfigMapper);
+    return endpoint.definition.favoriteFromEntity(entity, entityType, favoritesConfigMapper);
   }
 
   return null;

--- a/src/frontend/packages/core/src/shared/components/list/list-cards/meta-card/meta-card-base/meta-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-cards/meta-card/meta-card-base/meta-card.component.ts
@@ -25,7 +25,7 @@ export function createMetaCardMenuItemSeparator() {
   return {
     label: '-',
     separator: true,
-    action: () => {}
+    action: () => { }
   };
 }
 
@@ -79,7 +79,7 @@ export class MetaCardComponent implements OnDestroy {
           first(),
           tap(entity => this.favorite = getFavoriteFromEntity(
             entity,
-            entityConfig.schema.key,
+            entityConfig.schema.entityType,
             this.favoritesConfigMapper,
             entityConfig.schema.endpointType
           ))


### PR DESCRIPTION
- Came in post 3.2.0 (cbc20cc3ef153a 2020-05-07), which was I think part of the first iteration of splitting out cf files
- getFavoriteFromCfEntity used full entityKey (endpoint type + entity type)
- generic getFavoriteFromEntity uses only entity type
- this lead to console errors and failure to favourite using list's cards (see org spaces list)