### PR TITLE
Update moment imports to remove warning when building library

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-event/cf-app-autoscaler-events-config.service.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-event/cf-app-autoscaler-events-config.service.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import * as moment from 'moment';
+import moment from 'moment';
 
 import { CFAppState } from '../../../../../cloud-foundry/src/cf-app-state';
 import { ApplicationService } from '../../../../../cloud-foundry/src/features/applications/application.service';

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-list-config.service.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-list-config.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import * as moment from 'moment';
+import moment from 'moment';
 
 import { CFAppState } from '../../../../../cloud-foundry/src/cf-app-state';
 import { ApplicationService } from '../../../../../cloud-foundry/src/features/applications/application.service';

--- a/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
@@ -1,5 +1,5 @@
 import { Action, Store } from '@ngrx/store';
-import * as moment from 'moment';
+import moment from 'moment';
 import { combineLatest, Observable, of } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/log-stream-tab/log-stream-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/log-stream-tab/log-stream-tab.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { NgModel } from '@angular/forms';
 import { Store } from '@ngrx/store';
-import * as moment from 'moment';
+import moment from 'moment';
 import { NEVER, Observable, Subject } from 'rxjs';
 import makeWebSocketObservable, { GetWebSocketResponses } from 'rxjs-websockets';
-import { catchError, share, switchMap, map, first, startWith, debounceTime } from 'rxjs/operators';
+import { catchError, debounceTime, first, map, share, startWith, switchMap } from 'rxjs/operators';
 
 import { CFAppState } from '../../../../../../../../cloud-foundry/src/cf-app-state';
 import { LoggerService } from '../../../../../../../../core/src/core/logger.service';

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-firehose/cloud-foundry-firehose-formatter.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-firehose/cloud-foundry-firehose-formatter.ts
@@ -1,13 +1,13 @@
-/**
- * Formats log messages from the Cloud Foundry firehose
- */
-import * as moment from 'moment';
+import moment from 'moment';
 
 import { LoggerService } from '../../../../../../core/src/core/logger.service';
 import { UtilsService } from '../../../../../../core/src/core/utils.service';
 import { AnsiColorizer } from '../../../../../../core/src/shared/components/log-viewer/ansi-colorizer';
 import { FireHoseItem, HTTP_METHODS } from './cloud-foundry-firehose.types';
 
+/**
+ * Formats log messages from the Cloud Foundry firehose
+ */
 
 /* eslint-disable no-control-regex */
 const ANSI_ESCAPE_MATCHER = new RegExp('\x1B\\[([0-9;]*)m', 'g');

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import * as moment from 'moment';
+import moment from 'moment';
 import { Observable } from 'rxjs';
 import { combineLatest, filter, first, map } from 'rxjs/operators';
 

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import * as moment from 'moment';
+import moment from 'moment';
 import { Observable, of, Subject } from 'rxjs';
 import { filter, first, map } from 'rxjs/operators';
 

--- a/src/frontend/packages/core/src/shared/components/date-time/date-time.component.ts
+++ b/src/frontend/packages/core/src/shared/components/date-time/date-time.component.ts
@@ -1,9 +1,8 @@
-import { SetupModule } from './../../../features/setup/setup.module';
-import { Component, OnInit, Output, OnDestroy, Input, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import * as moment from 'moment';
-import { tap, map, filter, shareReplay, debounceTime } from 'rxjs/operators';
-import { combineLatest, Subscription, Observable } from 'rxjs';
+import moment from 'moment';
+import { combineLatest, Observable, Subscription } from 'rxjs';
+import { debounceTime, filter, map, shareReplay, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-date-time',

--- a/src/frontend/packages/core/src/shared/components/list/list.component.types.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list.component.types.ts
@@ -1,5 +1,5 @@
-import { Type } from '@angular/core';
-import * as moment from 'moment';
+import { Injectable, Type } from '@angular/core';
+import moment from 'moment';
 import { BehaviorSubject, combineLatest, Observable, of as observableOf } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
@@ -13,7 +13,6 @@ import { ListDataSource } from './data-sources-controllers/list-data-source';
 import { IListDataSource } from './data-sources-controllers/list-data-source-types';
 import { CardTypes } from './list-cards/card/card.component';
 import { ITableColumn, ITableText } from './list-table/table.types';
-import { Injectable } from "@angular/core";
 import { CardCell } from './list.types';
 
 export enum ListViewTypes {

--- a/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.ts
+++ b/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 import { Subscription } from 'rxjs';
 
 import { MetricsAction } from '../../../../../store/src/actions/metrics.actions';

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.ts
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.ts
@@ -2,7 +2,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { AfterViewInit, Component, Input, OnDestroy, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import * as moment from 'moment';
+import moment from 'moment';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 

--- a/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.ts
+++ b/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.ts
@@ -4,7 +4,7 @@ import { entityCatalog } from 'frontend/packages/store/src/entity-catalog/entity
 import {
   MAX_RECENT_COUNT,
 } from 'frontend/packages/store/src/reducers/current-user-roles-reducer/recently-visited.reducer.helpers';
-import * as moment from 'moment';
+import moment from 'moment';
 import { Observable, of as observableOf } from 'rxjs';
 import { map } from 'rxjs/operators';
 

--- a/src/frontend/packages/core/src/shared/components/start-end-date/start-end-date.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/start-end-date/start-end-date.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import * as moment from 'moment';
+import moment from 'moment';
 
 import { SharedModule } from './../../shared.module';
 import { StartEndDateComponent } from './start-end-date.component';

--- a/src/frontend/packages/core/src/shared/components/start-end-date/start-end-date.component.ts
+++ b/src/frontend/packages/core/src/shared/components/start-end-date/start-end-date.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 
 @Component({
   selector: 'app-start-end-date',

--- a/src/frontend/packages/core/src/shared/services/metrics-range-selector-manager.service.ts
+++ b/src/frontend/packages/core/src/shared/services/metrics-range-selector-manager.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime, takeWhile, tap } from 'rxjs/operators';
 

--- a/src/frontend/packages/core/src/shared/services/metrics-range-selector.service.ts
+++ b/src/frontend/packages/core/src/shared/services/metrics-range-selector.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 
 import { MetricQueryConfig, MetricsAction } from '../../../../store/src/actions/metrics.actions';
 import { IMetrics } from '../../../../store/src/types/base-metric.types';

--- a/src/frontend/packages/core/src/shared/services/metrics-range-selector.types.ts
+++ b/src/frontend/packages/core/src/shared/services/metrics-range-selector.types.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 
 import { MetricQueryType } from '../../../../store/src/types/metric.types';
 

--- a/src/frontend/packages/store/src/actions/internal-events.actions.ts
+++ b/src/frontend/packages/store/src/actions/internal-events.actions.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import * as moment from 'moment';
+import moment from 'moment';
 
 import {
   CLEAR_ENDPOINT_ERROR_EVENTS,

--- a/src/frontend/packages/store/src/monitors/internal-event.monitor.ts
+++ b/src/frontend/packages/store/src/monitors/internal-event.monitor.ts
@@ -1,13 +1,13 @@
 import { NgZone } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 import { combineLatest, Observable, of as observableOf } from 'rxjs';
 import { distinctUntilChanged, map, share, startWith } from 'rxjs/operators';
 
 import {
   InternalEventSeverity,
   InternalEventsState,
-  InternalEventSubjectState,
   InternalEventState,
+  InternalEventSubjectState,
 } from '../types/internal-events.types';
 
 export function newNonAngularInterval(ngZone: NgZone, intervalTime: number) {

--- a/src/test-e2e/locale.helper.ts
+++ b/src/test-e2e/locale.helper.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 import { browser, promise } from 'protractor';
 
 export class LocaleHelper {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,6 +12,8 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,    
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",


### PR DESCRIPTION
When we build `store` as a lib, we get these warnings.

See this article:
