### PR TITLE
Fix several space developer permission bugs

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
@@ -1,4 +1,4 @@
-<app-page-sub-nav *ngIf="canEditSpace$ | async">
+<app-page-sub-nav>
   <ng-container *ngIf="appAutoscalerPolicy$ | async as policy; else noPolicy">
     <button mat-button name="edit" (click)="updatePolicyPage()" class="nav-button-with-text">
       <span class="nav-button-with-text__span">
@@ -235,7 +235,7 @@
       </app-tile>
     </app-tile-group>
     <app-no-content-message *ngIf="showNoPolicyMessage$ | async" [icon]="'meter'" [iconFont]="'stratos-icons'"
-      [firstLine]="noPolicyMessageFirstLine" [secondLine]="(canEditSpace$ | async) ? noPolicyMessageSecondLine : ''">
+      [firstLine]="noPolicyMessageFirstLine" [secondLine]="noPolicyMessageSecondLine">
     </app-no-content-message>
   </app-tile-grid>
 </div>

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
@@ -1,4 +1,4 @@
-<app-page-sub-nav>
+<app-page-sub-nav *ngIf="canEditSpace$ | async">
   <ng-container *ngIf="appAutoscalerPolicy$ | async as policy; else noPolicy">
     <button mat-button name="edit" (click)="updatePolicyPage()" class="nav-button-with-text">
       <span class="nav-button-with-text__span">
@@ -235,7 +235,7 @@
       </app-tile>
     </app-tile-group>
     <app-no-content-message *ngIf="showNoPolicyMessage$ | async" [icon]="'meter'" [iconFont]="'stratos-icons'"
-      [firstLine]="noPolicyMessageFirstLine" [secondLine]="noPolicyMessageSecondLine">
+      [firstLine]="noPolicyMessageFirstLine" [secondLine]="(canEditSpace$ | async) ? noPolicyMessageSecondLine : ''">
     </app-no-content-message>
   </app-tile-grid>
 </div>

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.spec.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.spec.ts
@@ -15,6 +15,9 @@ import {
 import {
   RunningInstancesComponent,
 } from '../../../../cloud-foundry/src/shared/components/running-instances/running-instances.component';
+import {
+  cfCurrentUserPermissionsService,
+} from '../../../../cloud-foundry/src/user-permissions/cf-user-permissions-checkers';
 import { ApplicationServiceMock } from '../../../../cloud-foundry/test-framework/application-service-helper';
 import { CoreModule } from '../../../../core/src/core/core.module';
 import { SharedModule } from '../../../../core/src/shared/shared.module';
@@ -48,7 +51,8 @@ describe('AutoscalerTabExtensionComponent', () => {
       providers: [
         DatePipe,
         { provide: ApplicationService, useClass: ApplicationServiceMock },
-        TabNavService
+        TabNavService,
+        ...cfCurrentUserPermissionsService
       ]
     })
       .compileComponents();

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
@@ -2,11 +2,19 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { combineLatest, Observable, Subscription } from 'rxjs';
+import { combineLatest, Observable, of, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, first, map, pairwise, publishReplay, refCount, switchMap } from 'rxjs/operators';
 
-import { applicationEntityType } from '../../../../cloud-foundry/src/cf-entity-types';
-import { createEntityRelationPaginationKey } from '../../../../cloud-foundry/src/entity-relations/entity-relations.types';
+import { cfEntityCatalog } from '../../../../cloud-foundry/src/cf-entity-catalog';
+import {
+  applicationEntityType,
+  organizationEntityType,
+  spaceEntityType,
+} from '../../../../cloud-foundry/src/cf-entity-types';
+import {
+  createEntityRelationKey,
+  createEntityRelationPaginationKey,
+} from '../../../../cloud-foundry/src/entity-relations/entity-relations.types';
 import { ApplicationMonitorService } from '../../../../cloud-foundry/src/features/applications/application-monitor.service';
 import { ApplicationService } from '../../../../cloud-foundry/src/features/applications/application.service';
 import { getGuids } from '../../../../cloud-foundry/src/features/applications/application/application-base.component';
@@ -54,9 +62,32 @@ import { appAutoscalerAppMetricEntityType, autoscalerEntityFactory } from '../..
   link: 'autoscale',
   icon: 'meter',
   iconFont: 'stratos-icons',
-  hidden: (store: Store<AppState>, esf: EntityServiceFactory, activatedRoute: ActivatedRoute) => {
+  hidden: (store: Store<AppState>, esf: EntityServiceFactory, activatedRoute: ActivatedRoute, cups: CurrentUserPermissionsService) => {
     const endpointGuid = getGuids('cf')(activatedRoute) || window.location.pathname.split('/')[2];
-    return isAutoscalerEnabled(endpointGuid, esf).pipe(map(enabled => !enabled));
+    const appGuid = getGuids()(activatedRoute) || window.location.pathname.split('/')[3];
+    const appEntService = cfEntityCatalog.application.store.getEntityService(appGuid, endpointGuid, {
+      includeRelations: [
+        createEntityRelationKey(applicationEntityType, spaceEntityType),
+        createEntityRelationKey(spaceEntityType, organizationEntityType),
+      ],
+      populateMissing: true
+    })
+
+    const canEditSpace$ = appEntService.waitForEntity$.pipe(
+      switchMap(app => cups.can(
+        CfCurrentUserPermissions.APPLICATION_EDIT,
+        endpointGuid,
+        app.entity.entity.space.entity.organization_guid,
+        app.entity.entity.space.metadata.guid
+      )),
+    )
+
+    const autoscalerEnabled = isAutoscalerEnabled(endpointGuid, esf);
+
+    return canEditSpace$.pipe(
+      switchMap(canEditSpace => canEditSpace ? autoscalerEnabled : of(false)),
+      map(can => !can)
+    )
   }
 })
 @Component({
@@ -114,8 +145,6 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
     'results-per-page': '5',
     'order-direction': 'desc'
   };
-
-  public canEditSpace$: Observable<boolean>;
 
   ngOnDestroy(): void {
     if (this.appAutoscalerPolicySnackBarRef) {
@@ -224,18 +253,6 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
       publishReplay(1),
       refCount()
     );
-
-    this.canEditSpace$ = combineLatest(
-      this.applicationService.appOrg$,
-      this.applicationService.appSpace$
-    ).pipe(
-      switchMap(([org, space]) => this.cups.can(
-        CfCurrentUserPermissions.SPACE_EDIT,
-        this.applicationService.cfGuid,
-        org.metadata.guid,
-        space.metadata.guid
-      ))
-    )
   }
 
   getAppMetric(metricName: string, trigger: AppScalingTrigger, params: AutoscalerPaginationParams) {

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
@@ -73,7 +73,7 @@ import { appAutoscalerAppMetricEntityType, autoscalerEntityFactory } from '../..
       populateMissing: true
     })
 
-    const canEditSpace$ = appEntService.waitForEntity$.pipe(
+    const canEditApp$ = appEntService.waitForEntity$.pipe(
       switchMap(app => cups.can(
         CfCurrentUserPermissions.APPLICATION_EDIT,
         endpointGuid,
@@ -84,7 +84,7 @@ import { appAutoscalerAppMetricEntityType, autoscalerEntityFactory } from '../..
 
     const autoscalerEnabled = isAutoscalerEnabled(endpointGuid, esf);
 
-    return canEditSpace$.pipe(
+    return canEditApp$.pipe(
       switchMap(canEditSpace => canEditSpace ? autoscalerEnabled : of(false)),
       map(can => !can)
     )
@@ -163,8 +163,7 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
     private paginationMonitorFactory: PaginationMonitorFactory,
     private appAutoscalerPolicySnackBar: MatSnackBar,
     private appAutoscalerScalingHistorySnackBar: MatSnackBar,
-    private confirmDialog: ConfirmationDialogService,
-    private cups: CurrentUserPermissionsService
+    private confirmDialog: ConfirmationDialogService
   ) { }
 
   ngOnInit() {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -149,12 +149,12 @@
           </mat-card-content>
         </mat-card>
       </app-tile>
-      <app-tile id="app-build-tab-deployment-info">
+      <app-tile id="app-build-tab-deployment-info" *ngIf="(deploySource$ | async) as deploySource">
         <mat-card>
           <mat-card-header>
             <mat-card-title>Deployment Info</mat-card-title>
           </mat-card-header>
-          <mat-card-content *ngIf="(deploySource$ | async) as deploySource; else notDeployedFromStratos">
+          <mat-card-content>
             <span [ngSwitch]="deploySource.type">
               <app-metadata-item *ngSwitchCase="'giturl'" icon="code" label="Git Url">
                 <div matTooltip="{{ deploySource.branch + ' ' + (deploySource.commit | slice:0:8)}}"
@@ -183,9 +183,6 @@
               </app-metadata-item>
             </span>
           </mat-card-content>
-          <ng-template #notDeployedFromStratos>
-            <mat-card-content>None</mat-card-content>
-          </ng-template>
         </mat-card>
       </app-tile>
     </app-tile-group>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.html
@@ -5,7 +5,8 @@
   </mat-card-header>
   <mat-card-content class="card-app-instances__compact">
     <div *ngIf="!isEditing" class="card-app-instances__large">
-      <app-running-instances [instances]="(appService.application$ | async)?.app.entity?.instances" [cfGuid]="appService.cfGuid" [appGuid]="this.appService.appGuid">
+      <app-running-instances [instances]="(appService.application$ | async)?.app.entity?.instances"
+        [cfGuid]="appService.cfGuid" [appGuid]="this.appService.appGuid">
       </app-running-instances>
     </div>
     <form [hidden]="!isEditing" class="card-app-instances__form">
@@ -14,23 +15,27 @@
       </mat-form-field>
     </form>
   </mat-card-content>
-  <mat-card-actions *ngIf="showActions && (appService.applicationRunning$ | async) && !isEditing" class="card-app-instances__actions">
-    <button (click)="edit()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
-          <mat-icon>edit</mat-icon>
+  <ng-container *ngIf="canEditSpace$ | async">
+    <mat-card-actions *ngIf="showActions && (appService.applicationRunning$ | async) && !isEditing"
+      class="card-app-instances__actions">
+      <button (click)="edit()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
+        <mat-icon>edit</mat-icon>
       </button>
-    <button (click)="scaleDown()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
-          <mat-icon>remove_circle_outline</mat-icon>
+      <button (click)="scaleDown()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
+        <mat-icon>remove_circle_outline</mat-icon>
       </button>
-    <button (click)="scaleUp()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
-          <mat-icon>add_circle_outline</mat-icon>
+      <button (click)="scaleUp()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
+        <mat-icon>add_circle_outline</mat-icon>
       </button>
-  </mat-card-actions>
-  <mat-card-actions *ngIf="showActions && isEditing" class="card-app-instances__actions">
-    <button (click)="finishEdit(false)" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
-          <mat-icon>clear</mat-icon>
+    </mat-card-actions>
+    <mat-card-actions *ngIf="showActions && isEditing" class="card-app-instances__actions">
+      <button (click)="finishEdit(false)" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
+        <mat-icon>clear</mat-icon>
       </button>
-    <button (click)="finishEdit(true)" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
-            <mat-icon>done</mat-icon>
-        </button>
-  </mat-card-actions>
+      <button (click)="finishEdit(true)" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">
+        <mat-icon>done</mat-icon>
+      </button>
+    </mat-card-actions>
+  </ng-container>
+
 </mat-card>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.html
@@ -15,7 +15,7 @@
       </mat-form-field>
     </form>
   </mat-card-content>
-  <ng-container *ngIf="canEditSpace$ | async">
+  <ng-container *ngIf="canEditApp$ | async">
     <mat-card-actions *ngIf="showActions && (appService.applicationRunning$ | async) && !isEditing"
       class="card-app-instances__actions">
       <button (click)="edit()" mat-icon-button [disabled]="appService.isUpdatingApp$ | async">

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
@@ -30,7 +30,7 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
 
   status$: Observable<StratosStatus>;
 
-  public canEditSpace$: Observable<boolean>;
+  public canEditApp$: Observable<boolean>;
 
   constructor(
     public appService: ApplicationService,
@@ -42,12 +42,13 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
     this.status$ = this.appService.applicationState$.pipe(
       map(state => state.indicator)
     );
-    this.canEditSpace$ = combineLatest(
+    this.canEditApp$ = combineLatest(
       appService.appOrg$,
       appService.appSpace$
     ).pipe(
-      switchMap(([org, space]) => cups.can(CfCurrentUserPermissions.SPACE_EDIT, appService.cfGuid, org.metadata.guid, space.metadata.guid))
-    )
+      switchMap(([org, space]) =>
+        cups.can(CfCurrentUserPermissions.APPLICATION_EDIT, appService.cfGuid, org.metadata.guid, space.metadata.guid)
+      ))
 
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
@@ -1,13 +1,15 @@
-import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild, Renderer2 } from '@angular/core';
+import { Component, ElementRef, Input, OnDestroy, OnInit, Renderer2, ViewChild } from '@angular/core';
 import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar';
-import { Observable, Subscription } from 'rxjs';
-import { first, map } from 'rxjs/operators';
+import { combineLatest, Observable, Subscription } from 'rxjs';
+import { first, map, switchMap } from 'rxjs/operators';
 
 import { AppMetadataTypes } from '../../../../../../cloud-foundry/src/actions/app-metadata.actions';
 import { ApplicationService } from '../../../../../../cloud-foundry/src/features/applications/application.service';
+import { CurrentUserPermissionsService } from '../../../../../../core/src/core/permissions/current-user-permissions.service';
 import { ConfirmationDialogConfig } from '../../../../../../core/src/shared/components/confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../../../../core/src/shared/components/confirmation-dialog.service';
 import { StratosStatus } from '../../../../../../core/src/shared/shared.types';
+import { CfCurrentUserPermissions } from '../../../../user-permissions/cf-user-permissions-checkers';
 
 const appInstanceScaleToZeroConfirmation = new ConfirmationDialogConfig('Set Instance count to 0',
   'Are you sure you want to set the instance count to 0?', 'Confirm', true);
@@ -28,14 +30,25 @@ export class CardAppInstancesComponent implements OnInit, OnDestroy {
 
   status$: Observable<StratosStatus>;
 
+  public canEditSpace$: Observable<boolean>;
+
   constructor(
     public appService: ApplicationService,
     private renderer: Renderer2,
     private confirmDialog: ConfirmationDialogService,
-    private snackBar: MatSnackBar) {
+    private snackBar: MatSnackBar,
+    cups: CurrentUserPermissionsService
+  ) {
     this.status$ = this.appService.applicationState$.pipe(
       map(state => state.indicator)
     );
+    this.canEditSpace$ = combineLatest(
+      appService.appOrg$,
+      appService.appSpace$
+    ).pipe(
+      switchMap(([org, space]) => cups.can(CfCurrentUserPermissions.SPACE_EDIT, appService.cfGuid, org.metadata.guid, space.metadata.guid))
+    )
+
   }
 
   private currentCount = 0;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
@@ -162,7 +162,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
     },
     label: 'Terminate',
     description: ``, // Description depends on console user permission
-    createVisible: () => this.canEditSpace$
+    createVisible: () => this.canEditApp$
   };
 
   private listActionSsh: IListAction<any> = {
@@ -187,7 +187,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
           })
         );
       })),
-    createVisible: () => this.canEditSpace$
+    createVisible: () => this.canEditApp$
   };
 
   private singleActions = [
@@ -195,7 +195,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
     this.listActionSsh,
   ];
 
-  private canEditSpace$: Observable<boolean>;
+  private canEditApp$: Observable<boolean>;
 
   constructor(
     private store: Store<CFAppState>,
@@ -229,11 +229,13 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
       this,
     );
 
-    this.canEditSpace$ = combineLatestObs(
+    this.canEditApp$ = combineLatestObs(
       appService.appOrg$,
       appService.appSpace$
     ).pipe(
-      switchMap(([org, space]) => cups.can(CfCurrentUserPermissions.SPACE_EDIT, appService.cfGuid, org.metadata.guid, space.metadata.guid))
+      switchMap(([org, space]) =>
+        cups.can(CfCurrentUserPermissions.APPLICATION_EDIT, appService.cfGuid, org.metadata.guid, space.metadata.guid)
+      )
     )
   }
 

--- a/src/frontend/packages/cloud-foundry/src/user-permissions/cf-user-permissions-checkers.ts
+++ b/src/frontend/packages/cloud-foundry/src/user-permissions/cf-user-permissions-checkers.ts
@@ -396,7 +396,7 @@ export class CfUserPermissionsChecker extends BaseCurrentUserPermissionsChecker 
   }
 
   private getAllEndpointGuids() {
-    return this.store.select(connectedEndpointsSelector).pipe(
+    return this.store.select(connectedEndpointsSelector()).pipe(
       map(endpoints => Object.values(endpoints).filter(e => e.cnsi_type === CF_ENDPOINT_TYPE).map(endpoint => endpoint.guid))
     );
   }

--- a/src/frontend/packages/core/src/core/extension/extension-service.ts
+++ b/src/frontend/packages/core/src/core/extension/extension-service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgModule, ModuleWithProviders } from '@angular/core';
+import { Injectable, ModuleWithProviders, NgModule } from '@angular/core';
 import { ActivatedRoute, Route, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { AppState, GeneralEntityAppState } from '../../../../store/src/app-state';
 import { EntityServiceFactory } from '../../../../store/src/entity-service-factory.service';
 import { IPageSideNavTab } from '../../features/dashboard/page-side-nav/page-side-nav.component';
+import { CurrentUserPermissionsService } from '../permissions/current-user-permissions.service';
 
 export const extensionsActionRouteKey = 'extensionsActionsKey';
 
@@ -23,7 +24,12 @@ export interface StratosTabMetadata {
   link: string;
   icon?: string;
   iconFont?: string;
-  hidden?: (store: Store<AppState>, esf: EntityServiceFactory, activatedRoute: ActivatedRoute) => Observable<boolean>;
+  hidden?: (
+    store: Store<AppState>,
+    esf: EntityServiceFactory,
+    activatedRoute: ActivatedRoute,
+    cups: CurrentUserPermissionsService
+  ) => Observable<boolean>;
 }
 
 export interface StratosTabMetadataConfig extends StratosTabMetadata {
@@ -97,7 +103,7 @@ function addExtensionTab(tab: StratosTabType, target: any, props: StratosTabMeta
   });
   extensionMetadata.tabs[tab].push({
     ...props
-  });  
+  });
 }
 
 function addExtensionAction(action: StratosActionType, target: any, props: StratosActionMetadata) {

--- a/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.ts
+++ b/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.ts
@@ -4,10 +4,11 @@ import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 
 import { AppState } from '../../../../../store/src/app-state';
+import { EntityServiceFactory } from '../../../../../store/src/entity-service-factory.service';
 import { selectIsMobile } from '../../../../../store/src/selectors/dashboard.selectors';
 import { TabNavService } from '../../../../tab-nav.service';
-import { EntityServiceFactory } from '../../../../../store/src/entity-service-factory.service';
 import { StratosTabMetadata } from '../../../core/extension/extension-service';
+import { CurrentUserPermissionsService } from '../../../core/permissions/current-user-permissions.service';
 import { IBreadcrumb } from '../../../shared/components/breadcrumbs/breadcrumbs.types';
 
 export interface IPageSideNavTab extends StratosTabMetadata {
@@ -26,10 +27,13 @@ export class PageSideNavComponent implements OnInit {
     if (!tabs || (this.pTabs && tabs.length === this.pTabs.length)) {
       return;
     }
-    this.pTabs = tabs.map(tab => ({
-      ...tab,
-      hidden$: tab.hidden$ || (tab.hidden ? tab.hidden(this.store, this.esf, this.activatedRoute) : of(false))
-    }));
+    this.pTabs = tabs.map(tab => {
+      const hidden = (tab.hidden ? tab.hidden(this.store, this.esf, this.activatedRoute, this.cups) : of(false))
+      return {
+        ...tab,
+        hidden$: tab.hidden$ || hidden
+      }
+    });
   }
   get tabs(): IPageSideNavTab[] {
     return this.pTabs;
@@ -45,6 +49,7 @@ export class PageSideNavComponent implements OnInit {
     private store: Store<AppState>,
     private esf: EntityServiceFactory,
     private activatedRoute: ActivatedRoute,
+    private cups: CurrentUserPermissionsService
   ) {
     this.isMobile$ = this.store.select(selectIsMobile);
   }

--- a/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.ts
+++ b/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.ts
@@ -11,6 +11,8 @@ import { StratosTabMetadata } from '../../../core/extension/extension-service';
 import { CurrentUserPermissionsService } from '../../../core/permissions/current-user-permissions.service';
 import { IBreadcrumb } from '../../../shared/components/breadcrumbs/breadcrumbs.types';
 
+
+
 export interface IPageSideNavTab extends StratosTabMetadata {
   hidden$?: Observable<boolean>;
 }
@@ -27,13 +29,10 @@ export class PageSideNavComponent implements OnInit {
     if (!tabs || (this.pTabs && tabs.length === this.pTabs.length)) {
       return;
     }
-    this.pTabs = tabs.map(tab => {
-      const hidden = (tab.hidden ? tab.hidden(this.store, this.esf, this.activatedRoute, this.cups) : of(false))
-      return {
-        ...tab,
-        hidden$: tab.hidden$ || hidden
-      }
-    });
+    this.pTabs = tabs.map(tab => ({
+      ...tab,
+      hidden$: tab.hidden$ || (tab.hidden ? tab.hidden(this.store, this.esf, this.activatedRoute, this.cups) : of(false))
+    }));
   }
   get tabs(): IPageSideNavTab[] {
     return this.pTabs;

--- a/src/test-e2e/application/application-view-e2e.spec.ts
+++ b/src/test-e2e/application/application-view-e2e.spec.ts
@@ -135,8 +135,7 @@ describe('Application View -', () => {
       });
 
       it('Deployment Info', () => {
-        appSummary.cardDeployInfo.waitForTitle('Deployment Info');
-        expect(appSummary.cardDeployInfo.getContent()).toBe('None');
+        expect(appSummary.cardDeployInfo.isPresent()).toBeFalsy();
       });
     });
 


### PR DESCRIPTION
Hide deployment info card if not space developer or no deployment info
- fixes #4322, fixes #4347

Only space developers can create/unmap/delete routes in app routes table 
- fixes #4324

Only Space Developers should be able to change count, terminate or ssh to instances
- fixes #4330

Permissions: Only Space Developers should be able to create/edit/delete an Autoscaler policy
- fixes #4323

Users with no developer roles could click on add app button 
- fixes #4361
- fixes #4331

Improve visual case when we can't determine cf app deployment info
- fixes #4347