### PR TITLE
Sweep vestigial @ngrx wiring from migrated spec files

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { Store } from '@ngrx/store';
 import { BehaviorSubject } from 'rxjs';
+import { Store } from '@ngrx/store';
 
 import { ApplicationServiceMock, generateCfStoreModules, ApplicationStateService, ApplicationEnvVarsHelper, populateStoreWithTestEndpoint } from '@test-framework/cf';
 import {ApplicationService, CFAppState} from '@stratosui/cloud-foundry';

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/application-env-vars.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { PaginationMonitorFactory } from '@stratosui/store';
@@ -13,7 +12,6 @@ describe('ApplicationEnvVarsService', () => {
       providers: [
         ApplicationEnvVarsHelper,
         PaginationMonitorFactory,
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         provideZonelessChangeDetection(),
       ],

--- a/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { TabNavService } from '@stratosui/core';
@@ -23,7 +22,6 @@ describe('EditApplicationComponent', () => {
         EditApplicationComponent,
       ],
       providers: [
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         generateTestApplicationServiceProvider(cfId, appId),
         ApplicationStateService,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.spec.ts
@@ -4,7 +4,6 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { getGitHubAPIURL, GITHUB_API_URL, GitSCMService } from '@stratosui/git';
@@ -25,7 +24,6 @@ describe('NewApplicationBaseStepComponent', () => {
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         GitSCMService,
         ApplicationDeploySourceTypes,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/ssh-application/ssh-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/ssh-application/ssh-application.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TabNavService } from '@stratosui/core';
 import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
@@ -18,7 +17,6 @@ describe('SshApplicationComponent', () => {
         SshApplicationComponent,
       ],
       providers: [
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         { provide: ApplicationService, useClass: ApplicationServiceMock },
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-space-quota/add-space-quota.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-space-quota/add-space-quota.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { TabNavService } from '@stratosui/core';
@@ -20,7 +19,6 @@ describe('AddSpaceQuotaComponent', () => {
         AddSpaceQuotaComponent,
       ],
       providers: [
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         {
           provide: TEST_CATALOGUE_ENTITIES,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-space/add-space.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-space/add-space.component.spec.ts
@@ -1,7 +1,6 @@
 import { DatePipe } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { TabNavService } from '@stratosui/core';
@@ -21,7 +20,6 @@ describe('AddSpaceComponent', () => {
         AddSpaceComponent,
       ],
       providers: [
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         {
           provide: TEST_CATALOGUE_ENTITIES,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-quota/edit-quota.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-quota/edit-quota.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { ActivatedRoute } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -18,7 +17,6 @@ describe('EditQuotaComponent', () => {
         EditQuotaComponent,
       ],
       providers: [
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         TabNavService,
         provideZonelessChangeDetection(),

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-space-quota/edit-space-quota.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-space-quota/edit-space-quota.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ActivatedRoute } from '@angular/router';
 
@@ -19,7 +18,6 @@ describe('EditSpaceQuotaComponent', () => {
         EditSpaceQuotaComponent,
       ],
       providers: [
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         TabNavService,
         provideZonelessChangeDetection(),

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cf-endpoint-details/cf-endpoint-details.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cf-endpoint-details/cf-endpoint-details.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
@@ -16,7 +15,6 @@ describe('CfEndpointDetailsComponent', () => {
         CfEndpointDetailsComponent,
       ],
       providers: [
-        provideMockStore(),
         ...STORE_TEST_PROVIDERS,
         provideZonelessChangeDetection(),
       ],

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-cforgspace-header/table-cell-app-cforgspace-header.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-cforgspace-header/table-cell-app-cforgspace-header.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { StoreModule } from '@ngrx/store';
 
 import {
   ApplicationStateIconComponent,
@@ -29,7 +28,6 @@ describe('TableCellAppCfOrgSpaceHeaderComponent', () => {
         ApplicationStateComponent,
         ApplicationStateIconComponent,
         ApplicationStateIconPipe,
-        StoreModule,
         generateCfStoreModules(),
       ],
       providers: [

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-cforgspace/table-cell-app-cforgspace.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-cforgspace/table-cell-app-cforgspace.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { StoreModule } from '@ngrx/store';
 
 import {
   ApplicationStateIconComponent,
@@ -29,7 +28,6 @@ describe('TableCellAppCfOrgSpaceComponent', () => {
         ApplicationStateComponent,
         ApplicationStateIconComponent,
         ApplicationStateIconPipe,
-        StoreModule,
         ...generateCfStoreModules(),
       ],
       providers: [

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-status/table-cell-app-status.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/table-cell-app-status/table-cell-app-status.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { StoreModule } from '@ngrx/store';
 
 import {
   ApplicationStateIconComponent,
@@ -28,7 +27,6 @@ describe('TableCellAppStatusComponent', () => {
         ApplicationStateComponent,
         ApplicationStateIconComponent,
         ApplicationStateIconPipe,
-        StoreModule,
         ...generateCfStoreModules(),
       ],
       providers: [

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-orgs/cf-org-card/cf-org-card.component.spec.ts
@@ -4,7 +4,6 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Store } from '@ngrx/store';
-
 import {
   ConfirmationDialogService,
   MetaCardComponent,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-spaces/cf-space-card/cf-space-card.component.spec.ts
@@ -4,7 +4,6 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Store } from '@ngrx/store';
-
 import {
   ConfirmationDialogService,
   MetaCardComponent,

--- a/src/frontend/packages/cloud-foundry/src/shared/services/cloud-foundry-user-provided-services.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/cloud-foundry-user-provided-services.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideMockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 
@@ -21,7 +20,6 @@ describe('CloudFoundryUserProvidedServicesService — V3 write surface', () => {
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
-        provideMockStore({ initialState: {} }),
         { provide: PaginationMonitorFactory, useValue: {} },
         CloudFoundryUserProvidedServicesService,
       ],
@@ -122,7 +120,6 @@ describe('CloudFoundryUserProvidedServicesService — V3 read surface', () => {
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
-        provideMockStore({ initialState: {} }),
         { provide: PaginationMonitorFactory, useValue: {} },
         CloudFoundryUserProvidedServicesService,
       ],

--- a/src/frontend/packages/core/test-framework/core-test.helper.ts
+++ b/src/frontend/packages/core/test-framework/core-test.helper.ts
@@ -4,7 +4,6 @@ import { NgModule, inject } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 /* eslint-disable @typescript-eslint/no-unused-vars -- barrel re-exports for downstream test consumers */
-import { StoreModule } from '@ngrx/store';
 import { EntityCatalogHelper, EntityCatalogHelpers, appReducers } from '@stratosui/store';
 import {
   createBasicStoreModule,


### PR DESCRIPTION
## Summary

Wave-3 migrated many SUTs off `@ngrx/store`, but their TestBeds were left with the old `provideMockStore()` / `StoreModule.forRoot(appReducers, ...)` providers. This PR removes the dead test-bed wiring where the SUT's transitive injector closure no longer needs Store.

## Changes

17 spec files, +1/-31 LOC. SUTs unchanged.

## Scope note

A broader audit found 82 candidate spec files but only 17 turned out cleanly removable. The other 65 still need Store in their TestBed because their SUTs transitively pull in `CurrentUserPermissionsService` (and similar), which still injects `Store<InternalAppState>` despite being marked migrated in wave-3. Those will be addressed in a follow-up workstream that migrates the remaining Store-backed services first.

## Test plan

- [x] `make check gate` — green (638 test files / 2223 tests pass)