### PR TITLE
Document deployment with an ingress; make ingress host optional

### DIFF
--- a/deploy/kubernetes/console/README.md
+++ b/deploy/kubernetes/console/README.md
@@ -66,9 +66,9 @@ The following table lists the configurable parameters of the Stratos Helm chart 
 |console.service.servicePort|Service port for the console service|443|
 |console.service.externalName|External name for the console service when service type is ExternalName||
 |console.service.nodePort|Node port to use for the console service when service type is NodePort or LoadBalancer||
-|console.ingress.enabled|Enable ingress for the console service|false|
-|console.ingress.host|Host for the ingress resource|||
-|console.ingress.secretName|Name of an existing secret containing the TLS certificate for ingress|||
+|console.service.ingress.enabled|Enable ingress for the console service|false|
+|console.service.ingress.host|Host for the ingress resource|||
+|console.service.ingress.secretName|Name of an existing secret containing the TLS certificate for ingress|||
 |console.service.http.enabled|Enabled HTTP access to the console service (as well as HTTPS)|false|
 |console.service.http.servicePort|Service port for HTTP access to the console service when enabled|80|
 |console.service.http.nodePort|Node port for HTTP access to the console service (as well as HTTPS)||
@@ -190,6 +190,32 @@ helm install my-console stratos/console --namespace=console --set console.servic
 
 ## Using an Ingress Controller
 
+### Bare minimum Stratos deployment with an Ingress
+
+1. Deploy `ingress-nginx` Ingress controller into your Kubernetes cluster using the [Helm chart](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx) or [Kubernetes spec files](https://kubernetes.github.io/ingress-nginx/deploy/).
+2. Create `values.yaml` with the following Stratos Helm chart configuration values:
+```
+console:
+  service:
+    ingress:
+      enabled: true
+```
+3. Install Stratos:
+```
+helm repo add stratos https://cloudfoundry.github.io/stratos
+kubectl create namespace console
+helm install my-console stratos/console --namespace=console --values values.yaml
+```
+4. Obtain Ingress address by running `kubectl get ingress --namespace=console`, your Stratos installation should be accessible at that address.
+
+Note that configuration above would result in a deployment with self-signed HTTPS certificates and Stratos service being a default backend for the Ingress. The following steps most likely would be required for a production deployment:
+
+1. Acquire a static IP address for the Ingress.
+2. Assign a domain name to the static IP via a DNS record and set `console.service.ingress.host` value.
+3. Create a Kubernetes secret containing valid HTTPS certificates for the domain and set `console.service.ingress.secretName` value.
+
+### Ingress configuration
+
 If your Kubernetes Cluster supports Ingress, you can expose Stratos through Ingress by supplying the appropriate ingress configuration when installing.
 
 This configuration is described below:
@@ -202,7 +228,7 @@ This configuration is described below:
 |console.service.ingress.host|The host name that will be used for the Stratos service.||
 |console.service.ingress.secretName|The existing TLS secret that contains the certificate for ingress.||
 
-You must provide `console.service.ingress.host` when enabling ingress.
+If `console.service.ingress.host` isn't provided, Stratos service will be used as the default backend.
 
 By default a certificate will be generated for TLS. You can provide your own certificate by creating a secret and specifying this with `console.service.ingress.secretName`.
 

--- a/deploy/kubernetes/console/templates/NOTES.txt
+++ b/deploy/kubernetes/console/templates/NOTES.txt
@@ -3,9 +3,18 @@ Tech Preview is enabled, extra features will be shown.
 {{- end}}
 
 To access Stratos:
-{{- $ingress := .Values.console.ingress | default dict }}
+{{- $ingress := .Values.console.service.ingress | default dict }}
 {{- if $ingress.enabled }}
-From outside the cluster, the server URL is: http://{{ .Values.console.ingress.host }}
+{{- if .Values.console.service.ingress.host }}
+From outside the cluster, the server URL is: https://{{ .Values.console.service.ingress.host }}
+{{- else }}
+NOTE: It may take a few minutes for the Ingress IP to become available.
+You can watch the status of by running 'kubectl get ingress --namespace {{ .Release.Namespace }} -w {{ .Release.Name }}-ingress'
+
+Get the URL by running these commands in the same shell:
+  export INGRESS_ADDR=$(kubectl get ingress --namespace {{ .Release.Namespace }} --field-selector 'metadata.name={{ .Release.Name }}-ingress' -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}')
+  echo https://$INGRESS_ADDR
+{{- end }}
 {{- else }}
 Get the URL by running these commands in the same shell:
 {{- if contains "NodePort" .Values.console.service.type }}

--- a/deploy/kubernetes/console/templates/__helpers.tpl
+++ b/deploy/kubernetes/console/templates/__helpers.tpl
@@ -155,8 +155,6 @@ Ingress Host:
 {{ $host | quote }}
 {{- else if .Values.env.DOMAIN -}}
 {{ print "console." .Values.env.DOMAIN }}
-{{- else -}}
-{{ required "Host name is required" $host | quote }}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/kubernetes/console/templates/ingress.yaml
+++ b/deploy/kubernetes/console/templates/ingress.yaml
@@ -53,7 +53,7 @@ metadata:
     {{- if hasKey .Values.console.service.ingress.annotations "nginx.ingress.kubernetes.io/proxy-body-size" | not -}}
       {{ $_ := set .Values.console.service.ingress.annotations "nginx.ingress.kubernetes.io/proxy-body-size" "200m" }}
     {{- end }}
-    {{ $_ := set .Values.console.service.ingress.annotations "nginx.org/websocket-services" (print .Release.Name "-ui-ext") }}
+    {{- $_ := set .Values.console.service.ingress.annotations "nginx.org/websocket-services" (print .Release.Name "-ui-ext") }}
 {{ toYaml .Values.console.service.ingress.annotations | indent 4 }}
   labels:
     app.kubernetes.io/name: "stratos"
@@ -65,12 +65,17 @@ metadata:
     {{ $key }}: {{ $value }}
 {{- end }}    
 spec:
+{{- $host := (include "ingress.host" .) }}
   tls:
   - secretName: {{ default (print .Release.Name "-ingress-tls") .Values.console.service.ingress.secretName | quote }}
+    {{- if $host }}
     hosts:
-    - {{ template "ingress.host" . }}
+    - {{ $host }}
+    {{- end }}
   rules:
-    - host: {{ template "ingress.host" . }}
+    - {{ if $host -}}
+      host: {{ $host }}
+      {{ end -}}
       http:
         paths:
           - path: "/"


### PR DESCRIPTION
Fixes #4492: added documentation to the Helm chart readme.
Closes #4773: tested in all 3 CSP. Works with `ingress-nginx`. GKE has their own built-in implementation of the Ingress -- I wasn't able to make TLS work between the GKE ingress and the backend, so keeping `ingress-nginx` as the only documented option.

Made `ingress.host` optional, otherwise you have to add a DNS record or modify `/etc/hosts` (Ingress will not properly route requests without a valid `Host` header).