### PR TITLE
Improvements & more checks to autoscaler scheduled date tests

### DIFF
--- a/src/test-e2e/po/form.po.ts
+++ b/src/test-e2e/po/form.po.ts
@@ -325,6 +325,7 @@ export class FormComponent extends Component {
     keyString.split(/[ ,:\/]/).forEach((key) => {
       ctrl.sendKeys(key);
       if (key.length === 4) {
+        browser.sleep(500);
         ctrl.sendKeys(Key.ARROW_RIGHT);
       }
     });


### PR DESCRIPTION
- allow more time to skip between date and time values in date fields
- add a check to
- add checks to ensure we have the correct number of scheduled date rules
