### PR TITLE
Improvement and fix for no-content component

### DIFF
--- a/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-edit/table-cell-edit.component.scss
+++ b/src/frontend/packages/core/src/shared/components/list/list-table/table-cell-edit/table-cell-edit.component.scss
@@ -6,7 +6,7 @@
       font-size: 18px;
       height: 25px;
       line-height: 25px;
-      opacity: 60%;
+      opacity: .6;
       padding-left: 5px;
       width: 35px;
     }

--- a/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.html
+++ b/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.html
@@ -3,7 +3,7 @@
     <div class="app-no-content-container__link-text">{{toolbarLink.text}}</div>
     <mat-icon #toolbarRef class="app-no-content-container__link-icon">reply</mat-icon>
   </div>
-  <mat-icon [fontSet]="iconFont">{{icon}}</mat-icon>
+  <mat-icon class="icon" [fontSet]="iconFont">{{icon}}</mat-icon>
   <div *ngIf="firstLine" class="first-line">{{firstLine}}</div>
   <div class="second-line">
     <a *ngIf="secondLine?.link" [routerLink]="secondLine?.link">{{secondLine?.linkText}}</a>{{secondLine?.text}}

--- a/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.scss
+++ b/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.scss
@@ -26,7 +26,7 @@
   }
   &__link {
     display: flex;
-    opacity: 0%;
+    opacity: 0;
     position: absolute;
     right: 113px;
     top: 54px;
@@ -41,7 +41,7 @@
       margin-top: 26px;
     }
     &--show {
-      opacity: 100%;
+      opacity: 1;
       transition: opacity .6s;
     }
   }

--- a/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.theme.scss
+++ b/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.theme.scss
@@ -4,5 +4,10 @@
 
   .app-no-content-container {
     color: $subdued;
+    &__link,
+    .icon,
+    .first-line {
+      color:  mat-color($primary);
+    }
   }
 }


### PR DESCRIPTION
- add colour to improve monotone views on first load
- fix issue where production angular rounded opacity values specified as percentages down to single digit  (see angular/angular-cli#17440), thus hiding content. This affected
  - no-content header arrow 
  - import kube config table edit endpoint name cell
