### PR TITLE
jetstream: support generating TLS cert

### DIFF
--- a/src/jetstream/main_test.go
+++ b/src/jetstream/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/govau/cf-common/env"
@@ -153,5 +155,42 @@ func TestLoadDatabaseConfigWithInvalidSSLMode(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("Unexpected success - should not be able to load database configs with an invalid SSL Mode specified.")
+	}
+}
+
+func TestGenerateTLSCert(t *testing.T) {
+	pc := interfaces.PortalConfig{}
+	err := generateTLSCert(&pc)
+	if err != nil {
+		t.Errorf("Error generating TLS certificate: %w", err)
+		return
+	}
+	certBlock, rest := pem.Decode([]byte(pc.TLSCert))
+	if len(rest) > 0 {
+		t.Errorf("Extra bytes after certificate: %s", rest)
+	}
+	if certBlock.Type != "CERTIFICATE" {
+		t.Errorf("Invalid cerificate block type %s", certBlock.Type)
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		t.Errorf("Error parsing certificate: %w", err)
+		return
+	}
+	if err := cert.VerifyHostname("localhost"); err != nil {
+		t.Errorf("Certificate does not work for localhost: %w", err)
+	}
+	privBlock, rest := pem.Decode([]byte(pc.TLSCertKey))
+	if len(rest) > 0 {
+		t.Errorf("Extra bytes after private key: %s", rest)
+	}
+	if privBlock.Type != "RSA PRIVATE KEY" {
+		t.Errorf("Invalid private key block type %s", privBlock.Type)
+	}
+	privKey, err := x509.ParsePKCS1PrivateKey(privBlock.Bytes)
+	if err != nil {
+		t.Errorf("Could not parse private key: %w", err)
+	} else if !privKey.PublicKey.Equal(cert.PublicKey) {
+		t.Errorf("Certifcate public key does not match private key")
 	}
 }

--- a/src/jetstream/repository/interfaces/structs.go
+++ b/src/jetstream/repository/interfaces/structs.go
@@ -362,6 +362,7 @@ type PortalConfig struct {
 	TLSCertKey                         string   `configName:"CONSOLE_PROXY_CERT_KEY"`
 	TLSCertPath                        string   `configName:"CONSOLE_PROXY_CERT_PATH"`
 	TLSCertKeyPath                     string   `configName:"CONSOLE_PROXY_CERT_KEY_PATH"`
+	TLSCertGenerate                    bool     `configName:"CONSOLE_PROXY_CERT_GENERATE"`
 	CFClient                           string   `configName:"CF_CLIENT"`
 	CFClientSecret                     string   `configName:"CF_CLIENT_SECRET"`
 	AllowedOrigins                     []string `configName:"ALLOWED_ORIGINS"`


### PR DESCRIPTION
## Description
Add support to generate a self-signed TLS certificate for localhost, so that it can be used in situations where running the openssl command is difficult / inappropriate.

## Motivation and Context
I want to try distributing Stratos to users (similar to the [electron proof of concept](https://github.com/cloudfoundry/stratos/tree/master/electron)); in this case, shipping a pre-generated certificate wouldn't make sense, because it would mean it would expire in a year or two.  Since the golang standard library has good support for x509 anyway, it seemed easier to write the code to handle that on startup.

Node.js doesn't have the equivalent, and most of the packages there to do cert generation actually shell out to the `openssl` executable.  Additionally, pulling in a dependency for this seemed unwise.

## How Has This Been Tested?
- Ran stratos using the new code, checking that it generated an acceptable certificate.
- New test added.  This may be excessive?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message

I didn't see anywhere that would be obvious for new documentation; there didn't seem to be anywhere that listed the possible options.