### PR TITLE
Improve workload header

### DIFF
--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-runner/analysis-report-runner.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-runner/analysis-report-runner.component.html
@@ -5,14 +5,13 @@
         *ngFor="let analyzer of analyzers">{{ analyzer.name }}</button>
     </mat-menu>
 
-    <button mat-button [matMenuTriggerFor]="appMenu" *ngIf="analyzers.length > 0">
-      <span>Run Analysis</span>
+    <button mat-button [matMenuTriggerFor]="appMenu" *ngIf="analyzers.length > 0" class="report-runner__run">
+      <span>Analyze</span>
       <mat-icon>arrow_drop_down</mat-icon>
     </button>
 
-    <button (click)="showAnalyzersInfo()" mat-button *ngIf="analyzers.length > 0">
+    <button (click)="showAnalyzersInfo()" mat-icon-button *ngIf="analyzers.length > 0" class="report-runner__info">
       <mat-icon>help_outline</mat-icon>
-      <span>Analyzer Info</span>
     </button>
   </div>
 </ng-container>

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-runner/analysis-report-runner.component.scss
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-runner/analysis-report-runner.component.scss
@@ -2,4 +2,16 @@
   align-items: center;
   display: flex;
   justify-content: center;
+
+  &__run {
+    padding-right: 0;
+  }
+
+  &__info {
+    margin-left: -3px;
+    padding: 0;
+    width: 33px;
+    height: 33px;
+    line-height: 33px;
+  }
 }

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-selector/analysis-report-selector.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-selector/analysis-report-selector.component.html
@@ -13,7 +13,7 @@
       issues when arriving on an empty page and kicking off a run. The call to refresh the list returns too quickly and 
       doesn't contain the new report. This leaves user with no way to see report/refresh reports list
     -->
-    <button mat-button [matMenuTriggerFor]="appMenu">
+    <button mat-button [matMenuTriggerFor]="appMenu" class="analysis-menu-divider__overlay">
       <span>{{ prompt }}</span>
       <span *ngIf="selection">: {{ selection.title }}</span>
       <mat-icon>arrow_drop_down</mat-icon>

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-selector/analysis-report-selector.component.scss
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-selector/analysis-report-selector.component.scss
@@ -1,3 +1,7 @@
 .analysis-menu-divider {
   margin: 4px 0;
+
+  &__overlay {
+    padding: 0 8px;
+  }
 }

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-selector/analysis-report-selector.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-selector/analysis-report-selector.component.ts
@@ -21,7 +21,7 @@ export class AnalysisReportSelectorComponent implements OnInit, OnDestroy {
 
   @Input() endpoint;
   @Input() path;
-  @Input() prompt = 'Overlay Analysis';
+  @Input() prompt = 'Overlay';
   @Input() allowNone = true;
   @Input() autoSelect;
 

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-summary-tab/helm-release-summary-tab.component.scss
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-summary-tab/helm-release-summary-tab.component.scss
@@ -61,16 +61,24 @@
   min-width: 0;
 
   @include breakpoint(tablet) {
+    // 900px
     grid-column-gap: $bottom-space;
     grid-row-gap: $bottom-space;
     grid-template-columns: repeat(2, 1fr);
   }
 
   @include breakpoint(laptop) {
+    // 1200px
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (min-width: 1350px) {
+    // Without this, and the side nav expanded, the rows exceed the available H space... which pushed the `live reload` button out of view
     grid-template-columns: repeat(4, 1fr);
   }
 
   @include breakpoint(desktop) {
+    // 1800px
     grid-template-columns: repeat(5, 1fr);
   }
 }


### PR DESCRIPTION
fixes #4707

Two issues...
1. Fix issue where live reload button disappears in H shrinkage
   - due to kube resource cards pushing page size outside of viewable area
1. Reduce H space of analysis buttons in header
   - these were verbose
   - reducing the space makes them more accessible in smaller screens
