### PR TITLE
chore: silence container-push-base-images-develop workflow

### DIFF
--- a/.github/workflows/container-push-base-images-develop.yaml
+++ b/.github/workflows/container-push-base-images-develop.yaml
@@ -1,9 +1,12 @@
 name: container-push-base-images-develop
 
+# Disabled push trigger pending decision on workflow ownership: it pushes to
+# ghcr.io/anynines/ but lives on cloudfoundry/stratos and uses secrets
+# (GH_PACKAGES_USER / GH_PACKAGES_TOKEN) that have never been configured here,
+# so every develop push has failed since the workflow was added. Kept
+# workflow_dispatch so it can still be triggered manually if/when the
+# secrets are configured.
 on:
-  push:
-    branches:
-      - develop
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

The workflow `container-push-base-images-develop` has failed on every recorded run (28 of 28 failures, no successes). It pushes images to `ghcr.io/anynines/` (anynines's GHCR namespace) but lives on `cloudfoundry/stratos` and uses `GH_PACKAGES_USER` / `GH_PACKAGES_TOKEN` secrets that have never been configured here.

This change drops the `push:` trigger so develop pushes stop sending failed-build notifications. `workflow_dispatch:` is preserved so the workflow can be triggered manually if/when the secrets get configured.

## What this is *not*

- **Not** a fix for the underlying issue. The workflow still won't succeed if triggered manually until `GH_PACKAGES_USER` / `GH_PACKAGES_TOKEN` are populated.
- **Not** a removal. The workflow file stays so the capability isn't lost.

## Real long-term options (separate decision)

1. Move the workflow to the `anynines/stratos` fork where their secrets are accessible
2. Configure `GH_PACKAGES_USER` / `GH_PACKAGES_TOKEN` on `cloudfoundry/stratos` with anynines coordination
3. Delete the workflow if upstream doesn't want to publish to a vendor namespace

## Test plan

- [ ] After merge, no automatic run on next develop push
- [ ] Workflow remains visible under "Actions" tab (since `workflow_dispatch` keeps it registered)
- [ ] Manual trigger still possible via "Run workflow" button (will fail at GHCR login until secrets are set)