### PR TITLE
Remove dependencies between store and core that have crept in

### DIFF
--- a/src/frontend/packages/core/src/features/metrics/metrics.module.ts
+++ b/src/frontend/packages/core/src/features/metrics/metrics.module.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { stratosEntityCatalog } from '../../../../store/src/stratos-entity-catalog';
 import { CoreModule } from '../../core/core.module';
+import { BaseEndpointAuth } from '../../core/endpoint-auth';
 import { SharedModule } from '../../shared/shared.module';
 import { MetricsEndpointDetailsComponent } from './metrics-endpoint-details/metrics-endpoint-details.component';
 import { MetricsRoutingModule } from './metrics.routing';
@@ -23,4 +25,13 @@ import { MetricsService } from './services/metrics-service';
     MetricsEndpointDetailsComponent,
   ]
 })
-export class MetricsModule { }
+export class MetricsModule {
+
+  constructor() {
+    // Register the endpoint details component
+    // This is done here to break circular dependency - since the registration is done in the store package
+    // But the core package defines the component for the endpoint card details
+    stratosEntityCatalog.metricsEndpoint.setListComponent(MetricsEndpointDetailsComponent);
+    stratosEntityCatalog.metricsEndpoint.setAuthTypes([BaseEndpointAuth.UsernamePassword, BaseEndpointAuth.None]);
+  }
+}

--- a/src/frontend/packages/store/src/entity-catalog/entity-catalog-entity/entity-catalog-entity.ts
+++ b/src/frontend/packages/store/src/entity-catalog/entity-catalog-entity/entity-catalog-entity.ts
@@ -12,6 +12,7 @@ import {
   PaginationPageIteratorConfig,
 } from '../../entity-request-pipeline/pagination-request-base-handlers/pagination-iterator.pipe';
 import { EntityPipelineEntity, stratosEndpointGuidKey } from '../../entity-request-pipeline/pipeline.types';
+import { EndpointAuthTypeConfig } from '../../extension-types';
 import { EntitySchema } from '../../helpers/entity-schema';
 import { endpointEntityType, STRATOS_ENDPOINT_TYPE, stratosEntityFactory } from '../../helpers/stratos-entity-factory';
 import { EndpointModel } from '../../types/endpoint.types';
@@ -352,5 +353,20 @@ export class StratosCatalogEndpointEntity extends StratosBaseCatalogEntity<IEndp
       }
     });
   }
+
+  public setListComponent(component: any) {
+    // Can only be set once
+    if (!this.definition.listDetailsComponent) {
+      (this.definition as any).listDetailsComponent = component;
+    }
+  }
+
+  public setAuthTypes(authTypes: EndpointAuthTypeConfig[]) {
+    // Can only be set once
+    if (!this.definition.authTypes) {
+      (this.definition as any).authTypes = authTypes;
+    }
+  }
+  
 }
 

--- a/src/frontend/packages/store/src/entity-catalog/entity-catalog.spec.ts
+++ b/src/frontend/packages/store/src/entity-catalog/entity-catalog.spec.ts
@@ -1,6 +1,3 @@
-import {
-  EndpointListDetailsComponent,
-} from '../../../core/src/shared/components/list/list-types/endpoint/endpoint-list.helpers';
 import { EntitySchema } from '../helpers/entity-schema';
 import { endpointEntityType, stratosEntityFactory } from '../helpers/stratos-entity-factory';
 import { TestEntityCatalog } from './entity-catalog';
@@ -18,7 +15,7 @@ describe('EntityCatalogService', () => {
       iconFont: 'stratos-icons',
       logoUrl: '/core/assets/endpoint-icons/cloudfoundry.png',
       authTypes: [],
-      listDetailsComponent: EndpointListDetailsComponent,
+      listDetailsComponent: 'Test Component',
     } as IStratosEndpointDefinition;
   }
   function getDefaultSchema() {
@@ -136,7 +133,7 @@ describe('EntityCatalogService', () => {
       ...subtypeDefinition,
       icon: 'cloud_foundry',
       iconFont: 'stratos-icons',
-      listDetailsComponent: EndpointListDetailsComponent,
+      listDetailsComponent: 'Test Component',
       schema: {
         default: stratosEntityFactory(endpointEntityType)
       },

--- a/src/frontend/packages/store/src/monitors/internal-event-monitor.factory.spec.ts
+++ b/src/frontend/packages/store/src/monitors/internal-event-monitor.factory.spec.ts
@@ -1,7 +1,7 @@
-import { TestBed, inject } from '@angular/core/testing';
-import { InternalEventMonitorFactory } from './internal-event-monitor.factory';
-import { SharedModule } from '../../../core/src/shared/shared.module';
+import { inject, TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
+
+import { InternalEventMonitorFactory } from './internal-event-monitor.factory';
 
 
 describe('InternalEventMonitorFactory', () => {
@@ -9,7 +9,6 @@ describe('InternalEventMonitorFactory', () => {
     TestBed.configureTestingModule({
       providers: [InternalEventMonitorFactory],
       imports: [
-        SharedModule,
         StoreModule.forRoot({})
       ]
     });

--- a/src/frontend/packages/store/src/stratos-entity-generator.ts
+++ b/src/frontend/packages/store/src/stratos-entity-generator.ts
@@ -1,7 +1,3 @@
-import { BaseEndpointAuth } from '../../core/src/core/endpoint-auth';
-import {
-  MetricsEndpointDetailsComponent,
-} from '../../core/src/features/metrics/metrics-endpoint-details/metrics-endpoint-details.component';
 import {
   StratosBaseCatalogEntity,
   StratosCatalogEndpointEntity,
@@ -151,9 +147,8 @@ function generateMetricsEndpoint() {
     labelPlural: 'Metrics',
     tokenSharing: true,
     logoUrl: '/core/assets/endpoint-icons/metrics.svg',
-    authTypes: [BaseEndpointAuth.UsernamePassword, BaseEndpointAuth.None],
-    renderPriority: 1,
-    listDetailsComponent: MetricsEndpointDetailsComponent,
+    authTypes: null,
+    renderPriority: 1
   },
     metadata => `/endpoints/metrics/${metadata.guid}`
   )


### PR DESCRIPTION
We removed all dependencies between store -> core.

A couple crept in.

For now, I've cheated by adding methods to allow metrics entity data to be modified - ideally the registration would move to core, but that's a bigger change.