### PR TITLE
Handle table cell get/setters better

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.ts
@@ -62,6 +62,7 @@ export class AppAutoscalerMetricChartCardComponent extends CardCell<APIResource<
 
   @Input('row')
   set row(row: APIResource<AppScalingTrigger>) {
+    super.row = row;
     if (row) {
       if (row.entity.query && row.entity.query.params) {
         this.paramsMetricsStart = row.entity.query.params.start * 1000;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-instance/table-cell-cf-cell/table-cell-cf-cell.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-instance/table-cell-cf-cell/table-cell-cf-cell.component.ts
@@ -24,6 +24,7 @@ export class TableCellCfCellComponent extends TableCellCustom<ListAppInstance> i
     metricEntityService: EntityService<IMetrics<IMetricMatrixResult<IMetricCell>>>;
     cfGuid: string;
   }) {
+    super.config = config;
     if (!config) {
       return;
     }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-cforgspace/table-cell-app-cforgspace.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-cforgspace/table-cell-app-cforgspace.component.ts
@@ -15,6 +15,7 @@ export class TableCellAppCfOrgSpaceComponent extends TableCellAppCfOrgSpaceBase 
 
   @Input('row')
   set row(row: APIResource<IApp>) {
+    super.row = row;
     if (row) {
       this.init(row.entity.cfGuid, (row.entity.space as APIResource<ISpace>).entity.organization_guid, row.entity.space_guid);
     }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-status/table-cell-app-status.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-status/table-cell-app-status.component.ts
@@ -18,6 +18,7 @@ export class TableCellAppStatusComponent extends TableCellCustom<APIResource<IAp
   applicationState: ApplicationStateData;
   @Input('config')
   set config(value: { hideIcon: boolean, initialStateOnly: boolean, }) {
+    super.config = value;
     value = value || {
       hideIcon: false,
       initialStateOnly: false

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-confirm-roles/table-cell-confirm-org-space/table-cell-confirm-org-space.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-confirm-roles/table-cell-confirm-org-space/table-cell-confirm-org-space.component.ts
@@ -13,6 +13,7 @@ export class TableCellConfirmOrgSpaceComponent extends TableCellCustom<CfRoleCha
   chipsConfig: AppChip<CfRoleChangeWithNames>[];
   @Input('row')
   set row(row: CfRoleChangeWithNames) {
+    super.row = row;
     const chipConfig = new AppChip<CfRoleChangeWithNames>();
     chipConfig.key = row;
     chipConfig.value = row.spaceGuid ? `Space: ${row.spaceName}` : `Org: ${row.orgName}`;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-feature-flags/table-cell-feature-flag-description/table-cell-feature-flag-description.component.ts
@@ -15,6 +15,7 @@ export class TableCellFeatureFlagDescriptionComponent extends TableCellCustom<IF
 
   @Input()
   set row(row: IFeatureFlag) {
+    super.row = row;
     this.description = row ? FeatureFlagDescriptions[row.name] : null;
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/table-cell-route-apps-attached/table-cell-route-apps-attached.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-routes/table-cell-route-apps-attached/table-cell-route-apps-attached.component.ts
@@ -19,16 +19,14 @@ export class TableCellRouteAppsAttachedComponent extends TableCellCustom<any> im
 
   @Input('config')
   set config(config: any) {
+    super.config = config;
     this.config$.next(config);
   }
 
   @Input('row')
   set row(route: APIResource<CfRoute>) {
+    super.row = route;
     this.row$.next(route);
-  }
-
-  constructor() {
-    super();
   }
 
   ngOnInit(): void {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/cf-service-card/cf-service-card.component.ts
@@ -41,6 +41,7 @@ export class CfServiceCardComponent extends CardCell<APIResource<IService>> {
 
   @Input('row')
   set row(row: APIResource<IService>) {
+    super.row = row;
     if (row) {
       this.serviceEntity = row;
       this.extraInfo = null;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-broker/table-cell-service-broker.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-broker/table-cell-service-broker.component.ts
@@ -29,7 +29,7 @@ export class TableCellServiceBrokerComponent extends
 
   @Input()
   set row(row: APIResource<IService>) {
-    this.pRow = row;
+    super.row = row;
     if (row && !this.spaceLink$) {
       this.broker$ = cfEntityCatalog.serviceBroker.store.getEntityService(
         this.row.entity.service_broker_guid,
@@ -62,7 +62,7 @@ export class TableCellServiceBrokerComponent extends
     }
   }
   get row(): APIResource<IService> {
-    return this.pRow;
+    return super.row;
   }
 
   public spaceLink$: Observable<{

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-cf-breadcrumbs/table-cell-service-cf-breadcrumbs.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-cf-breadcrumbs/table-cell-service-cf-breadcrumbs.component.ts
@@ -18,6 +18,7 @@ export class TableCellServiceCfBreadcrumbsComponent extends TableCellCustom<APIR
 
   @Input()
   set row(pService: APIResource<IService>) {
+    super.row = pService;
     if (!pService || !!this.cfOrgSpace) {
       return;
     }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-provider/table-cell-service-provider.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-provider/table-cell-service-provider.component.ts
@@ -15,15 +15,12 @@ export class TableCellServiceProviderComponent extends TableCellCustom<APIResour
 
   @Input()
   set row(pService: APIResource<IService>) {
+    super.row = pService;
     if (!!pService && !!pService.entity.extra && !this.extraInfo) {
       try {
         this.extraInfo = JSON.parse(pService.entity.extra);
       } catch { }
     }
-  }
-
-  constructor() {
-    super();
   }
 
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-references/table-cell-service-references.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-references/table-cell-service-references.component.ts
@@ -15,16 +15,13 @@ export class TableCellServiceReferencesComponent extends TableCellCustom<APIReso
 
   @Input()
   set row(pService: APIResource<IService>) {
+    super.row = pService;
     if (!!pService && !!pService.entity.extra && !this.extraInfo) {
       try {
         this.extraInfo = JSON.parse(pService.entity.extra);
       } catch { }
     }
 
-  }
-
-  constructor() {
-    super();
   }
 
   hasDocumentationUrl() {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-tags/table-cell-service-tags.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-services/table-cell-service-tags/table-cell-service-tags.component.ts
@@ -16,10 +16,9 @@ export class TableCellServiceTagsComponent extends TableCellCustom<APIResource<I
 
   tags: AppChip<ServiceTag>[] = [];
 
-  private service;
   @Input()
   set row(pService: APIResource<IService>) {
-    this.service = pService;
+    super.row = pService;
     if (!pService) {
       return;
     }
@@ -29,10 +28,7 @@ export class TableCellServiceTagsComponent extends TableCellCustom<APIResource<I
     }));
   }
   get row(): APIResource<IService> {
-    return this.service;
+    return super.row;
   }
 
-  constructor() {
-    super();
-  }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-apps-attached/table-cell-service-instance-apps-attached.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-apps-attached/table-cell-service-instance-apps-attached.component.ts
@@ -29,11 +29,13 @@ export class TableCellServiceInstanceAppsAttachedComponent
 
   @Input('config')
   set config(config: any) {
+    super.config = config;
     this.config$.next(config);
   }
 
   @Input('row')
   set row(row: APIResource<IServiceInstance>) {
+    super.row = row;
     this.row$.next(row);
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-tags/table-cell-service-instance-tags.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces-service-instances/table-cell-service-instance-tags/table-cell-service-instance-tags.component.ts
@@ -21,6 +21,7 @@ export class TableCellServiceInstanceTagsComponent
   tags: AppChip<Tag>[] = [];
   @Input('row')
   set row(row) {
+    super.row = row;
     if (row) {
       this.tags.length = 0;
       if (row.entity && row.entity.service_instance && row.entity.service_instance.entity.tags) {
@@ -42,9 +43,4 @@ export class TableCellServiceInstanceTagsComponent
       }
     }
   }
-
-  constructor() {
-    super();
-  }
-
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-users/cf-permission-cell.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-users/cf-permission-cell.ts
@@ -33,6 +33,7 @@ export abstract class CfPermissionCellDirective<T> extends TableCellCustom<APIRe
 
   @Input('row')
   set row(row: APIResource<CfUser>) {
+    super.row = row;
     this.rowSubject.next(row);
     this.guid = row.metadata.guid;
     this.userEntity.next(row.entity);
@@ -40,6 +41,7 @@ export abstract class CfPermissionCellDirective<T> extends TableCellCustom<APIRe
 
   @Input()
   set config(config: any) {
+    super.config = config;
     this.configSubject.next(config);
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-plans/table-cell-service-plan-price/table-cell-service-plan-price.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-plans/table-cell-service-plan-price/table-cell-service-plan-price.component.ts
@@ -14,10 +14,9 @@ export class TableCellAServicePlanPriceComponent extends TableCellCustom<APIReso
   isFree: boolean;
   canShowCosts: boolean;
 
-  private pServicePlan;
   @Input()
   set row(servicePlan: APIResource<IServicePlan>) {
-    this.pServicePlan = servicePlan;
+    super.row = servicePlan;
     if (!servicePlan) {
       return;
     }
@@ -25,6 +24,6 @@ export class TableCellAServicePlanPriceComponent extends TableCellCustom<APIReso
     this.canShowCosts = canShowServicePlanCosts(servicePlan);
   }
   get row(): APIResource<IServicePlan> {
-    return this.pServicePlan;
+    return super.row;
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/service-instance-card/service-instance-card.component.ts
@@ -39,7 +39,7 @@ export class ServiceInstanceCardComponent extends CardCell<APIResource<IServiceI
 
   @Input('row')
   set row(row: APIResource<IServiceInstance>) {
-
+    super.row = row;
     if (row) {
       this.serviceInstanceEntity = row;
       const schema = cfEntityFactory(serviceInstancesEntityType);

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/user-provided-service-instance-card/user-provided-service-instance-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/services-wall/user-provided-service-instance-card/user-provided-service-instance-card.component.ts
@@ -38,6 +38,7 @@ export class UserProvidedServiceInstanceCardComponent extends CardCell<APIResour
 
   @Input('row')
   set row(row: APIResource<IUserProvidedServiceInstance>) {
+    super.row = row;
     if (row) {
       this.setup(row);
     }
@@ -107,14 +108,14 @@ export class UserProvidedServiceInstanceCardComponent extends CardCell<APIResour
       false,
       true
     );
-  }
+  };
 
   private delete = () => this.serviceActionHelperService.deleteServiceInstance(
     this.serviceInstanceEntity.metadata.guid,
     this.serviceInstanceEntity.entity.name,
     this.serviceInstanceEntity.entity.cfGuid,
     true
-  )
+  );
 
   private edit = () => this.serviceActionHelperService.startEditServiceBindingStepper(
     this.serviceInstanceEntity.metadata.guid,
@@ -123,7 +124,7 @@ export class UserProvidedServiceInstanceCardComponent extends CardCell<APIResour
       [CSI_CANCEL_URL]: '/services'
     },
     true
-  )
+  );
 
   getSpaceBreadcrumbs = () => ({ breadcrumbs: 'services-wall' });
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
@@ -1,9 +1,9 @@
 import { AfterContentInit, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
+import { JsonPointer } from '@cfstratos/ajsf-core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { delay } from 'rxjs/operators';
-import { JsonPointer } from '@cfstratos/ajsf-core';
 
 import { safeStringToObj } from '../../../../../core/src/core/utils.service';
 import { isValidJsonValidator } from '../../../../../core/src/shared/form-validators';
@@ -125,7 +125,7 @@ export class SchemaFormComponent implements OnInit, OnDestroy, AfterContentInit 
       return obj;
     }, {});
     return Object.keys(filterSchema).length > 0 ? filterSchema : null;
-  }
+  };
 
   onFormChange(formData) {
     this.formData = formData;
@@ -149,6 +149,6 @@ export class SchemaFormComponent implements OnInit, OnDestroy, AfterContentInit 
       }, '');
       return `${a} ${arrMessage} ${c.message} <br>`;
     }, '');
-  }
+  };
 
 }

--- a/src/frontend/packages/core/src/features/metrics/metrics-endpoint-details/metrics-endpoint-details.component.ts
+++ b/src/frontend/packages/core/src/features/metrics/metrics-endpoint-details/metrics-endpoint-details.component.ts
@@ -84,6 +84,7 @@ export class MetricsEndpointDetailsComponent extends EndpointListDetailsComponen
 
   @Input()
   set row(data: EndpointModel) {
+    super.row = data;
     this.guid$.next(data.guid);
   }
 }

--- a/src/frontend/packages/core/src/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/app-table-cell-default/app-table-cell-default.component.ts
@@ -16,9 +16,9 @@ export class TableCellDefaultComponent<T> extends TableCellCustom<T> implements 
   public cellDefinition: ICellDefinition<T>;
 
   @Input('row')
-  get row() { return this.pRow; }
+  get row() { return super.row; }
   set row(row: T) {
-    this.pRow = row;
+    super.row = row;
     if (row) {
       this.setValue(row, this.schemaKey);
       this.setSyncLink();

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-actions/table-cell-actions.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-actions/table-cell-actions.component.ts
@@ -20,9 +20,9 @@ export class TableCellActionsComponent<T> extends TableCellCustom<T> implements 
   rowState: Observable<RowState>;
 
   @Input('row')
-  get row() { return this.pRow; }
+  get row() { return super.row; }
   set row(row: T) {
-    this.pRow = row;
+    super.row = row;
     if (row) {
       this.initialise(row);
     }

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-boolean-indicator/table-cell-boolean-indicator.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-boolean-indicator/table-cell-boolean-indicator.component.ts
@@ -17,18 +17,18 @@ export interface TableCellBooleanIndicatorComponentConfig<T> {
 export class TableCellBooleanIndicatorComponent<T = any> extends TableCellCustom<T, TableCellBooleanIndicatorComponentConfig<T>> {
 
   @Input('row')
-  get row() { return this.pRow; }
+  get row() { return super.row; }
   set row(row: T) {
-    this.pRow = row;
+    super.row = row;
     if (this.config) {
       this.enabled = this.config.isEnabled(row);
     }
   }
 
   @Input('config')
-  get config() { return this.pConfig; }
+  get config() { return super.config; }
   set config(config: TableCellBooleanIndicatorComponentConfig<T>) {
-    this.pConfig = config;
+    super.config = config;
     if (!config) {
       return;
     }

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-edit/table-cell-edit.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-edit/table-cell-edit.component.ts
@@ -12,20 +12,19 @@ export class TableCellEditComponent<T> extends TableCellCustom<T> {
 
   @Input()
   get row(): T {
-    return this.pRow;
+    return super.row;
   }
   set row(row: T) {
-    this.pRow = row;
+    super.row = row;
   }
 
   @Input()
   set dataSource(dataSource: IListDataSource<T>) {
-    this.pDataSource = dataSource;
+    super.dataSource = dataSource;
   }
   get dataSource(): IListDataSource<T> {
-    return this.pDataSource;
+    return super.dataSource;
   }
-
 
   @Input()
   subtle: boolean;

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-expander/table-cell-expander.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-expander/table-cell-expander.component.ts
@@ -31,19 +31,25 @@ export class TableCellExpanderComponent<T = any> extends TableCellCustom<T, Cell
   }
 
   @Input() set config(config: CellConfigFunction<T>) {
-    this.pConfig = config;
+    super.config = config;
     this.updateRowId();
+  }
+  get config(): CellConfigFunction<T> {
+    return super.config;
   }
 
   @Input() set row(row: T) {
-    this.pRow = row;
+    super.row = row;
     this.updateRowId();
-
   }
+  get row(): T {
+    return super.row;
+  }
+
   public rowId = TableRowExpandedService.allExpanderState;
   private updateRowId() {
-    if (this.pConfig) {
-      const config: TableCellExpanderConfig = this.pConfig(this.pRow);
+    if (this.config) {
+      const config: TableCellExpanderConfig = this.config(this.row);
       this.rowId = config.rowId;
       this.expanded = this.expandedService.expanded[this.rowId];
     }

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-favorite/table-cell-favorite.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-favorite/table-cell-favorite.component.ts
@@ -26,13 +26,13 @@ export class TableCellFavoriteComponent<T, Y extends IFavoriteMetadata> extends
 
   @Input('config')
   set config(config: TableCellFavoriteComponentConfig<T, Y>) {
-    this.pConfig = config;
+    super.config = config;
     this.createUserFavorite();
   }
 
   @Input('row')
   set row(row: T) {
-    this.pRow = row;
+    super.row = row;
     this.createUserFavorite();
   }
 

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-icon/table-cell-icon.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-icon/table-cell-icon.component.ts
@@ -16,18 +16,18 @@ export class TableCellIconComponent<T = any> extends TableCellCustom<T, TableCel
 
 
   @Input('row')
-  get row() { return this.pRow; }
+  get row() { return super.row; }
   set row(row: T) {
-    this.pRow = row;
+    super.row = row;
     if (this.config) {
       this.icon = this.config.getIcon(row);
     }
   }
 
   @Input('config')
-  get config() { return this.pConfig; }
+  get config() { return super.config; }
   set config(config: TableCellIconComponentConfig<T>) {
-    this.pConfig = config;
+    super.config = config;
     if (!config) {
       return;
     }

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-radio/table-cell-radio.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-radio/table-cell-radio.component.ts
@@ -10,11 +10,10 @@ import { TableCellCustom } from '../../list.types';
 export class TableCellRadioComponent<T> extends TableCellCustom<T> implements OnInit {
   disable: boolean;
 
-  private r: T;
   @Input('row')
-  get row() { return this.r; }
+  get row() { return super.row; }
   set row(row: T) {
-    this.r = row;
+    super.row = row;
     if (row) {
       this.updateDisabled();
     }

--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-side-panel/table-cell-side-panel.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-side-panel/table-cell-side-panel.component.ts
@@ -20,16 +20,16 @@ export class TableCellSidePanelComponent<T = any, A = any> extends TableCellCust
   public actualConfig: TableCellSidePanelConfig<A>;
 
   @Input('row')
-  get row(): T { return this.pRow; }
+  get row(): T { return super.row; }
   set row(row: T) {
-    this.pRow = row;
+    super.row = row;
     this.updateConfig();
   }
 
   @Input('config')
-  get config() { return this.pConfig; }
+  get config() { return super.config; }
   set config(config: object | CellConfigFunction<T>) {
-    this.pConfig = config;
+    super.config = config;
     this.updateConfig();
   }
 

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/endpoint-card/endpoint-card.component.ts
@@ -67,10 +67,10 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
 
   @Input('row')
   set row(row: EndpointModel) {
+    super.row = row;
     if (!row) {
       return;
     }
-    this.pRow = row;
 
     this.endpointCatalogEntity = entityCatalog.getEndpoint(row.cnsi_type, row.sub_type);
     this.address = getFullEndpointApiUrl(row);
@@ -85,12 +85,12 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
 
   }
   get row(): EndpointModel {
-    return this.pRow;
+    return super.row;
   }
 
   @Input('dataSource')
   set dataSource(ds: BaseEndpointsDataSource) {
-    this.pDataSource = ds;
+    super.dataSource = ds;
 
     // Don't show card menu if the ds only provides a single endpoint type (for instance the cf endpoint page)
     if (ds && !ds.dsEndpointType && !this.cardMenu) {
@@ -98,7 +98,7 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
         const separator = endpointAction.label === '-';
         return {
           label: endpointAction.label,
-          action: () => endpointAction.action(this.pRow),
+          action: () => endpointAction.action(this.row),
           can: endpointAction.createVisible ? endpointAction.createVisible(this.rowObs) : null,
           separator
         };
@@ -145,7 +145,7 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
   }
 
   updateInnerComponent() {
-    if (!this.endpointDetails || !this.pRow) {
+    if (!this.endpointDetails || !this.row) {
       return;
     }
     const e = this.endpointCatalogEntity.definition;
@@ -161,10 +161,10 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
     }
 
     if (this.component) {
-      this.component.row = this.pRow;
+      this.component.row = this.row;
       this.component.isTable = false;
     }
-    this.component.row = this.pRow;
+    this.component.row = this.row;
     this.componentRef.changeDetectorRef.detectChanges();
 
 

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-address/table-cell-endpoint-address.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-address/table-cell-endpoint-address.component.ts
@@ -18,6 +18,7 @@ export class TableCellEndpointAddressComponent extends TableCellCustom<EndpointM
 
   @Input('row')
   set row(row: EndpointModel | RowWithEndpointId) {
+    super.row = row;
     /* tslint:disable-next-line:no-string-literal */
     const id = row['endpointId'] || row['guid'];
     this.endpointAddress$ = stratosEntityCatalog.endpoint.store.getEntityService(id).waitForEntity$.pipe(

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-details/table-cell-endpoint-details.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-details/table-cell-endpoint-details.component.ts
@@ -41,8 +41,7 @@ export class TableCellEndpointDetailsComponent extends TableCellCustom<EndpointM
 
   @Input('row')
   set row(row: EndpointModel) {
-    this.pRow = row;
-
+    super.row = row;
     const e = entityCatalog.getEndpoint(row.cnsi_type, row.sub_type).definition;
     if (!e || !e.listDetailsComponent) {
       return;
@@ -55,12 +54,12 @@ export class TableCellEndpointDetailsComponent extends TableCellCustom<EndpointM
     }
 
     if (this.cell) {
-      this.cell.row = this.pRow;
+      this.cell.row = this.row;
       this.cell.isTable = true;
     }
   }
   get row(): EndpointModel {
-    return this.pRow;
+    return super.row;
   }
 
   ngOnDestroy(): void {

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-name/table-cell-endpoint-name.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-name/table-cell-endpoint-name.component.ts
@@ -23,6 +23,7 @@ export class TableCellEndpointNameComponent extends TableCellCustom<EndpointMode
 
   @Input('row')
   set row(row: EndpointModel | RowWithEndpointId) {
+    super.row = row;
     /* tslint:disable-next-line:no-string-literal */
     const id = row['endpointId'] || row['guid'];
     this.endpoint$ = stratosEntityCatalog.endpoint.store.getEntityMonitor(id).entity$.pipe(

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
@@ -15,10 +15,10 @@ export class TableCellEndpointStatusComponent extends TableCellCustom<EndpointMo
 
   @Input()
   get row(): EndpointModel {
-    return this.pRow;
+    return super.row;
   }
   set row(row: EndpointModel) {
-    this.pRow = row;
+    super.row = row;
   }
 
   constructor() {

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-import/kube-config-table-import-status/kube-config-table-import-status.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-import/kube-config-table-import-status/kube-config-table-import-status.component.ts
@@ -16,12 +16,9 @@ export class KubeConfigTableImportStatusComponent extends TableCellCustom<KubeCo
 
   public state: Observable<IActionMonitorComponentState>;
 
-  constructor() {
-    super();
-  }
-
   @Input()
   set config(element) {
+    super.config = element;
     if (!this.state) {
       this.state = element(this.row);
     }

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-table-cert/kube-config-table-cert.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-table-cert/kube-config-table-cert.component.ts
@@ -25,11 +25,13 @@ export class KubeConfigTableCertComponent extends TableCellCustom<KubeConfigFile
     checked: boolean;
   }>(null);
   initialValue$ = this.initialValue.asObservable();
+  initialized = false;
 
   @Input()
   set row(row: KubeConfigFileCluster) {
-    if (!this.pRow) {
-      this.pRow = row;
+    super.row = row;
+    if (!this.initialized) {
+      this.initialized = true;
       if (row.cluster['insecure-skip-tls-verify']) {
         // User has manually specified default skip option
         this.initialValue.next({
@@ -49,7 +51,7 @@ export class KubeConfigTableCertComponent extends TableCellCustom<KubeConfigFile
     }
   }
   get row(): KubeConfigFileCluster {
-    return this.pRow;
+    return super.row;
   }
 
   constructor(

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-pods/kubernetes-pod-containers/kubernetes-pod-containers.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-pods/kubernetes-pod-containers/kubernetes-pod-containers.component.ts
@@ -4,12 +4,6 @@ import moment from 'moment';
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
-import {
-  BooleanIndicatorType,
-} from '../../../../../../core/src/shared/components/boolean-indicator/boolean-indicator.component';
-import {
-  TableCellBooleanIndicatorComponentConfig,
-} from '../../../../../../core/src/shared/components/list/list-table/table-cell-boolean-indicator/table-cell-boolean-indicator.component';
 import { CardCell } from '../../../../../../core/src/shared/components/list/list.types';
 import { kubeEntityCatalog } from '../../../kubernetes-entity-catalog';
 import { Container, ContainerState, ContainerStatus, InitContainer, KubernetesPod } from '../../../store/kube.types';
@@ -45,15 +39,9 @@ export class KubernetesPodContainersComponent extends CardCell<KubernetesPod> {
     }
   };
 
-  public readyBoolConfig: TableCellBooleanIndicatorComponentConfig<ContainerForTable> = {
-    isEnabled: (row: ContainerForTable) => row.containerStatus.ready,
-    type: BooleanIndicatorType.yesNo,
-    subtle: false,
-    showText: false
-  };
-
   @Input()
   set row(row: KubernetesPod) {
+    super.row = row;
     if (!row || !!this.containers$) {
       return;
     }
@@ -62,6 +50,9 @@ export class KubernetesPodContainersComponent extends CardCell<KubernetesPod> {
       filter(pod => !!pod),
       map(pod => this.map(pod)),
     );
+  }
+  get row(): KubernetesPod {
+    return super.row;
   }
 
   constructor(

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-pods/kubernetes-pod-status/kubernetes-pod-status.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-pods/kubernetes-pod-status/kubernetes-pod-status.component.ts
@@ -14,13 +14,13 @@ export class KubernetesPodStatusComponent extends TableCellCustom<KubernetesPod>
   public style = 'border-success';
 
   @Input('row')
-  get row(): KubernetesPod { return this.pRow; }
   set row(row: KubernetesPod) {
-    this.pRow = row;
+    super.row = row;
     if (row) {
       this.updateStatus();
     }
   }
+  get row(): KubernetesPod { return super.row; }
 
   private updateStatus() {
     const status = this.convertStatus(this.row.expandedStatus.status);

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-service-ports/kubernetes-service-ports.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-service-ports/kubernetes-service-ports.component.ts
@@ -9,12 +9,11 @@ import { KubeService } from '../../store/kube.types';
   styleUrls: ['./kubernetes-service-ports.component.scss']
 })
 export class KubernetesServicePortsComponent extends CardCell<KubeService> {
-
   @Input()
   get row(): KubeService {
-    return this.pRow;
+    return super.row;
   }
   set row(row: KubeService) {
-    this.pRow = row;
+    super.row = row;
   }
 }

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-release-card/helm-release-card.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-release-card/helm-release-card.component.ts
@@ -17,7 +17,7 @@ export class HelmReleaseCardComponent extends CardCell<HelmRelease> {
 
   @Input('row')
   set row(row: HelmRelease) {
-    this.pRow = row;
+    super.row = row;
     if (row) {
       this.status = row.status.charAt(0).toUpperCase() + row.status.substring(1);
       this.lastDeployed = this.datePipe.transform(row.info.last_deployed, 'medium');
@@ -31,7 +31,7 @@ export class HelmReleaseCardComponent extends CardCell<HelmRelease> {
     }
   }
   get row(): HelmRelease {
-    return this.pRow;
+    return super.row;
   }
 
 


### PR DESCRIPTION
- get and set were moved into abstract base class as part of ts bump
- we now need to ensure we get/set the correct way
- also ensure that the super properties are set correctly, even if we're not currently using them
- also contains minor cell tidy ups
