### PR TITLE
Fix alignment of no content messages on home page view

### DIFF
--- a/src/frontend/packages/core/src/features/home/home/home-page.component.html
+++ b/src/frontend/packages/core/src/features/home/home/home-page.component.html
@@ -26,12 +26,12 @@
   </div>
 </div>
 <ng-template #noEndpoints>
-  <div *ngIf="haveRegistered$ | async; else noneRegistered">
+  <div class="home-page" *ngIf="haveRegistered$ | async; else noneRegistered">
     <app-no-content-message [icon]="'settings_ethernet'" firstLine="There are no connected endpoints" 
     [secondLine]="{text: 'Use the Endpoints view to connect'}"></app-no-content-message>
   </div>
 </ng-template>
 
 <ng-template #noneRegistered>
-  <app-endpoints-missing [showToolbarHint]="false"></app-endpoints-missing>
+  <app-endpoints-missing class="home-page" [showToolbarHint]="false"></app-endpoints-missing>
 </ng-template>

--- a/src/frontend/packages/core/src/features/home/home/home-page.component.scss
+++ b/src/frontend/packages/core/src/features/home/home/home-page.component.scss
@@ -1,5 +1,7 @@
 :host {
   display: flex;
+  height: 100%;
+  width: 100%;
 }
 
 .home-page {


### PR DESCRIPTION
On the home page, with no endpoints registered or connected, the message is not correctly formatted