### PR TITLE
Metrics: Ensure trailing slashes are ignored when comparing URLs

### DIFF
--- a/src/frontend/packages/core/src/features/metrics/metrics.helpers.ts
+++ b/src/frontend/packages/core/src/features/metrics/metrics.helpers.ts
@@ -51,7 +51,7 @@ export function mapMetricsData(ep: MetricsEndpointProvider): MetricsEndpointInfo
     && Array.isArray(ep.provider.metadata.metrics_stratos)) {
     ep.provider.metadata.metrics_stratos.forEach(endp => {
       // See if we already know about this endpoint
-      const hasEndpoint = data.findIndex(i => i.url === endp.url || i.url === endp.cfEndpoint) !== -1;
+      const hasEndpoint = data.findIndex(i => compareUrl(i.url, endp.url) || compareUrl(i.url, endp.cfEndpoint)) !== -1;
       if (!hasEndpoint) {
         const catalogEndpoint = entityCatalog.getEndpoint(endp.type, '');
         if (catalogEndpoint) { // Provider metadata could give unknown endpoint
@@ -75,4 +75,17 @@ export function mapMetricsData(ep: MetricsEndpointProvider): MetricsEndpointInfo
     });
   }
   return data;
+}
+
+// Simple URL compare that ignores tailing forward slashes
+function compareUrl(a: string, b: string): boolean {
+  if (a && a.endsWith('/')) {
+    a = a.substr(0, a.length -1);
+  }
+
+  if (b && b.endsWith('/')) {
+    b = b.substr(0, b.length -1);
+  }
+
+  return a === b;
 }

--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -390,7 +390,11 @@ func compareURL(a, b string) bool {
 
 	aPort := getPort(ua)
 	bPort := getPort(ub)
-	return ua.Scheme == ub.Scheme && ua.Hostname() == ub.Hostname() && aPort == bPort && ua.Path == ub.Path
+
+	aPath := trimPath(ua.Path)
+	bPath := trimPath(ub.Path)
+
+	return ua.Scheme == ub.Scheme && ua.Hostname() == ub.Hostname() && aPort == bPort && aPath == bPath
 }
 
 func getPort(u *url.URL) string {
@@ -407,6 +411,13 @@ func getPort(u *url.URL) string {
 	}
 
 	return port
+}
+
+func trimPath(path string) string {
+	if strings.HasSuffix(path, "/") {
+		return path[:len(path)-1]
+	}
+	return path
 }
 
 func (m *MetricsSpecification) getMetricsEndpoints(userGUID string, cnsiList []string) (map[string]EndpointMetricsRelation, error) {

--- a/src/jetstream/plugins/metrics/main_test.go
+++ b/src/jetstream/plugins/metrics/main_test.go
@@ -23,6 +23,9 @@ func TestUrlComparision(t *testing.T) {
 		So(compareURL("http://test.com/a", "http://test.com/a"), ShouldBeTrue)
 		So(compareURL("http://test.com/a?one=two", "http://test.com/a?two=one"), ShouldBeTrue)
 
+		// Should ignore trailing slashes
+		So(compareURL("http://test.com/", "http://test.com"), ShouldBeTrue)
+
 	})
 
 }


### PR DESCRIPTION
Fixes #4527 