### PR TITLE
Fix check-e2e-pr.sh for pr's from other repos

### DIFF
--- a/deploy/ci/travis/check-e2e-pr.sh
+++ b/deploy/ci/travis/check-e2e-pr.sh
@@ -2,8 +2,8 @@
 
 if [ -n "${TRAVIS_PULL_REQUEST}" ]; then
   if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-    echo "Checking labels on ${TRAVIS_PULL_REQUEST_SLUG} #${TRAVIS_PULL_REQUEST}"
-    LABEL=$(curl -s "https://api.github.com/repos/${TRAVIS_PULL_REQUEST_SLUG}/pulls/${TRAVIS_PULL_REQUEST}" | jq -r '.labels[] | select(.name == "e2e-debug") | .name')
+    echo "Checking labels on ${TRAVIS_REPO_SLUG} #${TRAVIS_PULL_REQUEST}"
+    LABEL=$(curl -s "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/pulls/${TRAVIS_PULL_REQUEST}" | jq -r '.labels[] | select(.name == "e2e-debug") | .name')
     if [ "${LABEL}" == "e2e-debug" ]; then
       echo "PR has the 'e2e-debug' label - enabling debug logging for E2E tests"
       export STRATOS_E2E_DEBUG=true


### PR DESCRIPTION
- switch from TRAVIS_PULL_REQUEST_SLUG to TRAVIS_REPO_SLUG
- TRAVIS_PULL_REQUEST_SLUG prints repo where PR originated, whereas we want the repo where the PR is raised
- see https://docs.travis-ci.com/user/environment-variables/
