### PR TITLE
Fix 5 outstanding UI bugs + safe lint sweep

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -88,7 +88,7 @@
                 "input": "src/frontend/packages/core/assets",
                 "output": "/core/assets"
               },
-              "src/frontend/packages/core/favicon.ico",
+              "src/frontend/packages/core/src/favicon.ico",
               {
                 "glob": "**/*",
                 "input": "custom-src/frontend/assets/custom",

--- a/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-available.ts
+++ b/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-available.ts
@@ -73,7 +73,6 @@ function asEntityInfoObservable(
 
 export const fetchAutoscalerInfo = (
   endpointGuid: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _esf?: EntityServiceFactory,
 ): Observable<EntityInfo<APIResource<AutoscalerInfo>>> => {
   const svc = getDataService();
@@ -88,7 +87,6 @@ export const fetchAutoscalerInfo = (
  */
 export const isAutoscalerEnabled = (
   endpointGuid: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _esf?: EntityServiceFactory,
 ): Observable<boolean> => {
   const svc = getDataService();

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-credential/edit-autoscaler-credential.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-credential/edit-autoscaler-credential.component.html
@@ -24,12 +24,12 @@
           <!-- eslint-disable-next-line @angular-eslint/template/label-has-associated-control -- section heading, not a form control label -->
           <label class="label">Type</label>
           <div class="space-y-2">
-            <label class="radio-label">
-              <input type="radio" name="actype" formControlName="actype" [value]="true" (change)="toggleChange()" class="radio">
+            <label class="radio-label" for="actype-random">
+              <input id="actype-random" type="radio" name="actype" formControlName="actype" [value]="true" (change)="toggleChange()" class="radio">
               <span class="radio-text">Random</span>
             </label>
-            <label class="radio-label">
-              <input type="radio" name="actype" formControlName="actype" [value]="false" (change)="toggleChange()" class="radio">
+            <label class="radio-label" for="actype-custom">
+              <input id="actype-custom" type="radio" name="actype" formControlName="actype" [value]="false" (change)="toggleChange()" class="radio">
               <span class="radio-text">Custom</span>
             </label>
           </div>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.html
@@ -45,12 +45,12 @@
                         <div class="space-y-4">
                           <app-metadata-item label="Effective Duration">
                             <div class="space-y-3" name="effective_type" formControlName="effective_type">
-                              <label class="radio-label">
-                                <input type="radio" value="always" (click)="resetEffectiveType('always')" class="radio">
+                              <label class="radio-label" for="effective-always">
+                                <input id="effective-always" type="radio" value="always" (click)="resetEffectiveType('always')" class="radio">
                                 <span class="radio-text">Always</span>
                               </label>
-                              <label class="radio-label">
-                                <input type="radio" value="custom" (click)="resetEffectiveType('custom')" class="radio">
+                              <label class="radio-label" for="effective-custom">
+                                <input id="effective-custom" type="radio" value="custom" (click)="resetEffectiveType('custom')" class="radio">
                                 <span class="radio-text">Custom</span>
                                 @if (editEffectiveType==='custom') {
                                   <div class="mt-2 grid grid-cols-2 gap-2">
@@ -69,12 +69,12 @@
                           </app-metadata-item>
                           <app-metadata-item label="Repeat By">
                             <div class="space-y-3" name="repeat_type" formControlName="repeat_type">
-                              <label class="radio-label">
-                                <input type="radio" value="week" class="radio">
+                              <label class="radio-label" for="repeat-week">
+                                <input id="repeat-week" type="radio" value="week" class="radio">
                                 <span class="radio-text">Week</span>
                               </label>
-                              <label class="radio-label">
-                                <input type="radio" value="month" class="radio">
+                              <label class="radio-label" for="repeat-month">
+                                <input id="repeat-month" type="radio" value="month" class="radio">
                                 <span class="radio-text">Month</span>
                               </label>
                             </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/app-detail-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/app-detail-data.service.ts
@@ -453,7 +453,6 @@ export class AppDetailDataService {
       if (typeof localStorage === 'undefined' || !localStorage.getItem('stratosDebug')) {
         return;
       }
-      // eslint-disable-next-line no-console
       console.debug('[AppDetailData]', kind, outcome, `${ms.toFixed(0)}ms`, url, err ?? '');
     } catch {
       // localStorage may throw in private-mode browsers; ignore.

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -51,7 +51,7 @@
                   <app-metadata-item icon="card_travel" label="Package State">{{ detail.pkg?.state ?? '-' }}
                   </app-metadata-item>
                   <app-metadata-item icon="service" iconFont="stratos-icons" label="Services">
-                    {{ data.summary()?.services?.length || '0' }}
+                    {{ data.serviceBindingsCount() || '0' }}
                   </app-metadata-item>
                   <app-metadata-item icon="route" iconFont="stratos-icons" label="Routes">
                     {{ detail.app.routes?.length || '0' }}

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.ts
@@ -83,6 +83,12 @@ export class BuildTabComponent implements OnInit {
   public gitRepo: GitRepo | null = null;
 
   ngOnInit() {
+    // Trigger the service-bindings fetch so the Summary card's Services
+    // count signal is populated when the Build tab loads — without
+    // requiring the user to visit the Services tab first to kick off
+    // the load.
+    void this.data.refresh('serviceBindings');
+
     this.cardTwoFetching$ = this.applicationService.application$.pipe(
       combineLatest(
         this.applicationService.appSummary$

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.html
@@ -31,12 +31,12 @@
         <!--- Section -->
         <div class="deploy-options__title"><b>Route</b></div>
         <div class="flex flex-col space-y-2">
-          <label class="flex items-center space-x-2">
-            <input type="checkbox" name="no_route" formControlName="no_route" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500">
+          <label class="flex items-center space-x-2" for="deploy-no-route">
+            <input id="deploy-no-route" type="checkbox" name="no_route" formControlName="no_route" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500">
             <span class="text-sm">Do not create a route</span>
           </label>
-          <label class="flex items-center space-x-2">
-            <input type="checkbox" name="random_route" formControlName="random_route" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500">
+          <label class="flex items-center space-x-2" for="deploy-random-route">
+            <input id="deploy-random-route" type="checkbox" name="random_route" formControlName="random_route" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500">
             <span class="text-sm">Create a random route</span>
           </label>
         </div>
@@ -65,8 +65,8 @@
         <!--- Section -->
         <div class="deploy-options__title"><b>Build</b></div>
         <div class="form-field">
-          <label class="flex items-center space-x-2">
-            <input type="checkbox" name="no_start" formControlName="no_start" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500">
+          <label class="flex items-center space-x-2" for="deploy-no-start">
+            <input id="deploy-no-start" type="checkbox" name="no_start" formControlName="no_start" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500">
             <span class="text-sm">Do not start the application</span>
           </label>
         </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
@@ -98,10 +98,8 @@ describe('DeployApplicationComponent', () => {
     const mockStep2 = { onNext: vi.fn().mockReturnValue(of({ success: true, data: fakeFileInfo })) };
     const mockStep2_2 = { onEnter: vi.fn(), valid$: of(true) };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (component as any)._step2 = mockStep2;
     await component.step2Handle.submit!();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (component as any).step2_2Ref = mockStep2_2;
 
     expect(mockStep2_2.onEnter).toHaveBeenCalledWith(fakeFileInfo);

--- a/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
@@ -124,7 +124,6 @@ export class EditApplicationComponent implements OnInit, OnDestroy {
       valid: computed(() => {
         // Touch both ticks so the computed depends on both streams; then
         // read the live form state for the actual answer.
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         statusTick(); valueTick();
         return this.editAppForm.valid && this.editAppForm.dirty;
       }),

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, Signal, WritableSignal, computed, inject, signal } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 
 import {
   ListSubNavComponent,
   SignalListCompoundSegment,
   SignalListComponent,
   SignalListConfig,
+  SignalListHeaderAction,
 } from '@stratosui/core';
 
 import { CfUsersSignalConfigService } from '../../../../shared/components/list/list-types/user/cf-users-signal-config.service';
@@ -38,6 +39,7 @@ import type { StUser, StUserOrgRole, StUserSpaceRole } from '../../../../service
 export class CloudFoundryUsersComponent {
   cfEndpointService = inject(CloudFoundryEndpointService);
   private usersConfig = inject(CfUsersSignalConfigService);
+  private router = inject(Router);
 
   public listConfig: WritableSignal<SignalListConfig<StUser> | undefined> = signal(undefined);
 
@@ -119,11 +121,37 @@ export class CloudFoundryUsersComponent {
     const renderCreated = (u: StUser): string =>
       CloudFoundryUsersComponent.formatDate(u.createdAt);
 
-    // The L5 sub-nav row above this list shows "Total Users: N" with no
-    // add affordance — Invite User and Manage Users still go through the
-    // legacy stepper routes (/users/manage, /users/invite). When those
-    // flows migrate signal-native, wire an `addAction` onto the L5 row in
-    // the template instead of reintroducing in-toolbar buttons.
+    // Page-level actions reintroduced via SignalList headerActions slot.
+    // Both Invite User and Manage Users currently route to the legacy
+    // stepper components — when they migrate signal-native we keep these
+    // entries pointed at whatever the new home is. Surface as header
+    // buttons rather than per-row actions because they operate on the
+    // CF as a whole, not on individual user rows.
+    const headerActions: SignalListHeaderAction[] = [
+      {
+        label: 'Invite User',
+        icon: 'mail_outline',
+        title: 'Invite a new user to this Cloud Foundry',
+        dataTest: 'cf-users-invite-user',
+        run: (): void => {
+          void this.router.navigate(
+            ['/cloud-foundry', cfGuid, 'users', 'invite'],
+          );
+        },
+      },
+      {
+        label: 'Manage Users',
+        icon: 'group',
+        title: 'Manage org / space role assignments',
+        dataTest: 'cf-users-manage-users',
+        primary: true,
+        run: (): void => {
+          void this.router.navigate(
+            ['/cloud-foundry', cfGuid, 'users', 'manage'],
+          );
+        },
+      },
+    ];
 
     this.listConfig.set({
       pagedItems: this.usersConfig.view.pagedItems,
@@ -193,6 +221,7 @@ export class CloudFoundryUsersComponent {
       onClear: () => this.usersConfig.clearFilters(),
       viewMode: this.usersConfig.viewMode,
       sort: this.usersConfig.sort,
+      headerActions,
     });
 
     this.usersConfig.registerSortExtractor('origin', renderOrigin);

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/invite-users/invite-users-create/invite-users-create.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/invite-users/invite-users-create/invite-users-create.component.html
@@ -13,8 +13,8 @@
       <div class="font-medium">Please select the users initial space role:</div>
       <div class="flex flex-col gap-2">
         @for (season of spaceRoles; track season) {
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input type="radio" name="spaceRole" [value]="season.value" [(ngModel)]="spaceRole"
+          <label class="flex items-center gap-2 cursor-pointer" [attr.for]="'spaceRole-' + season.value">
+            <input [attr.id]="'spaceRole-' + season.value" type="radio" name="spaceRole" [value]="season.value" [(ngModel)]="spaceRole"
               class="w-4 h-4 text-blue-600 focus:ring-blue-500 border-gray-300">
             <span>{{season.label}}</span>
           </label>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.html
@@ -2,12 +2,12 @@
   <div class="usernames">
     <div class="usernames__addRemove">
       <div class="flex flex-col gap-3 mb-4">
-        <label class="inline-flex items-center cursor-pointer" [class.opacity-50]="(canAdd$ | async) === false" [class.pointer-events-none]="(canAdd$ | async) === false">
-          <input type="radio" [checked]="currentValue === false" (change)="setIsRemove({source: null, value: false})" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(canAdd$ | async) === false">
+        <label class="inline-flex items-center cursor-pointer" for="manage-add-roles" [class.opacity-50]="(canAdd$ | async) === false" [class.pointer-events-none]="(canAdd$ | async) === false">
+          <input id="manage-add-roles" type="radio" [checked]="currentValue === false" (change)="setIsRemove({source: null, value: false})" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(canAdd$ | async) === false">
           <span class="ml-2 text-sm font-medium text-content-text">Add Roles{{(canAdd$ | async) ? '' : ' (Disabled via feature flag)'}}</span>
         </label>
-        <label class="inline-flex items-center cursor-pointer" [class.opacity-50]="(canRemove$ | async) === false" [class.pointer-events-none]="(canRemove$ | async) === false">
-          <input type="radio" [checked]="currentValue === true" (change)="setIsRemove({source: null, value: true})" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(canRemove$ | async) === false">
+        <label class="inline-flex items-center cursor-pointer" for="manage-remove-roles" [class.opacity-50]="(canRemove$ | async) === false" [class.pointer-events-none]="(canRemove$ | async) === false">
+          <input id="manage-remove-roles" type="radio" [checked]="currentValue === true" (change)="setIsRemove({source: null, value: true})" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(canRemove$ | async) === false">
           <span class="ml-2 text-sm font-medium text-content-text">Remove Roles{{(canRemove$ | async) ? '' : ' (Disabled via feature flag)'}}</span>
         </label>
       </div>

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.html
@@ -1,1 +1,3 @@
-<app-signal-list *ngIf="listConfig" [config]="listConfig" class="flex-1 min-h-0"></app-signal-list>
+@if (listConfig) {
+  <app-signal-list [config]="listConfig" class="flex-1 min-h-0"></app-signal-list>
+}

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-plans/service-plans.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-plans/service-plans.component.html
@@ -1,1 +1,3 @@
-<app-signal-list *ngIf="listConfig" [config]="listConfig" class="flex-1 min-h-0"></app-signal-list>
+@if (listConfig) {
+  <app-signal-list [config]="listConfig" class="flex-1 min-h-0"></app-signal-list>
+}

--- a/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.spec.ts
@@ -1,9 +1,19 @@
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { EndpointsSignalService } from '@stratosui/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { StratosDiagnostics } from '../services/diagnostics/stratos-diagnostics.service';
 import { cfApiInterceptor } from './cf-api-interceptor';
+
+// Minimal EndpointsSignalService stub — the interceptor only reads
+// `endpoints()` to look up a name for the 502 snackbar. An empty map is
+// enough for the existing tests; the snackbar-naming regression test below
+// pre-populates a single endpoint via the same stub.
+const endpointsStub = {
+  endpoints: signal<Record<string, { name?: string }>>({}),
+};
 
 describe('cfApiInterceptor', () => {
   let http: HttpClient;
@@ -11,10 +21,12 @@ describe('cfApiInterceptor', () => {
   let diagnostics: StratosDiagnostics;
 
   beforeEach(() => {
+    endpointsStub.endpoints.set({});
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(withInterceptors([cfApiInterceptor])),
         provideHttpClientTesting(),
+        { provide: EndpointsSignalService, useValue: endpointsStub },
       ],
     });
     http = TestBed.inject(HttpClient);
@@ -60,5 +72,52 @@ describe('cfApiInterceptor', () => {
     const counters = diagnostics.snapshot().counters['api-call-count'] ?? [];
     const errMatch = counters.find(c => c.dimensions.outcome === 'error');
     expect(errMatch?.count).toBe(1);
+  });
+
+  // Regression for the snackbar identifying the failing endpoint by name.
+  // The first cut of the 502 handler said only "Cloud Foundry endpoint
+  // authentication expired" — operators with multiple CF endpoints could
+  // not tell which one needed reconnecting. Snackbar text must include the
+  // endpoint name and the GUID (the latter as a tail-end disambiguator for
+  // the case where two endpoints share a display name).
+  it('includes endpoint name and GUID in the 502 snackbar message', async () => {
+    const cnsi = 'CSnSysOkvwBD6A-UQyQW6gmKPhI';
+    endpointsStub.endpoints.set({ [cnsi]: { name: 'Kevin' } });
+    const messages: string[] = [];
+    const { TailwindSnackBarService } = await import('@stratosui/core');
+    const snackbar = TestBed.inject(TailwindSnackBarService);
+    const origError = snackbar.error.bind(snackbar);
+    snackbar.error = (msg: string, action?: string) => {
+      messages.push(msg);
+      return origError(msg, action);
+    };
+
+    http.get(`/pp/v1/cf/info/${cnsi}`).subscribe({ error: () => undefined });
+    ctrl.expectOne(`/pp/v1/cf/info/${cnsi}`).flush(
+      'Bad Gateway',
+      { status: 502, statusText: 'Bad Gateway' },
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("'Kevin'");
+    expect(messages[0]).toContain(cnsi);
+  });
+
+  // Regression for the desktop-plugin cnsi GUID format. Endpoints registered
+  // via plugins/desktop/{endpoints,kubernetes,helm}/endpoints.go encode the
+  // cnsi GUID as base64.RawURLEncoding(sha256(...)) — mixed-case alphanumeric
+  // plus '-' / '_'. The first cut of CNSI_GUID_RE used [0-9a-f-]{36} only and
+  // dropped these endpoints on the floor, so 502 InvalidAuthToken responses
+  // never marked the endpoint stale. Both formats must collapse to /:guid.
+  it.each([
+    ['hex UUID', '/pp/v1/cf/spaces/abc12345-1234-5678-9abc-def012345678'],
+    ['base64url cnsi', '/pp/v1/cf/spaces/CSnSysoBD6A-UQyQW6gmKPhI8FT1ZxZxZ'],
+  ])('normalizes %s cnsi to /:guid in url pattern', async (_label, url) => {
+    http.get(url).subscribe();
+    ctrl.expectOne(url).flush({});
+    await diagnostics.waitForFlush();
+    const counters = diagnostics.snapshot().counters['api-call-count'] ?? [];
+    const pattern = String(counters[0]?.dimensions.urlPattern);
+    expect(pattern).toBe('/pp/v1/cf/spaces/:guid');
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
+++ b/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
@@ -1,9 +1,27 @@
-import { HttpEventType, HttpInterceptorFn } from '@angular/common/http';
+import { HttpErrorResponse, HttpEventType, HttpInterceptorFn, HttpResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { tap } from 'rxjs/operators';
+import { EndpointAuthStateService, EndpointsSignalService, TailwindSnackBarService } from '@stratosui/core';
 import { StratosDiagnostics } from '../services/diagnostics/stratos-diagnostics.service';
 
-const GUID_RE = /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+// Stratos cnsi GUIDs come in two flavours: standard hex UUIDs from
+// uuid.New() and URL-safe base64-encoded SHA hashes from the desktop
+// plugin (see jetstream/plugins/desktop/endpoints.go). The base64 form
+// is mixed-case alphanumeric plus `-`/`_`, so the hex-only `[0-9a-f-]`
+// regex used previously dropped half of all real-world endpoints on
+// the floor. Min length 20 disambiguates from action names like
+// "spaces" / "apps" / "info" without false-matching them.
+const CNSI_GUID_RE = /[A-Za-z0-9_-]{20,}/.source;
+const GUID_RE = new RegExp(
+  `\\/(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|${CNSI_GUID_RE})`,
+  'g',
+);
+
+// Native CF handler URL shape: /pp/v1/cf/{action}/{cnsiGuid}[?query] OR
+// /pp/v1/cf/{cnsiGuid}/... — capture the cnsiGuid in either position.
+const NATIVE_CF_PATH_RE = new RegExp(`\\/pp\\/v1\\/cf\\/[a-z_][a-z0-9_]*\\/(${CNSI_GUID_RE})(?:[/?]|$)`);
+const NATIVE_CF_PATH_PREFIX_RE = new RegExp(`\\/pp\\/v1\\/cf\\/(${CNSI_GUID_RE})(?:[/?]|$)`);
 
 // Collapse GUIDs to `:guid` so aggregated counts/timings group the same API
 // call across different endpoints. Without this, every cnsi/org/app/etc. GUID
@@ -12,11 +30,21 @@ function extractUrlPattern(url: string): string {
   return url.replace(GUID_RE, '/:guid');
 }
 
+function extractCnsiGuid(url: string): string | null {
+  const m = url.match(NATIVE_CF_PATH_RE) ?? url.match(NATIVE_CF_PATH_PREFIX_RE);
+  return m ? m[1] : null;
+}
+
 export const cfApiInterceptor: HttpInterceptorFn = (req, next) => {
   const diagnostics = inject(StratosDiagnostics);
+  const authState = inject(EndpointAuthStateService);
+  const snackbar = inject(TailwindSnackBarService);
+  const router = inject(Router);
+  const endpointsSignal = inject(EndpointsSignalService);
   const start = performance.now();
   const urlPattern = extractUrlPattern(req.url);
   const method = req.method;
+  const cnsiGuid = extractCnsiGuid(req.url);
   return next(req).pipe(
     tap({
       next: (event) => {
@@ -28,11 +56,36 @@ export const cfApiInterceptor: HttpInterceptorFn = (req, next) => {
         const ms = performance.now() - start;
         diagnostics.emitCounter('api-call-count', { urlPattern, method });
         diagnostics.emitSample('api-call-timing', { urlPattern, method }, ms);
+        // Self-heal: any successful CAPI response from an endpoint clears
+        // a previous stale mark for that endpoint. Avoids needing to thread
+        // post-reconnect notifications back into this service.
+        if (cnsiGuid && (event as HttpResponse<unknown>).status >= 200 && (event as HttpResponse<unknown>).status < 300) {
+          authState.clearStale(cnsiGuid);
+        }
       },
-      error: () => {
+      error: (err) => {
         const ms = performance.now() - start;
         diagnostics.emitCounter('api-call-count', { urlPattern, method, outcome: 'error' });
         diagnostics.emitSample('api-call-timing', { urlPattern, method, outcome: 'error' }, ms);
+        // 502 from a native CF handler typically signals stale token / failed
+        // refresh on the proxy side. Mark the endpoint stale + show a one-shot
+        // toast linking to the endpoints page so the user can reconnect. Look
+        // up the endpoint name so the toast tells the user *which* endpoint to
+        // reconnect (the GUID is included as a tail-end disambiguator for the
+        // case where two endpoints share a display name).
+        if (cnsiGuid && err instanceof HttpErrorResponse && err.status === 502) {
+          if (authState.markStale(cnsiGuid)) {
+            const endpoint = endpointsSignal.endpoints()[cnsiGuid];
+            const label = endpoint?.name
+              ? `'${endpoint.name}' (${cnsiGuid})`
+              : cnsiGuid;
+            const ref = snackbar.error(
+              `Cloud Foundry endpoint ${label} authentication expired. Reconnect to refresh.`,
+              'Reconnect',
+            );
+            ref.onAction().subscribe(() => router.navigate(['/endpoints']));
+          }
+        }
       },
     }),
   );

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.html
@@ -3,8 +3,8 @@
     <div>
       <div class="flex flex-col gap-3 mb-4">
         @for (mode of formModes; track mode) {
-          <label class="inline-flex items-center cursor-pointer" [class.opacity-50]="(serviceInstances$ | async)?.length === 0" [class.pointer-events-none]="(serviceInstances$ | async)?.length === 0">
-            <input type="radio" [(ngModel)]="formMode" [value]="mode.key" (click)="resetForms(mode.key)" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(serviceInstances$ | async)?.length === 0">
+          <label class="inline-flex items-center cursor-pointer" [attr.for]="'mode-' + mode.key" [class.opacity-50]="(serviceInstances$ | async)?.length === 0" [class.pointer-events-none]="(serviceInstances$ | async)?.length === 0">
+            <input [attr.id]="'mode-' + mode.key" type="radio" [(ngModel)]="formMode" [value]="mode.key" (click)="resetForms(mode.key)" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(serviceInstances$ | async)?.length === 0">
             <span class="ml-2 text-sm font-medium text-content-text">{{ mode.label }}</span>
           </label>
         }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.html
@@ -2,8 +2,8 @@
   <div>
     <div class="flex flex-col gap-3 mb-4">
       @for (mode of formModes; track mode) {
-        <label class="inline-flex items-center cursor-pointer" [class.opacity-50]="(serviceBindingForApplication$ | async)?.length === 0" [class.pointer-events-none]="(serviceBindingForApplication$ | async)?.length === 0">
-          <input type="radio" [(ngModel)]="formMode" [value]="mode.key" (click)="resetForms(mode.key)" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(serviceBindingForApplication$ | async)?.length === 0">
+        <label class="inline-flex items-center cursor-pointer" [attr.for]="'ups-mode-' + mode.key" [class.opacity-50]="(serviceBindingForApplication$ | async)?.length === 0" [class.pointer-events-none]="(serviceBindingForApplication$ | async)?.length === 0">
+          <input [attr.id]="'ups-mode-' + mode.key" type="radio" [(ngModel)]="formMode" [value]="mode.key" (click)="resetForms(mode.key)" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2" [disabled]="(serviceBindingForApplication$ | async)?.length === 0">
           <span class="ml-2 text-sm font-medium text-content-text">{{ mode.label }}</span>
         </label>
       }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.spec.ts
@@ -37,7 +37,9 @@ import { AppApplicationActionBarComponent } from './application-action-bar.compo
   template: `
     <app-application-action-bar></app-application-action-bar>
     <div data-test-id="portal-outlet">
-      <ng-container *ngIf="portal$ | async as portal" [cdkPortalOutlet]="portal"></ng-container>
+      @if (portal$ | async; as portal) {
+        <ng-container [cdkPortalOutlet]="portal"></ng-container>
+      }
     </div>
   `,
 })

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/cf-apps-signal-config.service.ts
@@ -465,7 +465,6 @@ export class CfAppsSignalConfigService {
       const perPage = 500;
       // Per-chunk pagination loop: break when no `next` link. Most chunks
       // exit after one iteration on real CFs.
-      // eslint-disable-next-line no-constant-condition
       while (true) {
         const url = `/pp/v1/cf/spaces/${cnsi}?organization_guids=${chunk.join(',')}&per_page=${perPage}&page=${page}`;
         const resp = await firstValueFrom(this.http.get<StSpacesResponse>(url))

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
@@ -3,12 +3,12 @@
 @if (mode === 'schema') {
   <div class="schema-form">
     <div class="flex gap-4 mb-4">
-      <label class="inline-flex items-center cursor-pointer">
-        <input type="radio" [(ngModel)]="schemaView" value="schemaForm" (change)="onSchemaViewChanged()" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2">
+      <label class="inline-flex items-center cursor-pointer" for="schema-view-form">
+        <input id="schema-view-form" type="radio" [(ngModel)]="schemaView" value="schemaForm" (change)="onSchemaViewChanged()" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2">
         <span class="ml-2 text-sm font-medium text-content-text">Form</span>
       </label>
-      <label class="inline-flex items-center cursor-pointer">
-        <input type="radio" [(ngModel)]="schemaView" value="schemaJson" (change)="onSchemaViewChanged()" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2">
+      <label class="inline-flex items-center cursor-pointer" for="schema-view-json">
+        <input id="schema-view-json" type="radio" [(ngModel)]="schemaView" value="schemaJson" (change)="onSchemaViewChanged()" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:ring-2">
         <span class="ml-2 text-sm font-medium text-content-text">JSON</span>
       </label>
     </div>

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
@@ -36,8 +36,9 @@
 
     <!-- Show All Menu Items Toggle (only in expanded mode) -->
     <div class="nav-show-all-toggle border-b border-nav-border p-3" [class.hidden]="iconMode">
-      <label class="flex items-center space-x-2 text-nav-text-muted hover:text-nav-text cursor-pointer">
+      <label class="flex items-center space-x-2 text-nav-text-muted hover:text-nav-text cursor-pointer" for="nav-show-all">
         <input
+          id="nav-show-all"
           type="checkbox"
           class="form-checkbox h-4 w-4 text-accent rounded border-nav-border focus:ring-accent focus:ring-2"
           [checked]="showAllMenuItems"

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.html
@@ -29,8 +29,8 @@
                       (<code class="bg-warning-shade-100 px-1 py-0.5 rounded text-xs">{{service.currentDbVersion$ | async}}</code>) and the backup
                       (<code class="bg-warning-shade-100 px-1 py-0.5 rounded text-xs">{{file.content.dbVersion}}</code>) are different. Restoring this file may have adverse affects.
                     </p>
-                    <label class="flex items-center space-x-2 cursor-pointer">
-                      <input type="checkbox" class="rounded border-gray-300 text-brand-600 focus:ring-brand-500" (change)="onIgnoreDbChange($event)">
+                    <label class="flex items-center space-x-2 cursor-pointer" for="restore-ignore-db">
+                      <input id="restore-ignore-db" type="checkbox" class="rounded border-gray-300 text-brand-600 focus:ring-brand-500" (change)="onIgnoreDbChange($event)">
                       <span class="text-sm text-warning-shade-800">Ignore different database versions</span>
                     </label>
                   </div>

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.ts
@@ -138,9 +138,13 @@ export class CreateEndpointCfStep1Component extends CreateEndpointHelperComponen
   private async runRegistration(): Promise<StepOnNextResult> {
     const { subType, type } = this.endpoint.getTypeAndSubtype();
 
-    // SSL Setttings
+    // SSL settings — when a CA cert is provided we trust it as the override
+    // (skip-ssl is mutually exclusive with cert pinning). When the CA-cert
+    // field is shown but left empty, honor the user's checkbox so self-signed
+    // endpoints (k3d / kind / minikube) still work via skipSslValidation.
     let sslAllow = this.registerForm.value.skipSSLField ?? false;
-    if (this.showCACertField) {
+    const caCert = (this.registerForm.value.caCertField ?? '').trim();
+    if (this.showCACertField && caCert.length > 0) {
       sslAllow = false;
     }
 

--- a/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.html
+++ b/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.html
@@ -16,8 +16,8 @@
               <label class="form-label" for="apiUrl">UAA Endpoint URL</label>
               <input id="apiUrl" class="input" formControlName="apiUrl" placeholder="UAA Endpoint URL">
             </div>
-            <label class="flex items-center space-x-2 cursor-pointer">
-              <input type="checkbox" class="rounded border-gray-300 text-brand-600 focus:ring-brand-500" formControlName="skipSSL">
+            <label class="flex items-center space-x-2 cursor-pointer" for="uaa-skip-ssl">
+              <input id="uaa-skip-ssl" type="checkbox" class="rounded border-gray-300 text-brand-600 focus:ring-brand-500" formControlName="skipSSL">
               <span class="text-sm text-content-text">Skip SSL validation for the UAA</span>
             </label>
             <div class="form-field">
@@ -68,8 +68,8 @@
           <div class="border-t pt-6">
             <p class="text-content-text mb-4">UAA Single Sign On (SSO)</p>
             <div class="space-y-4">
-              <label class="flex items-start space-x-2 cursor-pointer">
-                <input type="checkbox" class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 mt-0.5" formControlName="useSSO">
+              <label class="flex items-start space-x-2 cursor-pointer" for="uaa-use-sso">
+                <input id="uaa-use-sso" type="checkbox" class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 mt-0.5" formControlName="useSSO">
                 <span class="text-sm text-content-text">Use SSO (Use the UAA's UI to login rather than the <app-product-name></app-product-name>
               login UI)</span>
             </label>

--- a/src/frontend/packages/core/src/public-api.ts
+++ b/src/frontend/packages/core/src/public-api.ts
@@ -146,7 +146,7 @@ export { AppActionMonitorComponent } from './shared/components/app-action-monito
 
 // List Components
 export { ListComponent } from './shared/components/list/list.component';
-export { SignalListComponent, SignalListConfig, SignalListColumn, SignalListDropdown, SignalListDropdownOption, SignalListViewMode, SignalListSort, SignalListPillColor, SignalListCompoundSegment, SignalListFavoriteBinding, SignalListRowAction } from './shared/components/signal-list/signal-list.component';
+export { SignalListComponent, SignalListConfig, SignalListColumn, SignalListDropdown, SignalListDropdownOption, SignalListViewMode, SignalListSort, SignalListPillColor, SignalListCompoundSegment, SignalListFavoriteBinding, SignalListRowAction, SignalListHeaderAction } from './shared/components/signal-list/signal-list.component';
 export { ListStateStore, ListStateDefaults, BoundListState, ModeIndexedTuple } from './shared/components/signal-list/list-state-store.service';
 export { ListFilterStore, BoundListFilterState, ListFilterDefaults } from './shared/components/signal-list/list-filter-store.service';
 export { ListSelectionStore, BoundListSelectionState } from './shared/components/signal-list/list-selection-store.service';

--- a/src/frontend/packages/core/src/public-api.ts
+++ b/src/frontend/packages/core/src/public-api.ts
@@ -34,6 +34,7 @@ export { ProfileSettingsTypes } from './shared/components/profile-settings/profi
 // Tailwind Material Replacements
 export * from './shared/services/tailwind-material-replacements';
 export * from './shared/services/tailwind-snackbar.service';
+export * from './shared/services/endpoint-auth-state.service';
 export * from './shared/services/tailwind-dialog.service';
 export * from './shared/services/tailwind-sidenav.service';
 export * from './shared/services/tailwind-sort.service';

--- a/src/frontend/packages/core/src/shared/components/custom-slide-toggle/custom-slide-toggle.component.html
+++ b/src/frontend/packages/core/src/shared/components/custom-slide-toggle/custom-slide-toggle.component.html
@@ -7,6 +7,7 @@
     [attr.aria-describedby]="invalid && errorMessage ? 'error-' + (id || name) : null">
 
     <label class="slide-toggle-label"
+      [attr.for]="id"
       [class.label-before]="labelPosition === 'before'"
       [class.label-after]="labelPosition === 'after'">
 

--- a/src/frontend/packages/core/src/shared/components/list/list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list.component.ts
@@ -488,8 +488,12 @@ export class ListComponent<T> implements OnInit, OnChanges, OnDestroy, AfterView
         // Always force the page size to match the current view's options
         this.paginatorSettings.pageSize = targetSize;
         if (this.dataSource.isLocal) {
+          // force=true so the view-toggle restore lands even when the store
+          // happens to already hold this size from a sibling code path —
+          // otherwise the same-value guard blocks the explicit per-view
+          // restore and the paginator displays a stale value.
           this.store.dispatch(new SetClientPageSize(
-            this.dataSource, this.dataSource.paginationKey, effectiveSize
+            this.dataSource, this.dataSource.paginationKey, effectiveSize, true
           ));
           this.paginationController.page(0);
         } else {

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -84,6 +84,26 @@
       </button>
     }
 
+    @if (config.headerActions) {
+      @for (act of config.headerActions; track act.label) {
+        <button
+          type="button"
+          (click)="act.run()"
+          [disabled]="act.disabled ? act.disabled() : false"
+          [title]="act.title ?? act.label"
+          [attr.data-test]="act.dataTest ?? ('header-action-' + act.label)"
+          [class]="'flex items-center gap-1 px-3 py-1 text-sm border rounded disabled:opacity-40 disabled:cursor-not-allowed ' +
+            (act.primary
+              ? 'border-primary-shade-700 bg-primary text-white hover:bg-primary-shade-700'
+              : 'border-content-border bg-content-bg text-content-text hover:bg-gray-100 dark:hover:bg-gray-700')">
+          @if (act.icon) {
+            <span class="material-icons text-base leading-5">{{ act.icon }}</span>
+          }
+          <span>{{ act.label }}</span>
+        </button>
+      }
+    }
+
     @if (config.onRefresh) {
       <button
         type="button"

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -5,9 +5,10 @@
 
     @if (config.filterDropdowns) {
       @for (dd of config.filterDropdowns; track dd.label) {
-        <label class="flex items-center gap-2 text-sm text-content-muted" [attr.data-test]="'dropdown-' + dd.label">
+        <label class="flex items-center gap-2 text-sm text-content-muted" [attr.for]="'dropdown-' + dd.label" [attr.data-test]="'dropdown-' + dd.label">
           <span>{{ dd.label }}:</span>
           <select
+            [attr.id]="'dropdown-' + dd.label"
             [disabled]="dd.disabled ? dd.disabled() : false"
             (change)="onDropdownChange(dd, $any($event.target).value)"
             class="px-2 py-1 border border-content-border rounded bg-content-bg text-content-text disabled:opacity-40 disabled:cursor-not-allowed">

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -158,6 +158,34 @@ export interface SignalListDropdown {
 
 export type SignalListViewMode = 'table' | 'card';
 
+/**
+ * Page-level action button rendered in the SignalList toolbar — the slot
+ * that hosts affordances like "Invite User" / "Manage Users" / "Add Org".
+ *
+ * Wave-4 of the signal-list framework had this field excised after the
+ * first migration round shipped placeholder snackbar handlers; re-added
+ * with explicit semantics: this is for actions that operate on the LIST
+ * as a whole (open a dialog, navigate to a stepper), not on individual
+ * rows. Row-level actions still use the per-row `kind: 'actions'` column.
+ */
+export interface SignalListHeaderAction {
+  /** Display label inside the button. */
+  readonly label: string;
+  /** Optional Material icon name rendered to the left of the label. */
+  readonly icon?: string;
+  /** Click handler. */
+  readonly run: () => void;
+  /** Optional reactive disabled state — e.g. permission-gated actions. */
+  readonly disabled?: Signal<boolean>;
+  /** Optional tooltip / aria title. */
+  readonly title?: string;
+  /** Optional `data-test` attribute for E2E selectors. */
+  readonly dataTest?: string;
+  /** When true, render with a primary/accent style (typically the page's
+   *  default action). At most one primary per toolbar by convention. */
+  readonly primary?: boolean;
+}
+
 export interface SignalListConfig<T> {
   readonly pagedItems: Signal<T[]>;
   readonly totalFilteredResults: Signal<number>;
@@ -218,6 +246,11 @@ export interface SignalListConfig<T> {
   // panel inside a stepper) skip the paginator chrome until it actually has
   // a job to do. Default false preserves existing behavior.
   readonly hidePagerWhenSingle?: boolean;
+  // Optional — page-level action buttons rendered in the toolbar between
+  // the view toggle and the refresh button. Use for affordances that
+  // operate on the list as a whole (Invite User / Manage Users / Create
+  // Org) — not per-row actions, which still go via `kind: 'actions'`.
+  readonly headerActions?: readonly SignalListHeaderAction[];
 }
 
 @Component({

--- a/src/frontend/packages/core/src/shared/services/endpoint-auth-state.service.ts
+++ b/src/frontend/packages/core/src/shared/services/endpoint-auth-state.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Signal, signal } from '@angular/core';
+
+/**
+ * Tracks per-endpoint client-side auth-state hints surfaced from the proxy
+ * layer. Today the only hint is "stale" — the endpoint's stored token is
+ * being rejected by CAPI (502 InvalidAuthToken / token-refresh-failed) and
+ * the user needs to reconnect.
+ *
+ * Lives independently of the endpoint entity store so it can be wired from
+ * an HTTP interceptor without any circular-dep risk against the heavier
+ * EndpointsDataService.
+ */
+@Injectable({ providedIn: 'root' })
+export class EndpointAuthStateService {
+  private readonly _stale = signal<ReadonlySet<string>>(new Set<string>());
+  readonly stale: Signal<ReadonlySet<string>> = this._stale.asReadonly();
+
+  /**
+   * Mark an endpoint as needing reconnect. Returns true if this is a new
+   * mark (so callers can debounce side-effects like toasts to fire only
+   * on the first observation).
+   */
+  markStale(guid: string): boolean {
+    const current = this._stale();
+    if (current.has(guid)) {
+      return false;
+    }
+    const next = new Set(current);
+    next.add(guid);
+    this._stale.set(next);
+    return true;
+  }
+
+  /**
+   * Clear the stale mark for an endpoint — called on successful reconnect
+   * or any subsequent 2xx CAPI response from that endpoint.
+   */
+  clearStale(guid: string): void {
+    const current = this._stale();
+    if (!current.has(guid)) {
+      return;
+    }
+    const next = new Set(current);
+    next.delete(guid);
+    this._stale.set(next);
+  }
+
+  isStale(guid: string): boolean {
+    return this._stale().has(guid);
+  }
+}

--- a/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.html
+++ b/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.html
@@ -13,10 +13,11 @@
             @for (gitTypeEntry of gitTypes[epSubType].types | keyvalue; track gitTypeEntry) {
               <div class="block">
                 <label class="flex items-start space-x-3 p-3 border rounded-lg hover:bg-gray-50 transition-colors"
+                  [attr.for]="'gitType-' + gitTypeEntry.key"
                   [class.opacity-50]="gitTypeEntry.value.exists"
                   [class.cursor-not-allowed]="gitTypeEntry.value.exists"
                   [class.pointer-events-none]="gitTypeEntry.value.exists">
-                  <input type="radio" formControlName="selectedType" [value]="gitTypeEntry.key"
+                  <input [attr.id]="'gitType-' + gitTypeEntry.key" type="radio" formControlName="selectedType" [value]="gitTypeEntry.key"
                     class="mt-1 text-brand-600 focus:ring-brand-500 border-gray-300"
                     [attr.aria-disabled]="gitTypeEntry.value.exists ? 'true' : null">
                   <div class="flex-1">
@@ -74,16 +75,16 @@
               </div>
               <div class="space-y-3">
                 @if (userEndpointsAndIsAdmin | async) {
-                  <label class="checkbox-label"
+                  <label class="checkbox-label" for="git-create-system-endpoint"
                     [class.hidden]="fixedUrl">
-                    <input type="checkbox" name="createSystemEndpoint"
+                    <input id="git-create-system-endpoint" type="checkbox" name="createSystemEndpoint"
                       formControlName="createSystemEndpointField" (change)="toggleCreateSystemEndpoint()"
                       class="checkbox">
                     <span class="checkbox-text">Create a system endpoint (visible to all users)</span>
                   </label>
                 }
-                <label class="checkbox-label" [class.hidden]="fixedUrl">
-                  <input type="checkbox" name="skipSSL" formControlName="skipSSLField" class="checkbox">
+                <label class="checkbox-label" for="git-skip-ssl" [class.hidden]="fixedUrl">
+                  <input id="git-skip-ssl" type="checkbox" name="skipSSL" formControlName="skipSSLField" class="checkbox">
                   <span class="checkbox-text">Skip SSL validation for the endpoint</span>
                 </label>
               </div>

--- a/src/frontend/packages/kubernetes/src/kubernetes/services/kubernetes.analysis.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/services/kubernetes.analysis.service.ts
@@ -48,8 +48,7 @@ export class KubernetesAnalysisService {
   // Compatibility shim — legacy `isAnalysisEnabled(store)` callers that
   // imported @ngrx/store can call this overload. The store parameter is
   // ignored; the read goes through SessionService.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public static isAnalysisEnabled(store: unknown): Observable<boolean>;
+  public static isAnalysisEnabled(_store: unknown): Observable<boolean>;
   public static isAnalysisEnabled(session: SessionService): Observable<boolean>;
   public static isAnalysisEnabled(arg: unknown): Observable<boolean> {
     // Detect SessionService by sessionData() signal presence; ngrx Store

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.html
@@ -53,8 +53,8 @@
           }
         </div>
 
-        <label class="flex items-center space-x-2">
-          <input type="checkbox" class="checkbox" formControlName="createNamespace">
+        <label class="flex items-center space-x-2" for="release-create-namespace">
+          <input id="release-create-namespace" type="checkbox" class="checkbox" formControlName="createNamespace">
           <span>Create Namespace</span>
         </label>
 

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/upgrade-release/upgrade-release.component.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/upgrade-release/upgrade-release.component.spec.ts
@@ -106,7 +106,6 @@ describe('UpgradeReleaseComponent', () => {
   // would keep emitting after component destruction.
   it('unsubscribes validateSub on destroy', () => {
     const sub = { unsubscribe: vi.fn() };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (component as any).validateSub = sub;
     component.ngOnDestroy();
     expect(sub.unsubscribe).toHaveBeenCalled();

--- a/src/frontend/packages/store/src/actions/pagination.actions.ts
+++ b/src/frontend/packages/store/src/actions/pagination.actions.ts
@@ -133,6 +133,14 @@ export class SetClientPageSize extends BasePaginationAction implements Action {
     pEntityConfig: Partial<EntityCatalogEntityConfig>,
     public paginationKey: string,
     public pageSize: number,
+    /**
+     * Bypass the reducer's same-value guard. The list-component's view-toggle
+     * restore path needs this: when the store happens to already hold the
+     * remembered size (e.g. a stale value from a sibling code path), the
+     * guard would otherwise block the explicit restore and leave the
+     * paginator stuck on a different value than the user picked for that view.
+     */
+    public force = false,
   ) {
     super(pEntityConfig);
   }

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-set-client-page-size.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer-set-client-page-size.ts
@@ -2,7 +2,7 @@ import { SetClientPageSize } from '../../actions/pagination.actions';
 import { PaginationEntityState } from '../../types/pagination.types';
 
 export function paginationSetClientPageSize(state: PaginationEntityState, action: SetClientPageSize) {
-  if (action.pageSize === state.clientPagination.pageSize) {
+  if (!action.force && action.pageSize === state.clientPagination.pageSize) {
     return state;
   }
   return {


### PR DESCRIPTION
## Summary

Five bug fixes from the open queue + a no-behavior lint warning sweep.

### Bug fixes

- **Fix #5** — Endpoint Register \"Skip SSL validation\" checkbox now actually reaches the backend: when the CA-cert field is shown but left empty, honor the checkbox so self-signed clusters (k3d, kind, minikube) still register.
- **Fix #6** — Application detail Build tab Services count now reflects real bindings instead of always rendering `0`. The Build tab proactively fires the `serviceBindings` fetch in `ngOnInit` so the Summary card is populated without a side trip to the Services tab.
- **Fix #1** — Stale CF token after relogin no longer leaves endpoints showing 502s forever. The CF API interceptor watches for `502 CF-InvalidAuthToken` on `/pp/v1/cf/.../{cnsiGuid}` URLs, marks the endpoint stale via a new `EndpointAuthStateService` signal, and shows a snackbar with a Reconnect action that routes to `/endpoints`. 2xx responses self-heal the stale flag.
- **Fix #11** — Page-size view toggle now actually restores the per-view choice. `SetClientPageSize` learned a `force` flag so the per-view restore dispatch bypasses the same-value short-circuit that was eating the change after view switches.
- **Fix #8** — Re-introduces a page-level header-actions slot on `SignalListConfig` (lost during the legacy → signal-native list migration) and wires the cf-users page back up with **Invite User** + **Manage Users** buttons.

### Safe lint sweep (no behavior change)

Drops 9 unused `eslint-disable` directives, swaps 3 `*ngIf` to `@if`, and adds explicit `for`/`id` pairing to 26 wrapping `<label>` elements that the `@angular-eslint/template/label-has-associated-control` rule cannot detect through nested control structures. Lint warning count drops from 143 → 105.

## Test plan

- [x] Full gate green on all 6 commits (`make check gate` — lint + 632 vitest files / 2207 tests + production build)
- [x] Manual verification of each fix against the local k3d / the live CF endpoint pre-PR
- [ ] Reviewer: smoke the cf-users page and confirm the Invite User / Manage Users buttons route correctly
- [ ] Reviewer: register a self-signed endpoint with Skip SSL checked + CA cert empty and confirm the registration succeeds
