### PR TITLE
Fix service stepper navigation

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-tabs-base/service-tabs-base.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-tabs-base/service-tabs-base.component.html
@@ -1,11 +1,11 @@
 <app-page-header [tabs]="tabLinks" tabsHeader="Service" [breadcrumbs]="breadcrumbs">
   <div class="app-page-header">
-    {{ getServiceLabel() | async }}
+    {{ serviceLabel$ | async }}
   </div>
   <div class="page-header-right">
     <ng-container *appCfUserPermission="canCreateServiceInstance">
-      <button mat-icon-button name="add-service-instance" [routerLink]="addServiceInstanceLink()"
-        [queryParams]="isServiceSpaceScoped() | async" [disabled]="!(hasVisiblePlans$ | async)">
+      <button mat-icon-button name="add-service-instance" [routerLink]="addServiceInstanceLink"
+        [queryParams]="isServiceSpaceScoped$ | async" [disabled]="!(hasVisiblePlans$ | async)">
         <mat-icon [matTooltip]="toolTipText$ | async">add</mat-icon>
       </button>
     </ng-container>

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-tabs-base/service-tabs-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-tabs-base/service-tabs-base.component.ts
@@ -6,6 +6,7 @@ import { map, publishReplay, refCount } from 'rxjs/operators';
 import { CFAppState } from '../../../../../cloud-foundry/src/cf-app-state';
 import { IPageSideNavTab } from '../../../../../core/src/features/dashboard/page-side-nav/page-side-nav.component';
 import { IHeaderBreadcrumb } from '../../../../../core/src/shared/components/page-header/page-header.types';
+import { CSI_CANCEL_URL } from '../../../shared/components/add-service-instance/csi-mode.service';
 import { CfCurrentUserPermissions } from '../../../user-permissions/cf-user-permissions-checkers';
 import { getServiceName } from '../services-helper';
 import { ServicesService } from '../services.service';
@@ -20,6 +21,9 @@ export class ServiceTabsBaseComponent {
   toolTipText$: Observable<string>;
   hasVisiblePlans$: Observable<boolean>;
   servicesSubscription: Subscription;
+  isServiceSpaceScoped$: Observable<any>;
+  addServiceInstanceLink: string[];
+  serviceLabel$: Observable<string>;
 
   tabLinks: IPageSideNavTab[] = [
     {
@@ -59,24 +63,23 @@ export class ServiceTabsBaseComponent {
           return 'Cannot create service instance (no public or visible plans exist for service)';
         }
       }));
-
-  }
-
-  addServiceInstanceLink = () => [
-    '/marketplace',
-    this.servicesService.cfGuid,
-    this.servicesService.serviceGuid,
-    'create'
-  ]
-
-  isServiceSpaceScoped = () => this.servicesService.isSpaceScoped$;
-
-  getServiceLabel = (): Observable<string> => {
-    return this.servicesService.service$.pipe(
+    this.isServiceSpaceScoped$ = this.servicesService.isSpaceScoped$.pipe(
+      map(queryParams => ({
+        ...queryParams,
+        [CSI_CANCEL_URL]: `/marketplace/${this.servicesService.cfGuid}/${this.servicesService.serviceGuid}/instances`
+      }))
+    )
+    this.addServiceInstanceLink = [
+      '/marketplace',
+      this.servicesService.cfGuid,
+      this.servicesService.serviceGuid,
+      'create'
+    ]
+    this.serviceLabel$ = this.servicesService.service$.pipe(
       map(getServiceName),
       publishReplay(1),
       refCount()
-    );
+    )
   }
 
 }

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/services.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/services.service.ts
@@ -132,6 +132,7 @@ export class ServicesService {
       map(o => (o.length === 0 ? null : o[0]))
     );
     this.isSpaceScoped$ = this.serviceBroker$.pipe(
+      first(),
       map(o => o ? o.entity.space_guid : null),
       switchMap(spaceGuid => {
         if (!spaceGuid) {
@@ -151,7 +152,8 @@ export class ServicesService {
             })),
           );
         }
-      })
+      }),
+      first()
     );
     this.serviceInstances$ = this.allServiceInstances$.pipe(
       map(instances => instances.filter(instance => instance.entity.service_guid === this.serviceGuid))

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.html
@@ -3,7 +3,7 @@
   <div class="page-header-right">
     <ng-container *ngIf="(haveConnectedCf$ | async)">
       <ng-container *appCfUserPermission="canCreateServiceInstance">
-        <button mat-icon-button [routerLink]="'/services/new/'">
+        <button mat-icon-button [routerLink]="'/services/new/'" [queryParams]="location">
           <mat-icon>add</mat-icon>
         </button>
       </ng-container>

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../../cloud-foundry/src/shared/data-services/cf-org-space-service.service';
 import { CloudFoundryService } from '../../../../../cloud-foundry/src/shared/data-services/cloud-foundry.service';
 import { ListConfig } from '../../../../../core/src/shared/components/list/list.component.types';
+import { CSI_CANCEL_URL } from '../../../shared/components/add-service-instance/csi-mode.service';
 import { CfCurrentUserPermissions } from '../../../user-permissions/cf-user-permissions-checkers';
 
 @Component({
@@ -35,6 +36,7 @@ export class ServicesWallComponent implements OnDestroy {
   canCreateServiceInstance: CfCurrentUserPermissions;
   initCfOrgSpaceService: Subscription;
   cfIds$: Observable<string[]>;
+  location: { [CSI_CANCEL_URL]: string };
 
   constructor(
     public cloudFoundryService: CloudFoundryService,
@@ -57,6 +59,10 @@ export class ServicesWallComponent implements OnDestroy {
     this.haveConnectedCf$ = cloudFoundryService.connectedCFEndpoints$.pipe(
       map(endpoints => !!endpoints && endpoints.length > 0)
     );
+
+    this.location = {
+      [CSI_CANCEL_URL]: `/services`
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.html
@@ -1,7 +1,7 @@
 <app-page-header>
   Choose Service Type
 </app-page-header>
-<app-steppers [cancel]="'/services'">
+<app-steppers [cancel]="cancelUrl">
   <app-step [hideNextButton]="true">
     <div class="select-service-step">
       <h3>Choose service type to {{ bindApp ? 'bind' : 'create' }}</h3>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/csi-mode.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/csi-mode.service.ts
@@ -186,10 +186,13 @@ export class CsiModeService {
       // - good catch all
       // - doesn't work that well for marketplace/service create instance --> success (should go to marketplace/service/instance)
       // - if user has refreshed on stepper (previous url was login) use the old cancelUrl best-guess value
-      const previousNavigation = router.getCurrentNavigation().previousNavigation || { finalUrl: '' };
-      const previousUrl = previousNavigation.finalUrl.toString();
-      if (previousUrl !== '/login') {
-        this.cancelUrl = previousUrl;
+      const currentNavigation = router.getCurrentNavigation();
+      if (currentNavigation &&
+        currentNavigation.previousNavigation &&
+        currentNavigation.previousNavigation.finalUrl &&
+        currentNavigation.previousNavigation.finalUrl.toString() !== '/login'
+      ) {
+        this.cancelUrl = currentNavigation.previousNavigation.finalUrl.toString();
       }
     }
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/csi-mode.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/csi-mode.service.ts
@@ -19,10 +19,24 @@ export const enum CreateServiceFormMode {
   BindServiceInstance = 'bind-service-instance',
 }
 
-export const CANCEL_SPACE_ID_PARAM = 'space-guid';
-export const CANCEL_ORG_ID_PARAM = 'org-guid';
-export const CANCEL_USER_PROVIDED = 'up';
+/**
+ * Where should the user be taken on cancel (and success). If not supplied will fall back on previous location and then deduced from
+ * params
+ */
 export const CSI_CANCEL_URL = 'cancel'
+
+/**
+ * Used when `CSI_CANCEL_URL` is not supplied
+ */
+export const CANCEL_SPACE_ID_PARAM = 'space-guid';
+/**
+ * Used when `CSI_CANCEL_URL` is not supplied
+ */
+export const CANCEL_ORG_ID_PARAM = 'org-guid';
+/**
+ * Used when `CSI_CANCEL_URL` is not supplied
+ */
+export const CANCEL_USER_PROVIDED = 'up';
 
 interface ViewDetail {
   showSelectCf: boolean;
@@ -45,6 +59,9 @@ export class CsiModeService {
 
   private mode: string;
   public viewDetail: ViewDetail;
+  /**
+   * Where should the user be taken on cancel (and success). Taken from url param, previous location or deduced
+   */
   public cancelUrl: string;
   // This property is only used when launching the Create Service Instance Wizard from the Marketplace
   spaceScopedDetails: SpaceScopedService = { isSpaceScoped: false };
@@ -169,7 +186,8 @@ export class CsiModeService {
       // - good catch all
       // - doesn't work that well for marketplace/service create instance --> success (should go to marketplace/service/instance)
       // - if user has refreshed on stepper (previous url was login) use the old cancelUrl best-guess value
-      const previousUrl = router.getCurrentNavigation().previousNavigation.finalUrl.toString();
+      const previousNavigation = router.getCurrentNavigation().previousNavigation || { finalUrl: '' };
+      const previousUrl = previousNavigation.finalUrl.toString();
       if (previousUrl !== '/login') {
         this.cancelUrl = previousUrl;
       }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.ts
@@ -31,7 +31,6 @@ import {
 } from '../../../../../../cloud-foundry/src/actions/create-service-instance.actions';
 import { pathGet, safeStringToObj } from '../../../../../../core/src/core/utils.service';
 import { StepOnNextResult } from '../../../../../../core/src/shared/components/stepper/step/step.component';
-import { RouterNav } from '../../../../../../store/src/actions/router.actions';
 import { getDefaultRequestState, RequestInfoState } from '../../../../../../store/src/reducers/api-request-reducer/types';
 import { APIResource, NormalizedResponse } from '../../../../../../store/src/types/api.types';
 import { UpdateServiceInstance } from '../../../../actions/service-instances.actions';
@@ -297,7 +296,7 @@ export class SpecifyDetailsStepComponent implements OnDestroy, AfterContentInit 
       this.longRunningOpService.handleLongRunningCreateService(bindApp);
       // Return to app page instead of falling through to service page
       if (bindApp) {
-        return observableOf(this.routeToServices(state.cfGuid, state.bindAppGuid));
+        return observableOf(this.routeToServices());
       }
     } else if (request.error) {
       // The request has errored, report this back
@@ -318,7 +317,7 @@ export class SpecifyDetailsStepComponent implements OnDestroy, AfterContentInit 
           } else {
             // Refetch env vars for app, since they have been changed by CF
             cfEntityCatalog.appEnvVar.api.getMultiple(state.bindAppGuid, state.cfGuid);
-            return this.routeToServices(state.cfGuid, state.bindAppGuid);
+            return this.routeToServices();
           }
         })
       );
@@ -356,13 +355,12 @@ export class SpecifyDetailsStepComponent implements OnDestroy, AfterContentInit 
     );
   }
 
-  routeToServices = (cfGuid: string = null, appGuid: string = null): StepOnNextResult => {
-    if (this.modeService.isAppServicesMode()) {
-      this.store.dispatch(new RouterNav({ path: ['/applications', cfGuid, appGuid, 'services'] }));
-    } else {
-      this.store.dispatch(new RouterNav({ path: ['/services'] }));
-    }
-    return { success: true };
+  routeToServices = (): StepOnNextResult => {
+    return {
+      success: true,
+      // We should always go back to where we came from, aka 'cancel' location.
+      redirect: true,
+    };
   }
 
   private setServiceInstanceGuid = (request: { creating: boolean; error: boolean; response: { result: any[]; }; }) =>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-card/app-service-binding-card.component.ts
@@ -34,6 +34,7 @@ import {
 import { AppEnvVarsState } from '../../../../../../store/types/app-metadata.types';
 import { CfCurrentUserPermissions } from '../../../../../../user-permissions/cf-user-permissions-checkers';
 import { ServiceActionHelperService } from '../../../../../data-services/service-action-helper.service';
+import { CSI_CANCEL_URL } from '../../../../add-service-instance/csi-mode.service';
 import { EnvVarViewComponent } from '../../../../env-var-view/env-var-view.component';
 
 
@@ -241,7 +242,10 @@ export class AppServiceBindingCardComponent extends CardCell<APIResource<IServic
   private edit = () => this.serviceActionHelperService.startEditServiceBindingStepper(
     this.row.entity.service_instance_guid,
     this.appService.cfGuid,
-    { appId: this.appService.appGuid },
+    {
+      appId: this.appService.appGuid,
+      [CSI_CANCEL_URL]: `/applications/${this.appService.cfGuid}/${this.appService.appGuid}/services`
+    },
     this.isUserProvidedServiceInstance
   )
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-list-config.service.ts
@@ -19,7 +19,6 @@ import {
 import { ListView } from '../../../../../../../store/src/actions/list.actions';
 import { RouterNav } from '../../../../../../../store/src/actions/router.actions';
 import { APIResource } from '../../../../../../../store/src/types/api.types';
-import { GetAppServiceBindings } from '../../../../../actions/application-service-routes.actions';
 import { IServiceBinding } from '../../../../../cf-api-svc.types';
 import { ApplicationService } from '../../../../../features/applications/application.service';
 import { isServiceInstance, isUserProvidedServiceInstance } from '../../../../../features/cloud-foundry/cf.helpers';
@@ -57,17 +56,12 @@ export class AppServiceBindingListConfigService extends BaseCfListConfig<APIReso
 
   private listActionEdit: IListAction<APIResource<IServiceBinding>> = {
     action: (item) => {
-      // FIXME: If the user cancels stepper this leaks #4295
       this.serviceActionHelperService.startEditServiceBindingStepper(
         item.entity.service_instance_guid,
         this.appService.cfGuid,
         { appId: this.appService.appGuid },
         !!isUserProvidedServiceInstance(item.entity.service_instance.entity)
-      ).subscribe(res => {
-        if (!res.error) {
-          this.store.dispatch(new GetAppServiceBindings(this.appService.appGuid, this.appService.cfGuid));
-        }
-      });
+      );
     },
     label: 'Edit',
     createVisible: () => this.appService.waitForAppEntity$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-list-config.service.ts
@@ -24,6 +24,7 @@ import { ApplicationService } from '../../../../../features/applications/applica
 import { isServiceInstance, isUserProvidedServiceInstance } from '../../../../../features/cloud-foundry/cf.helpers';
 import { CfCurrentUserPermissions } from '../../../../../user-permissions/cf-user-permissions-checkers';
 import { ServiceActionHelperService } from '../../../../data-services/service-action-helper.service';
+import { CSI_CANCEL_URL } from '../../../add-service-instance/csi-mode.service';
 import { BaseCfListConfig } from '../base-cf/base-cf-list-config';
 import {
   TableCellServiceInstanceTagsComponent,
@@ -59,7 +60,10 @@ export class AppServiceBindingListConfigService extends BaseCfListConfig<APIReso
       this.serviceActionHelperService.startEditServiceBindingStepper(
         item.entity.service_instance_guid,
         this.appService.cfGuid,
-        { appId: this.appService.appGuid },
+        {
+          appId: this.appService.appGuid,
+          [CSI_CANCEL_URL]: `/applications/${this.appService.cfGuid}/${this.appService.appGuid}/services`
+        },
         !!isUserProvidedServiceInstance(item.entity.service_instance.entity)
       );
     },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-sevice-bindings/app-service-binding-list-config.service.ts
@@ -102,7 +102,7 @@ export class AppServiceBindingListConfigService extends BaseCfListConfig<APIReso
     return [
       {
         columnId: 'name',
-        headerCell: () => 'Service Instances',
+        headerCell: () => 'Name',
         cellDefinition: {
           getValue: (row) => row.entity.service_instance.entity.name
         },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
@@ -62,7 +62,7 @@ export class CfServiceInstancesListConfigBase implements IListConfig<APIResource
   protected serviceInstanceColumns: ITableColumn<APIResource<IServiceInstance>>[] = [
     {
       columnId: 'name',
-      headerCell: () => 'Service Instance',
+      headerCell: () => 'Name',
       cellDefinition: {
         getValue: (row) => `${row.entity.name}`
       },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-service-instances-list-config.base.ts
@@ -21,9 +21,10 @@ import {
 import { ListView } from '../../../../../../../store/src/actions/list.actions';
 import { APIResource } from '../../../../../../../store/src/types/api.types';
 import { IServiceInstance } from '../../../../../cf-api-svc.types';
+import { isUserProvidedServiceInstance } from '../../../../../features/cloud-foundry/cf.helpers';
 import { CfCurrentUserPermissions } from '../../../../../user-permissions/cf-user-permissions-checkers';
 import { ServiceActionHelperService } from '../../../../data-services/service-action-helper.service';
-import { CANCEL_ORG_ID_PARAM, CANCEL_SPACE_ID_PARAM } from '../../../add-service-instance/csi-mode.service';
+import { CANCEL_ORG_ID_PARAM, CANCEL_SPACE_ID_PARAM, CSI_CANCEL_URL } from '../../../add-service-instance/csi-mode.service';
 import {
   TableCellAppCfOrgSpaceHeaderComponent,
 } from '../app/table-cell-app-cforgspace-header/table-cell-app-cforgspace-header.component';
@@ -149,10 +150,15 @@ export class CfServiceInstancesListConfigBase implements IListConfig<APIResource
 
   private listActionEdit: IListAction<APIResource> = {
     action: (item: APIResource<IServiceInstance>) =>
-      this.serviceActionHelperService.startEditServiceBindingStepper(item.metadata.guid, item.entity.cfGuid, {
-        [CANCEL_SPACE_ID_PARAM]: item.entity.space_guid,
-        [CANCEL_ORG_ID_PARAM]: item.entity.space.entity.organization_guid
-      }),
+      this.serviceActionHelperService.startEditServiceBindingStepper(
+        item.metadata.guid,
+        item.entity.cfGuid,
+        {
+          [CANCEL_SPACE_ID_PARAM]: item.entity.space_guid,
+          [CANCEL_ORG_ID_PARAM]: item.entity.space.entity.organization_guid,
+          [CSI_CANCEL_URL]: this.rootLocation
+        },
+        !!isUserProvidedServiceInstance(item.entity)),
     label: 'Edit',
     description: 'Edit Service Instance',
     createVisible: (row$: Observable<APIResource<IServiceInstance>>) =>
@@ -176,7 +182,8 @@ export class CfServiceInstancesListConfigBase implements IListConfig<APIResource
     protected store: Store<CFAppState>,
     protected datePipe: DatePipe,
     protected currentUserPermissionsService: CurrentUserPermissionsService,
-    private serviceActionHelperService: ServiceActionHelperService
+    private serviceActionHelperService: ServiceActionHelperService,
+    private rootLocation: string
   ) {
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-user-service-instances-list-config.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-user-service-instances-list-config.ts
@@ -65,7 +65,7 @@ export class CfUserServiceInstancesListConfigBase implements IListConfig<APIReso
   protected serviceInstanceColumns: ITableColumn<APIResource<IUserProvidedServiceInstance>>[] = [
     {
       columnId: 'name',
-      headerCell: () => 'Service Instance',
+      headerCell: () => 'Name',
       cellDefinition: {
         getValue: (row) => `${row.entity.name}`
       },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-user-service-instances-list-config.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-user-service-instances-list-config.ts
@@ -28,6 +28,7 @@ import {
   CANCEL_ORG_ID_PARAM,
   CANCEL_SPACE_ID_PARAM,
   CANCEL_USER_PROVIDED,
+  CSI_CANCEL_URL,
 } from '../../../add-service-instance/csi-mode.service';
 import {
   CfSpacesUserServiceInstancesDataSource,
@@ -152,7 +153,8 @@ export class CfUserServiceInstancesListConfigBase implements IListConfig<APIReso
         {
           [CANCEL_SPACE_ID_PARAM]: item.entity.space_guid,
           [CANCEL_ORG_ID_PARAM]: item.entity.space.entity.organization_guid,
-          [CANCEL_USER_PROVIDED]: true
+          [CANCEL_USER_PROVIDED]: true,
+          [CSI_CANCEL_URL]: `/cloud-foundry/${this.cfSpaceService.cfGuid}/organizations/${this.cfSpaceService.orgGuid}/spaces/${this.cfSpaceService.spaceGuid}/service-instances`
         },
         true),
     label: 'Edit',
@@ -176,7 +178,7 @@ export class CfUserServiceInstancesListConfigBase implements IListConfig<APIReso
 
   constructor(
     protected store: Store<CFAppState>,
-    cfSpaceService: CloudFoundrySpaceService,
+    private cfSpaceService: CloudFoundrySpaceService,
     protected datePipe: DatePipe,
     protected currentUserPermissionsService: CurrentUserPermissionsService,
     private serviceActionHelperService: ServiceActionHelperService

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces-service-instances/cf-spaces-service-instances-list-config.service.ts
@@ -30,7 +30,13 @@ export class CfSpacesServiceInstancesListConfigService extends CfServiceInstance
     datePipe: DatePipe,
     currentUserPermissionsService: CurrentUserPermissionsService,
     serviceActionHelperService: ServiceActionHelperService) {
-    super(store, datePipe, currentUserPermissionsService, serviceActionHelperService);
+    super(
+      store,
+      datePipe,
+      currentUserPermissionsService,
+      serviceActionHelperService,
+      `/cloud-foundry/${cfSpaceService.cfGuid}/organizations/${cfSpaceService.orgGuid}/spaces/${cfSpaceService.spaceGuid}/service-instances`
+    );
     this.dataSource = new CfSpacesServiceInstancesDataSource(cfSpaceService.cfGuid, cfSpaceService.spaceGuid, this.store, this);
     this.serviceInstanceColumns.find(column => column.columnId === 'attachedApps').cellConfig = {
       breadcrumbs: 'space-services'

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instances/service-instances-data-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instances/service-instances-data-source.ts
@@ -31,6 +31,7 @@ export class ServiceInstancesDataSource extends ListDataSource<APIResource> {
       paginationKey,
       isLocal: true,
       transformEntities: [
+        { type: 'filter', field: 'entity.name' },
         (entities: APIResource[], paginationState: PaginationEntityState) => {
           return entities.filter(e => e.entity.service_guid === serviceGuid);
         }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instances/service-instances-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instances/service-instances-list-config.service.ts
@@ -6,6 +6,7 @@ import { CFAppState } from '../../../../../../../cloud-foundry/src/cf-app-state'
 import {
   CurrentUserPermissionsService,
 } from '../../../../../../../core/src/core/permissions/current-user-permissions.service';
+import { ITableText } from '../../../../../../../core/src/shared/components/list/list-table/table.types';
 import { ServicesService } from '../../../../../features/service-catalog/services.service';
 import { ServiceActionHelperService } from '../../../../data-services/service-action-helper.service';
 import { CfServiceInstancesListConfigBase } from '../cf-services/cf-service-instances-list-config.base';
@@ -19,6 +20,13 @@ import { ServiceInstancesDataSource } from './service-instances-data-source';
  */
 @Injectable()
 export class ServiceInstancesListConfigService extends CfServiceInstancesListConfigBase {
+
+  enableTextFilter = true;
+  text: ITableText = {
+    title: null,
+    filter: 'Search by name',
+    noEntries: 'There are no service instances',
+  };
 
   constructor(
     store: Store<CFAppState>,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instances/service-instances-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instances/service-instances-list-config.service.ts
@@ -26,7 +26,13 @@ export class ServiceInstancesListConfigService extends CfServiceInstancesListCon
     datePipe: DatePipe,
     currentUserPermissionsService: CurrentUserPermissionsService,
     serviceActionHelperService: ServiceActionHelperService) {
-    super(store, datePipe, currentUserPermissionsService, serviceActionHelperService);
+    super(
+      store,
+      datePipe,
+      currentUserPermissionsService,
+      serviceActionHelperService,
+      `/marketplace/${servicesService.cfGuid}/${servicesService.serviceGuid}/instances`
+    );
     // Remove 'Service' column
     this.serviceInstanceColumns.splice(1, 1);
     this.dataSource = new ServiceInstancesDataSource(servicesService.cfGuid, servicesService.serviceGuid, store, this);

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
@@ -25,6 +25,7 @@ import {
 import { CfCurrentUserPermissions } from '../../../../../../user-permissions/cf-user-permissions-checkers';
 import { ServiceActionHelperService } from '../../../../../data-services/service-action-helper.service';
 import { CfOrgSpaceLabelService } from '../../../../../services/cf-org-space-label.service';
+import { CSI_CANCEL_URL } from '../../../../add-service-instance/csi-mode.service';
 
 @Component({
   selector: 'app-service-instance-card',
@@ -130,7 +131,9 @@ export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceI
   private edit = () => this.serviceActionHelperService.startEditServiceBindingStepper(
     this.serviceInstanceEntity.metadata.guid,
     this.serviceInstanceEntity.entity.cfGuid,
-    null
+    {
+      [CSI_CANCEL_URL]: '/services'
+    }
   )
 
   getServiceName = () => {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/service-instances-wall-list-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/service-instances-wall-list-config.service.ts
@@ -70,7 +70,13 @@ export class ServiceInstancesWallListConfigService extends CfServiceInstancesLis
     currentUserPermissionsService: CurrentUserPermissionsService,
     serviceActionHelperService: ServiceActionHelperService
   ) {
-    super(store, datePipe, currentUserPermissionsService, serviceActionHelperService);
+    super(
+      store,
+      datePipe,
+      currentUserPermissionsService,
+      serviceActionHelperService,
+      `/services`
+    );
     const multiFilterConfigs = [
       createCfOrgSpaceFilterConfig('cf', 'Cloud Foundry', this.cfOrgSpaceService.cf),
       createCfOrgSpaceFilterConfig('org', 'Organization', this.cfOrgSpaceService.org),

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/user-provided-service-instance-card/user-provided-service-instance-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/user-provided-service-instance-card/user-provided-service-instance-card.component.ts
@@ -19,6 +19,7 @@ import { cfEntityFactory } from '../../../../../../cf-entity-factory';
 import { CfCurrentUserPermissions } from '../../../../../../user-permissions/cf-user-permissions-checkers';
 import { ServiceActionHelperService } from '../../../../../data-services/service-action-helper.service';
 import { CfOrgSpaceLabelService } from '../../../../../services/cf-org-space-label.service';
+import { CSI_CANCEL_URL } from '../../../../add-service-instance/csi-mode.service';
 
 
 @Component({
@@ -120,7 +121,9 @@ export class UserProvidedServiceInstanceCardComponent extends CardCell<APIResour
   private edit = () => this.serviceActionHelperService.startEditServiceBindingStepper(
     this.serviceInstanceEntity.metadata.guid,
     this.serviceInstanceEntity.entity.cfGuid,
-    null,
+    {
+      [CSI_CANCEL_URL]: '/services'
+    },
     true
   )
 

--- a/src/test-e2e/marketplace/create-marketplace-service-instance.po.ts
+++ b/src/test-e2e/marketplace/create-marketplace-service-instance.po.ts
@@ -11,4 +11,12 @@ export class CreateMarketplaceServiceInstance extends Page {
     this.stepper = new CreateServiceInstanceStepper();
   }
 
+  isActivePage() {
+    return super.isActivePage(true);
+  }
+
+  waitForPage() {
+    return super.waitForPage(undefined, true);
+  }
+
 }

--- a/src/test-e2e/marketplace/create-marketplace-service-instance.po.ts
+++ b/src/test-e2e/marketplace/create-marketplace-service-instance.po.ts
@@ -6,7 +6,7 @@ export class CreateMarketplaceServiceInstance extends Page {
 
   public stepper: CreateServiceInstanceStepper;
 
-  constructor(url = '/services/new/service?base-previous-redirect=%2Fservices%2Fnew') {
+  constructor(url = '/services/new/service') {
     super(url);
     this.stepper = new CreateServiceInstanceStepper();
   }

--- a/src/test-e2e/marketplace/create-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instance-e2e.spec.ts
@@ -29,8 +29,7 @@ describe('Create Service Instance', () => {
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
     servicesHelperE2E = new ServicesHelperE2E(e2eSetup, createMarketplaceServiceInstance);
-    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
-
+    createMarketplaceServiceInstance.waitForPage();
   });
 
   describe('Long running tests - ', () => {
@@ -38,6 +37,8 @@ describe('Create Service Instance', () => {
     extendE2ETestTime(timeout);
 
     it('- should be able to create a service instance', () => {
+      expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+
       serviceInstanceName = servicesHelperE2E.createServiceInstanceName();
 
       servicesHelperE2E.createService(e2e.secrets.getDefaultCFEndpoint().services.publicService.name, serviceInstanceName);
@@ -49,16 +50,17 @@ describe('Create Service Instance', () => {
   });
 
   it('- should return user to Service summary when cancelled on CFOrgSpace selection', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
 
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace();
     createMarketplaceServiceInstance.stepper.cancel();
 
     servicesWall.waitForPage();
-
   });
 
   it('- should return user to Service summary when cancelled on Service selection', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
 
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace();
@@ -75,6 +77,7 @@ describe('Create Service Instance', () => {
   });
 
   it('- should return user to Service summary when cancelled on App binding selection', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
 
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace();
@@ -95,6 +98,8 @@ describe('Create Service Instance', () => {
   });
 
   it('- should return user to Service summary when cancelled on service instance details', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace();
     createMarketplaceServiceInstance.stepper.next();

--- a/src/test-e2e/marketplace/create-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instance-e2e.spec.ts
@@ -29,10 +29,8 @@ describe('Create Service Instance', () => {
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
     servicesHelperE2E = new ServicesHelperE2E(e2eSetup, createMarketplaceServiceInstance);
-  });
-
-  it('- should reach create service instance page', () => {
     expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+
   });
 
   describe('Long running tests - ', () => {

--- a/src/test-e2e/marketplace/create-service-instance-private-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instance-private-e2e.spec.ts
@@ -28,9 +28,6 @@ describe('Create Service Instance of Private Service', () => {
     createServiceInstance.navigateTo();
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
-  });
-
-  it('- should reach create service instance page', () => {
     expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
   });
 

--- a/src/test-e2e/marketplace/create-service-instance-private-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instance-private-e2e.spec.ts
@@ -28,7 +28,7 @@ describe('Create Service Instance of Private Service', () => {
     createServiceInstance.navigateTo();
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
-    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+    createMarketplaceServiceInstance.waitForPage();
   });
 
   describe('Long running tests - ', () => {
@@ -36,6 +36,8 @@ describe('Create Service Instance of Private Service', () => {
     extendE2ETestTime(timeout);
 
     it('- should be able to to create a service instance', () => {
+      expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+
       serviceInstanceName = servicesHelperE2E.createServiceInstanceName();
 
       servicesHelperE2E.createService(e2e.secrets.getDefaultCFEndpoint().services.privateService.name, serviceInstanceName, false);
@@ -48,6 +50,7 @@ describe('Create Service Instance of Private Service', () => {
   });
 
   it('- should return user to Service summary when cancelled on CFOrgSpace selection', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
 
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace();
@@ -58,6 +61,7 @@ describe('Create Service Instance of Private Service', () => {
   });
 
   it('- should return user to Service summary when cancelled on Service selection', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
 
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace();
@@ -74,6 +78,7 @@ describe('Create Service Instance of Private Service', () => {
   });
 
   it('- should not show service plan if wrong org/space are selected', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
 
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace(e2e.secrets.getDefaultCFEndpoint().services.privateService.invalidOrgName,

--- a/src/test-e2e/marketplace/create-service-instance-space-scoped-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instance-space-scoped-e2e.spec.ts
@@ -27,10 +27,6 @@ describe('Create Service Instance of Space Scoped Service', () => {
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
     servicesHelperE2E = new ServicesHelperE2E(e2eSetup, createMarketplaceServiceInstance);
-  });
-
-
-  it('- should reach create service instance page', () => {
     expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
   });
 

--- a/src/test-e2e/marketplace/create-service-instance-space-scoped-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instance-space-scoped-e2e.spec.ts
@@ -27,7 +27,7 @@ describe('Create Service Instance of Space Scoped Service', () => {
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
     servicesHelperE2E = new ServicesHelperE2E(e2eSetup, createMarketplaceServiceInstance);
-    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+    createMarketplaceServiceInstance.waitForPage();
   });
 
   describe('Long running tests - ', () => {
@@ -35,6 +35,8 @@ describe('Create Service Instance of Space Scoped Service', () => {
     extendE2ETestTime(timeout);
 
     it('- should be able to to create a service instance', () => {
+      expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+
       serviceInstanceName = servicesHelperE2E.createServiceInstanceName();
 
       servicesHelperE2E.createService(e2e.secrets.getDefaultCFEndpoint().services.spaceScopedService.name, serviceInstanceName);
@@ -46,6 +48,7 @@ describe('Create Service Instance of Space Scoped Service', () => {
   });
 
   it('- should not show service plan if wrong org/space are selected', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
 
     // Select CF/Org/Space
     servicesHelperE2E.setCfOrgSpace(e2e.secrets.getDefaultCFEndpoint().services.spaceScopedService.invalidOrgName,

--- a/src/test-e2e/marketplace/create-service-instance.po.ts
+++ b/src/test-e2e/marketplace/create-service-instance.po.ts
@@ -1,10 +1,10 @@
-
+import {
+  SERVICE_INSTANCE_TYPES,
+} from '../../frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance.types';
 import { Page } from '../po/page.po';
 import { BaseCreateServiceInstanceStepper } from './base-create-service-instance-stepper.po';
 import { CreateMarketplaceServiceInstance } from './create-marketplace-service-instance.po';
-import {
-  SERVICE_INSTANCE_TYPES
-} from '../../frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance.types';
+
 
 export class CreateServiceInstance extends Page {
 
@@ -21,6 +21,14 @@ export class CreateServiceInstance extends Page {
 
   constructor(url = '/services/new') {
     super(url);
+  }
+
+  isActivePage() {
+    return super.isActivePage(true);
+  }
+
+  waitForPage() {
+    return super.waitForPage(undefined, true);
   }
 
 }

--- a/src/test-e2e/marketplace/create-service-instances-bind-app-e2e.spec.ts
+++ b/src/test-e2e/marketplace/create-service-instances-bind-app-e2e.spec.ts
@@ -30,16 +30,15 @@ describe('Create Service Instance with binding', () => {
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
     servicesHelperE2E = new ServicesHelperE2E(e2eSetup, createMarketplaceServiceInstance, servicesHelperE2E);
-  });
-
-  it('- should reach create service instance page', () => {
-    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+    createMarketplaceServiceInstance.waitForPage();
   });
 
   describe('Long running tests - ', () => {
     extendE2ETestTime(100000);
 
     it('- should be able to to create a service instance with binding', () => {
+      expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+
       serviceInstanceName = servicesHelperE2E.createServiceInstanceName();
 
       const servicesSecrets = e2e.secrets.getDefaultCFEndpoint().services;

--- a/src/test-e2e/marketplace/create-ups-service-instance.po.ts
+++ b/src/test-e2e/marketplace/create-ups-service-instance.po.ts
@@ -10,4 +10,13 @@ export class CreateUserProvidedServiceInstance extends Page {
     super(url);
     this.stepper = new CreateServiceInstanceStepper();
   }
+
+  isActivePage() {
+    return super.isActivePage(true);
+  }
+
+  waitForPage() {
+    return super.waitForPage(undefined, true);
+  }
+
 }

--- a/src/test-e2e/marketplace/delete-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/delete-service-instance-e2e.spec.ts
@@ -1,13 +1,13 @@
 import { e2e } from '../e2e';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
 import { extendE2ETestTime } from '../helpers/extend-test-helpers';
+import { ConfirmDialogComponent } from '../po/confirm-dialog';
+import { ListComponent } from '../po/list.po';
+import { MetaCardTitleType } from '../po/meta-card.po';
 import { CreateMarketplaceServiceInstance } from './create-marketplace-service-instance.po';
 import { CreateServiceInstance } from './create-service-instance.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
-import { ConfirmDialogComponent } from '../po/confirm-dialog';
-import { MetaCardTitleType } from '../po/meta-card.po';
-import { ListComponent } from '../po/list.po';
 
 // Regression test for:
 // - Deleting a service instance in the services list will delete the service but the list incorerctly shows no services

--- a/src/test-e2e/marketplace/delete-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/delete-service-instance-e2e.spec.ts
@@ -10,7 +10,7 @@ import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
 
 // Regression test for:
-// - Deleting a service instance in the services list will delete the service but the list incorerctly shows no services
+// - Deleting a service instance in the services list will delete the service but the list incorrectly shows no services
 describe('Delete Service Instance', () => {
   const createServiceInstance = new CreateServiceInstance();
   let createMarketplaceServiceInstance: CreateMarketplaceServiceInstance;
@@ -41,13 +41,12 @@ describe('Delete Service Instance', () => {
     createServiceInstance.waitForPage();
     createMarketplaceServiceInstance = createServiceInstance.selectMarketplace();
     servicesHelperE2E = new ServicesHelperE2E(e2eSetup, createMarketplaceServiceInstance);
-  });
-
-  it('should go to create service instance view', () => {
-    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+    createMarketplaceServiceInstance.waitForPage();
   });
 
   it('should be able to create a service instance', () => {
+    expect(createMarketplaceServiceInstance.isActivePage()).toBeTruthy();
+
     const serviceInstanceName = servicesHelperE2E.createServiceInstanceName();
     names.push(serviceInstanceName);
     servicesHelperE2E.createService(e2e.secrets.getDefaultCFEndpoint().services.publicService.name, serviceInstanceName);

--- a/src/test-e2e/marketplace/delete-ups-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/delete-ups-service-instance-e2e.spec.ts
@@ -1,13 +1,13 @@
 import { e2e } from '../e2e';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
 import { extendE2ETestTime } from '../helpers/extend-test-helpers';
+import { ConfirmDialogComponent } from '../po/confirm-dialog';
+import { ListComponent } from '../po/list.po';
+import { MetaCardTitleType } from '../po/meta-card.po';
 import { CreateServiceInstance } from './create-service-instance.po';
+import { CreateUserProvidedServiceInstance } from './create-ups-service-instance.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
-import { ConfirmDialogComponent } from '../po/confirm-dialog';
-import { MetaCardTitleType } from '../po/meta-card.po';
-import { ListComponent } from '../po/list.po';
-import { CreateUserProvidedServiceInstance } from './create-ups-service-instance.po';
 
 describe('Delete Service Instance (User Provided Service)', () => {
   const createServiceInstance = new CreateServiceInstance();

--- a/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
+++ b/src/test-e2e/marketplace/edit-service-instance-e2e.spec.ts
@@ -65,7 +65,10 @@ describe('Edit Service Instance', () => {
         menu.waitUntilNotShown();
 
         return browser.getCurrentUrl().then(url => {
-          expect(url.endsWith('edit')).toBeTruthy();
+          const query = url.indexOf('?');
+          const urlWithoutQuery = query >= 0 ? url.substring(0, query) : url;
+          expect(urlWithoutQuery.endsWith('edit')).toBeTruthy();
+
           servicesHelperE2E.setServicePlan(true);
           servicesHelperE2E.createServiceInstance.stepper.next();
 

--- a/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
+++ b/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
@@ -4,13 +4,15 @@ import { e2e, E2ESetup } from '../e2e';
 import { ConsoleUserType } from '../helpers/e2e-helpers';
 import { extendE2ETestTime } from '../helpers/extend-test-helpers';
 import { CreateMarketplaceServiceInstance } from './create-marketplace-service-instance.po';
+import { MarketplaceInstancesPage } from './marketplace-instances.po';
 import { MarketplaceSummaryPage } from './marketplace-summary.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
 
-describe('Service Instance from Marketplace', () => {
+fdescribe('Service Instance from Marketplace', () => {
   let setup: E2ESetup;
   const servicesWall = new ServicesWallPage();
+  let servicesInstances: MarketplaceInstancesPage;
   const timeout = 60000;
   let serviceInstanceName: string;
 
@@ -22,23 +24,18 @@ describe('Service Instance from Marketplace', () => {
       .getInfo();
   });
 
-  describe('Create Public Service Instance', () => {
+  fdescribe('Create Public Service Instance', () => {
     let servicesHelperE2E: ServicesHelperE2E;
     let marketplaceSummaryPage: MarketplaceSummaryPage;
     const serviceName = e2e.secrets.getDefaultCFEndpoint().services.publicService.name;
     beforeAll(() => init(setup, serviceName).then(res => {
       servicesHelperE2E = res.servicesHelper;
       marketplaceSummaryPage = res.summaryPage;
-
     }));
 
     beforeEach(() => {
       marketplaceSummaryPage.navigateTo();
       marketplaceSummaryPage.waitForPage();
-    });
-
-    it('- should have an Add Service Instance button', () => {
-      expect(marketplaceSummaryPage.getAddServiceInstanceButton().isPresent()).toBeTruthy();
     });
 
     describe('Long running test', () => {
@@ -66,10 +63,6 @@ describe('Service Instance from Marketplace', () => {
       marketplaceSummaryPage.waitForPage();
     });
 
-    it('- should have an Add Service Instance button', () => {
-      expect(marketplaceSummaryPage.getAddServiceInstanceButton().isPresent()).toBeTruthy();
-    });
-
     describe('Long running test', () => {
       extendE2ETestTime(timeout);
       it('- should be able to create a new service instance', () => {
@@ -95,11 +88,8 @@ describe('Service Instance from Marketplace', () => {
       marketplaceSummaryPage.waitForPage();
     });
 
-    it('- should have an Add Service Instance button', () => {
-      expect(marketplaceSummaryPage.getAddServiceInstanceButton().isPresent()).toBeTruthy();
-    });
-
     describe('Long running test', () => {
+
       extendE2ETestTime(timeout);
       it('- should be able to create a new service instance', () => {
         serviceInstanceName = servicesHelperE2E.createServiceInstanceName();
@@ -109,47 +99,45 @@ describe('Service Instance from Marketplace', () => {
 
     afterAll(() => servicesHelperE2E.cleanUpServiceInstance(serviceInstanceName));
   });
+
+  function createService(
+    marketplaceSummaryPage: MarketplaceSummaryPage,
+    servicesHelperE2E: ServicesHelperE2E,
+    serviceName: string,
+    servicesWall: ServicesWallPage,
+    serviceInstanceName: string
+  ) {
+    expect(marketplaceSummaryPage.getAddServiceInstanceButton().isPresent()).toBeTruthy();
+    marketplaceSummaryPage.getAddServiceInstanceButton().click();
+    servicesHelperE2E.createServiceInstance.waitForPage();
+    browser.getCurrentUrl().then(url => {
+      expect(url.indexOf('isSpaceScoped=false') >= 0).toBeTruthy();
+      // Proceed to create a service instance
+      servicesHelperE2E.createService(serviceName, serviceInstanceName, true);
+
+      servicesInstances.waitForPage();
+      servicesInstances.list.table.findRow('name', serviceInstanceName, true);
+    });
+  }
+
+  function init(
+    setup: E2ESetup,
+    serviceName: string,
+  ) {
+    const defaultCf = e2e.secrets.getDefaultCFEndpoint();
+    const endpointGuid = e2e.helper.getEndpointGuid(e2e.info, defaultCf.name);
+
+    const servicesHelperE2E = new ServicesHelperE2E(setup);
+    return servicesHelperE2E.fetchServices(endpointGuid).then(response => {
+      serviceName = e2e.secrets.getDefaultCFEndpoint().services.publicService.name;
+      const service = response.resources.find(e => e.entity.label === serviceName);
+      const serviceGuid = service.metadata.guid;
+      servicesHelperE2E.setCreateServiceInstance(
+        new CreateMarketplaceServiceInstance('/marketplace/' + endpointGuid + '/' + serviceGuid + '/create')
+      );
+      servicesInstances = new MarketplaceInstancesPage(endpointGuid, serviceGuid);
+      const marketplaceSummaryPage = new MarketplaceSummaryPage(endpointGuid, serviceGuid);
+      return { servicesHelper: servicesHelperE2E, summaryPage: marketplaceSummaryPage };
+    });
+  }
 });
-
-function createService(
-  marketplaceSummaryPage: MarketplaceSummaryPage,
-  servicesHelperE2E: ServicesHelperE2E,
-  serviceName: string,
-  servicesWall: ServicesWallPage,
-  serviceInstanceName: string
-) {
-  const button = marketplaceSummaryPage.header.getIconButton('add');
-  expect(button).toBeDefined();
-  button.then(bt => bt.click());
-  browser.getCurrentUrl().then(url => {
-    expect(url.endsWith('create?isSpaceScoped=false')).toBeTruthy();
-    // Proceed to create a service instance
-    servicesHelperE2E.createService(serviceName, serviceInstanceName, true);
-
-    servicesWall.waitForPage();
-
-    servicesHelperE2E.getServiceCardWithTitle(servicesWall.serviceInstancesList, serviceInstanceName);
-
-  });
-}
-
-function init(
-  setup: E2ESetup,
-  serviceName: string,
-) {
-  const defaultCf = e2e.secrets.getDefaultCFEndpoint();
-  const endpointGuid = e2e.helper.getEndpointGuid(e2e.info, defaultCf.name);
-
-  const servicesHelperE2E = new ServicesHelperE2E(setup);
-  return servicesHelperE2E.fetchServices(endpointGuid).then(response => {
-    serviceName = e2e.secrets.getDefaultCFEndpoint().services.publicService.name;
-    const service = response.resources.find(e => e.entity.label === serviceName);
-    const serviceGuid = service.metadata.guid;
-    servicesHelperE2E.setCreateServiceInstance(
-      new CreateMarketplaceServiceInstance('/marketplace/' + endpointGuid + '/' + serviceGuid + '/create')
-    );
-    const marketplaceSummaryPage = new MarketplaceSummaryPage(endpointGuid, serviceGuid);
-    return { servicesHelper: servicesHelperE2E, summaryPage: marketplaceSummaryPage };
-  });
-}
-

--- a/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
+++ b/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
@@ -136,7 +136,6 @@ function createService(
 function init(
   setup: E2ESetup,
   serviceName: string,
-  spaceScoped = false
 ) {
   const defaultCf = e2e.secrets.getDefaultCFEndpoint();
   const endpointGuid = e2e.helper.getEndpointGuid(e2e.info, defaultCf.name);
@@ -147,8 +146,8 @@ function init(
     const service = response.resources.find(e => e.entity.label === serviceName);
     const serviceGuid = service.metadata.guid;
     servicesHelperE2E.setCreateServiceInstance(
-      new CreateMarketplaceServiceInstance('/marketplace/' + endpointGuid + '/' + serviceGuid +
-        '/create?isSpaceScoped=' + (spaceScoped ? 'true' : 'false')));
+      new CreateMarketplaceServiceInstance('/marketplace/' + endpointGuid + '/' + serviceGuid + '/create')
+    );
     const marketplaceSummaryPage = new MarketplaceSummaryPage(endpointGuid, serviceGuid);
     return { servicesHelper: servicesHelperE2E, summaryPage: marketplaceSummaryPage };
   });

--- a/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
+++ b/src/test-e2e/marketplace/marketplace-create-service-instances-e2e.spec.ts
@@ -9,7 +9,7 @@ import { MarketplaceSummaryPage } from './marketplace-summary.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 import { ServicesWallPage } from './services-wall.po';
 
-fdescribe('Service Instance from Marketplace', () => {
+describe('Service Instance from Marketplace', () => {
   let setup: E2ESetup;
   const servicesWall = new ServicesWallPage();
   let servicesInstances: MarketplaceInstancesPage;
@@ -24,7 +24,7 @@ fdescribe('Service Instance from Marketplace', () => {
       .getInfo();
   });
 
-  fdescribe('Create Public Service Instance', () => {
+  describe('Create Public Service Instance', () => {
     let servicesHelperE2E: ServicesHelperE2E;
     let marketplaceSummaryPage: MarketplaceSummaryPage;
     const serviceName = e2e.secrets.getDefaultCFEndpoint().services.publicService.name;
@@ -116,6 +116,7 @@ fdescribe('Service Instance from Marketplace', () => {
       servicesHelperE2E.createService(serviceName, serviceInstanceName, true);
 
       servicesInstances.waitForPage();
+      servicesInstances.list.header.setSearchText(serviceInstanceName);
       servicesInstances.list.table.findRow('name', serviceInstanceName, true);
     });
   }

--- a/src/test-e2e/marketplace/marketplace-instances.po.ts
+++ b/src/test-e2e/marketplace/marketplace-instances.po.ts
@@ -1,0 +1,11 @@
+import { ListComponent } from '../po/list.po';
+import { Page } from '../po/page.po';
+
+export class MarketplaceInstancesPage extends Page {
+  public list = new ListComponent();
+
+  constructor(cfGuid: string, serviceGuid: string) {
+    super(`/marketplace/${cfGuid}/${serviceGuid}/instances`);
+  }
+
+}

--- a/src/test-e2e/marketplace/marketplace-summary-e2e.spec.ts
+++ b/src/test-e2e/marketplace/marketplace-summary-e2e.spec.ts
@@ -1,7 +1,8 @@
-import { MarketplaceSummaryPage } from './marketplace-summary.po';
-import { ConsoleUserType } from '../helpers/e2e-helpers';
-import { e2e } from '../e2e';
 import { browser } from 'protractor';
+
+import { e2e } from '../e2e';
+import { ConsoleUserType } from '../helpers/e2e-helpers';
+import { MarketplaceSummaryPage } from './marketplace-summary.po';
 import { ServicesHelperE2E } from './services-helper-e2e';
 
 describe('Marketplace Summary', () => {
@@ -56,7 +57,7 @@ describe('Marketplace Summary', () => {
       expect(button).toBeDefined();
       button.then(bt => bt.click());
       browser.getCurrentUrl().then(url => {
-        expect(url.endsWith('create?isSpaceScoped=false')).toBeTruthy();
+        expect(url.indexOf('create?isSpaceScoped=false') >= 0).toBeTruthy();
       });
     });
   });

--- a/src/test-e2e/marketplace/marketplace-summary.po.ts
+++ b/src/test-e2e/marketplace/marketplace-summary.po.ts
@@ -23,4 +23,5 @@ export class MarketplaceSummaryPage extends Page {
     return element(by.name('add-service-instance'));
   }
 
+
 }

--- a/src/test-e2e/marketplace/services-wall-e2e.spec.ts
+++ b/src/test-e2e/marketplace/services-wall-e2e.spec.ts
@@ -128,8 +128,11 @@ describe('Service Instances Wall', () => {
         expect(editMenuItem.getText()).toEqual('Edit');
         expect(editMenuItem.isEnabled()).toBeTruthy();
         editMenuItem.click();
+
         browser.getCurrentUrl().then(url => {
-          expect(url.endsWith('edit')).toBeTruthy();
+          const query = url.indexOf('?');
+          const urlWithoutQuery = query >= 0 ? url.substring(0, query) : url;
+          expect(urlWithoutQuery.endsWith('edit')).toBeTruthy();
         });
         const createMarketplaceServiceInstance = new CreateMarketplaceServiceInstance();
         createMarketplaceServiceInstance.stepper.cancel();

--- a/src/test-e2e/marketplace/services-wall.po.ts
+++ b/src/test-e2e/marketplace/services-wall.po.ts
@@ -44,6 +44,10 @@ export class ServicesWallPage extends Page {
     }));
   }
 
+  isActivePage() {
+    return super.isActivePage(true);
+  }
+
   waitForPage() {
     return super.waitForPage(undefined, true);
   }

--- a/src/test-e2e/marketplace/services-wall.po.ts
+++ b/src/test-e2e/marketplace/services-wall.po.ts
@@ -1,4 +1,4 @@
-import { ElementArrayFinder, ElementFinder, promise, element, by } from 'protractor';
+import { by, element, ElementArrayFinder, ElementFinder, promise } from 'protractor';
 
 import { ListComponent } from '../po/list.po';
 import { MetaCard, MetaCardTitleType } from '../po/meta-card.po';
@@ -42,5 +42,9 @@ export class ServicesWallPage extends Page {
       planName: items[2].value,
       applicationsAttached: items[3].value,
     }));
+  }
+
+  waitForPage() {
+    return super.waitForPage(undefined, true);
   }
 }


### PR DESCRIPTION
App Service Edit Binding: cancel of stepper results in leaked subscription 
- fixes #4295

Cancel/create in service instance stepper returns to incorrect locations 
- fixes #4052

By
- In service stepper on cancel return to previous location, only fall back on calculated previous location on fresh load in stepper
- In service stepper on success return to the same cancel location
- In create service instance select service type step ensure we set the correct cancelUrl

Contributes to 
- Improve handling of create/edit service instances #4051
- 'Edit' service instance in application services tabs doesn't allow edit of binding #4079