### PR TITLE
Security: Command injection risk in global teardown process-kill commands

### DIFF
--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const BACKEND_PORT = process.env.BACKEND_PORT || '5543';
 
@@ -13,11 +13,15 @@ const BACKEND_PORT = process.env.BACKEND_PORT || '5543';
  * A single pkill pattern matches both.
  */
 async function globalTeardown() {
+  if (!/^\d{2,5}$/.test(BACKEND_PORT)) {
+    return;
+  }
+
   const pattern = `e2e:${BACKEND_PORT}`;
   try {
-    const pids = execSync(`pgrep -f '${pattern}'`, { encoding: 'utf8' }).trim();
+    const pids = execFileSync('pgrep', ['-f', pattern], { encoding: 'utf8' }).trim();
     if (pids) {
-      execSync(`pkill -f '${pattern}'`);
+      execFileSync('pkill', ['-f', pattern]);
       console.log(`  Stopped e2e test servers (session ${BACKEND_PORT}).`);
     }
   } catch {


### PR DESCRIPTION
## Summary

Security: Command injection risk in global teardown process-kill commands

## Problem

**Severity**: `High` | **File**: `e2e/global-teardown.ts:L16`

The teardown script builds shell commands with `BACKEND_PORT` from environment variables and passes them to `execSync` (`pgrep -f 'e2e:${BACKEND_PORT}'` / `pkill -f 'e2e:${BACKEND_PORT}'`). If `BACKEND_PORT` is attacker-controlled (e.g., in CI or local env), shell metacharacters or quote-breaking payloads could inject arbitrary commands.

## Solution

Avoid shell interpolation. Use `spawn`/`execFile` with argument arrays and strict validation of `BACKEND_PORT` (e.g., `/^\d{2,5}$/`). Example: validate port, then call `pgrep`/`pkill` with args `['-f', `e2e:${port}`]` without invoking a shell.

## Changes

- `e2e/global-teardown.ts` (modified)