### PR TITLE
Fix cf push

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
     disk_quota: 1024M
     host: console
     timeout: 180
-    buildpack: https://github.com/cloudfoundry-incubator/stratos-buildpack#v3
+    buildpack: https://github.com/cloudfoundry-incubator/stratos-buildpack#v4.0
     health-check-type: port
 #    env:
 # Override CF API endpoint URL inferred from VCAP_APPLICATION env 


### PR DESCRIPTION
Needed an update to the buildpack.

backend build fails as swag is not available - because GOPATH not set in the buildpack