### PR TITLE
Use a subtle color for the app page header

### DIFF
--- a/src/frontend/packages/core/sass/mat-desktop.scss
+++ b/src/frontend/packages/core/sass/mat-desktop.scss
@@ -108,7 +108,20 @@ $desktop-toggle-button-item-height: $desktop-menu-item-height - 2px;
 
   // Smaller page header
   .page-header .page-header__toolbar {
+    font-size: 18px;
     height: $desktop-page-header-height;
+
+    h1 {
+      font-size: 18px;
+    }
+
+    mat-icon {
+      font-size: 20px;
+      height: 20px;
+      line-height: 20px;
+      width: 20px;
+    }
+
   }
 
   .dashboard .dashboard__inner {

--- a/src/frontend/packages/core/src/core/entity-favorite-star/entity-favorite-star.component.scss
+++ b/src/frontend/packages/core/src/core/entity-favorite-star/entity-favorite-star.component.scss
@@ -1,6 +1,8 @@
 $size: 24px;
 .favorite-star {
+  align-items: center;
   cursor: pointer;
+  display: flex;
   height: $size;
   width: $size;
 }

--- a/src/frontend/packages/core/src/features/dashboard/dashboard-base/dashboard-base.component.scss
+++ b/src/frontend/packages/core/src/features/dashboard/dashboard-base/dashboard-base.component.scss
@@ -82,7 +82,7 @@ $app-header-height: 56px;
   $breadcrumb-opacity: .7;
   $breadcrumb-hover-opacity: 1;
   $breadcrumb-padding: 3px;
-  $font-size: 20px;
+  $font-size: 18px;
 
   align-items: center;
   border-bottom: 1px solid rgba(0, 0, 0, .1);

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.scss
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.scss
@@ -114,9 +114,12 @@ $bottom-index: $top-index - 1;
     align-items: center;
     display: flex;
     margin-top: -8px;
-    padding: 15px;
+    padding: 10px 15px;
   }
   &__username-text {
+    font-size: 14px;
+    font-weight: bold;
+    line-height: 14px;
     margin-left: 10px;
   }
   &__menu-inner {

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.theme.scss
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.theme.scss
@@ -14,6 +14,7 @@
   $username-background: $menu-background-color;
   $header-background: map-get($app-theme, header-background-color);
   $header-foreground: map-get($app-theme, header-foreground-color);
+  $header-border: map-get($app-theme, header-border-color);
   $underflow-background: map-get($app-theme, underflow-background-color);
   $underflow-foreground: map-get($app-theme, underflow-foreground-color);
 
@@ -28,6 +29,9 @@
     &__toolbar {
       background-color: $header-background;
       color: $header-foreground;
+      @if $header-border and $header-border != 'none' {
+        border-bottom: 1px solid $header-border;
+      }
     }
     &__warning-count {
       background-color: mat-color($primary);

--- a/src/frontend/packages/core/src/shared/components/sidepanel-preview/sidepanel-preview.component.theme.scss
+++ b/src/frontend/packages/core/src/shared/components/sidepanel-preview/sidepanel-preview.component.theme.scss
@@ -3,10 +3,14 @@
   $background-color: map-get($app-theme, app-background-color);
   $darker-background-color: darken($background-color, 4%);
   $foreground: map-get($theme, foreground);
+  $header-border: map-get($app-theme, header-border-color);
 
   .sidepanel-preview__header {
     background-color: $darker-background-color;
-    border-top: 1px solid mat-color($foreground, divider);
+
+    @if not $header-border or $header-border == 'none' {
+      border-top: 1px solid mat-color($foreground, divider);
+    }
   }
 
   .sidepanel-preview__content {

--- a/src/frontend/packages/core/src/shared/components/user-avatar/user-avatar.component.theme.scss
+++ b/src/frontend/packages/core/src/shared/components/user-avatar/user-avatar.component.theme.scss
@@ -5,6 +5,11 @@
   $user-avatar-underflow-invert-colors: map-get($app-theme, user-avatar-underflow-invert-colors);
   $user-avatar-header-invert-colors: map-get($app-theme, user-avatar-header-invert-colors);
 
+  $user-avatar-header-background-color: map-get($app-theme, user-avatar-header-background-color);
+  @if not $user-avatar-header-background-color or $user-avatar-header-background-color == 'none' {
+    $user-avatar-header-background-color: map-get($app-theme, user-avatar-background-color);
+  }
+
   .user-avatar {
     &__initials {
       background-color: $user-avatar-background-color;
@@ -25,9 +30,14 @@
     .user-avatar {
       .user-avatar__initials.user-avatar__header {
         background-color: $user-avatar-foreground-color;
-        color: $user-avatar-background-color;
+        color: $user-avatar-header-background-color;
+      }
+    }
+  } @else {
+    .user-avatar {
+      .user-avatar__initials.user-avatar__header {
+        background-color: $user-avatar-header-background-color;
       }
     }
   }
-
 }

--- a/src/frontend/packages/theme/_helper.scss
+++ b/src/frontend/packages/theme/_helper.scss
@@ -33,11 +33,37 @@ $oss-dark-theme: mat-dark-theme($oss-dark-primary, $oss-dark-accent, $oss-dark-w
 }
 
 @function stratos-default-dark-theme() {
-  @return stratos-theme-helper($oss-dark-theme);
+  $theme: stratos-theme-helper($oss-dark-theme);
+  $app-theme: map-get($theme, app-theme);
+  $app-theme: map-merge($app-theme, (
+    header-background-color: #333,
+    header-border-color: #555,   
+    user-avatar-header-invert-colors: false,
+    user-avatar-header-background-color: #888,
+  ));
+  $theme: map-merge($theme, (
+    app-theme: $app-theme
+  ));
+
+  @return $theme;  
+
 }
 
 @function stratos-default-light-theme() {
-  @return stratos-theme-helper($oss-theme);
+  $theme: stratos-theme-helper($oss-theme);
+  $app-theme: map-get($theme, app-theme);
+  $app-theme: map-merge($app-theme, (
+    header-background-color: #fff,
+    header-foreground-color: #444,
+    header-border-color: #d8d8d8,   
+    user-avatar-header-invert-colors: false,
+    user-avatar-header-background-color: #888,
+  ));
+  $theme: map-merge($theme, (
+    app-theme: $app-theme
+  ));
+
+  @return $theme;  
 }
 
 // Creates the app theme and applies it to the application
@@ -75,6 +101,7 @@ $oss-dark-theme: mat-dark-theme($oss-dark-primary, $oss-dark-accent, $oss-dark-w
       ansi-colors: $ansi-color-palette,
       header-background-color: mat-color($primary),
       header-foreground-color: mat-contrast($primary, 500),
+      header-border-color: none,
       stratos-title-show-text: false,
       // Does the header background color span across the top, or is the sidenav background color used for the top-left portion
       header-background-span: false,


### PR DESCRIPTION
I've been staring at the Stratos screen a lot while redoing the home screen - the blue page header is getting to me - its time for a change.

This PR uses a more subtle page header - for both light and dark themes.
