### PR TITLE
API Keys e2e: Wait for page before proceeding

### DIFF
--- a/src/test-e2e/apikeys/apikeys-e2e.spec.ts
+++ b/src/test-e2e/apikeys/apikeys-e2e.spec.ts
@@ -2,6 +2,7 @@ import { promise } from 'protractor';
 
 import { MessageNoContentPo } from '../application/po/message-no-autoscaler-policy';
 import { e2e } from '../e2e';
+import { EndpointsPage } from '../endpoints/endpoints.po';
 import { ConsoleUserType, E2EHelpers } from '../helpers/e2e-helpers';
 import { Component } from '../po/component.po';
 import { ConfirmDialogComponent } from '../po/confirm-dialog';
@@ -15,7 +16,9 @@ describe('API Keys -', () => {
 
   let helper: ApiKeyE2eHelper;
   let newKeysComment: string;
-  let page = new APIKeyListPage();
+  const page = new APIKeyListPage();
+  const endpointsPage = new EndpointsPage();
+
   let currentKeysCount = promise.fullyResolved(0);
 
   beforeAll(() => {
@@ -29,6 +32,12 @@ describe('API Keys -', () => {
 
   // Should be ran in sequence
   describe('Ordered Tests - ', () => {
+
+    it('Should load UI', () => {
+      // Wait for the UI to load - should go to the endpoints page
+      endpointsPage.waitForPage();
+    });
+
     it('Navigate to api key page', () => {
       page.header.clickUserMenuItem('API Keys');
       page.waitForPage();


### PR DESCRIPTION
Improve reliability of API Keys e2e tests by waiting for page to load.