### PR TITLE
Workstream A wrap-up: app-detail native handlers + apps OrgGUID

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/app-detail-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/app-detail-data.service.spec.ts
@@ -97,19 +97,42 @@ const MOCK_ENV = {
 };
 
 const MOCK_SPACE = {
-  metadata: { guid: 'sp-1', created_at: '', updated_at: '', url: '' },
-  entity: { name: 'my-space', organization_guid: 'org-1' },
+  guid: 'sp-1',
+  name: 'my-space',
+  orgGuid: 'org-1',
+  createdAt: '',
+  updatedAt: '',
+  cnsiGuid: CNSI,
+  appCount: 0,
+  routeCount: 0,
 };
 
 const MOCK_ORG = {
-  metadata: { guid: 'org-1', created_at: '', updated_at: '', url: '' },
-  entity: { name: 'my-org' },
+  guid: 'org-1',
+  name: 'my-org',
+  status: 'active',
+  quotaGuid: '',
+  labels: {},
+  annotations: {},
+  createdAt: '',
+  updatedAt: '',
+  cnsiGuid: CNSI,
 };
 
 const MOCK_DOMAINS_RESPONSE = {
   resources: [
-    { metadata: { guid: 'd-1', created_at: '', updated_at: '', url: '' }, entity: { name: 'example.com' } },
+    {
+      guid: 'd-1',
+      name: 'example.com',
+      internal: false,
+      supportedProtocols: ['http'],
+      sharedOrgGuids: [],
+      cnsiGuid: CNSI,
+      createdAt: '',
+      updatedAt: '',
+    },
   ],
+  pagination: { totalResults: 1 },
 };
 
 /**
@@ -277,8 +300,8 @@ describe('AppDetailDataService', () => {
   // Phase 1a (parallel): app + envVars (no separate /summary fetch — the
   // composed StAppDetail envelope carries every Summary-tab field).
   // Phase 1b: stats (conditional on app.state === STARTED).
-  // Phase 2:  space (V2 proxy — until org/space migration).
-  // Phase 3:  org → domains (sequential).
+  // Phase 2:  space (Jetstream native handler).
+  // Phase 3:  org → domains (sequential, Jetstream native handlers).
   // -------------------------------------------------------------------------
 
   it('refresh("all") phase 1: app + envVars in parallel, then stats, then space/org/domains', async () => {
@@ -295,15 +318,15 @@ describe('AppDetailDataService', () => {
 
     // Phase 2: space request needs app.spaceGuid
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/spaces/sp-1`).flush(MOCK_SPACE);
+    httpMock.expectOne(`/pp/v1/cf/spaces/cnsi-1/sp-1`).flush(MOCK_SPACE);
 
-    // Phase 3a: org needs space.organization_guid
+    // Phase 3a: org needs space.orgGuid
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/organizations/org-1`).flush(MOCK_ORG);
+    httpMock.expectOne(`/pp/v1/cf/org/cnsi-1/org-1`).flush(MOCK_ORG);
 
-    // Phase 3b: domains needs org.metadata.guid
+    // Phase 3b: domains needs org.guid
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/organizations/org-1/domains`).flush(MOCK_DOMAINS_RESPONSE);
+    httpMock.expectOne(`/pp/v1/cf/org/cnsi-1/org-1/private_domains`).flush(MOCK_DOMAINS_RESPONSE);
 
     await promise;
 
@@ -327,13 +350,13 @@ describe('AppDetailDataService', () => {
     httpMock.expectOne(STATS_URL).flush(MOCK_STATS_RESPONSE);
 
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/spaces/sp-1`).flush(MOCK_SPACE);
+    httpMock.expectOne(`/pp/v1/cf/spaces/cnsi-1/sp-1`).flush(MOCK_SPACE);
 
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/organizations/org-1`).flush(MOCK_ORG);
+    httpMock.expectOne(`/pp/v1/cf/org/cnsi-1/org-1`).flush(MOCK_ORG);
 
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/organizations/org-1/domains`).flush(MOCK_DOMAINS_RESPONSE);
+    httpMock.expectOne(`/pp/v1/cf/org/cnsi-1/org-1/private_domains`).flush(MOCK_DOMAINS_RESPONSE);
 
     await promise;
 
@@ -360,7 +383,7 @@ describe('AppDetailDataService', () => {
 
     expect(svc.space()).toBeUndefined();
     expect(svc.org()).toBeUndefined();
-    httpMock.expectNone(`/pp/v1/proxy/v2/spaces/sp-1`);
+    httpMock.expectNone(`/pp/v1/cf/spaces/cnsi-1/sp-1`);
   });
 
   it('sets lastPolledAt after a successful refresh("all")', async () => {
@@ -375,13 +398,13 @@ describe('AppDetailDataService', () => {
     httpMock.expectOne(STATS_URL).flush(MOCK_STATS_RESPONSE);
 
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/spaces/sp-1`).flush(MOCK_SPACE);
+    httpMock.expectOne(`/pp/v1/cf/spaces/cnsi-1/sp-1`).flush(MOCK_SPACE);
 
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/organizations/org-1`).flush(MOCK_ORG);
+    httpMock.expectOne(`/pp/v1/cf/org/cnsi-1/org-1`).flush(MOCK_ORG);
 
     await tick();
-    httpMock.expectOne(`/pp/v1/proxy/v2/organizations/org-1/domains`).flush(MOCK_DOMAINS_RESPONSE);
+    httpMock.expectOne(`/pp/v1/cf/org/cnsi-1/org-1/private_domains`).flush(MOCK_DOMAINS_RESPONSE);
 
     await promise;
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/app-detail-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/app-detail-data.service.ts
@@ -1,21 +1,25 @@
-import { Injectable, computed, effect, inject, signal, Signal, WritableSignal } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable, computed, effect, inject, signal, Signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
 import { AppDetailPrefs } from './app-detail-prefs.service';
 import { AppLifecycleStateService } from './app-lifecycle-state.service';
 import { ApplicationStateService, ApplicationStateData } from '../../shared/services/application-state.service';
-import { IApp, IAppSummary, IDomain, IOrganization, ISpace } from '../../cf-api.types';
+import { IApp, IAppSummary } from '../../cf-api.types';
 import { APIResource } from '@stratosui/store';
 import { EnvVarStratosProject } from './application/application-tabs-base/tabs/build-tab/application-env-vars.service';
 import {
   StAppDetail,
   StAppRoutesResponse,
   StAppStat,
+  StDomain,
+  StratosPagedResponse,
   StEnvVars,
+  StOrg,
   StRoute,
   StServiceCredentialBinding,
   StServiceCredentialBindingsResponse,
+  StSpace,
   StratosError,
 } from '../../services/endpoint-data/stratos-types';
 import { stToLegacy } from '../../services/v3-to-legacy-adapter';
@@ -36,8 +40,8 @@ interface StAppStatsResponse {
  * signals via the `stToLegacy` adapter so unmigrated cards/tabs keep
  * reading their familiar shape during the migration.
  *
- * Space / org / domains stay v2-shaped for now — those are addressed in
- * a later slice when the org/space detail pages migrate.
+ * Space / org / domains are sourced from Jetstream native handlers and
+ * exposed as Stratos-native shapes (`StSpace`, `StOrg`, `StDomain[]`).
  *
  * Provide at application-base.component so signals are torn down when the
  * user navigates away from the app detail page. DO NOT add `providedIn:'root'`.
@@ -59,11 +63,12 @@ export class AppDetailDataService {
   private readonly _envVars = signal<StEnvVars | undefined>(undefined);
   private readonly _stats = signal<StAppStat[]>([]);
 
-  // Space / org / domains stay V2-shaped — out of scope for slice 1 commit 4.
-  // These switch to V3 native handlers when the org/space detail pages migrate.
-  private readonly _space = signal<APIResource<ISpace> | undefined>(undefined);
-  private readonly _org = signal<APIResource<IOrganization> | undefined>(undefined);
-  private readonly _domains = signal<IDomain[]>([]);
+  // Space / org / domains — Stratos-native shapes from Jetstream native
+  // handlers. Backend translates v2/v3 under the hood; the frontend never
+  // touches `/pp/v1/proxy/v2/...` directly.
+  private readonly _space = signal<StSpace | undefined>(undefined);
+  private readonly _org = signal<StOrg | undefined>(undefined);
+  private readonly _domains = signal<StDomain[]>([]);
 
   // Per-app routes — V3-shaped via the native handler. Null until first load
   // so consumers can distinguish "haven't fetched yet" from "fetched, empty".
@@ -117,9 +122,9 @@ export class AppDetailDataService {
   /** Trimmed V3 stats — one row per running instance with `{ index, state }`. */
   readonly stats: Signal<StAppStat[]> = this._stats.asReadonly();
 
-  readonly space: Signal<APIResource<ISpace> | undefined> = this._space.asReadonly();
-  readonly org: Signal<APIResource<IOrganization> | undefined> = this._org.asReadonly();
-  readonly domains: Signal<IDomain[]> = this._domains.asReadonly();
+  readonly space: Signal<StSpace | undefined> = this._space.asReadonly();
+  readonly org: Signal<StOrg | undefined> = this._org.asReadonly();
+  readonly domains: Signal<StDomain[]> = this._domains.asReadonly();
   readonly loading: Signal<Record<EntityKind, boolean>> = this._loading.asReadonly();
   readonly errors: Signal<Record<EntityKind, StratosError | null>> = this._errors.asReadonly();
   readonly lastPolledAt: Signal<Date | null> = this._lastPolledAt.asReadonly();
@@ -302,7 +307,7 @@ export class AppDetailDataService {
    *   Phase 1b (conditional): stats — only when state is STARTED to avoid
    *     a noisy 400 from CF's CF-AppStoppedStatsError on stopped apps.
    *   Phase 2 (sequential): space (needs app.spaceGuid), then org (needs
-   *     space.organization_guid), then domains (needs org.guid).
+   *     space.orgGuid), then domains (needs org.guid).
    */
   async refresh(scope: EntityKind | 'all' = 'all'): Promise<void> {
     if (scope === 'all') {
@@ -340,9 +345,9 @@ export class AppDetailDataService {
   // ---------------------------------------------------------------------------
   // URL helpers
   //
-  // App detail / env / stats now hit Jetstream native handlers — the cnsi
-  // is in the path, no x-cap-passthrough header needed. Space / org /
-  // domains still hit the V2 proxy until those pages migrate (slice 2+).
+  // All entity fetches hit Jetstream native handlers — cnsi is in the
+  // path and responses come back as Stratos-native shapes. No
+  // `x-cap-passthrough` header needed; the frontend never talks v2 wire.
   // ---------------------------------------------------------------------------
 
   private nativeAppDetailUrl(): string {
@@ -362,29 +367,15 @@ export class AppDetailDataService {
   }
 
   private spaceUrl(spaceGuid: string): string {
-    return `/pp/v1/proxy/v2/spaces/${spaceGuid}`;
+    return `/pp/v1/cf/spaces/${this.cnsiGuid}/${spaceGuid}`;
   }
 
   private orgUrl(orgGuid: string): string {
-    return `/pp/v1/proxy/v2/organizations/${orgGuid}`;
+    return `/pp/v1/cf/org/${this.cnsiGuid}/${orgGuid}`;
   }
 
   private orgDomainsUrl(orgGuid: string): string {
-    return `/pp/v1/proxy/v2/organizations/${orgGuid}/domains`;
-  }
-
-  /**
-   * Headers required by the V2 proxy paths (space / org / domains). Native
-   * handlers don't need these — cnsi is in the path and the response is
-   * the raw shape, no envelope.
-   */
-  private v2ProxyHeaders(): { headers: HttpHeaders } {
-    return {
-      headers: new HttpHeaders({
-        'x-cap-cnsi-list': this.cnsiGuid,
-        'x-cap-passthrough': 'true',
-      }),
-    };
+    return `/pp/v1/cf/org/${this.cnsiGuid}/${orgGuid}/private_domains`;
   }
 
   // ---------------------------------------------------------------------------
@@ -478,7 +469,7 @@ export class AppDetailDataService {
     this._errors.update(m => ({ ...m, space: null }));
     try {
       const value = await firstValueFrom(
-        this.http.get<APIResource<ISpace>>(this.spaceUrl(spaceGuid), this.v2ProxyHeaders())
+        this.http.get<StSpace>(this.spaceUrl(spaceGuid))
       );
       this._space.set(value);
     } catch (err: unknown) {
@@ -489,7 +480,7 @@ export class AppDetailDataService {
   }
 
   private async fetchOrg(): Promise<void> {
-    const orgGuid = this._space()?.entity?.organization_guid;
+    const orgGuid = this._space()?.orgGuid;
     if (!orgGuid) {
       return;
     }
@@ -497,7 +488,7 @@ export class AppDetailDataService {
     this._errors.update(m => ({ ...m, org: null }));
     try {
       const value = await firstValueFrom(
-        this.http.get<APIResource<IOrganization>>(this.orgUrl(orgGuid), this.v2ProxyHeaders())
+        this.http.get<StOrg>(this.orgUrl(orgGuid))
       );
       this._org.set(value);
     } catch (err: unknown) {
@@ -613,7 +604,7 @@ export class AppDetailDataService {
   }
 
   private async fetchDomains(): Promise<void> {
-    const orgGuid = this._org()?.metadata?.guid;
+    const orgGuid = this._org()?.guid;
     if (!orgGuid) {
       return;
     }
@@ -621,7 +612,7 @@ export class AppDetailDataService {
     this._errors.update(m => ({ ...m, domains: null }));
     try {
       const result = await firstValueFrom(
-        this.http.get<{ resources: IDomain[] }>(this.orgDomainsUrl(orgGuid), this.v2ProxyHeaders())
+        this.http.get<StratosPagedResponse<StDomain>>(this.orgDomainsUrl(orgGuid))
       );
       this._domains.set(result?.resources ?? []);
     } catch (err: unknown) {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.ts
@@ -63,10 +63,10 @@ export class ApplicationDeleteComponent {
     this.seed?.appName || this.dataService.app()?.entity?.name || ''
   );
   public readonly orgName = computed(() =>
-    this.seed?.orgName || this.dataService.org()?.entity?.name || ''
+    this.seed?.orgName || this.dataService.org()?.name || ''
   );
   public readonly spaceName = computed(() =>
-    this.seed?.spaceName || this.dataService.space()?.entity?.name || ''
+    this.seed?.spaceName || this.dataService.space()?.name || ''
   );
   public readonly endpointName = computed(() =>
     this.seed?.endpointName || this.cfEndpointService.endpoint()?.entity?.name || ''

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application.service.spec.ts
@@ -326,8 +326,8 @@ describe('ApplicationService (facade shim)', () => {
     expect(count).toBe(0);   // filter blocks undefined (initial value)
 
     dataStub._org.set({
-      metadata: { guid: 'org-1', created_at: '', updated_at: '', url: '' },
-      entity: { name: 'my-org' },
+      guid: 'org-1',
+      name: 'my-org',
     });
     await tick();
     expect(count).toBe(1);
@@ -342,8 +342,8 @@ describe('ApplicationService (facade shim)', () => {
     expect(count).toBe(0);   // filter blocks undefined (initial value)
 
     dataStub._space.set({
-      metadata: { guid: 'sp-1', created_at: '', updated_at: '', url: '' },
-      entity: { name: 'my-space' },
+      guid: 'sp-1',
+      name: 'my-space',
     });
     await tick();
     expect(count).toBe(1);
@@ -360,13 +360,14 @@ describe('ApplicationService (facade shim)', () => {
     expect(v.length).toBe(0);
   });
 
-  it('orgDomains$ wraps IDomain entries into APIResource shape', async () => {
+  it('orgDomains$ passes through StDomain entries unchanged', async () => {
     dataStub._domains.set([
       { guid: 'd-1', name: 'example.com' } as any,
     ]);
     const v = await firstValueFrom(svc.orgDomains$.pipe(take(1)));
     expect(v.length).toBe(1);
-    expect(v[0].metadata?.guid).toBe('d-1');
+    expect(v[0].guid).toBe('d-1');
+    expect(v[0].name).toBe('example.com');
   });
 
   // -------------------------------------------------------------------------

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application.service.ts
@@ -27,7 +27,8 @@ import {
   spaceEntityType,
   stackEntityType
 } from '../../cf-entity-types';
-import { IApp, IAppSummary, IDomain, IOrganization, ISpace } from '../../cf-api.types';
+import { IApp, IAppSummary } from '../../cf-api.types';
+import { StDomain, StOrg, StSpace } from '../../services/endpoint-data/stratos-types';
 import { cfEntityCatalog } from '../../cf-entity-catalog';
 import { createEntityRelationKey } from '../../entity-relations/entity-relations.types';
 import { ApplicationStateData, ApplicationStateService } from '../../shared/services/application-state.service';
@@ -223,29 +224,27 @@ export class ApplicationService {
   applicationRunning$: Observable<boolean> = toObservable(this.detail.running);
 
   /**
-   * appOrg$ — APIResource<IOrganization> | undefined.
+   * appOrg$ — StOrg | undefined.
    * Used by build-tab, action-bar, tabs-base (breadcrumbs, env-vars permission).
    */
-  appOrg$: Observable<APIResource<IOrganization>> = toObservable(
-    computed(() => this.detail.org() as APIResource<IOrganization>)
+  appOrg$: Observable<StOrg | undefined> = toObservable(
+    computed(() => this.detail.org())
   ).pipe(filter(org => !!org));
 
   /**
-   * appSpace$ — APIResource<ISpace> | undefined.
+   * appSpace$ — StSpace | undefined.
    * Used by build-tab, action-bar, tabs-base (breadcrumbs, env-vars permission).
    */
-  appSpace$: Observable<APIResource<ISpace>> = toObservable(
-    computed(() => this.detail.space() as APIResource<ISpace>)
+  appSpace$: Observable<StSpace | undefined> = toObservable(
+    computed(() => this.detail.space())
   ).pipe(filter(space => !!space));
 
   /**
-   * orgDomains$ — APIResource<IDomain>[].
+   * orgDomains$ — StDomain[].
    * Used by add-routes to list available domains for the org.
-   * Note: data service returns IDomain[] (unwrapped). Wrap to match the
-   * legacy APIResource<IDomain>[] shape that consumers expect.
    */
-  orgDomains$: Observable<APIResource<IDomain>[]> = toObservable(
-    computed(() => (this.detail.domains() ?? []).map(d => wrapDomain(d)))
+  orgDomains$: Observable<StDomain[]> = toObservable(
+    computed(() => this.detail.domains() ?? [])
   );
 
   /**
@@ -377,21 +376,5 @@ function requestInfoOf(fetching: boolean, error: any): RequestInfoState {
     creating: false,
     updating: { [rootUpdatingKey]: { busy: false, error: false, message: '' } },
     deleting: { busy: false, error: false, message: '', deleted: false },
-  };
-}
-
-/**
- * Wrap a plain IDomain into the APIResource shape that legacy consumers expect.
- * The domain entity from /organizations/{id}/domains is already APIResource-shaped
- * on the wire but the data service stores IDomain[]. Check if already wrapped.
- */
-function wrapDomain(d: IDomain): APIResource<IDomain> {
-  // If it's already an APIResource (has metadata.guid), pass through.
-  if ((d as any)?.metadata?.guid) {
-    return d as any;
-  }
-  return {
-    metadata: { guid: (d as any).guid ?? '', created_at: '', updated_at: '', url: '' },
-    entity: d,
   };
 }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -26,7 +26,6 @@ import {
   EntitySchema,
   ActionState,
   endpointEntitiesSelector,
-  APIResource,
   EndpointModel,
   IFavoriteMetadata,
   UserFavoriteManager
@@ -36,13 +35,12 @@ import {
   applicationEntityType,
   UpdateExistingApplication,
   IApp,
-  IOrganization,
-  ISpace,
   CF_ENDPOINT_TYPE,
   ApplicationService,
   CfCurrentUserPermissions,
   ApplicationStateData
 } from '@stratosui/cloud-foundry';
+import { StOrg, StSpace } from '../../../../services/endpoint-data/stratos-types';
 import { AppApplicationActionBarComponent } from '../../../../shared/components/application-action-bar/application-action-bar.component';
 import { AppApplicationActionsService } from '../../../../shared/services/application-actions.service';
 import { AppLifecycleProgressService } from '../../../../shared/components/app-lifecycle-progress/app-lifecycle-progress.service';
@@ -112,7 +110,7 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
       // endpoint reducer hydrating after waitForAppEntity$ already replayed)
       // produces console TypeErrors on every navigation.
       filter(([app, endpoints, org, space]) =>
-        !!endpoints?.[app.entity.entity.cfGuid] && !!org?.entity && !!space?.entity
+        !!endpoints?.[app.entity.entity.cfGuid] && !!org && !!space
       ),
       map(([app, endpoints, org, space]) => {
         return this.getBreadcrumbs(
@@ -127,7 +125,7 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
 
     const appDoesNotHaveEnvVars$ = this.applicationService.appSpace$.pipe(
       switchMap(space => this.currentUserPermissionsService.can(CfCurrentUserPermissions.APPLICATION_VIEW_ENV_VARS,
-        this.applicationService.cfGuid, space.metadata.guid)
+        this.applicationService.cfGuid, space.guid)
       ),
       map(can => !can),
     );
@@ -199,15 +197,15 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
   private getBreadcrumbs(
     application: IApp,
     endpoint: EndpointModel,
-    org: APIResource<IOrganization>,
-    space: APIResource<ISpace>
+    org: StOrg,
+    space: StSpace
   ) {
     const baseCFUrl = `/cloud-foundry/${application.cfGuid}`;
-    const baseOrgUrl = `${baseCFUrl}/organizations/${org.metadata.guid}`;
+    const baseOrgUrl = `${baseCFUrl}/organizations/${org.guid}`;
 
     const baseSpaceBreadcrumbs = [
       { value: endpoint.name, routerLink: `${baseCFUrl}/organizations` },
-      { value: org.entity.name, routerLink: `${baseOrgUrl}/spaces` }
+      { value: org.name, routerLink: `${baseOrgUrl}/spaces` }
     ];
 
     return [
@@ -218,28 +216,28 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
         key: 'space',
         breadcrumbs: [
           ...baseSpaceBreadcrumbs,
-          { value: space.entity.name, routerLink: `${baseOrgUrl}/spaces/${space.metadata.guid}/apps` }
+          { value: space.name, routerLink: `${baseOrgUrl}/spaces/${space.guid}/apps` }
         ]
       },
       {
         key: 'space-services',
         breadcrumbs: [
           ...baseSpaceBreadcrumbs,
-          { value: space.entity.name, routerLink: `${baseOrgUrl}/spaces/${space.metadata.guid}/service-instances` }
+          { value: space.name, routerLink: `${baseOrgUrl}/spaces/${space.guid}/service-instances` }
         ]
       },
       {
         key: 'space-user-services',
         breadcrumbs: [
           ...baseSpaceBreadcrumbs,
-          { value: space.entity.name, routerLink: `${baseOrgUrl}/spaces/${space.metadata.guid}/user-service-instances` }
+          { value: space.name, routerLink: `${baseOrgUrl}/spaces/${space.guid}/user-service-instances` }
         ]
       },
       {
         key: 'space-routes',
         breadcrumbs: [
           ...baseSpaceBreadcrumbs,
-          { value: space.entity.name, routerLink: `${baseOrgUrl}/spaces/${space.metadata.guid}/routes` }
+          { value: space.name, routerLink: `${baseOrgUrl}/spaces/${space.guid}/routes` }
         ]
       },
       {
@@ -258,14 +256,14 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
         key: 'space-summary',
         breadcrumbs: [
           ...baseSpaceBreadcrumbs,
-          { value: space.entity.name, routerLink: `${baseOrgUrl}/spaces/${space.metadata.guid}/summary` }
+          { value: space.name, routerLink: `${baseOrgUrl}/spaces/${space.guid}/summary` }
         ]
       },
       {
         key: 'org',
         breadcrumbs: [
           { value: endpoint.name, routerLink: `${baseCFUrl}/organizations` },
-          { value: org.entity.name, routerLink: `${baseOrgUrl}/summary` },
+          { value: org.name, routerLink: `${baseOrgUrl}/summary` },
         ]
       },
       {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -79,7 +79,7 @@
                    org/space signals haven't emitted yet. -->
               <app-metadata-item iconFont="stratos-icons" icon="organization" label="Organization">
                 @if (data.org(); as appOrg) {
-                  <a [routerLink]="['/cloud-foundry/' + applicationService.cfGuid + '/organizations/' + appOrg.metadata.guid]">{{ appOrg.entity.name }}</a>
+                  <a [routerLink]="['/cloud-foundry/' + applicationService.cfGuid + '/organizations/' + appOrg.guid]">{{ appOrg.name }}</a>
                 } @else {
                   —
                 }
@@ -87,12 +87,12 @@
               <app-metadata-item iconFont="stratos-icons" icon="virtual_space" label="Space">
                 @if (data.org(); as appOrg) {
                   @if (data.space(); as appSpace) {
-                    <a [routerLink]="['/cloud-foundry/' + applicationService.cfGuid + '/organizations/' + appOrg.metadata?.guid + '/spaces/' + appSpace.metadata?.guid]">{{ appSpace.entity.name }}</a>
+                    <a [routerLink]="['/cloud-foundry/' + applicationService.cfGuid + '/organizations/' + appOrg.guid + '/spaces/' + appSpace.guid]">{{ appSpace.name }}</a>
                   } @else {
                     —
                   }
                 } @else if (data.space(); as appSpace) {
-                  {{ appSpace.entity.name }}
+                  {{ appSpace.name }}
                 } @else {
                   —
                 }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.ts
@@ -94,7 +94,7 @@ export class BuildTabComponent implements OnInit {
     this.sshStatus$ = this.applicationService.application$.pipe(
       combineLatest(this.applicationService.appSpace$),
       map(([app, space]) => {
-        if (!space.entity.allow_ssh) {
+        if (!space.allowSsh) {
           return 'Disabled by the space';
         } else {
           return app.app.entity.enable_ssh ? 'Yes' : 'No';
@@ -106,7 +106,7 @@ export class BuildTabComponent implements OnInit {
       switchMap(space => this.cups.can(
         CfCurrentUserPermissions.APPLICATION_VIEW_ENV_VARS,
         this.applicationService.cfGuid,
-        space.metadata.guid)
+        space.guid)
       )
     );
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/cli-info-application/cli-info-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/cli-info-application/cli-info-application.component.ts
@@ -61,8 +61,8 @@ export class CliInfoApplicationComponent implements OnInit {
       filter(([app, space, org, ep]) => !!app && !!space && !!org && !!ep),
       map(([app, space, org, ep]) => ({
         appName: app.app.entity.name,
-        spaceName: space.entity.name,
-        orgName: org.entity.name,
+        spaceName: space.name,
+        orgName: org.name,
         apiEndpoint: getFullEndpointApiUrl(ep.entity),
         username: ep.entity.user ? ep.entity.user.name : ''
       })),

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
@@ -222,6 +222,10 @@ export interface StSpace {
   // when the backend enrichment fetch fails.
   appCount: number;
   routeCount: number;
+  // V3 space-feature `ssh` flag — populated only by detail handlers
+  // (getNativeSpaceDetail). List handlers leave it `false` to avoid
+  // an N+1 /v3/spaces/{guid}/features/ssh fetch per space.
+  allowSsh: boolean;
 }
 
 export interface StOrgDetail extends StOrg {
@@ -706,6 +710,20 @@ export interface StDomain {
 export interface StDomainsResponse {
   resources: StDomain[];
   totalResults: number;
+}
+
+// Mirrors the Go StratosPagedResponse[T] envelope returned by multi-resource
+// native handlers — paged metadata under `pagination`, not flat `totalResults`.
+// Single-resource detail handlers do NOT use this; they return their resource
+// shape directly.
+export interface StratosPagedResponse<T> {
+  resources: T[];
+  pagination: {
+    totalResults: number;
+    totalPages?: number;
+    page?: number;
+    perPage?: number;
+  };
 }
 
 // StOrgQuota is the Stratos-shaped DTO for a CF organization quota.

--- a/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.html
@@ -4,7 +4,7 @@
       @if (applicationService.appSpace$ | async; as space) {
         <div class="summary__actions">
           <ng-container
-            *appCfUserPermission="manageAppPermission;spaceGuid:space.metadata.guid;endpointGuid:applicationService.cfGuid">
+            *appCfUserPermission="manageAppPermission;spaceGuid:space.guid;endpointGuid:applicationService.cfGuid">
             <app-page-sub-nav-section>
               @if (applicationService.applicationState$ | async) {
                 <button class="btn btn-secondary btn-icon" name="edit"

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.spec.ts
@@ -50,8 +50,8 @@ function makeAppServiceStub() {
   return {
     cfGuid: 'cf-1',
     appGuid: 'app-1',
-    appOrg$: of({ metadata: { guid: 'org-1' } }),
-    appSpace$: of({ metadata: { guid: 'space-1' } }),
+    appOrg$: of({ guid: 'org-1' }),
+    appSpace$: of({ guid: 'space-1' }),
   };
 }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
@@ -113,8 +113,8 @@ export class CardAppInstancesComponent implements OnDestroy {
         this.cups.can(
           CfCurrentUserPermissions.APPLICATION_EDIT,
           this.appService.cfGuid,
-          org.metadata.guid,
-          space.metadata.guid,
+          org!.guid,
+          space!.guid,
         ),
       ),
     ),

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app-instance/cf-app-instances-config.service.ts
@@ -197,8 +197,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
               app.entity.entity &&
               app.entity.entity.enable_ssh &&
               space &&
-              space.entity &&
-              space.entity.allow_ssh
+              space.allowSsh
             );
           })
         );
@@ -247,7 +246,7 @@ export class CfAppInstancesConfigService implements IListConfig<ListAppInstance>
       appService.appSpace$
     ).pipe(
       switchMap(([org, space]) =>
-        cups.can(CfCurrentUserPermissions.APPLICATION_EDIT, appService.cfGuid, org.metadata.guid, space.metadata.guid)
+        cups.can(CfCurrentUserPermissions.APPLICATION_EDIT, appService.cfGuid, org!.guid, space!.guid)
       )
     );
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/github-commits/github-commits-list-config-app-tab.service.ts
@@ -107,7 +107,7 @@ export class GithubCommitsListConfigServiceAppTab extends GithubCommitsListConfi
     ).subscribe(([app, space]) => {
       this.cfGuid = app.entity.entity.cfGuid;
       this.spaceGuid = app.entity.entity.space_guid;
-      this.orgGuid = space.entity.organization_guid;
+      this.orgGuid = space.orgGuid;
       this.appGuid = app.entity.metadata.guid;
     });
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.spec.ts
@@ -26,8 +26,8 @@ function makeAppServiceStub(cfGuid = 'cf-1', appGuid = 'app-1') {
     cfGuid,
     appGuid,
     application$: new BehaviorSubject({ app: { entity: { name: 'test-app' } } }),
-    appOrg$: new BehaviorSubject({ entity: { name: 'test-org' } }),
-    appSpace$: new BehaviorSubject({ entity: { name: 'test-space' } }),
+    appOrg$: new BehaviorSubject({ guid: 'test-org-guid', name: 'test-org' }),
+    appSpace$: new BehaviorSubject({ guid: 'test-space-guid', name: 'test-space' }),
   };
 }
 
@@ -50,8 +50,8 @@ function makeDataServiceStub(opts: { instances?: number, runningStats?: number }
   }));
   return {
     app: signal({ entity: { name: 'test-app', instances } }),
-    org: signal({ entity: { name: 'test-org' } }),
-    space: signal({ entity: { name: 'test-space' } }),
+    org: signal({ guid: 'test-org-guid', name: 'test-org' }),
+    space: signal({ guid: 'test-space-guid', name: 'test-space' }),
     stats: signal(stats),
     summary: signal({ memory: 256, disk_quota: 512 }),
     lastPolledAt: signal(new Date()),

--- a/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.ts
@@ -376,8 +376,8 @@ export class AppApplicationActionsService {
     } else {
       appName = this.dataService.app()?.entity?.name ?? this.applicationService.appGuid;
       cfName = this.cfEndpointService.endpoint()?.entity?.name ?? this.applicationService.cfGuid;
-      orgName = this.dataService.org()?.entity?.name ?? '?';
-      spaceName = this.dataService.space()?.entity?.name ?? '?';
+      orgName = this.dataService.org()?.name ?? '?';
+      spaceName = this.dataService.space()?.name ?? '?';
     }
     const message =
       `${verb} "${appName}" on Cloud Foundry "${cfName}" — org "${orgName}" / space "${spaceName}"?`;
@@ -449,8 +449,8 @@ export class AppApplicationActionsService {
     this.deleteSelection.seed(appGuid, {
       appName: this.dataService.app()?.entity?.name ?? appGuid,
       endpointName: this.cfEndpointService.endpoint()?.entity?.name ?? cfGuid,
-      orgName: this.dataService.org()?.entity?.name ?? '',
-      spaceName: this.dataService.space()?.entity?.name ?? '',
+      orgName: this.dataService.org()?.name ?? '',
+      spaceName: this.dataService.space()?.name ?? '',
     });
     this.router.navigate(['/applications', cfGuid, appGuid, 'delete']);
   }

--- a/src/frontend/packages/cloud-foundry/test-framework/application-service-helper.ts
+++ b/src/frontend/packages/cloud-foundry/test-framework/application-service-helper.ts
@@ -5,7 +5,8 @@ import { signal, computed } from '@angular/core';
 import { APP_GUID, CF_GUID } from '@stratosui/core';
 import { EntityService, RequestInfoState, APIResource, EntityInfo } from '@stratosui/store';
 import { ApplicationService } from '@stratosui/cloud-foundry';
-import { IApp, IAppSummary, IDomain, IOrganization, ISpace } from '../src/cf-api.types';
+import { IApp, IAppSummary } from '../src/cf-api.types';
+import { StDomain, StOrg, StSpace } from '../src/services/endpoint-data/stratos-types';
 import { ApplicationData } from '../src/features/applications/application.service';
 import { EnvVarStratosProject } from '../src/features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service';
 import { ApplicationStateData } from '../src/shared/services/application-state.service';
@@ -54,15 +55,29 @@ export class ApplicationServiceMock {
     fetching: false
   } as ApplicationData);
 
-  private appOrgSubject = new BehaviorSubject<APIResource<IOrganization>>(createEntity<IOrganization>({
+  private appOrgSubject = new BehaviorSubject<StOrg | undefined>({
+    guid: 'mockOrgGuid',
     name: 'mockOrg',
-    guid: 'mockOrgGuid'
-  } as IOrganization));
+    status: 'active',
+    quotaGuid: '',
+    labels: {},
+    annotations: {},
+    createdAt: '',
+    updatedAt: '',
+    cnsiGuid: this.cfGuid,
+  });
 
-  private appSpaceSubject = new BehaviorSubject<APIResource<ISpace>>(createEntity<ISpace>({
+  private appSpaceSubject = new BehaviorSubject<StSpace | undefined>({
+    guid: 'mockSpaceGuid',
     name: 'mockSpace',
-    guid: 'mockSpaceGuid'
-  } as ISpace));
+    orgGuid: 'mockOrgGuid',
+    createdAt: '',
+    updatedAt: '',
+    cnsiGuid: this.cfGuid,
+    appCount: 0,
+    routeCount: 0,
+    allowSsh: false,
+  });
 
   application$: Observable<ApplicationData> = this.appSubject.asObservable();
   app$: Observable<EntityInfo<APIResource<IApp>>> = this.application$.pipe(
@@ -93,10 +108,10 @@ export class ApplicationServiceMock {
     indicator: null,
     actions: {}
   });
-  appOrg$: Observable<APIResource<IOrganization>> = this.appOrgSubject.asObservable();
-  appSpace$: Observable<APIResource<ISpace>> = this.appSpaceSubject.asObservable();
+  appOrg$: Observable<StOrg | undefined> = this.appOrgSubject.asObservable();
+  appSpace$: Observable<StSpace | undefined> = this.appSpaceSubject.asObservable();
   applicationRunning$: Observable<boolean> = observableOf(false);
-  orgDomains$: Observable<APIResource<IDomain>[]> = observableOf([]);
+  orgDomains$: Observable<StDomain[]> = observableOf([]);
   entityService: EntityService<APIResource<IApp<unknown>>> = {
     waitForEntity$: of({}),
     updatingSection$: of({}),

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -459,6 +459,9 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 		}
 		if space, ok := spaces[s.SpaceGUID]; ok {
 			s.SpaceName = space.Name
+			if orgGuid := relationshipGUID(space.Relationships.Organization); orgGuid != "" {
+				s.OrgGUID = &orgGuid
+			}
 		}
 		if rts, ok := routesByApp[r.GUID]; ok {
 			s.Routes = rts
@@ -755,6 +758,47 @@ func (c *CloudFoundrySpecification) getNativeOrgDetail(ctx echo.Context) error {
 	detail := StOrgDetail{
 		StOrg:  toStOrg(*r),
 		Spaces: []StSpace{},
+	}
+
+	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return ctx.JSON(http.StatusOK, detail)
+}
+
+// getNativeSpaceDetail handles GET /pp/v1/cf/spaces/{cnsiGuid}/{spaceGuid}.
+//
+// Single CAPI Get + an opportunistic /v3/spaces/{guid}/features/ssh fetch
+// to surface the V3 space-feature `ssh` flag (which V3 moved off the
+// space resource). The feature fetch is best-effort: on failure we log
+// and return AllowSSH=false rather than failing the whole detail call —
+// the SSH/env-var UI just falls back to its disabled state.
+func (c *CloudFoundrySpecification) getNativeSpaceDetail(ctx echo.Context) error {
+	cnsiGUID := ctx.Param("cnsiGuid")
+	spaceGUID := ctx.Param("spaceGuid")
+	userGUID, err := c.getUserGUID(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	cfClient, err := newCapiClient(ctx.Request().Context(), c.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	r, err := cfClient.Spaces().Get(ctx.Request().Context(), spaceGUID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+	}
+
+	detail := StSpaceDetail{
+		StSpace: toStSpace(*r),
+	}
+
+	// Best-effort SSH-feature lookup. V3 split this off the space resource
+	// to /v3/spaces/{guid}/features/ssh; failure here is non-fatal.
+	if feature, ferr := cfClient.Spaces().GetFeature(ctx.Request().Context(), spaceGUID, "ssh"); ferr != nil {
+		log.Warnf("getNativeSpaceDetail: ssh feature lookup failed for space %s: %v", spaceGUID, ferr)
+	} else if feature != nil {
+		detail.AllowSSH = feature.Enabled
 	}
 
 	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)

--- a/src/jetstream/plugins/cloudfoundry/native_handlers_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers_test.go
@@ -519,6 +519,109 @@ func TestGetNativeOrgDetail(t *testing.T) {
 	assert.Equal(t, []StSpace{}, resp.Spaces)
 }
 
+func TestGetNativeSpaceDetail(t *testing.T) {
+	t.Run("populates allowSsh from features endpoint", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/v3":
+				w.Write([]byte(`{"links":{}}`))
+			case "/v3/spaces/sp-1":
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"guid":       "sp-1",
+					"name":       "dev",
+					"created_at": "2024-01-01T00:00:00Z",
+					"updated_at": "2024-01-02T00:00:00Z",
+					"relationships": map[string]interface{}{
+						"organization": map[string]interface{}{"data": map[string]interface{}{"guid": "org-1"}},
+					},
+				})
+			case "/v3/spaces/sp-1/features/ssh":
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"name": "ssh", "enabled": true,
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer ts.Close()
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/spaces/cnsi-1/sp-1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("cnsiGuid", "spaceGuid")
+		ctx.SetParamValues("cnsi-1", "sp-1")
+
+		plugin := &CloudFoundrySpecification{
+			testProxy: &mockNativeCFProxy{
+				userID:      "user-1",
+				cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(ts.URL)},
+				tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+			},
+		}
+
+		require.NoError(t, plugin.getNativeSpaceDetail(ctx))
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp StSpaceDetail
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, "sp-1", resp.GUID)
+		assert.Equal(t, "dev", resp.Name)
+		assert.Equal(t, "org-1", resp.OrgGUID)
+		assert.True(t, resp.AllowSSH)
+	})
+
+	t.Run("ssh feature failure leaves allowSsh false but succeeds", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/v3":
+				w.Write([]byte(`{"links":{}}`))
+			case "/v3/spaces/sp-2":
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"guid":       "sp-2",
+					"name":       "prod",
+					"created_at": "2024-01-01T00:00:00Z",
+					"updated_at": "2024-01-02T00:00:00Z",
+					"relationships": map[string]interface{}{
+						"organization": map[string]interface{}{"data": map[string]interface{}{"guid": "org-1"}},
+					},
+				})
+			case "/v3/spaces/sp-2/features/ssh":
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"errors":[{"detail":"boom"}]}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer ts.Close()
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/spaces/cnsi-1/sp-2", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("cnsiGuid", "spaceGuid")
+		ctx.SetParamValues("cnsi-1", "sp-2")
+
+		plugin := &CloudFoundrySpecification{
+			testProxy: &mockNativeCFProxy{
+				userID:      "user-1",
+				cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(ts.URL)},
+				tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+			},
+		}
+
+		require.NoError(t, plugin.getNativeSpaceDetail(ctx))
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp StSpaceDetail
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.Equal(t, "sp-2", resp.GUID)
+		assert.False(t, resp.AllowSSH)
+	})
+}
+
 func TestGetNativeOrgSpaces(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/src/jetstream/plugins/cloudfoundry/native_routes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_routes.go
@@ -19,6 +19,7 @@ func (c *CloudFoundrySpecification) addNativeRoutes(echoGroup *echo.Group) {
 	echoGroup.GET("/cf/app-stats/:cnsiGuid/:appGuid", c.getAppStats)
 	echoGroup.DELETE("/cf/orgs/:cnsiGuid/:orgGuid", c.deleteNativeOrg)
 	echoGroup.DELETE("/cf/spaces/:cnsiGuid/:spaceGuid", c.deleteNativeSpace)
+	echoGroup.GET("/cf/spaces/:cnsiGuid/:spaceGuid", c.getNativeSpaceDetail)
 	echoGroup.PUT("/cf/apps/:cnsiGuid/:appGuid/routes/:routeGuid", c.assignRouteToApp)
 	echoGroup.GET("/cf/spaces/:cnsiGuid", c.getNativeSpaces)
 	echoGroup.GET("/cf/routes/:cnsiGuid", c.getNativeRouteCount)

--- a/src/jetstream/plugins/cloudfoundry/native_types.go
+++ b/src/jetstream/plugins/cloudfoundry/native_types.go
@@ -67,11 +67,23 @@ type StSpace struct {
 	// pattern's lazy-non-fatal default branch).
 	AppCount   int `json:"appCount"`
 	RouteCount int `json:"routeCount"`
+	// AllowSSH mirrors the V3 space-feature `ssh` (V3 moved this off the
+	// space resource onto /v3/spaces/{guid}/features/ssh). Populated only
+	// by detail handlers (getNativeSpaceDetail); list handlers leave it at
+	// the default `false` to avoid an N+1 feature fetch per space.
+	AllowSSH bool `json:"allowSsh"`
 }
 
 type StOrgDetail struct {
 	StOrg
 	Spaces []StSpace `json:"spaces"`
+}
+
+// StSpaceDetail is the per-space detail wrapper. Kept as a thin embed
+// of StSpace today (mirrors StOrgDetail) so we can extend the detail
+// payload without breaking the list shape.
+type StSpaceDetail struct {
+	StSpace
 }
 
 type StOrgsResponse struct {


### PR DESCRIPTION
## Summary
- Replaces the last three v2 proxy URL fetches in `AppDetailDataService` (space, org, org-domains) with Stratos native handlers; adds `getNativeSpaceDetail` to serve a single space with `allowSsh` resolved via the V3 SSH feature endpoint.
- Flips `_space`/`_org`/`_domains` signal types to flat `StSpace`/`StOrg`/`StDomain`; `ApplicationService` façade types follow; nine consumers + test helpers + `wrapDomain` shim retired.
- A6 deep-relations fix: `getNativeApps` now extracts the space→org relation into `StApp.OrgGUID` (silent regression where app-wall org column rendered "—").
- Adds `StratosPagedResponse<T>` TS interface mirroring the Go envelope returned by multi-resource native handlers.

This closes the wire-swap intent of Workstream A. The Stratos↔backend interface no longer hits `/pp/v1/proxy/v2/...` from the frontend; backend native handlers own the V2/V3 translation.

## Test plan
- [x] `cd src/jetstream && go build ./...` clean
- [x] `bunx tsc --noEmit -p packages/cloud-foundry/tsconfig.lib.json` clean
- [x] Targeted vitest: `application-actions.service.spec.ts` 22/22 pass after dataService stub flat-shape fix
- [x] Backend unit test added for `getNativeSpaceDetail` (happy path + SSH-feature-fail path)
- [x] Live verify post-deploy CF: app detail Summary tab renders correct org/space names + deep links; new `getNativeSpaceDetail` returns 200 in ~900ms
- [x] Live verify of A6 fix: `/pp/v1/cf/apps/<cnsi>?per_page=3` returns `orgGuid` populated on every app
- [ ] Full `make check gate` — to be batched at the end of any subsequent A/B follow-ups; not run for this PR alone since A workstream is now closed

## Notes
- Workstream A is functionally complete — see `project_v3_workstream_plan.md` in the KS for the full status table.
- A8 (V3 restage) and A7 (cli/v8 8.18.3) were already on develop; the workstream doc had them mis-marked as outstanding.
