### PR TITLE
Add Nix files

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Bun + Angular Nix development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          name = "bun-angular-dev-shell";
+
+          buildInputs = [
+            pkgs.bun
+            pkgs.nodejs_20
+            pkgs.pnpm
+            pkgs.git
+            pkgs.openssl
+            pkgs.watchman
+          ];
+
+          shellHook = ''
+            echo "✅ Bun + Angular dev shell"
+            echo "bun: $(bun --version)"
+            echo "node: $(node --version)"
+            echo "pnpm: $(pnpm --version)"
+            echo ""
+            echo "If Angular CLI isn't installed:"
+            echo "  npm install -g @angular/cli"
+          '';
+        };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import (builtins.getFlake (toString ./.)).devShells.${builtins.currentSystem}.default)


### PR DESCRIPTION
This pull request introduces a Nix flake setup to streamline the development environment for Bun and Angular projects on machines using Nix. The main changes add reproducible and convenient shell configurations using Nix, making it easier for developers to get started and maintain consistency across systems.

**Nix Flake Development Environment Setup:**

* Added a new `flake.nix` file that defines a Nix flake for a Bun + Angular development shell, including all necessary dependencies (`bun`, `nodejs_20`, `pnpm`, `git`, `openssl`, `watchman`) and a helpful shell hook for environment information and Angular CLI installation instructions.
* Updated `shell.nix` to import the default development shell from the flake, ensuring that the environment is reproducible and consistent for all contributors.