### PR TITLE
Opt JS actions into Node.js 24 ahead of GitHub flip

### DIFF
--- a/.github/workflows/container-push-base-images-develop.yaml
+++ b/.github/workflows/container-push-base-images-develop.yaml
@@ -6,6 +6,9 @@ on:
       - develop
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   push-store-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/stratos
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 permissions:
   contents: read

--- a/.github/workflows/documentation-versioning.yml
+++ b/.github/workflows/documentation-versioning.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   update-docs-internal-versions:
     if: github.repository == 'cloudfoundry/stratos'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build-docs:
     if: github.event_name != 'push' && github.repository == 'cloudfoundry/stratos'


### PR DESCRIPTION
## Summary

GitHub forces JavaScript-based actions onto Node.js 24 starting June 2nd 2026, with Node 20 removed entirely September 16th 2026. Until then Node-20 actions emit a deprecation warning on every workflow run.

Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level for the four workflows that use Node-20 JavaScript actions:

- `container-push-base-images-develop.yaml` (`docker/login-action@v2`)
- `docker.yml` (`docker/login-action@v3`, `setup-buildx-action`)
- `documentation.yml` (`actions/checkout@v1`, `actions/setup-node@v1`)
- `documentation-versioning.yml` (`actions/checkout@v1`, `actions/setup-node@v1`)

Opting in now surfaces any Node-24 compatibility issues with these actions while we still have control to revert per-workflow, rather than discovering them during the forced default flip.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The `Username and password required` failure on `container-push-base-images-develop.yaml` is a separate concern (missing `GH_PACKAGES_USER` / `GH_PACKAGES_TOKEN` repo secrets, plus the hardcoded `-o anynines` org argument) and is not addressed here.

## Test plan

- [ ] CI deprecation warning on Node 20 actions disappears on the next push to `develop`
- [ ] `docker.yml` runs on a workflow_dispatch with no Node-version warnings
- [ ] If any action breaks under Node 24 in practice, revert this branch's env-var on that specific workflow