### PR TITLE
Minor Kube Fixes

### DIFF
--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details.component.html
@@ -2,18 +2,21 @@
   <app-panel *ngIf="!chart && !initing" class="app-panel--container">
     <h2>Sorry, we couldn't find the chart</h2>
   </app-panel>
+  <app-panel *ngIf="chart && !currentVersion && !initing" class="app-panel--container">
+    <h2>Sorry, we couldn't find the version information for this chart</h2>
+  </app-panel>
   <app-loader [loading]="loading">
-    <div class="chart-details__wrapper">
-      <app-entity-summary-title class="summary-title" *ngIf="chart" [title]="chart.attributes.name"
-        [subTitle]="chartSubTitle" [subText]="chart.attributes.description" [imagePath]="iconUrl">
+    <div class="chart-details__wrapper" *ngIf="chart && currentVersion">
+      <app-entity-summary-title class="summary-title" [title]="chart.attributes.name" [subTitle]="chartSubTitle"
+        [subText]="chart.attributes.description" [imagePath]="iconUrl">
         <div class="chart-details__content">
           <article class="chart-details__content__docs">
-            <app-chart-details-readme [currentVersion]=currentVersion></app-chart-details-readme>
+            <app-chart-details-readme [currentVersion]="currentVersion"></app-chart-details-readme>
           </article>
         </div>
       </app-entity-summary-title>
-      <aside *ngIf="chart" class="chart-details__content__info">
-        <app-chart-details-info [chart]=chart [currentVersion]=currentVersion></app-chart-details-info>
+      <aside class="chart-details__content__info">
+        <app-chart-details-info [chart]="chart" [currentVersion]="currentVersion"></app-chart-details-info>
       </aside>
     </div>
   </app-loader>

--- a/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
@@ -1,18 +1,18 @@
 <app-tile-grid fit="true">
   <app-tile-group class="k8s-home-card__plain-tiles">
     <app-tile>
-      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/nodes"
-        icon="apps" label="Nodes" labelSingular="Node" value="{{ nodeCount$ | async }}">
+      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/nodes" icon="apps" label="Nodes"
+        labelSingular="Node" value="{{ nodeCount$ | async }}">
       </app-card-number-metric>
     </app-tile>
     <app-tile>
-      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/namespaces"
-        icon="language" label="Namespaces" labelSingular="Node" value="{{ namespaceCount$ | async }}">
+      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/namespaces" icon="language"
+        label="Namespaces" labelSingular="Node" value="{{ namespaceCount$ | async }}">
       </app-card-number-metric>
     </app-tile>
     <app-tile>
-      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/pods"
-        icon="apps" label="Pods" labelSingular="Pod" value="{{ podCount$ | async }}">
+      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/resource/pod" icon="apps" label="Pods"
+        labelSingular="Pod" value="{{ podCount$ | async }}">
       </app-card-number-metric>
     </app-tile>
   </app-tile-group>

--- a/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
@@ -6,7 +6,7 @@
       </app-card-number-metric>
     </app-tile>
     <app-tile>
-      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/namespaces" icon="language"
+      <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/resource/namespace" icon="language"
         label="Namespaces" labelSingular="Node" value="{{ namespaceCount$ | async }}">
       </app-card-number-metric>
     </app-tile>


### PR DESCRIPTION
- Helm Chart Summary: Ensure we handle the case where the helm chart versions info is unable
  - artifact hub/appscode/kubedb chart - the chart loads ok, but but versions is unavailable
- Helm List - Reset button failed to reset repo filter
- Kube Home Card - Pods list link lead to 404