### PR TITLE
Improve the presentation of advanced options in endpoint registration

### DIFF
--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
@@ -16,18 +16,23 @@
   <mat-checkbox matInput name="skipSll" #skipSllField="ngModel" ngModel>Skip SSL validation for the endpoint
   </mat-checkbox>
   <div *ngIf="showAdvancedFields" class="create-endpoint__section">
-    <h1 class="create-endpoint__section-title">Advanced Information (Optional)</h1>
-    <mat-form-field>
-      <input matInput id="client_id" name="client_id" ngModel #clientIDField="ngModel" placeholder="Client ID">
-    </mat-form-field>
-    <mat-form-field>
-      <input matInput id="client_secret" name="client_secret" ngModel #clientSecretField="ngModel"
-        placeholder="Client Secret" [type]="!show ? 'password' : 'text'">
-      <button mat-icon-button matSuffix (click)="show = !show" [attr.aria-label]="'Hide Secret'"
-        [attr.aria-pressed]="!show">
-        <mat-icon>{{!show ? 'visibility_off' : 'visibility'}}</mat-icon>
-      </button>
-    </mat-form-field>
+    <mat-checkbox matInput (change)="toggleAdvancedOptions()">Show Advanced Options</mat-checkbox>
+    <div [ngClass]="{'create-endpoint__shown': showAdvancedOptions}" class="create-endpoint__advanced">
+      <h1>Advanced Options</h1>
+      <p>Client ID and Client Secret do not normally need to be specified.</p>
+      <p>Note that these are not administrator credentials and only need to be specified if your endpoint uses non-standard configuration.</p>
+      <mat-form-field>
+        <input matInput id="client_id" name="client_id" ngModel #clientIDField="ngModel" placeholder="Client ID">
+      </mat-form-field>
+      <mat-form-field>
+        <input matInput id="client_secret" name="client_secret" ngModel #clientSecretField="ngModel"
+          placeholder="Client Secret" [type]="!show ? 'password' : 'text'">
+        <button mat-icon-button matSuffix (click)="show = !show" [attr.aria-label]="'Hide Secret'"
+          [attr.aria-pressed]="!show">
+          <mat-icon>{{!show ? 'visibility_off' : 'visibility'}}</mat-icon>
+        </button>
+      </mat-form-field>
+    </div>
   </div>
   <div *ngIf="endpointTypeSupportsSSO" class="create-endpoint__sso">
     <mat-checkbox matInput name="ssoAllowed" #ssoAllowedField="ngModel" ngModel>Allow SSO login to this endpoint

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.scss
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.scss
@@ -7,6 +7,17 @@ mat-checkbox {
   padding-top: 40px;
 }
 
+form.stepper-form {
+  max-width: unset;
+  mat-form-field,
+  mat-checkbox {
+    max-width: 450px;
+  }
+  P {
+    max-width: unset;
+  }
+}
+
 .create-endpoint {
   &__section {
     margin-top: 40px;
@@ -17,5 +28,22 @@ mat-checkbox {
   }
   &__sso {
     margin-top: 40px;
+  }
+  &__advanced {
+    display: flex;
+    flex-direction: column;
+    height: 0;
+    margin-left: 24px;
+    overflow: hidden;
+    h1 {
+      font-size: 14px;
+    }
+    p {
+      font-size: 14px;
+      margin: 5px 0;
+    }
+  }
+  &__shown {
+    height: auto;
   }
 }

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.ts
@@ -53,6 +53,8 @@ export class CreateEndpointCfStep1Component implements IStepperStep, AfterConten
   endpoint: StratosCatalogEndpointEntity;
   show = false;
 
+  showAdvancedOptions = false;
+
   constructor(
     activatedRoute: ActivatedRoute,
     private snackBarService: SnackBarService
@@ -129,5 +131,9 @@ export class CreateEndpointCfStep1Component implements IStepperStep, AfterConten
 
     // Only allow SSL if the endpoint type is Cloud Foundry
     this.endpointTypeSupportsSSO = endpoint.definition.type === 'cf';
+  }
+
+  toggleAdvancedOptions() {
+    this.showAdvancedOptions = !this.showAdvancedOptions;
   }
 }


### PR DESCRIPTION
We've had a few people use admin credentials in the Client ID and Client Secret fields when registering an endpoint.

This PR improves the presentation and hides the advanced fields by default.

Fixes #4767 