### PR TITLE
Ensure `are you still there` dialog is closed before showing logging out page

### DIFF
--- a/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.spec.ts
+++ b/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.spec.ts
@@ -56,7 +56,7 @@ describe('LogOutDialogComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should naivgate after countdown', fakeAsync(() => {
+  it('should navigate after countdown', fakeAsync(() => {
     const spy = spyOn(router, 'navigate');
 
     component.data = {

--- a/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.ts
+++ b/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.ts
@@ -31,6 +31,7 @@ export class LogOutDialogComponent implements OnInit, OnDestroy {
           this.countDown = this.calcCountdown();
           if (this.countDown <= 0) {
             this.autoLogout.unsubscribe();
+            this.dialogRef.close(false);
             this.router.navigate(['/login/logout']);
           } else {
             this.percentage = ((this.countdownTotal - this.countDown) / this.countdownTotal) * 100;

--- a/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.ts
+++ b/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.ts
@@ -31,8 +31,8 @@ export class LogOutDialogComponent implements OnInit, OnDestroy {
           this.countDown = this.calcCountdown();
           if (this.countDown <= 0) {
             this.autoLogout.unsubscribe();
-            this.dialogRef.close(false);
             this.router.navigate(['/login/logout']);
+            this.dialogRef.close(false);
           } else {
             this.percentage = ((this.countdownTotal - this.countDown) / this.countdownTotal) * 100;
           }

--- a/src/frontend/packages/core/src/core/permissions/stratos-user-permissions.checker.ts
+++ b/src/frontend/packages/core/src/core/permissions/stratos-user-permissions.checker.ts
@@ -1,6 +1,6 @@
 import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { filter, switchMap } from 'rxjs/operators';
 
 import { GeneralEntityAppState } from '../../../../store/src/app-state';
 import { selectSessionData } from '../../../../store/src/reducers/auth.reducer';
@@ -61,7 +61,7 @@ export const stratosPermissionConfigs: IPermissionConfigs = {
 };
 
 export class StratosUserPermissionsChecker extends BaseCurrentUserPermissionsChecker implements ICurrentUserPermissionsChecker {
-  constructor(private store: Store<GeneralEntityAppState>, ) {
+  constructor(private store: Store<GeneralEntityAppState>,) {
     super();
   }
 
@@ -114,6 +114,7 @@ export class StratosUserPermissionsChecker extends BaseCurrentUserPermissionsChe
 
   private apiKeyCheck(): Observable<boolean> {
     return this.store.select(selectSessionData()).pipe(
+      filter(sessionData => !!sessionData),
       switchMap(sessionData => {
         switch (sessionData.config.APIKeysEnabled) {
           case APIKeysEnabled.ADMIN_ONLY:

--- a/src/frontend/packages/core/src/logged-in.service.ts
+++ b/src/frontend/packages/core/src/logged-in.service.ts
@@ -55,7 +55,7 @@ export class LoggedInService {
 
     this.sub = this.store.select(s => s.auth)
       .subscribe((auth: AuthState) => {
-        if (auth.loggedIn && auth.sessionData && auth.sessionData.valid) {
+        if (auth.loggedIn && auth.sessionData && auth.sessionData.valid && !auth.error) {
           if (!this.sessionChecker || this.sessionChecker.closed) {
             this.openSessionCheckerPoll();
           }


### PR DESCRIPTION
- fixes #4468
- Tested by.... src/frontend/packages/core/src/logged-in.service.ts
   ```
    this._promptInactiveUser(Date.now() + (1 * 1000 * 10));
    this.closeSessionCheckerPoll();
    // if (aboutToExpire) {
    //   const idleDelta = now - this.lastUserInteraction;
    //   const userIsActive = idleDelta < this.userIdlePeriod;
    //   const pageVisible = new PageVisible(document);
    //   if ((!dashboardState.timeoutSession && pageVisible.isPageVisible()) || userIsActive) {
    //     this.store.dispatch(new VerifySession(false, false));
    //   } else {
    //     this._promptInactiveUser(safeExpire);
    //     this.closeSessionCheckerPoll();
    //   }
    // }
   ``` 