### PR TITLE
Fix sql helm hub removal statement for mariadb

### DIFF
--- a/src/jetstream/plugins/monocular/20201007113503_RemoveHelmHub.go
+++ b/src/jetstream/plugins/monocular/20201007113503_RemoveHelmHub.go
@@ -10,7 +10,7 @@ import (
 
 func init() {
 	datastore.RegisterMigration(20201007113503, "RemoveHelmHub", func(txn *sql.Tx, conf *goose.DBConf) error {
-		cleanCNSIS := "DELETE FROM cnsis WHERE guid IN (SELECT guid FROM cnsis WHERE cnsi_type='helm' AND sub_type='hub');"
+		cleanCNSIS := "DELETE FROM cnsis WHERE cnsi_type='helm' AND sub_type='hub';"
 		_, err := txn.Exec(cleanCNSIS)
 		if err != nil {
 			return err


### PR DESCRIPTION
- select part was an artefact from a deleted statement
- totally not needed now
