### PR TITLE
fix unicode rendering in application logstreams

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/log-stream-tab/log-stream-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/log-stream-tab/log-stream-tab.component.ts
@@ -105,7 +105,7 @@ export class LogStreamTabComponent implements OnInit {
         msgColour = 'red';
         bold = true;
       }
-      const messageString = this.colorizer.colorize(atob(messageObj.message), msgColour, bold) + '\n';
+      const messageString = this.colorizer.colorize(decodeURIComponent(escape(atob(messageObj.message))), msgColour, bold) + '\n';
       return timeStamp + ': ' + messageSource + ' ' + messageString;
     } catch (error) {
       console.error('Failed to filter jsonMessage from WebSocket: ' + JSON.stringify(error));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR wraps the `atob` call used when decoding messages to be rendered in the logstream tab component.  The wrapping causes unicode characters to be rendered correctly instead of being rendered as two incorrect characters.

Fixes #4807 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I work at a German company, many applications log with unicode characters like ü and ß in the text.  It is annoying and ugly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I created a simple application that logs unicode characters on demand.  I observed that its output was incorrectly rendered in the application logstream without this change, and correctly rendered with it (I'm happy to provide the source for that test app if required, it's trivial). 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message