### PR TITLE
Theme Builder: Cast types

### DIFF
--- a/src/frontend/packages/devkit/src/builders/theme.builder.ts
+++ b/src/frontend/packages/devkit/src/builders/theme.builder.ts
@@ -27,7 +27,7 @@ async function commandBuilder(
 
     // Copy all files from root to the outPath
 
-    FS.copySync(prjMetadata.root, outPath);
+    FS.copySync(prjMetadata.root as string, outPath);
 
     // We can remove scripts from the package.json file
     const pkgFile = Packages.loadPackageFile(outPath);


### PR DESCRIPTION
## Description
In this case, `prjMetadata.root` is an untyped JSON result (that is, it can be object, array, number, etc.), but `FS.copySync` needs to take a string; do an explicit cast here to make TypeScript happy.

## Motivation and Context
My build was failing:
```
Error: src/builders/theme.builder.ts(30,17): error TS2345: Argument of type 'string | number | boolean | JsonArray | JsonObject' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'.
```

It is unclear why this doesn't seem to show up in CI.  I _think_ it's because this only shows up if TypeScript has type information for `fs-extra`, that is, if the [`@types/fs-extra`](https://www.npmjs.com/package/@types/fs-extra) package was installed; otherwise, TS just treats `FS` as `any`, and doesn't do any type checking.  I don't understand why I managed to have that package, though…

## How Has This Been Tested?
Built locally (with `@types/fs-extra`) and checked that the failure doesn't show up anymore.  As this is just a cast, there is no runtime effect.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Hopefully.)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message