### PR TITLE
Consume SSL certs provided as VCAP ENV var for secure db connection

### DIFF
--- a/src/jetstream/datastore/database_cf_config.go
+++ b/src/jetstream/datastore/database_cf_config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -77,13 +78,35 @@ func findDatabaseConfig(vcapServices map[string][]VCAPService, db *DatabaseConfi
 		// 1) Check db config in credentials
 		db.Username = getDBCredentialsValue(dbCredentials["username"])
 		db.Password = getDBCredentialsValue(dbCredentials["password"])
-		db.Host = getDBCredentialsValue(dbCredentials["hostname"])
+		db.Host = getDBCredentialsValue(dbCredentials["host"])
 		db.SSLMode = env.String("DB_SSL_MODE", "disable")
 		db.Port, _ = strconv.Atoi(getDBCredentialsValue(dbCredentials["port"]))
 		// Note - Both isPostgresService and isMySQLService look at the credentials uri & tags
 		if isPostgresService(service) {
 			db.DatabaseProvider = "pgsql"
-			db.Database = getDBCredentialsValue(dbCredentials["dbname"])
+			db.Database = getDBCredentialsValue(dbCredentials["name"])
+			if db.SSLMode == string(SSLVerifyCA) {
+				log.Infof("Attempting to use SSL for database connection")
+				tempFile, err := os.CreateTemp("", "postgres-ssl-*.crt")
+				if err != nil {
+					log.Warnf("Failed store Cloud Foundry service certificate in temp file; could not create temp file: %s", err.Error())
+					return false
+				}
+
+				_, err = tempFile.WriteString(getDBCredentialsValue(dbCredentials["cacrt"]))
+				if err != nil {
+					log.Warnf("Failed store Cloud Foundry service certificate in temp file; could not write to temp file: %s", err.Error())
+					return false
+				}
+
+				err = tempFile.Close()
+				if err != nil {
+					log.Warnf("Failed store Cloud Foundry service certificate in temp file; could not save temp file after writing: %s", err.Error())
+					return false
+				}
+
+				db.SSLRootCertificate = tempFile.Name()
+			}
 		} else if isMySQLService(service) {
 			db.DatabaseProvider = "mysql"
 			db.Database = getDBCredentialsValue(dbCredentials["name"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously service instances which provide SSL certificates via VCAP ENVs could not be consumed and had to be manually added to the config.
This PR allows for the SSL cert to be read from the VCAP ENVs provided by the service instance for establishing a secure connection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change allows for ease of use when utilising service instance that provide SSL certs via VCAP ENVs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests have been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message