### PR TITLE
Move GET `/tokens` into `api` group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ branches:
   only:
     - master
     - v2-master
+    - "4.2.1"
     - e2e-tests
 cache:
   directories:

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -1018,13 +1018,13 @@ func (p *portalProxy) registerRoutes(e *echo.Echo, needSetupMiddleware bool) {
 	// Disconnect endpoint
 	stableAPIGroup.DELETE("/tokens/:cnsi_guid", p.logoutOfCNSI)
 
+	// Connect to Endpoint (SSO)
+	stableAPIGroup.GET("/tokens", p.ssoLoginToCNSI)
+
 	// CNSI operations
 	stableAPIGroup.GET("/endpoints", p.listCNSIs)
 
 	sessionAuthGroup := sessionGroup.Group("/auth")
-
-	// Connect to Endpoint (SSO)
-	sessionAuthGroup.GET("/tokens", p.ssoLoginToCNSI)
 
 	// Verify Session
 	sessionAuthGroup.GET("/session/verify", p.verifySession)


### PR DESCRIPTION
- this means it's available with an api key (the redirect is correctly returned but will not show in browser)
- fixes #4716
- tested both uses of SSO - stratos log in and endpoint connect
