### PR TITLE
Store api_keys.last_used in UTC

### DIFF
--- a/src/jetstream/repository/apikeys/psql_apikeys.go
+++ b/src/jetstream/repository/apikeys/psql_apikeys.go
@@ -158,7 +158,7 @@ func (p *PgsqlAPIKeysRepository) DeleteAPIKey(userGUID string, keyGUID string) e
 func (p *PgsqlAPIKeysRepository) UpdateAPIKeyLastUsed(keyGUID string) error {
 	log.Debug("UpdateAPIKeyLastUsed")
 
-	err := execQuery(p, sqlQueries.UpdateAPIKeyLastUsed, time.Now(), keyGUID)
+	err := execQuery(p, sqlQueries.UpdateAPIKeyLastUsed, time.Now().UTC(), keyGUID)
 	if err != nil {
 		return fmt.Errorf("UpdateAPIKeyLastUsed: %v", err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Store api_keys.last_used in UTC to make dealing with those timestamps easier on the frontend.