### PR TITLE
Helm: Remove need for --recreate-pods when upgrading

### DIFF
--- a/deploy/ci/automation/helmtest.sh
+++ b/deploy/ci/automation/helmtest.sh
@@ -164,7 +164,7 @@ CHART_FILE="${KUBE_FOLDER}/console-${DEV_IMAGE_VERSION}.tgz"
 echo "Chart file path: ${CHART_FILE}"
 
 log "Upgrading using latest Helm Chart"
-helm upgrade ${NAME} "${CHART_FILE}" --recreate-pods --debug --set consoleVersion=${DEV_IMAGE_VERSION} --set imagePullPolicy=Always
+helm upgrade ${NAME} "${CHART_FILE}" --debug --set consoleVersion=${DEV_IMAGE_VERSION} --set imagePullPolicy=Always
 
 checkVersion console-${DEV_IMAGE_VERSION}
 waitForHelmRelease
@@ -177,7 +177,7 @@ sed -i.bak -e 's/appVersion: '"${DEV_IMAGE_VERSION}"'/appVersion: 0.2.0/g' "${HE
 cat "${HELM_TMP}/Chart.yaml"
 
 log "Upgrading using latest Helm Chart (checking chart upgrade)"
-helm upgrade ${NAME} "${HELM_TMP}" --recreate-pods --debug --set imagePullPolicy=Always
+helm upgrade ${NAME} "${HELM_TMP}" --debug --set imagePullPolicy=Always
 
 waitForHelmRelease
 checkVersion console-0.2.0
@@ -204,7 +204,7 @@ helm install ${HELM_REPO_NAME}/console --name ${NAME} --namespace ${NAMESPACE}
 waitForHelmRelease
 
 log "Upgrading using --reuse-values"
-helm upgrade ${NAME} "${HELM_TMP}" --recreate-pods --debug --reuse-values
+helm upgrade ${NAME} "${HELM_TMP}" --debug --reuse-values
 
 waitForHelmRelease
 # Should have used same values as before

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -220,7 +220,7 @@ $ helm repo update
 To update an instance, the following assumes your instance is called `my-console`, and overrides have been specified in a file called `overrides.yaml`.
 
 ```
-$ helm upgrade -f overrides.yaml my-console stratos/console --recreate-pods
+$ helm upgrade -f overrides.yaml my-console stratos/console
 ```
 
 After the upgrade, perform a `helm list` to ensure your console is the latest version.

--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -236,6 +236,7 @@ pushd "${DEST_HELM_CHART_PATH}" > /dev/null
 rm -rf "${DEST_HELM_CHART_PATH}/**/*.orig"
 
 # Run customization script if there is one
+# This can do things like provide a custom __stratos.tpl file
 if [ -f "${STRATOS_PATH}/custom-src/deploy/kubernetes/customize-helm.sh" ]; then
   printf "${YELLOW}${BOLD}Applying Helm Chart customizations${RESET}\n"
   "${STRATOS_PATH}/custom-src/deploy/kubernetes/customize-helm.sh" "${DEST_HELM_CHART_PATH}"

--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -221,11 +221,6 @@ fi
 
 log "-- Building Helm Chart"
 
-# Apply any chart customizations added by a fork
-if [ "${HAS_CUSTOM_BUILD}" == "true" ]; then
-  custom_helm_build
-fi
-
 # Don't change the chart in the repo, copy it and modify it locally
 
 SRC_HELM_CHART_PATH="${STRATOS_PATH}/deploy/kubernetes/console"

--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -221,6 +221,11 @@ fi
 
 log "-- Building Helm Chart"
 
+# Apply any chart customizations added by a fork
+if [ "${HAS_CUSTOM_BUILD}" == "true" ]; then
+  custom_helm_build
+fi
+
 # Don't change the chart in the repo, copy it and modify it locally
 
 SRC_HELM_CHART_PATH="${STRATOS_PATH}/deploy/kubernetes/console"

--- a/deploy/kubernetes/console/README.md
+++ b/deploy/kubernetes/console/README.md
@@ -155,10 +155,8 @@ helm repo update
 To update an instance, the following assumes your instance is called `my-console`:
 
 ```
-helm upgrade my-console stratos/console --recreate-pods
+helm upgrade my-console stratos/console
 ```
-
-> Note: You *must* use the `--recreate-pods` flag when upgrading
 
 After the upgrade, perform a `helm list` to ensure your console is the latest version.
 

--- a/deploy/kubernetes/console/templates/__stratos.tpl
+++ b/deploy/kubernetes/console/templates/__stratos.tpl
@@ -1,0 +1,5 @@
+# Customizations for the Helm Chart
+
+# Extra env vars for the Jetstream Pod in deployment.yaml
+{{- define "stratosJetstreamEnv" }}
+{{- end }}

--- a/deploy/kubernetes/console/templates/config-init.yaml
+++ b/deploy/kubernetes/console/templates/config-init.yaml
@@ -102,6 +102,8 @@ spec:
 {{- end }}
       containers:
       - env:
+        - name: STRATOS_IMAGE_REF
+          value: "{{.Values.consoleVersion}}:{{ .Release.Revision }}"
         - name: "STRATOS_VOLUME_MIGRATION"
           value: "true"
         - name: "IS_UPGRADE"

--- a/deploy/kubernetes/console/templates/database.yaml
+++ b/deploy/kubernetes/console/templates/database.yaml
@@ -60,6 +60,8 @@ spec:
         image: {{.Values.kube.registry.hostname}}/{{.Values.kube.organization}}/{{.Values.images.mariadb}}:{{.Values.consoleVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         env:
+        - name: STRATOS_IMAGE_REF
+          value: "{{.Values.consoleVersion}}:{{ .Release.Revision }}"
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
           name: https
           protocol: TCP
         env:
+        - name: STRATOS_IMAGE_REF
+          value: "{{.Values.consoleVersion}}:{{ .Release.Revision }}"
         - name: CONSOLE_CERT_PATH
           value: "/{{ .Release.Name }}-cert-volume"
         volumeMounts:
@@ -75,6 +77,8 @@ spec:
         imagePullPolicy: {{.Values.imagePullPolicy}}
         name: proxy
         env:
+        - name: STRATOS_IMAGE_REF
+          value: "{{.Values.consoleVersion}}:{{ .Release.Revision }}"
         - name: STRATOS_HELM_RELEASE
           value: "{{ .Release.Name }}"
         - name: DB_USER
@@ -277,6 +281,7 @@ spec:
         - name: UI_LIST_ALLOW_LOAD_MAXED
           value: {{ default "false" .Values.console.ui.listAllowLoadMaxed | quote }}
         {{- end }}
+        {{- include "stratosJetstreamEnv" . | indent 8 }}
         readinessProbe:
           httpGet:
             path: /pp/v1/ping


### PR DESCRIPTION
Fixes #4132

Also adds `__stratos.tpl` as an extension point for forks to modify the helm chart without needing to modify the upstream files