### PR TITLE
Fix install/upgrade chart error notifications

### DIFF
--- a/src/frontend/packages/core/sass/components/mat-snack-bar.scss
+++ b/src/frontend/packages/core/sass/components/mat-snack-bar.scss
@@ -1,0 +1,9 @@
+.mat-snack-bar-container.stepper-snack-bar {
+  .mat-simple-snackbar {
+    & > span {
+      max-height: 150px;
+      overflow-y: auto;
+      word-break: break-word;
+    }
+  }
+}

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -146,7 +146,7 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
               this.setActive(this.currentIndex + 1);
             }
           } else if (!success && message) {
-            this.snackBarRef = this.snackBar.open(message, 'Dismiss');
+            this.snackBarRef = this.snackBar.open(message, 'Dismiss', { panelClass: 'stepper-snack-bar' });
           }
           return [];
         })).subscribe();

--- a/src/frontend/packages/core/src/styles.scss
+++ b/src/frontend/packages/core/src/styles.scss
@@ -7,6 +7,7 @@
 @import '../sass/components/card-wall';
 @import '../sass/components/mat-card';
 @import '../sass/components/mat-popup';
+@import '../sass/components/mat-snack-bar';
 @import '../sass/components/mat-tabs';
 @import '../sass/components/mat-table';
 @import '../sass/components/mat-button-toggle-group';

--- a/src/jetstream/plugins/kubernetes/install_release.go
+++ b/src/jetstream/plugins/kubernetes/install_release.go
@@ -66,7 +66,7 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 
 	chart, err := c.loadChart(params.ChartURL)
 	if err != nil {
-		return interfaces.NewJetstreamUserErrorf("Could not load chart: %v+", err)
+		return interfaces.NewJetstreamErrorf("Could not load chart: %v+", err)
 	}
 
 	endpointGUID := params.Endpoint
@@ -91,7 +91,7 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 	coreclient := clientset.CoreV1()
 	_, err = coreclient.Namespaces().Get(params.Namespace, metav1.GetOptions{})
 	if err != nil {
-		return interfaces.NewJetstreamUserErrorf("Namespace '%s' does not exist", params.Namespace)
+		return interfaces.NewJetstreamErrorf("Namespace '%s' does not exist", params.Namespace)
 	}
 
 	// Check release name is valid and does not already exist

--- a/src/jetstream/plugins/kubernetes/install_release.go
+++ b/src/jetstream/plugins/kubernetes/install_release.go
@@ -56,17 +56,17 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 	var params installRequest
 	err := json.Unmarshal(buf.Bytes(), &params)
 	if err != nil {
-		return interfaces.NewJetstreamErrorf("Could not get Create Release Parameters: %v+", err)
+		return interfaces.NewJetstreamUserErrorf("Could not get Create Release Parameters: %v+", err)
 	}
 
 	// Client must give us the download URL for the chart
 	if len(params.ChartURL) == 0 {
-		return interfaces.NewJetstreamErrorf("Client did not supply Chart download URL")
+		return interfaces.NewJetstreamUserError("Client did not supply Chart download URL")
 	}
 
 	chart, err := c.loadChart(params.ChartURL)
 	if err != nil {
-		return interfaces.NewJetstreamErrorf("Could not load chart: %v+", err)
+		return interfaces.NewJetstreamUserErrorf("Could not load chart: %v+", err)
 	}
 
 	endpointGUID := params.Endpoint
@@ -74,7 +74,7 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 
 	config, hc, err := c.GetHelmConfiguration(endpointGUID, userGUID, params.Namespace)
 	if err != nil {
-		return interfaces.NewJetstreamErrorf("Could not get Helm Configuration for endpoint: %+v", err)
+		return interfaces.NewJetstreamUserErrorf("Could not get Helm Configuration for endpoint: %+v", err)
 	}
 
 	defer hc.Cleanup()
@@ -82,7 +82,7 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 	userSuppliedValues := map[string]interface{}{}
 	if err := yaml.Unmarshal([]byte(params.Values), &userSuppliedValues); err != nil {
 		// Could not parse the user's values
-		return interfaces.NewJetstreamErrorf("Could not parse values: %+v", err)
+		return interfaces.NewJetstreamUserErrorf("Could not parse values: %+v", err)
 	}
 
 	// In Helm 3, the namespace must already exist
@@ -91,7 +91,7 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 	coreclient := clientset.CoreV1()
 	_, err = coreclient.Namespaces().Get(params.Namespace, metav1.GetOptions{})
 	if err != nil {
-		return interfaces.NewJetstreamErrorf("Namespace '%s' does not exist", params.Namespace)
+		return interfaces.NewJetstreamUserErrorf("Namespace '%s' does not exist", params.Namespace)
 	}
 
 	// Check release name is valid and does not already exist
@@ -107,7 +107,7 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 
 	release, err := install.Run(chart, userSuppliedValues)
 	if err != nil {
-		return interfaces.NewJetstreamError(fmt.Sprintf("Error installing %+v", err))
+		return interfaces.NewJetstreamUserErrorf(fmt.Sprintf("Error installing: %+v", err))
 	}
 
 	return ec.JSON(200, release)

--- a/src/jetstream/repository/interfaces/jetstream_error.go
+++ b/src/jetstream/repository/interfaces/jetstream_error.go
@@ -89,5 +89,5 @@ func NewJetstreamUserError(userFacingError string) JetstreamError {
 // NewJetstreamUserErrorf creates a new JetStream error indicating that the error is a user error
 func NewJetstreamUserErrorf(userFacingError string, args ...interface{}) JetstreamError {
 	message := fmt.Sprintf(userFacingError, args...)
-	return NewJetstreamError(message)
+	return NewJetstreamUserError(message)
 }


### PR DESCRIPTION
fixes #4673
- errors that are 5XX show up as endpoint errors, these are tied into the notification bell and are distruptive
- if there's something wrong in the chart we often got a 5XX error
- in src/jetstream/plugins/kubernetes/install_release.go it's hard to determine if the error is user or system based
- this pr switches the assumption to all user based errors


fixes #4672
- the error message associated with a helm install can be pretty big
- ensure stepper snack bar can handle it