### PR TITLE
Add env var support for ssl mode

### DIFF
--- a/src/jetstream/datastore/database_cf_config.go
+++ b/src/jetstream/datastore/database_cf_config.go
@@ -47,10 +47,10 @@ func ParseCFEnvs(db *DatabaseConfig, env *env.VarSet) (bool, error) {
 		log.Info("No DB configurations defined, will use SQLite")
 		return false, nil
 	}
-	return findDatabaseConfig(vcapServices, db), nil
+	return findDatabaseConfig(vcapServices, db, env), nil
 }
 
-func findDatabaseConfig(vcapServices map[string][]VCAPService, db *DatabaseConfig) bool {
+func findDatabaseConfig(vcapServices map[string][]VCAPService, db *DatabaseConfig, env *env.VarSet) bool {
 	var service VCAPService
 	configs := findDatabaseConfigurations(vcapServices)
 	log.Infof("Found %d database service instances", len(configs))
@@ -78,7 +78,7 @@ func findDatabaseConfig(vcapServices map[string][]VCAPService, db *DatabaseConfi
 		db.Username = getDBCredentialsValue(dbCredentials["username"])
 		db.Password = getDBCredentialsValue(dbCredentials["password"])
 		db.Host = getDBCredentialsValue(dbCredentials["hostname"])
-		db.SSLMode = "disable"
+		db.SSLMode = env.String("DB_SSL_MODE", "disable")
 		db.Port, _ = strconv.Atoi(getDBCredentialsValue(dbCredentials["port"]))
 		// Note - Both isPostgresService and isMySQLService look at the credentials uri & tags
 		if isPostgresService(service) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
SSL mode for the database connection string was not configurable. This change allows configuration of this via env var `DB_SSL_MODE`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enabling encrypted connections to backend databases should be allowed.

<!--- If it fixes an open issue, please link to the issue here. -->
This issue is filed upstream at https://github.com/cloudfoundry/stratos/issues/4434.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The existing tests validate TLS connection strings work.
<!--- Include details of your testing environment, tests ran to see how -->

<!--- your change affects other areas of the code, etc. -->
The value of the supplied mode is already validated [here](https://github.com/cloudfoundry/stratos/blob/master/src/jetstream/datastore/datastore.go#L105-L122).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message