### PR TITLE
fix tests after integration of root api endpoint from CloudController

### DIFF
--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -23,12 +23,16 @@ type AuthProvider struct {
 	UserInfo GetUserInfoFromToken
 }
 
+type LogCacheLink struct {
+	Href string `json:"href"`
+}
+
+type ApiRootLinks struct {
+	LogCache LogCacheLink `json:"log_cache"`
+}
+
 type ApiRoot struct {
-	Links struct {
-		LogCache struct {
-			Href string `json:"href"`
-		} `json:"log_cache"`
-	} `json:"links"`
+	Links ApiRootLinks
 }
 
 // V2Info is the response for the Cloud Foundry /v2/info API
@@ -47,7 +51,7 @@ type V2Info struct {
 
 type EndpointInfo struct {
 	ApiRoot ApiRoot
-	V2Info V2Info
+	V2Info  V2Info
 }
 
 type InfoFunc func(apiEndpoint string, skipSSLValidation bool, caCert string) (CNSIRecord, interface{}, error)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In the merged PR [5064,](https://github.com/cloudfoundry/stratos/pull/5064) the detection of the log endpoint got changed, but not the corresponding tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With this PR, the tests should now be fixed again.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

running the tests with 
```
./build/bk-build.sh test
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message