### PR TITLE
Update CI resource images to ghcr.io

### DIFF
--- a/deploy/ci/build-aio-image-canary.yml
+++ b/deploy/ci/build-aio-image-canary.yml
@@ -10,7 +10,7 @@ resource_types:
 - name: stratos-git-resource
   type: docker-image
   source:
-    repository: splatform/stratos-git-tag-resource
+    repository: ghcr.io/cf-stratos/stratos-git-tag-resource
 
 resources:
 # Stratos Git Repository

--- a/deploy/ci/build-aio-image-nightly.yml
+++ b/deploy/ci/build-aio-image-nightly.yml
@@ -10,7 +10,7 @@ resource_types:
 - name: stratos-git-resource
   type: docker-image
   source:
-    repository: splatform/stratos-git-tag-resource
+    repository: ghcr.io/cf-stratos/stratos-git-tag-resource
 
 resources:
 # Stratos Git Repository

--- a/deploy/ci/build-aio-image-stable.yml
+++ b/deploy/ci/build-aio-image-stable.yml
@@ -12,7 +12,7 @@ resource_types:
 - name: stratos-git-resource
   type: docker-image
   source:
-    repository: splatform/stratos-git-tag-resource
+    repository: ghcr.io/cf-stratos/stratos-git-tag-resource
 
 resources:
 # Stratos Git Repository

--- a/deploy/ci/console-make-release.yml
+++ b/deploy/ci/console-make-release.yml
@@ -3,7 +3,7 @@ resource_types:
 - name: stratos-git-resource
   type: docker-image
   source:
-    repository: splatform/stratos-git-tag-resource
+    repository: ghcr.io/cf-stratos/stratos-git-tag-resource
 resources:
 # Stratos Git Repository
 - name: stratos

--- a/deploy/ci/scripts/Dockerfile.stratos-ci
+++ b/deploy/ci/scripts/Dockerfile.stratos-ci
@@ -1,7 +1,7 @@
-# Publihsed as splatform/stratos-ci-concourse
+# Published as ghcr.io/cf-stratos/stratos-ci-concourse
 
 # Use:
-# docker build -f Dockerfile.stratos-ci . -t splatform/stratos-ci-concourse:latest
+# docker build -f Dockerfile.stratos-ci . -t ghcr.io/cf-stratos/stratos-ci-concourse:latest
 
 # Default Image used to run tasks - contains Helm
 

--- a/deploy/ci/scripts/build-git-tag-resource.sh
+++ b/deploy/ci/scripts/build-git-tag-resource.sh
@@ -13,7 +13,7 @@ chmod +x ./git-resource/assets/check
 echo "#!/bin/bash" >  ./git-resource/test/all.sh
 echo "#!/bin/bash" >  ./git-resource/integration-tests/integration.sh
 
-docker build ./git-resource -t splatform/stratos-git-tag-resource:latest
-docker push splatform/stratos-git-tag-resource:latest
+docker build ./git-resource -t ghcr.io/cf-stratos/stratos-git-tag-resource:latest
+docker push ghcr.io/cf-stratos/stratos-git-tag-resource:latest
 rm -rf ./tmp
 echo "All done"

--- a/deploy/ci/tasks/dev-releases/check-docker-image.yml
+++ b/deploy/ci/tasks/dev-releases/check-docker-image.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 
 run:
   path: sh

--- a/deploy/ci/tasks/dev-releases/check-gh-release.yml
+++ b/deploy/ci/tasks/dev-releases/check-gh-release.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 
 run:
   path: sh

--- a/deploy/ci/tasks/dev-releases/create-chart.yml
+++ b/deploy/ci/tasks/dev-releases/create-chart.yml
@@ -10,7 +10,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 
 run:
   path: sh

--- a/deploy/ci/tasks/dev-releases/create-helm-pr.yml
+++ b/deploy/ci/tasks/dev-releases/create-helm-pr.yml
@@ -8,7 +8,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 params:
   GIT_USER:
   GIT_EMAIL:

--- a/deploy/ci/tasks/dev-releases/create-nightly-chart.yml
+++ b/deploy/ci/tasks/dev-releases/create-nightly-chart.yml
@@ -9,7 +9,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 
 run:
   path: bash

--- a/deploy/ci/tasks/dev-releases/generate-tag-files.yml
+++ b/deploy/ci/tasks/dev-releases/generate-tag-files.yml
@@ -9,7 +9,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 
 run:
   path: bash

--- a/deploy/ci/tasks/dev-releases/make-release.yml
+++ b/deploy/ci/tasks/dev-releases/make-release.yml
@@ -10,7 +10,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 run:
   path: sh
   args:

--- a/deploy/ci/tasks/dev-releases/update-gh-release.yml
+++ b/deploy/ci/tasks/dev-releases/update-gh-release.yml
@@ -8,7 +8,7 @@ image_resource:
   type: docker-image
   source:
    # Generated using scripts/Dockerfile.stratos-ci
-   repository: splatform/stratos-ci-concourse
+   repository: ghcr.io/cf-stratos/stratos-ci-concourse
 
 run:
   path: sh


### PR DESCRIPTION
This PR moves the two container images used by the Concourse release pipelines to ghcr.io.
