### PR TITLE
Helm Chart: Add NOTES.txt template & update chart.yaml

### DIFF
--- a/deploy/kubernetes/build.sh
+++ b/deploy/kubernetes/build.sh
@@ -296,5 +296,5 @@ printf "${RESET}"
 echo
 echo "To deploy using Helm, execute the following:"
 echo 
-echo "    helm install helm-chart --namespace console --name my-console"
+echo "    helm install my-console ./helm-chart --namespace console"
 echo

--- a/deploy/kubernetes/console/Chart.yaml
+++ b/deploy/kubernetes/console/Chart.yaml
@@ -6,10 +6,10 @@ appVersion: 0.1.0
 sources:
   - https://github.com/cloudfoundry/stratos
 icon: https://raw.githubusercontent.com/cloudfoundry/stratos/master/deploy/kubernetes/console/icon.png
+home: https://stratos.app
 maintainers:
   - name: Stratos Maintainers
     email: stratos-maintainers@suse.de
-    home: https://stratos.app
 keywords:
   - Stratos
   - "Cloud Foundry"

--- a/deploy/kubernetes/console/Chart.yaml
+++ b/deploy/kubernetes/console/Chart.yaml
@@ -1,8 +1,17 @@
 apiVersion: v1
-description: A Helm chart for deploying Stratos UI Console
+description: A Helm chart for deploying Stratos
 name: console
 version: 0.1.0
 appVersion: 0.1.0
 sources:
   - https://github.com/cloudfoundry/stratos
 icon: https://raw.githubusercontent.com/cloudfoundry/stratos/master/deploy/kubernetes/console/icon.png
+maintainers:
+  - name: Stratos @ SUSE
+    email: TODO: RC
+    url: https://stratos.app
+keywords:
+  - Stratos
+  - Cloud Foundry
+  - Kubernetes
+  - Helm

--- a/deploy/kubernetes/console/Chart.yaml
+++ b/deploy/kubernetes/console/Chart.yaml
@@ -8,10 +8,10 @@ sources:
 icon: https://raw.githubusercontent.com/cloudfoundry/stratos/master/deploy/kubernetes/console/icon.png
 maintainers:
   - name: Stratos @ SUSE
-    email: TODO: RC
+    email: "TODO: RC"
     url: https://stratos.app
 keywords:
   - Stratos
-  - Cloud Foundry
+  - "Cloud Foundry"
   - Kubernetes
   - Helm

--- a/deploy/kubernetes/console/Chart.yaml
+++ b/deploy/kubernetes/console/Chart.yaml
@@ -7,9 +7,9 @@ sources:
   - https://github.com/cloudfoundry/stratos
 icon: https://raw.githubusercontent.com/cloudfoundry/stratos/master/deploy/kubernetes/console/icon.png
 maintainers:
-  - name: Stratos @ SUSE
-    email: "TODO: RC"
-    url: https://stratos.app
+  - name: Stratos Maintainers
+    email: stratos-maintainers@suse.de
+    home: https://stratos.app
 keywords:
   - Stratos
   - "Cloud Foundry"

--- a/deploy/kubernetes/console/templates/NOTES.txt
+++ b/deploy/kubernetes/console/templates/NOTES.txt
@@ -1,17 +1,17 @@
-{{ if .Values.console.techPreview -}}
+{{- if .Values.console.techPreview }}
 Tech Preview is enabled, extra features will be shown.
+{{- end}}
 
-{{ end }}
-
-{{- $ingress := .Values.console.ingress | default dict -}}
-{{ if $ingress.enabled -}}
+To access Stratos:
+{{- $ingress := .Values.console.ingress | default dict }}
+{{- if $ingress.enabled }}
 From outside the cluster, the server URL is: http://{{ .Values.console.ingress.host }}
 {{- else }}
 Get the URL by running these commands in the same shell:
 {{- if contains "NodePort" .Values.console.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services console-ui-ext)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo https://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.console.service.type }}
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w console-ui-ext'
@@ -20,7 +20,7 @@ Get the URL by running these commands in the same shell:
   echo http://$SERVICE_IP:{{ .Values.console.service.servicePort }}
 {{- else if contains "ClusterIP"  .Values.console.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=stratos-0,component=ui" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9090
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 443
 {{- end }}
 {{- end }}
 

--- a/deploy/kubernetes/console/templates/NOTES.txt
+++ b/deploy/kubernetes/console/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Thank you for installing Stratos.
+
+Your release is named {{ .Release.Name }} and is in the namespace {{ .Release.Namespace }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/deploy/kubernetes/console/templates/NOTES.txt
+++ b/deploy/kubernetes/console/templates/NOTES.txt
@@ -1,8 +1,7 @@
-Thank you for installing Stratos.
-
-Your release is named {{ .Release.Name }} and is in the namespace {{ .Release.Namespace }}.
+Thank you for installing Stratos. Your release is named '{{ .Release.Name }}' and is in the namespace '{{ .Release.Namespace }}'.
 
 To learn more about the release, try:
-
   $ helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
-  $ helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ kubectl get services -n {{ .Release.Namespace }}
+  $ kubectl get pods -n {{ .Release.Namespace }}

--- a/deploy/kubernetes/console/templates/NOTES.txt
+++ b/deploy/kubernetes/console/templates/NOTES.txt
@@ -1,4 +1,28 @@
-Thank you for installing Stratos. Your release is named '{{ .Release.Name }}' and is in the namespace '{{ .Release.Namespace }}'.
+{{ if .Values.console.techPreview -}}
+Tech Preview is enabled, extra features will be shown.
+
+{{ end }}
+
+{{- $ingress := .Values.console.ingress | default dict -}}
+{{ if $ingress.enabled -}}
+From outside the cluster, the server URL is: http://{{ .Values.console.ingress.host }}
+{{- else }}
+Get the URL by running these commands in the same shell:
+{{- if contains "NodePort" .Values.console.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services console-ui-ext)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.console.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w console-ui-ext'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} console-ui-ext -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.console.service.servicePor }}
+{{- else if contains "ClusterIP"  .Values.console.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=stratos-0,component=ui" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9090
+{{- end }}
+{{- end }}
 
 To learn more about the release, try:
   $ helm status {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/deploy/kubernetes/console/templates/NOTES.txt
+++ b/deploy/kubernetes/console/templates/NOTES.txt
@@ -17,7 +17,7 @@ Get the URL by running these commands in the same shell:
         You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w console-ui-ext'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} console-ui-ext -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.console.service.servicePor }}
+  echo http://$SERVICE_IP:{{ .Values.console.service.servicePort }}
 {{- else if contains "ClusterIP"  .Values.console.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=stratos-0,component=ui" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9090


### PR DESCRIPTION
- Add NOTES template
- Add maintainers and keywords to chart.yaml
- contributes to #4556 

helm install lookes like....
```
$ helm install console stratos-ui/deploy/kubernetes/console --namespace=notes-test -f stratos.yaml
NAME: console
LAST DEPLOYED: Tue Sep 15 11:48:52 2020
NAMESPACE: notes-test
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Tech Preview is enabled, extra features will be shown.

To access Stratos:
Get the URL by running these commands in the same shell:
  export NODE_PORT=$(kubectl get --namespace notes-test -o jsonpath="{.spec.ports[0].nodePort}" services console-ui-ext)
  export NODE_IP=$(kubectl get nodes --namespace notes-test -o jsonpath="{.items[0].status.addresses[0].address}")
  echo https://$NODE_IP:$NODE_PORT

To learn more about the release, try:
  $ helm status console -n notes-test
  $ helm get values console -n notes-test
  $ kubectl get services -n notes-test
  $ kubectl get pods -n notes-test

```
