### PR TITLE
Improve autoscaler e2e logging

### DIFF
--- a/src/test-e2e/po/form.po.ts
+++ b/src/test-e2e/po/form.po.ts
@@ -1,10 +1,8 @@
-import { e2e } from './../e2e';
 import { browser, by, element, promise } from 'protractor';
 import { ElementArrayFinder, ElementFinder, protractor } from 'protractor/built';
 import { Key } from 'selenium-webdriver';
 
 import { Component } from './component.po';
-import { P } from '@angular/cdk/keycodes';
 
 const until = protractor.ExpectedConditions;
 

--- a/src/test-e2e/po/list.po.ts
+++ b/src/test-e2e/po/list.po.ts
@@ -14,6 +14,10 @@ export interface CardMetadata {
   click: () => void;
 }
 
+export interface TableData {
+  [columnHeader: string]: string
+}
+
 // Page Object for the List Table View
 export class ListTableComponent extends Component {
 
@@ -59,7 +63,7 @@ export class ListTableComponent extends Component {
     });
   }
 
-  getTableData(): promise.Promise<{ [columnHeader: string]: string }[]> {
+  getTableData(): promise.Promise<TableData[]> {
     return this.getTableDataRaw().then(tableData => {
       const table = [];
       tableData.rows.forEach((row: string[]) => {


### PR DESCRIPTION
- it looks like the AS returns scaling events 1-2 mins after they occur, which is too late for the test
- add additional logging to print out event table data in case of alternative events being raised
- fix logging if wait for events times out
- add hint in later test that depends on AS scaling event
