### PR TITLE
Fix size and position of header notification badge icon

### DIFF
--- a/src/frontend/packages/core/sass/mat-desktop.scss
+++ b/src/frontend/packages/core/sass/mat-desktop.scss
@@ -122,6 +122,13 @@ $desktop-toggle-button-item-height: $desktop-menu-item-height - 2px;
       width: 20px;
     }
 
+    .page-header__notification-button .mat-badge-medium .mat-badge-content {
+      height: 18px;
+      line-height: 18px;
+      right: -8px;
+      top: -8px;
+      width: 18px;
+    }
   }
 
   .dashboard .dashboard__inner {

--- a/src/frontend/packages/core/sass/mat-desktop.scss
+++ b/src/frontend/packages/core/sass/mat-desktop.scss
@@ -122,7 +122,7 @@ $desktop-toggle-button-item-height: $desktop-menu-item-height - 2px;
       width: 20px;
     }
 
-    .page-header__notification-button .mat-badge-medium .mat-badge-content {
+    .page-header__notification-button .mat-badge-medium.mat-badge-overlap .mat-badge-content {
       height: 18px;
       line-height: 18px;
       right: -8px;

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.scss
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.scss
@@ -99,6 +99,7 @@ $bottom-index: $top-index - 1;
     height: 20vh;
   }
   &__divider {
+    cursor: default;
     opacity: .3;
     padding: 0 10px 0 5px;
   }

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.theme.scss
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.theme.scss
@@ -51,7 +51,11 @@
       color: $underflow-foreground;
     }
     &__divider {
-      color: mat-contrast($primary, 500);
+      @if $header-border and $header-border != 'none' {
+        color: $header-border;
+      } @else {
+        color: mat-contrast($primary, 500);
+      }
     }
     &__menu-icon {
       background-color: mat-contrast($primary, 500);


### PR DESCRIPTION
The icons in the page header were made smaller for desktop mode but the notification overlay was forgotten - this PR fixes the size of that on desktop.

It also fixes the colour of the separator between the icons in the header - although the colour currently used is lighter than I'd like.