### PR TITLE
Fix GitHub branch limit

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/actions/deploy-applications.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/deploy-applications.actions.ts
@@ -86,6 +86,7 @@ export class FetchBranchesForProject implements PaginatedAction {
   type = FETCH_BRANCHES_FOR_PROJECT;
   entityType = gitBranchesEntityType;
   paginationKey: string;
+  flattenPagination = true;
 
   static createPaginationKey = (scm: GitSCM, projectName: string) => scm.getType() + ':' + projectName;
 }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -247,7 +247,7 @@ export class DeployApplicationStep2Component
       .pipe(
         // Wait for a new project name change
         filter(state => state && !state.checking && !state.error && state.exists),
-        distinctUntilChanged((x, y) => x.name === y.name),
+        distinctUntilChanged((x, y) => x.name.toLowerCase() === y.name.toLowerCase()),
         // Convert project name into branches pagination observable
         switchMap(state =>
           cfEntityCatalog.gitBranch.store.getPaginationService(null, null, {

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-pagination.helper.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-pagination.helper.ts
@@ -26,8 +26,8 @@ type GithubPaginationResponse<T = any> = {
  */
 type GithubPaginationArrayResponse<T = any> = T[];
 
-const GITHUB_PER_PAGE_PARAM = 'per_page';
-const GITHUB_PER_PAGE_PARAM_VALUE = 100;
+export const GITHUB_PER_PAGE_PARAM = 'per_page';
+export const GITHUB_PER_PAGE_PARAM_VALUE = 100;
 const GITHUB_MAX_PAGES = 5;
 const GITHUB_PAGE_PARAM = 'page';
 const GITHUB_LINK_PAGE_REGEX = /page=([\d]*)/

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-pagination.helper.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-pagination.helper.ts
@@ -1,0 +1,152 @@
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { PaginationFlattener } from '@stratosui/store';
+import { Observable } from 'rxjs';
+
+// --------------- Note ----------------
+// There are two types of pagination github uses
+// 1) Pagination info is in the body of the response (GithubPaginationResponse / GithubFlattenerPaginationConfig)
+//    - Array is in the body of the response
+//    - Things like total number of results in the body of the response
+// 2) Pagination info is in the response header (GithubPaginationArrayResponse / GithubFlattenerForArrayPaginationConfig)
+//    - Array is the body of the response
+//    - Thinks like total number of results are in a `link` property in the response header
+
+
+/**
+ * Body of a github pagination response (pagination info inside body)
+ */
+type GithubPaginationResponse<T = any> = {
+  incomplete_results: boolean,
+  items: T[],
+  total_count: number
+}
+
+/**
+ * Body of a github pagination response (pagination info is in header)
+ */
+type GithubPaginationArrayResponse<T = any> = T[];
+
+const GITHUB_PER_PAGE_PARAM = 'per_page';
+const GITHUB_PER_PAGE_PARAM_VALUE = 100;
+const GITHUB_MAX_PAGES = 5;
+const GITHUB_PAGE_PARAM = 'page';
+const GITHUB_LINK_PAGE_REGEX = /page=([\d]*)/
+
+/**
+ * Config used with `flattenPagination`. To use when the pagination info is in the body
+ */
+export class GithubFlattenerPaginationConfig<T> implements PaginationFlattener<T[], GithubPaginationResponse<T>> {
+  constructor(
+    private httpClient: HttpClient,
+    public url: string,
+  ) { }
+
+  getTotalPages = (res: GithubPaginationResponse<T>): number => {
+    const total = Math.floor(this.getTotalResults(res) / GITHUB_PER_PAGE_PARAM_VALUE) + 1;
+    if (total > GITHUB_MAX_PAGES) {
+      console.warn(`Not fetching all github entities (too many pages: ${total})`)
+      return GITHUB_MAX_PAGES;
+    }
+    return total;
+  }
+  getTotalResults = (res: GithubPaginationResponse<T>): number => {
+    return res.total_count;
+  };
+  mergePages = (response: any[]): T[] => {
+    return response.reduce((all, res) => {
+      return all.concat(...res.items);
+    }, [] as T[])
+  };
+  fetch = (...args: any[]): Observable<GithubPaginationResponse<T>> => {
+    return this.httpClient.get<GithubPaginationResponse<T>>(
+      this.url,
+      {
+        params: {
+          ...args[0]
+        },
+      }
+    );
+  };
+  buildFetchParams = (i: number): any[] => {
+    const requestOption = {
+      [GITHUB_PAGE_PARAM]: i.toString(),
+      [GITHUB_PER_PAGE_PARAM]: GITHUB_PER_PAGE_PARAM_VALUE.toString()
+    };
+    return [requestOption];
+  };
+  clearResults = (res: GithubPaginationResponse<T>, allResults: number) => {
+    throw new Error('Not Implemented')
+  };
+}
+
+/**
+ * Config used with `flattenPagination`. To use when the pagination info in the response header
+ */
+export class GithubFlattenerForArrayPaginationConfig<T> implements PaginationFlattener<GithubPaginationArrayResponse<T>, HttpResponse<GithubPaginationArrayResponse<T>>> {
+  constructor(
+    private httpClient: HttpClient,
+    public url: string,
+  ) { }
+
+  getTotalPages = (res: HttpResponse<GithubPaginationArrayResponse<T>>): number => {
+    // Link: <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=2>; rel="next",
+    // <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last"
+
+    const link = res.headers.get('link');
+    if (!link) {
+      // There's no `link` if there's only one page.....
+      return 1;
+    }
+    const parts = link.split(',');
+    if (!parts.length) {
+      throw new Error('Unable to depagination github request (no commas in `link`)');
+    }
+    const last = parts.find(part => part.endsWith('rel="last"'))
+    if (!last) {
+      throw new Error('Unable to depagination github request (no `last` in `link`)');
+    }
+    const trimmedLast = last.trim();
+    const lastUrl = trimmedLast.slice(1, trimmedLast.indexOf('>'));
+    const lastPageNumber = GITHUB_LINK_PAGE_REGEX.exec(lastUrl);
+    if (lastPageNumber.length < 2) {
+      throw new Error(`Unable to depagination github request (could not find page number in ${lastUrl})`)
+    }
+
+    const total = parseInt(lastPageNumber[1], 10);
+    if (total > GITHUB_MAX_PAGES) {
+      console.warn(`Not fetching all github entities (too many pages: ${total})`)
+      return GITHUB_MAX_PAGES;
+    }
+    return total;
+  }
+  getTotalResults = (res: HttpResponse<GithubPaginationArrayResponse<T>>): number => {
+    return this.getTotalPages(res) * GITHUB_PER_PAGE_PARAM_VALUE;
+  };
+  mergePages = (response: any[]): GithubPaginationArrayResponse<T> => {
+    return response.reduce((all, res) => {
+      return all.concat(...res.body);
+    }, [] as GithubPaginationArrayResponse<T>)
+  };
+  fetch = (...args: any[]): Observable<HttpResponse<GithubPaginationArrayResponse<T>>> => {
+    return this.httpClient.get<GithubPaginationArrayResponse<T>>(
+      this.url,
+      {
+        params: {
+          ...args[0]
+        },
+        // Required to ensure we can access the https response header
+        observe: 'response'
+      }
+    );
+  };
+  buildFetchParams = (i: number): any[] => {
+    const requestOption = {
+      [GITHUB_PAGE_PARAM]: i.toString(),
+      [GITHUB_PER_PAGE_PARAM]: GITHUB_PER_PAGE_PARAM_VALUE.toString()
+    };
+    return [requestOption];
+  };
+  clearResults = (res: HttpResponse<GithubPaginationArrayResponse<T>>, allResults: number) => {
+    throw new Error('Not Implemented')
+  };
+}

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-scm.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-scm.ts
@@ -5,7 +5,12 @@ import { map } from 'rxjs/operators';
 
 import { getGitHubAPIURL } from '../../../../../core/src/core/github.helpers';
 import { GitBranch, GitCommit, GitRepo } from '../../../store/types/git.types';
-import { GithubFlattenerForArrayPaginationConfig, GithubFlattenerPaginationConfig } from './github-pagination.helper';
+import {
+  GITHUB_PER_PAGE_PARAM,
+  GITHUB_PER_PAGE_PARAM_VALUE,
+  GithubFlattenerForArrayPaginationConfig,
+  GithubFlattenerPaginationConfig,
+} from './github-pagination.helper';
 import { GitSCM, SCMIcon } from './scm';
 import { GitSCMType } from './scm.service';
 
@@ -58,7 +63,12 @@ export class GitHubSCM implements GitSCM {
   }
 
   getCommits(httpClient: HttpClient, projectName: string, ref: string): Observable<GitCommit[]> {
-    return httpClient.get(`${this.gitHubURL}/repos/${projectName}/commits?sha=${ref}`) as Observable<GitCommit[]>;
+    return httpClient.get<GitCommit[]>(
+      `${this.gitHubURL}/repos/${projectName}/commits?sha=${ref}`, {
+      params: {
+        [GITHUB_PER_PAGE_PARAM]: GITHUB_PER_PAGE_PARAM_VALUE.toString()
+      }
+    });
   }
 
   getCloneURL(projectName: string): string {

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-scm.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/github-scm.ts
@@ -1,9 +1,11 @@
 import { HttpClient } from '@angular/common/http';
+import { flattenPagination } from '@stratosui/store';
 import { Observable } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 import { getGitHubAPIURL } from '../../../../../core/src/core/github.helpers';
 import { GitBranch, GitCommit, GitRepo } from '../../../store/types/git.types';
+import { GithubFlattenerForArrayPaginationConfig, GithubFlattenerPaginationConfig } from './github-pagination.helper';
 import { GitSCM, SCMIcon } from './scm';
 import { GitSCMType } from './scm.service';
 
@@ -37,7 +39,14 @@ export class GitHubSCM implements GitSCM {
   }
 
   getBranches(httpClient: HttpClient, projectName: string): Observable<GitBranch[]> {
-    return httpClient.get(`${this.gitHubURL}/repos/${projectName}/branches`) as Observable<GitBranch[]>;
+    const url = `${this.gitHubURL}/repos/${projectName}/branches`;
+    const config = new GithubFlattenerForArrayPaginationConfig<GitBranch>(httpClient, url)
+    const firstRequest = config.fetch(...config.buildFetchParams(1))
+    return flattenPagination(
+      null,
+      firstRequest,
+      config
+    )
   }
 
   getCommit(httpClient: HttpClient, projectName: string, commitSha: string): Observable<GitCommit> {
@@ -70,12 +79,18 @@ export class GitHubSCM implements GitSCM {
     if (prjParts.length > 1) {
       url = `${this.gitHubURL}/search/repositories?q=${prjParts[1]}+in:name+fork:true+user:${prjParts[0]}`;
     }
-    return httpClient.get(url).pipe(
-      filter((repos: any) => !!repos.items),
+
+    const config = new GithubFlattenerPaginationConfig<GitRepo>(httpClient, url)
+    const firstRequest = config.fetch(...config.buildFetchParams(1))
+    return flattenPagination(
+      null,
+      firstRequest,
+      config
+    ).pipe(
       map(repos => {
-        return repos.items.map(item => item.full_name);
+        return repos.map(item => item.full_name);
       })
-    );
+    )
   }
 
   public convertCommit(projectName: string, commit: any): GitCommit {

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/gitlab-scm.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/scm/gitlab-scm.ts
@@ -8,6 +8,8 @@ import { GitSCM, SCMIcon } from './scm';
 import { GitSCMType } from './scm.service';
 
 const gitLabAPIUrl = 'https://gitlab.com/api/v4';
+const GITLAB_PER_PAGE_PARAM = 'per_page';
+const GITLAB_PER_PAGE_PARAM_VALUE = 100;
 
 export class GitLabSCM implements GitSCM {
 
@@ -59,7 +61,13 @@ export class GitLabSCM implements GitSCM {
 
   getBranches(httpClient: HttpClient, projectName: string): Observable<GitBranch[]> {
     const prjNameEncoded = encodeURIComponent(projectName);
-    return httpClient.get(`${gitLabAPIUrl}/projects/${prjNameEncoded}/repository/branches`).pipe(
+    return httpClient.get(
+      `${gitLabAPIUrl}/projects/${prjNameEncoded}/repository/branches`, {
+      params: {
+        [GITLAB_PER_PAGE_PARAM]: GITLAB_PER_PAGE_PARAM_VALUE.toString()
+      }
+    }
+    ).pipe(
       map((data: any) => {
         const branches = [];
         data.forEach(b => {
@@ -87,7 +95,13 @@ export class GitLabSCM implements GitSCM {
 
   getCommits(httpClient: HttpClient, projectName: string, commitSha: string): Observable<GitCommit[]> {
     const prjNameEncoded = encodeURIComponent(projectName);
-    return httpClient.get(`${gitLabAPIUrl}/projects/${prjNameEncoded}/repository/commits?ref_name=${commitSha}`).pipe(
+    return httpClient.get(
+      `${gitLabAPIUrl}/projects/${prjNameEncoded}/repository/commits?ref_name=${commitSha}`, {
+      params: {
+        [GITLAB_PER_PAGE_PARAM]: GITLAB_PER_PAGE_PARAM_VALUE.toString()
+      }
+    }
+    ).pipe(
       map((data: any) => {
         const commits = [];
         data.forEach(c => commits.push(this.convertCommit(projectName, c)));
@@ -114,7 +128,11 @@ export class GitLabSCM implements GitSCM {
     if (prjParts.length > 1) {
       url = `${gitLabAPIUrl}/users/${prjParts[0]}/projects?search=${prjParts[1]}`;
     }
-    return httpClient.get(url).pipe(
+    return httpClient.get(url, {
+      params: {
+        [GITLAB_PER_PAGE_PARAM]: GITLAB_PER_PAGE_PARAM_VALUE.toString()
+      }
+    }).pipe(
       map((repos: any) => {
         return repos.map(item => item.path_with_namespace);
       })

--- a/src/frontend/packages/store/src/entity-request-pipeline/entity-pagination-request-pipeline.ts
+++ b/src/frontend/packages/store/src/entity-request-pipeline/entity-pagination-request-pipeline.ts
@@ -10,7 +10,6 @@ import {
   StratosCatalogEntity,
 } from '../entity-catalog/entity-catalog-entity/entity-catalog-entity';
 import { IStratosEntityDefinition } from '../entity-catalog/entity-catalog.types';
-import { PaginationFlattenerConfig } from '../helpers/paginated-request-helpers';
 import { selectPaginationState } from '../selectors/pagination.selectors';
 import { PaginatedAction, PaginationEntityState } from '../types/pagination.types';
 import {
@@ -69,7 +68,6 @@ function getRequestObservable(
 }
 export interface PaginatedRequestPipelineConfig<T extends AppState = InternalAppState> extends BasePipelineConfig<T> {
   action: PaginatedAction;
-  pageFlattenerConfig: PaginationFlattenerConfig;
 }
 export const basePaginatedRequestPipeline: EntityRequestPipeline = (
   store: Store<AppState>,

--- a/src/frontend/packages/store/src/public-api.ts
+++ b/src/frontend/packages/store/src/public-api.ts
@@ -2,8 +2,11 @@
  * Public API Surface of store
  */
 
- // Helpers
- export * from './helpers/store-helpers';
 
- // App State
- export { AppState } from './app-state';
+// Helpers
+export * from './helpers/store-helpers';
+
+// App State
+export { AppState } from './app-state';
+
+export { flattenPagination, PaginationFlattener } from './helpers/paginated-request-helpers';


### PR DESCRIPTION
- `de-paginate` github requests to list repos and branches
- increase default page size of all github and gitlab pagination requests
- fix two cases were we'd dupe the request to fetch github branches
- fixes #3966
- we're not quite where we should be with these requests yet...
  - they need to be tied into the generic entity catalogue request pipeline. this would result in the effects, and the pagination changes here, being removed. this would require the pagination params process to be re-written/fixed (it applies cf api params)
  - they should be in their own endpoint type