### PR TITLE
Dynamically show smaller tiles in endpoint register tile list

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.html
@@ -7,7 +7,7 @@
       <h3>Select application source</h3>
       <p>To create an application you can either deploy from a specific source or create an application shell. An
         application shell is an empty application with no package associated with it.</p>
-      <app-tile-selector [options]="tileSelectorConfig" [smallerTiles]="true" (selection)="selectedTile = $event">
+      <app-tile-selector [options]="tileSelectorConfig" [dynamicSmallerTiles]="6" (selection)="selectedTile = $event">
       </app-tile-selector>
     </div>
   </app-step>

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component.html
@@ -12,7 +12,7 @@
         the 'Connecting' process. To do this return to the Endpoints page.
       </p>
     -->
-      <app-tile-selector [options]="tileSelectorConfig$ | async" [smallerTiles]="true"
+      <app-tile-selector [options]="tileSelectorConfig$ | async" [dynamicSmallerTiles]="6"
         (selection)="selectedTile = $event">
       </app-tile-selector>
     </div>

--- a/src/frontend/packages/core/src/shared/components/tile-selector/tile-selector.component.ts
+++ b/src/frontend/packages/core/src/shared/components/tile-selector/tile-selector.component.ts
@@ -13,6 +13,7 @@ export class TileSelectorComponent {
   public hiddenOptions: ITileConfig[] = [];
   public showingMore = false;
   @Input() smallerTiles = false;
+  @Input() dynamicSmallerTiles = 0;
   @Input() set options(options: ITileConfig[]) {
     if (!options) {
       return;
@@ -30,6 +31,9 @@ export class TileSelectorComponent {
     });
     this.pOptions = groupedOptions.show;
     this.hiddenOptions = groupedOptions.hidden;
+    if (!!this.dynamicSmallerTiles) {
+      this.smallerTiles = options.length > this.dynamicSmallerTiles;
+    }
   }
 
   get options() {


### PR DESCRIPTION
- we may want to just have a default smaller tile limit in app-tile-selector
  and not have the endpoint and app steppers overwrite
