### PR TITLE
Show source of chart if artifact hub and another repo are connected

### DIFF
--- a/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.html
@@ -1,1 +1,2 @@
-<app-chart-item [chart]="row" [showDescription]="false"></app-chart-item>
+<app-chart-item [chart]="row" [showDescription]="false" [artifactHubAndOthers$]="artifactHubAndOthers$">
+</app-chart-item>

--- a/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.html
@@ -1,2 +1,2 @@
-<app-chart-item [chart]="row" [showDescription]="false" [artifactHubAndOthers$]="artifactHubAndOthers$">
+<app-chart-item [chart]="row" [showDescription]="false" [artifactHubAndHelmRepoTypes$]="artifactHubAndHelmRepoTypes$">
 </app-chart-item>

--- a/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.ts
@@ -1,6 +1,10 @@
 import { Component, Input } from '@angular/core';
+import { Observable } from 'rxjs';
+import { filter, first, map, publishReplay, refCount } from 'rxjs/operators';
 
 import { CardCell } from '../../../../../core/src/shared/components/list/list.types';
+import { stratosEntityCatalog } from '../../../../../store/src/stratos-entity-catalog';
+import { HELM_HUB_ENDPOINT_TYPE } from '../../helm-entity-factory';
 import { MonocularChart } from '../../store/helm.types';
 
 @Component({
@@ -12,7 +16,16 @@ export class MonocularChartCardComponent extends CardCell<MonocularChart> {
 
   @Input() row: MonocularChart;
 
+  public artifactHubAndOthers$: Observable<boolean>;
+
   constructor() {
     super();
+    this.artifactHubAndOthers$ = stratosEntityCatalog.endpoint.store.getAll.getPaginationService().entities$.pipe(
+      filter(entities => !!entities),
+      first(),
+      map(endpoints => !!endpoints.find(ep => ep.sub_type === HELM_HUB_ENDPOINT_TYPE) && endpoints.length > 1),
+      publishReplay(1),
+      refCount()
+    );
   }
 }

--- a/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/list-types/monocular-chart-card/monocular-chart-card.component.ts
@@ -4,7 +4,7 @@ import { filter, first, map, publishReplay, refCount } from 'rxjs/operators';
 
 import { CardCell } from '../../../../../core/src/shared/components/list/list.types';
 import { stratosEntityCatalog } from '../../../../../store/src/stratos-entity-catalog';
-import { HELM_HUB_ENDPOINT_TYPE } from '../../helm-entity-factory';
+import { HELM_ENDPOINT_TYPE, HELM_HUB_ENDPOINT_TYPE, HELM_REPO_ENDPOINT_TYPE } from '../../helm-entity-factory';
 import { MonocularChart } from '../../store/helm.types';
 
 @Component({
@@ -16,14 +16,33 @@ export class MonocularChartCardComponent extends CardCell<MonocularChart> {
 
   @Input() row: MonocularChart;
 
-  public artifactHubAndOthers$: Observable<boolean>;
+  public artifactHubAndHelmRepoTypes$: Observable<boolean>;
 
   constructor() {
     super();
-    this.artifactHubAndOthers$ = stratosEntityCatalog.endpoint.store.getAll.getPaginationService().entities$.pipe(
-      filter(entities => !!entities),
+    this.artifactHubAndHelmRepoTypes$ = stratosEntityCatalog.endpoint.store.getAll.getPaginationService().entities$.pipe(
+      filter(endpoints => !!endpoints), // Wait until we have some entities
       first(),
-      map(endpoints => !!endpoints.find(ep => ep.sub_type === HELM_HUB_ENDPOINT_TYPE) && endpoints.length > 1),
+      map(endpoints => {
+        let haveArtifactHub = false;
+        let haveHelmRepo = false;
+        for (const ep of endpoints) {
+          if (ep.cnsi_type !== HELM_ENDPOINT_TYPE) {
+            continue;
+          }
+
+          if (ep.sub_type === HELM_HUB_ENDPOINT_TYPE) {
+            haveArtifactHub = true;
+          } else if (ep.sub_type === HELM_REPO_ENDPOINT_TYPE) {
+            haveHelmRepo = true;
+          }
+
+          if (haveArtifactHub && haveHelmRepo) {
+            return true;
+          }
+        }
+        return false;
+      }),
       publishReplay(1),
       refCount()
     );

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.html
@@ -1,9 +1,7 @@
-<app-list-item class="chart-item" [detailUrl]="goToDetailUrl()" height="auto">
+<app-list-item class="chart-item" [detailUrl]="goToDetailUrl()" height="auto"
+  [artifactHubAndOthers$]="artifactHubAndOthers$" [chart]="chart">
   <img class="list-item-logo chart-item-logo" alt="{{ chart.attributes.name }}'s logo" src="{{ iconUrl }}" />
   <div class="list-item-info chart-item-info">
-    <p>
-      <span class="chart-item-info__version" *ngIf="endpointName$ | async as endpointNam">{{endpointNam}}</span>
-    </p>
     <h2 class="chart-item-info__title">
       <a [href]="goToDetailUrl()"
         [routerLink]="goToDetailUrl()">{{ chart.attributes.repo.name }}/{{ chart.attributes.name }}</a>

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.html
@@ -1,5 +1,5 @@
 <app-list-item class="chart-item" [detailUrl]="goToDetailUrl()" height="auto"
-  [artifactHubAndOthers$]="artifactHubAndOthers$" [chart]="chart">
+  [artifactHubAndHelmRepoTypes$]="artifactHubAndHelmRepoTypes$" [chart]="chart">
   <img class="list-item-logo chart-item-logo" alt="{{ chart.attributes.name }}'s logo" src="{{ iconUrl }}" />
   <div class="list-item-info chart-item-info">
     <h2 class="chart-item-info__title">

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.html
@@ -1,8 +1,12 @@
 <app-list-item class="chart-item" [detailUrl]="goToDetailUrl()" height="auto">
   <img class="list-item-logo chart-item-logo" alt="{{ chart.attributes.name }}'s logo" src="{{ iconUrl }}" />
   <div class="list-item-info chart-item-info">
+    <p>
+      <span class="chart-item-info__version" *ngIf="endpointName$ | async as endpointNam">{{endpointNam}}</span>
+    </p>
     <h2 class="chart-item-info__title">
-        <a [href]="goToDetailUrl()" [routerLink]="goToDetailUrl()">{{ chart.attributes.repo.name }}/{{ chart.attributes.name }}</a>
+      <a [href]="goToDetailUrl()"
+        [routerLink]="goToDetailUrl()">{{ chart.attributes.repo.name }}/{{ chart.attributes.name }}</a>
     </h2>
     <p>
       <span class="chart-item-info__version"

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable, of } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
-import { stratosEntityCatalog } from '../../../../../store/src/stratos-entity-catalog';
 import { Chart } from '../shared/models/chart';
 import { ChartsService } from '../shared/services/charts.service';
 
@@ -23,28 +21,12 @@ export class ChartItemComponent implements OnInit {
   public showDescription = true;
 
   public artifactHubAndOthers$: Observable<boolean>;
-  public endpointName$: Observable<string>;
 
   constructor(private chartsService: ChartsService) {
   }
 
   ngOnInit() {
     this.iconUrl = this.chartsService.getChartIconURL(this.chart);
-    this.endpointName$ = this.artifactHubAndOthers$.pipe(
-      switchMap(artifactHubAndOthers => {
-        // Only show if we have artifact hub registered and there's other helm repo's also registered
-        if (!artifactHubAndOthers) {
-          return of(null);
-        }
-        if (!this.chart.monocularEndpointId) {
-          return of('Stratos');
-        } else {
-          return stratosEntityCatalog.endpoint.store.getEntityMonitor(this.chart.monocularEndpointId).entity$.pipe(
-            map(endpoint => endpoint.name)
-          );
-        }
-      }),
-    );
   }
 
   goToDetailUrl(): string {

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-item/chart-item.component.ts
@@ -9,7 +9,7 @@ import { ChartsService } from '../shared/services/charts.service';
   templateUrl: './chart-item.component.html',
   styleUrls: ['./chart-item.component.scss'],
   /* tslint:disable-next-line:no-inputs-metadata-property */
-  inputs: ['chart', 'showVersion', 'showDescription', 'artifactHubAndOthers$']
+  inputs: ['chart', 'showVersion', 'showDescription', 'artifactHubAndHelmRepoTypes$']
 })
 export class ChartItemComponent implements OnInit {
   public iconUrl: string;
@@ -20,7 +20,7 @@ export class ChartItemComponent implements OnInit {
   // Truncate the description
   public showDescription = true;
 
-  public artifactHubAndOthers$: Observable<boolean>;
+  public artifactHubAndHelmRepoTypes$: Observable<boolean>;
 
   constructor(private chartsService: ChartsService) {
   }

--- a/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.html
@@ -1,4 +1,12 @@
 <div class="list-item">
+  <div *ngIf="showArtifactHub$ | async" class="list-item-svg" matTooltip="Artifact Hub">
+    <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round"
+      stroke-linejoin="round" class="mr-2" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z">
+      </path>
+    </svg>
+  </div>
   <a [href]="detailUrl" [routerLink]="detailUrl">
     <div class="list-item-content" [ngClass]="{'list-item__auto-height': height === 'auto'}">
       <div class="list-item-logo">

--- a/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.scss
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.scss
@@ -56,4 +56,10 @@ $list-item-content-min-height: 140px;
       padding: 10px 0;
     }
   }
+
+  &-svg {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+  }
 }

--- a/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.ts
@@ -1,15 +1,31 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { Chart } from '../shared/models/chart';
 
 @Component({
   selector: 'app-list-item',
   templateUrl: './list-item.component.html',
   styleUrls: ['./list-item.component.scss'],
   /* tslint:disable-next-line:no-inputs-metadata-property */
-  inputs: ['detailUrl']
+  inputs: ['detailUrl'],
 })
-export class ListItemComponent {
+export class ListItemComponent implements OnInit {
 
   @Input() height = 'default';
+  @Input() public artifactHubAndOthers$: Observable<boolean>;
+  @Input() chart: Chart;
 
   public detailUrl: string;
+  public showArtifactHub$: Observable<boolean>;
+
+  ngOnInit() {
+    this.showArtifactHub$ = this.artifactHubAndOthers$ ? this.artifactHubAndOthers$.pipe(
+      map(artifactHubAndOthers =>
+        // Only show if we have artifact hub registered, there's other helm repo's also registered and this chart is from artifact hub
+        artifactHubAndOthers && !!this.chart.monocularEndpointId
+      ),
+    ) : of(false);
+  }
 }

--- a/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/list-item/list-item.component.ts
@@ -14,17 +14,17 @@ import { Chart } from '../shared/models/chart';
 export class ListItemComponent implements OnInit {
 
   @Input() height = 'default';
-  @Input() public artifactHubAndOthers$: Observable<boolean>;
+  @Input() public artifactHubAndHelmRepoTypes$: Observable<boolean>;
   @Input() chart: Chart;
 
   public detailUrl: string;
   public showArtifactHub$: Observable<boolean>;
 
   ngOnInit() {
-    this.showArtifactHub$ = this.artifactHubAndOthers$ ? this.artifactHubAndOthers$.pipe(
-      map(artifactHubAndOthers =>
+    this.showArtifactHub$ = this.artifactHubAndHelmRepoTypes$ ? this.artifactHubAndHelmRepoTypes$.pipe(
+      map(artifactHubAndHelmRepoTypes =>
         // Only show if we have artifact hub registered, there's other helm repo's also registered and this chart is from artifact hub
-        artifactHubAndOthers && !!this.chart.monocularEndpointId
+        artifactHubAndHelmRepoTypes && !!this.chart.monocularEndpointId
       ),
     ) : of(false);
   }


### PR DESCRIPTION
- In the charts list we only show repo name
- When only normal helm repos are registered this is fine
- When artifact hub is registered though duplicate repo/chart text can appear
- Now we show where the chart came from .. but only if artifact hub and another repo are registered... and for artifact hub
- fixes #4717

