### PR TITLE
Fix nginx config to include /api

### DIFF
--- a/deploy/containers/nginx/conf/nginx.dev.conf
+++ b/deploy/containers/nginx/conf/nginx.dev.conf
@@ -66,6 +66,19 @@ http {
             proxy_set_header        Connection $connection_upgrade;
         }
 
+        location /api/ {
+            proxy_pass_header       Server;
+            proxy_set_header        Host $http_host;
+            proxy_redirect          off;
+            proxy_set_header        X-Real-IP $remote_addr;
+            proxy_set_header        X-Scheme $scheme;
+            proxy_pass              https://portalproxy/api/;
+            proxy_intercept_errors  on;
+            proxy_http_version      1.1;
+            proxy_set_header        Upgrade $http_upgrade;
+            proxy_set_header        Connection $connection_upgrade;
+        }        
+
         location / {
             root                    /usr/share/nginx/html;
             add_header Cache-Control no-cache;

--- a/deploy/containers/nginx/conf/nginx.k8s.conf
+++ b/deploy/containers/nginx/conf/nginx.k8s.conf
@@ -66,6 +66,19 @@ http {
             proxy_set_header        Connection $connection_upgrade;
         }
 
+        location /api/ {
+            proxy_pass_header       Server;
+            proxy_set_header        Host $http_host;
+            proxy_redirect          off;
+            proxy_set_header        X-Real-IP $remote_addr;
+            proxy_set_header        X-Scheme $scheme;
+            proxy_pass              https://portalproxy/api/;
+            proxy_intercept_errors  on;
+            proxy_http_version      1.1;
+            proxy_set_header        Upgrade $http_upgrade;
+            proxy_set_header        Connection $connection_upgrade;
+        }        
+
         location / {
             root                    /usr/share/nginx/html;
             add_header Cache-Control no-cache;

--- a/deploy/stratos-ui-release/jobs/frontend/templates/nginx.conf.erb
+++ b/deploy/stratos-ui-release/jobs/frontend/templates/nginx.conf.erb
@@ -65,6 +65,19 @@ http {
             proxy_set_header        Connection $connection_upgrade;
         }
 
+        location /api/ {
+            proxy_pass_header       Server;
+            proxy_set_header        Host $http_host;
+            proxy_redirect          off;
+            proxy_set_header        X-Real-IP $remote_addr;
+            proxy_set_header        X-Scheme $scheme;
+            proxy_pass              https://portalproxy/api/;
+            proxy_intercept_errors  on;
+            proxy_http_version      1.1;
+            proxy_set_header        Upgrade $http_upgrade;
+            proxy_set_header        Connection $connection_upgrade;
+        }        
+
         location / {
             root                    /var/vcap/packages/frontend;
             add_header X-Frame-Options SAMEORIGIN;


### PR DESCRIPTION
/api calls don't work when fronted by nginx - e.g. in Kubernetes deployment