### PR TITLE
Fix git related issues found in release testing

### DIFF
--- a/deploy/containers/nginx/conf/nginx.dev.conf
+++ b/deploy/containers/nginx/conf/nginx.dev.conf
@@ -66,13 +66,13 @@ http {
             proxy_set_header        Connection $connection_upgrade;
         }
 
-        location /api/ {
+        location /api {
             proxy_pass_header       Server;
             proxy_set_header        Host $http_host;
             proxy_redirect          off;
             proxy_set_header        X-Real-IP $remote_addr;
             proxy_set_header        X-Scheme $scheme;
-            proxy_pass              https://portalproxy/api/;
+            proxy_pass              https://portalproxy;
             proxy_intercept_errors  on;
             proxy_http_version      1.1;
             proxy_set_header        Upgrade $http_upgrade;

--- a/deploy/containers/nginx/conf/nginx.k8s.conf
+++ b/deploy/containers/nginx/conf/nginx.k8s.conf
@@ -66,18 +66,18 @@ http {
             proxy_set_header        Connection $connection_upgrade;
         }
 
-        location /api/ {
+        location /api {
             proxy_pass_header       Server;
             proxy_set_header        Host $http_host;
             proxy_redirect          off;
             proxy_set_header        X-Real-IP $remote_addr;
             proxy_set_header        X-Scheme $scheme;
-            proxy_pass              https://portalproxy/api/;
+            proxy_pass              https://portalproxy;
             proxy_intercept_errors  on;
             proxy_http_version      1.1;
             proxy_set_header        Upgrade $http_upgrade;
             proxy_set_header        Connection $connection_upgrade;
-        }        
+        }
 
         location / {
             root                    /usr/share/nginx/html;

--- a/deploy/kubernetes/console/templates/NOTES.txt
+++ b/deploy/kubernetes/console/templates/NOTES.txt
@@ -28,7 +28,7 @@ Get the URL by running these commands in the same shell:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-ui-ext -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.console.service.servicePort }}
 {{- else if contains "ClusterIP"  .Values.console.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=stratos-0,component=ui" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ .Release.Name }},component=stratos" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 443
 {{- end }}
 {{- end }}

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-deployer.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-deployer.ts
@@ -341,7 +341,7 @@ export class DeployApplicationDeployer {
         break;
       case SocketEventTypes.CLOSE_FAILED_CLONE:
         this.onClose(log, 'Deploy Failed - Failed to clone repository!',
-          'Failed to deploy app! Please make sure the repository is public.');
+          'Failed to deploy app! Please make sure the repository is accessible.');
         break;
       case SocketEventTypes.CLOSE_FAILED_NO_BRANCH:
         this.onClose(log, 'Deploy Failed - Failed to located branch!',

--- a/src/jetstream/plugins/cfapppush/types.go
+++ b/src/jetstream/plugins/cfapppush/types.go
@@ -117,7 +117,8 @@ type Applications struct {
 }
 
 type CloneDetails struct {
-	Url    string
-	Branch string
-	Commit string
+	Url       string
+	LoggerUrl string
+	Branch    string
+	Commit    string
 }


### PR DESCRIPTION
- Don't show git api keys when deploying an application
  - In the application env var
  - In the jetstream log if the clone fails
- Ensure nginx passes encoded paths through unmangled
  - In helm/kube deployment gitlab projects failed to fetch due to mangled project name
  - Echo context reports c.Param(*) as `projects/richardcox/my-private-repo` instead of `projects/richardcox%2Fmy-private-repo`
  - This is a separate fix to one implemented earlier where url.String() was mangling the path/project name
  - See https://serverfault.com/a/463932 for fix details, TL;DR if proxy_pass contains uri whole path is mangled/unescaped
  - Fixes core problem, still needs further testing
- Also fixed the helm chart note's `ClusterIP` instructions