### PR TITLE
Fix CF App Restage

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/actions/app-metadata.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/app-metadata.actions.ts
@@ -1,7 +1,7 @@
 import { HttpRequest } from '@angular/common/http';
 
 import { PaginatedAction } from '../../../store/src/types/pagination.types';
-import { ICFAction, RequestEntityLocation } from '../../../store/src/types/request.types';
+import { ICFAction } from '../../../store/src/types/request.types';
 import { cfEntityFactory } from '../cf-entity-factory';
 import { appEnvVarsEntityType, applicationEntityType, appStatsEntityType, appSummaryEntityType } from '../cf-entity-types';
 import { createEntityRelationPaginationKey } from '../entity-relations/entity-relations.types';
@@ -39,7 +39,6 @@ export class GetAppStatsAction extends CFStartAction implements PaginatedAction,
     'order-direction': 'desc',
     'order-direction-field': 'index',
   };
-  entityLocation = RequestEntityLocation.ARRAY;
 }
 
 export class GetAppEnvVarsAction extends CFStartAction implements PaginatedAction, ICFAction {

--- a/src/frontend/packages/cloud-foundry/src/actions/application.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/application.actions.ts
@@ -1,4 +1,4 @@
-import { HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
+import { HttpParams, HttpRequest } from '@angular/common/http';
 
 import { pick } from '../../../store/src/helpers/reducer.helper';
 import { ActionMergeFunction } from '../../../store/src/types/api.types';
@@ -164,9 +164,6 @@ export class DeleteApplication extends CFStartAction implements ICFAction {
       `apps/${guid}`,
       null,
       {
-        headers: new HttpHeaders({
-          'x-cap-passthrough': 'true'
-        }),
         params: new HttpParams({
           fromObject: {
             recursive: 'true'
@@ -192,12 +189,7 @@ export class DeleteApplicationInstance extends CFStartAction
     this.options = new HttpRequest(
       'DELETE',
       `apps/${appGuid}/instances/${index}`,
-      null,
-      {
-        headers: new HttpHeaders({
-          'x-cap-passthrough': 'true'
-        })
-      }
+      null
     );
     this.guid = `${appGuid}-${index}`;
   }
@@ -215,11 +207,6 @@ export class RestageApplication extends CFStartAction implements ICFAction {
       'POST',
       `apps/${guid}/restage`,
       null,
-      {
-        headers: new HttpHeaders({
-          'x-cap-passthrough': 'true'
-        })
-      }
     );
   }
   actions = [RESTAGE, RESTAGE_SUCCESS, RESTAGE_FAILED];

--- a/src/frontend/packages/cloud-foundry/src/actions/feature-flags.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/feature-flags.actions.ts
@@ -3,7 +3,6 @@ import { HttpRequest } from '@angular/common/http';
 import { getActions } from '../../../store/src/actions/action.helper';
 import { endpointEntityType } from '../../../store/src/helpers/stratos-entity-factory';
 import { PaginatedAction } from '../../../store/src/types/pagination.types';
-import { RequestEntityLocation } from '../../../store/src/types/request.types';
 import { cfEntityFactory } from '../cf-entity-factory';
 import { featureFlagEntityType } from '../cf-entity-types';
 import { createEntityRelationPaginationKey } from '../entity-relations/entity-relations.types';
@@ -25,7 +24,6 @@ export class GetAllFeatureFlags extends CFStartAction implements PaginatedAction
   actions = getActions('Feature Flags', 'Fetch all');
   options: HttpRequest<any>;
   flattenPagination = true;
-  entityLocation = RequestEntityLocation.ARRAY;
   initialParams = {
     page: 1,
     'order-direction': 'desc',

--- a/src/frontend/packages/cloud-foundry/src/actions/relation.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/relation.actions.ts
@@ -2,7 +2,7 @@ import { HttpParams, HttpRequest } from '@angular/common/http';
 
 import { EntityCatalogEntityConfig } from '../../../store/src/entity-catalog/entity-catalog.types';
 import { PaginatedAction } from '../../../store/src/types/pagination.types';
-import { RequestActionEntity, RequestEntityLocation } from '../../../store/src/types/request.types';
+import { RequestActionEntity } from '../../../store/src/types/request.types';
 import { EntityTreeRelation } from '../entity-relations/entity-relation-tree';
 import { EntityInlineChildAction, EntityInlineParentAction } from '../entity-relations/entity-relations.types';
 import { CFStartAction } from './cf-action.types';
@@ -95,8 +95,6 @@ export class FetchRelationSingleAction extends FetchRelationAction {
       populateMissing,
       url,
     );
-    this.entityLocation = RequestEntityLocation.OBJECT;
     this.entity = child.entity;
   }
-  entityLocation: RequestEntityLocation;
 }

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/entity-relations-validate.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/entity-relations-validate.spec.ts
@@ -9,11 +9,7 @@ import { InternalAppState, IRequestTypeState } from '../../../store/src/app-stat
 import { EntityCatalogTestModuleManualStore, TEST_CATALOGUE_ENTITIES } from '../../../store/src/entity-catalog-test.module';
 import { entityCatalog } from '../../../store/src/entity-catalog/entity-catalog';
 import { EntityCatalogEntityConfig } from '../../../store/src/entity-catalog/entity-catalog.types';
-import {
-  EntityRequestAction,
-  RequestEntityLocation,
-  WrapperRequestActionSuccess,
-} from '../../../store/src/types/request.types';
+import { EntityRequestAction, WrapperRequestActionSuccess } from '../../../store/src/types/request.types';
 import {
   entityRelationMissingQuotaGuid,
   entityRelationMissingQuotaUrl,
@@ -444,7 +440,6 @@ describe('Entity Relations - validate -', () => {
       const associateAPIAction: EntityRequestAction = {
         endpointGuid: getOrgAction.endpointGuid,
         entity: getOrgAction.entity[0],
-        entityLocation: RequestEntityLocation.OBJECT,
         guid: orgGuid,
         entityType: organizationEntityType,
         type: '[Entity] Associate with parent',

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/entity-relations.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/entity-relations.ts
@@ -17,11 +17,7 @@ import { getAPIRequestDataState, selectEntity, selectRequestInfo } from '../../.
 import { selectPaginationState } from '../../../store/src/selectors/pagination.selectors';
 import { APIResource, NormalizedResponse } from '../../../store/src/types/api.types';
 import { isPaginatedAction, PaginatedAction, PaginationEntityState } from '../../../store/src/types/pagination.types';
-import {
-  EntityRequestAction,
-  RequestEntityLocation,
-  WrapperRequestActionSuccess,
-} from '../../../store/src/types/request.types';
+import { EntityRequestAction, WrapperRequestActionSuccess } from '../../../store/src/types/request.types';
 import { FetchRelationAction, FetchRelationPaginatedAction, FetchRelationSingleAction } from '../actions/relation.actions';
 import { EntityTreeRelation } from './entity-relation-tree';
 import { validationPostProcessor } from './entity-relations-post-processor';
@@ -341,7 +337,6 @@ function associateChildWithParent(
         const parentAction: EntityRequestAction = {
           endpointGuid: action.endpointGuid,
           entity: catalogEntity.getSchema(action.parentEntityConfig.schemaKey),
-          entityLocation: RequestEntityLocation.OBJECT,
           guid: action.parentGuid,
           entityType: action.parentEntityConfig.entityType,
           endpointType: action.parentEntityConfig.endpointType,

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/processors/org-space-post-processor.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/processors/org-space-post-processor.ts
@@ -8,7 +8,7 @@ import { deepMergeState, mergeEntity } from '../../../../store/src/helpers/reduc
 import { selectPaginationState } from '../../../../store/src/selectors/pagination.selectors';
 import { APIResource } from '../../../../store/src/types/api.types';
 import { PaginatedAction, PaginationEntityState } from '../../../../store/src/types/pagination.types';
-import { RequestEntityLocation, WrapperRequestActionSuccess } from '../../../../store/src/types/request.types';
+import { WrapperRequestActionSuccess } from '../../../../store/src/types/request.types';
 import { GetOrganization } from '../../actions/organization.actions';
 import { GetSpace } from '../../actions/space.actions';
 import { getCFEntityKey } from '../../cf-entity-helpers';
@@ -105,7 +105,6 @@ export function orgSpacePostProcess(
       actions: [],
       endpointGuid: action.endpointGuid,
       entity: userCatalogEntity.getSchema(),
-      entityLocation: RequestEntityLocation.ARRAY,
       entityType: userCatalogEntity.definition.type,
       endpointType: CF_ENDPOINT_TYPE,
       type: '[Entity] Post-process Org/Space Users',

--- a/src/frontend/packages/store/src/types/request.types.ts
+++ b/src/frontend/packages/store/src/types/request.types.ts
@@ -53,7 +53,6 @@ export interface EntityRequestAction extends EntityCatalogEntityConfig, RequestA
    * For single entity requests
    */
   guid?: string;
-  entityLocation?: RequestEntityLocation;
   /**
    * For delete requests we clear the pagination sections (include all pages) of all list matching the same entity type. In some cases,
    * like local lists, we want to immediately remove that entry instead of clearing the table and refetching all data. This flag allows that

--- a/src/frontend/packages/store/src/types/request.types.ts
+++ b/src/frontend/packages/store/src/types/request.types.ts
@@ -18,16 +18,6 @@ export interface RequestAction extends Action, BasePipelineRequestAction, Single
   updatingKey?: string;
 }
 
-/**
- * The entities in the response can live in a few different places. This will tell us where to look in the response to gather the entities
- * @export
- */
-export enum RequestEntityLocation {
-  RESOURCE, // The response is an object and the entities list is within a 'resource' param. Falls back to 'OBJECT' if missing.
-  ARRAY, // The response is an array which contains the entities
-  OBJECT, // The response is the entity
-}
-
 export type RequestActionEntity = EntitySchema | EntitySchema[];
 export interface EntityRequestAction extends EntityCatalogEntityConfig, RequestAction {
   /**


### PR DESCRIPTION
- fixes #4392
- also removes obsolete action param `entityLocation` and `RequestEntityLocation`