### PR TITLE
W36-C: signal-native auth/session/roles + retire stratos/endpoint schema-only catalog

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/cf-pagination-maxed-state.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-pagination-maxed-state.ts
@@ -1,23 +1,58 @@
+import { Injector } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
-import { combineLatest, of } from 'rxjs';
+import { Observable, combineLatest, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { AppState, PaginatedAction, selectSessionData } from '@stratosui/store';
+import {
+  AppState,
+  AuthDataService,
+  PaginatedAction,
+  SessionData,
+  selectSessionData,
+} from '@stratosui/store';
 
 const ENTITY_TYPE_DEFAULT_MAX = 600;
 
+/**
+ * W36-C Wave 3: session-data reads route through {@link AuthDataService}
+ * (the C-W1 signal-native facade) instead of `store.select(selectSessionData())`.
+ *
+ * The framework still hands these handlers a `Store` (call sites are in
+ * `ListDataSource` and `MaxListMessageComponent`). At runtime Angular
+ * populates `store.injector`, which lets us resolve `AuthDataService`
+ * and bridge its `sessionData` signal back to an observable scoped to
+ * the same injector. The legacy `store.select(selectSessionData())` path
+ * remains as a fallback for unit tests that construct a bare `Store`
+ * mock without an Injector — it is never exercised in production.
+ *
+ * When the auth reducer eventually collapses into `AuthDataService`,
+ * the fallback branch and the `selectSessionData` import go away
+ * together.
+ */
+function sessionData$(store: Store<AppState>): Observable<SessionData | null> {
+  const injector = (store as unknown as { injector?: Injector }).injector;
+  if (injector) {
+    const authData = injector.get(AuthDataService, null);
+    if (authData) {
+      return toObservable(authData.sessionData, { injector });
+    }
+  }
+  return store.select(selectSessionData());
+}
+
 export const cfMaxedStateHandlers = {
   canIgnoreMaxedState: (store: Store<AppState>) =>
-    store.select(selectSessionData()).pipe(
-      map(sessionData => !!sessionData.config.listAllowLoadMaxed),
+    sessionData$(store).pipe(
+      map(sessionData => !!sessionData?.config.listAllowLoadMaxed),
     ),
 
   maxedStateStartAt: (store: Store<AppState>, action: PaginatedAction) => {
     if (!action.flattenPaginationMax) {
       return of(null);
     }
-    const beValue$ = store.select(selectSessionData()).pipe(
-      map(sessionData => sessionData.config.listMaxSize),
+    const beValue$ = sessionData$(store).pipe(
+      map(sessionData => sessionData?.config.listMaxSize ?? null),
     );
     const userOverride$ = of(null);
     return combineLatest([beValue$, userOverride$]).pipe(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/cf-roles.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/cf-roles.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, inject } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { Store } from '@stratosui/store';
 import { combineLatest, Observable, of as observableOf } from 'rxjs';
 import { take,
   combineLatest as combineLatestOperators,
@@ -16,9 +15,7 @@ import { take,
 import { CurrentUserPermissionsService } from '../../../../../../core/src/core/permissions/current-user-permissions.service';
 import { endpointEntityType } from '../../../../../../store/src/helpers/stratos-entity-factory';
 import { APIResource, EntityInfo } from '../../../../../../store/src/types/api.types';
-import { UsersRolesSetChanges } from '../../../../actions/users-roles.actions';
 import { IOrganization, ISpace } from '../../../../cf-api.types';
-import { CFAppState } from '../../../../cf-app-state';
 import { cfEntityCatalog } from '../../../../cf-entity-catalog';
 import { organizationEntityType, spaceEntityType } from '../../../../cf-entity-types';
 import {
@@ -37,7 +34,6 @@ import { canUpdateOrgSpaceRoles } from '../../cf.helpers';
   providedIn: 'root'
 })
 export class CfRolesService {
-  private store = inject<Store<CFAppState>>(Store);
   private cfUserService = inject(CfUserService);
   private userPerms = inject(CurrentUserPermissionsService);
   private rolesData = inject(CfUsersRolesDataService);
@@ -180,7 +176,7 @@ export class CfRolesService {
         pickedUsers.forEach(user => {
           changes.push(...this.createRolesUserDiff(existingRoles, newRoles, changes, user, orgGuid));
         });
-        this.store.dispatch(new UsersRolesSetChanges(changes));
+        this.rolesData.setChanges(changes);
         return changes;
       })
     );

--- a/src/frontend/packages/cloud-foundry/src/public_api.ts
+++ b/src/frontend/packages/cloud-foundry/src/public_api.ts
@@ -33,6 +33,7 @@ export { createCfOrSpaceMultipleFilterFn } from './shared/data-services/cf-org-s
 // Permissions
 export { CfCurrentUserPermissions, cfCurrentUserPermissionsService } from './user-permissions/cf-user-permissions-checkers';
 export { CfCurrentUserRolesSignalService } from './user-permissions/cf-current-user-roles-signal.service';
+export { CfCurrentUserRolesDataService } from './services/cf-current-user-roles-data.service';
 
 // Test helpers
 export * from './entity-relations/entity-relations-spec-helper';

--- a/src/frontend/packages/cloud-foundry/src/services/cf-current-user-roles-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/cf-current-user-roles-data.service.spec.ts
@@ -1,0 +1,131 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { CurrentUserRolesDataService } from '@stratosui/store';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { CF_ENDPOINT_TYPE } from '../cf-types';
+import {
+  IAllCfRolesState,
+  IGlobalRolesState,
+} from '../store/types/cf-current-user-roles.types';
+import { CfScopeStrings } from '../user-permissions/cf-user-permissions.types';
+import { CfCurrentUserRolesDataService } from './cf-current-user-roles-data.service';
+
+const ENDPOINT_A = 'cf-guid-a';
+
+function makeGlobal(overrides: Partial<IGlobalRolesState> = {}): IGlobalRolesState {
+  return {
+    isAdmin: false,
+    isReadOnlyAdmin: false,
+    isGlobalAuditor: false,
+    canRead: true,
+    canWrite: false,
+    scopes: [],
+    ...overrides,
+  };
+}
+
+function makeCfRolesState(overrides: { global?: Partial<IGlobalRolesState> } = {}) {
+  return {
+    global: makeGlobal(overrides.global),
+    spaces: {},
+    organizations: {},
+    state: { initialised: true, fetching: false, error: false },
+  };
+}
+
+function makeAllCfRolesState(byGuid: Record<string, ReturnType<typeof makeCfRolesState>>): IAllCfRolesState {
+  return byGuid as unknown as IAllCfRolesState;
+}
+
+function makeOuterState(cfState?: IAllCfRolesState) {
+  return {
+    internal: { isAdmin: false, scopes: [] },
+    endpoints: cfState ? { [CF_ENDPOINT_TYPE]: cfState } : {},
+    state: { initialised: false, fetching: false, error: false },
+  };
+}
+
+describe('CfCurrentUserRolesDataService', () => {
+  let slice$: BehaviorSubject<unknown>;
+
+  beforeEach(() => {
+    slice$ = new BehaviorSubject<unknown>(makeOuterState());
+    const stubStore = {
+      select: () => slice$.asObservable(),
+      dispatch: () => undefined,
+    };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: Store, useValue: stubStore },
+        CurrentUserRolesDataService,
+        CfCurrentUserRolesDataService,
+      ],
+    });
+  });
+
+  it('returns null for endpoint state until the slice populates', () => {
+    const svc = TestBed.inject(CfCurrentUserRolesDataService);
+    expect(svc.cfRolesState()).toBeUndefined();
+    expect(svc.cfEndpointRolesState(ENDPOINT_A)()).toBeNull();
+    expect(svc.cfGlobalState(ENDPOINT_A, 'isAdmin')()).toBe(false);
+    expect(svc.cfEndpointHasScope(ENDPOINT_A, 'scope.x' as CfScopeStrings)()).toBe(false);
+  });
+
+  it('projects cf-side state per-endpoint guid through signals', () => {
+    const svc = TestBed.inject(CfCurrentUserRolesDataService);
+    slice$.next(
+      makeOuterState(
+        makeAllCfRolesState({
+          [ENDPOINT_A]: makeCfRolesState({
+            global: { isAdmin: true, scopes: ['cloud_controller.admin'] },
+          }),
+        }),
+      ),
+    );
+
+    expect(svc.cfEndpointRolesState(ENDPOINT_A)()).not.toBeNull();
+    expect(svc.cfGlobalState(ENDPOINT_A, 'isAdmin')()).toBe(true);
+    expect(svc.cfGlobalState(ENDPOINT_A, 'isReadOnlyAdmin')()).toBe(false);
+    expect(svc.cfEndpointHasScope(ENDPOINT_A, 'cloud_controller.admin' as CfScopeStrings)).toBeDefined();
+    expect(
+      svc.cfEndpointHasScope(ENDPOINT_A, 'cloud_controller.admin' as CfScopeStrings)(),
+    ).toBe(true);
+    expect(
+      svc.cfEndpointHasScope(ENDPOINT_A, 'cloud_controller.write' as CfScopeStrings)(),
+    ).toBe(false);
+  });
+
+  it('exposes observable variants matching the legacy selector shape', async () => {
+    const svc = TestBed.inject(CfCurrentUserRolesDataService);
+    slice$.next(
+      makeOuterState(
+        makeAllCfRolesState({
+          [ENDPOINT_A]: makeCfRolesState({
+            global: { isAdmin: true, scopes: ['scope.a'] },
+          }),
+        }),
+      ),
+    );
+
+    await expect(firstValueFrom(svc.cfGlobalState$(ENDPOINT_A, 'isAdmin'))).resolves.toBe(true);
+    await expect(
+      firstValueFrom(svc.cfEndpointHasScope$(ENDPOINT_A, 'scope.a' as CfScopeStrings)),
+    ).resolves.toBe(true);
+    const rolesState = await firstValueFrom(svc.cfEndpointRolesState$(ENDPOINT_A));
+    expect(rolesState).toBeDefined();
+    expect(rolesState?.global?.isAdmin).toBe(true);
+  });
+
+  it('returns null/false for endpoints that are not present', async () => {
+    const svc = TestBed.inject(CfCurrentUserRolesDataService);
+    slice$.next(makeOuterState(makeAllCfRolesState({})));
+    expect(svc.cfEndpointRolesState('missing')()).toBeNull();
+    expect(svc.cfGlobalState('missing', 'isAdmin')()).toBe(false);
+    await expect(firstValueFrom(svc.cfGlobalState$('missing', 'isAdmin'))).resolves.toBe(false);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/cf-current-user-roles-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/cf-current-user-roles-data.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Signal, computed, inject } from '@angular/core';
+import {
+  CurrentUserRolesDataService,
+  PermissionValues,
+} from '@stratosui/store';
+import { Observable, distinctUntilChanged, map } from 'rxjs';
+
+import { CF_ENDPOINT_TYPE } from '../cf-types';
+import {
+  IAllCfRolesState,
+  ICfRolesState,
+  IGlobalRolesState,
+} from '../store/types/cf-current-user-roles.types';
+import { CfScopeStrings } from '../user-permissions/cf-user-permissions.types';
+
+/**
+ * W36-C Wave 2 signal-native facade over the cf-side
+ * `currentUserRoles.endpoints[CF_ENDPOINT_TYPE]` slice.
+ *
+ * Delegates the single store bridge to {@link CurrentUserRolesDataService}
+ * (in the store package) and projects the cf-specific subtree —
+ * `state.currentUserRoles.endpoints['cf']` — into per-endpoint signals.
+ *
+ * Mirrors the pattern from the W36-C Wave 1 `AuthDataService`:
+ *   - signal-out for new consumers
+ *   - parametric `*$` observable getters preserved so the legacy
+ *     rxjs-shaped pipelines in {@link CfUserPermissionsChecker} keep
+ *     compiling unchanged through the facade in
+ *     {@link CfCurrentUserRolesSignalService}
+ *
+ * Per-endpoint reads choose a `Signal<...>` factory (returned per-guid)
+ * rather than a `Signal<Map<guid, ...>>` aggregate because the consumer
+ * pipelines already shape by endpoint guid and per-guid memoisation
+ * matches the legacy `compose(...)` selector behaviour.
+ */
+@Injectable({ providedIn: 'root' })
+export class CfCurrentUserRolesDataService {
+  private rolesData = inject(CurrentUserRolesDataService);
+
+  /** All cf endpoint role state — keyed by endpoint guid. */
+  readonly cfRolesState: Signal<IAllCfRolesState | undefined> = computed(
+    () => this.rolesData.state()?.endpoints?.[CF_ENDPOINT_TYPE] as IAllCfRolesState | undefined,
+  );
+
+  /** Cf endpoint role state for a single endpoint guid. `null` until populated. */
+  cfEndpointRolesState(endpointGuid: string): Signal<ICfRolesState | null> {
+    return computed(() => {
+      const all = this.cfRolesState();
+      return all ? (all[endpointGuid] ?? null) : null;
+    });
+  }
+
+  /** Cf global role state for a single endpoint guid. `null` until populated. */
+  cfGlobalRolesState(endpointGuid: string): Signal<IGlobalRolesState | null> {
+    return computed(() => this.cfEndpointRolesState(endpointGuid)()?.global ?? null);
+  }
+
+  /** Per-(endpoint, role) boolean — replaces `getCurrentUserCFGlobalState`. */
+  cfGlobalState(endpointGuid: string, permission: PermissionValues): Signal<boolean> {
+    return computed(() => {
+      const global = this.cfGlobalRolesState(endpointGuid)() as Record<string, any> | null;
+      return global ? !!global[permission] : false;
+    });
+  }
+
+  /** Per-(endpoint, scope) boolean — replaces `getCurrentUserCFEndpointHasScope`. */
+  cfEndpointHasScope(endpointGuid: string, scope: CfScopeStrings | string): Signal<boolean> {
+    return computed(() => {
+      const scopes = this.cfGlobalRolesState(endpointGuid)()?.scopes;
+      return !!scopes?.includes(scope as string);
+    });
+  }
+
+  // ---- observable surface (preserved for legacy checker pipelines) -------
+
+  cfEndpointRolesState$(endpointGuid: string): Observable<ICfRolesState> {
+    return this.rolesData.state$.pipe(
+      map(state => {
+        const all = state?.endpoints?.[CF_ENDPOINT_TYPE] as IAllCfRolesState | undefined;
+        return (all ? all[endpointGuid] : null) as ICfRolesState;
+      }),
+      distinctUntilChanged(),
+    );
+  }
+
+  cfGlobalState$(endpointGuid: string, permission: PermissionValues): Observable<boolean> {
+    return this.rolesData.state$.pipe(
+      map(state => {
+        const all = state?.endpoints?.[CF_ENDPOINT_TYPE] as IAllCfRolesState | undefined;
+        const global = all?.[endpointGuid]?.global as Record<string, any> | undefined;
+        return global ? !!global[permission] : false;
+      }),
+      distinctUntilChanged(),
+    );
+  }
+
+  cfEndpointHasScope$(endpointGuid: string, scope: CfScopeStrings | string): Observable<boolean> {
+    return this.rolesData.state$.pipe(
+      map(state => {
+        const all = state?.endpoints?.[CF_ENDPOINT_TYPE] as IAllCfRolesState | undefined;
+        const scopes = all?.[endpointGuid]?.global?.scopes;
+        return !!scopes?.includes(scope as string);
+      }),
+      distinctUntilChanged(),
+    );
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-users-roles-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-users-roles-data.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { describe, expect, it, beforeEach } from 'vitest';
 
+import { UsersRolesSetChanges } from '../../actions/users-roles.actions';
 import { CfUser, IUserPermissionInOrg } from '../../store/types/cf-user.types';
 import { CfRoleChange, UsersRolesState } from '../../store/types/users-roles.types';
 import { CfUsersRolesDataService } from './cf-users-roles-data.service';
@@ -72,5 +73,19 @@ describe('CfUsersRolesDataService', () => {
     expect(svc.cfGuid()).toBe('cf-2');
     expect(svc.isRemove()).toBe(true);
     expect(svc.isSetByUsername()).toBe(false);
+  });
+
+  it('setChanges dispatches UsersRolesSetChanges with the provided diff', () => {
+    const dispatched: unknown[] = [];
+    store.scannedActions$.subscribe(a => dispatched.push(a));
+
+    const newChange: CfRoleChange = { ...change, role: 'auditors' as any };
+    svc.setChanges([newChange]);
+
+    const setAction = dispatched.find(
+      (a): a is UsersRolesSetChanges => a instanceof UsersRolesSetChanges,
+    );
+    expect(setAction).toBeDefined();
+    expect(setAction!.changes).toEqual([newChange]);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-users-roles-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-users-roles-data.service.ts
@@ -3,6 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 
 import { Store } from '@stratosui/store';
 
+import { UsersRolesSetChanges } from '../../actions/users-roles.actions';
 import { CFAppState } from '../../cf-app-state';
 import {
   selectCfUsersIsRemove,
@@ -24,9 +25,11 @@ import { CfUser, IUserPermissionInOrg } from '../../store/types/cf-user.types';
 // cf-role-checkbox) can drop their `store.select(selectCfUsers...)`
 // calls without waiting for the underlying NgRx reducer to migrate.
 //
-// The wizard still mutates state through reducer actions; this service
-// is read-only on top. Each accessor is a stable Signal wired through
-// toSignal once at construction.
+// Reads are signal-out (toSignal-wrapped selectors); writes are a
+// thin set of mutation methods that wrap the existing reducer actions
+// so consumers don't have to `inject(Store)` for the dispatch leg.
+// When the reducer eventually folds into this service, the public
+// surface stays put — only the internal `store` bridge goes away.
 @Injectable({ providedIn: 'root' })
 export class CfUsersRolesDataService {
   private readonly store = inject<Store<CFAppState>>(Store);
@@ -70,4 +73,15 @@ export class CfUsersRolesDataService {
     this.store.select(selectCfUsersIsSetByUsername),
     { initialValue: undefined },
   );
+
+  /**
+   * Replace the wizard's pending role-change set. Wraps the
+   * {@link UsersRolesSetChanges} reducer action so consumers (the
+   * manage-users review step in `CfRolesService`, the remove-user
+   * confirm step) don't have to `inject(Store)` for this single
+   * dispatch.
+   */
+  setChanges(changes: CfRoleChange[]): void {
+    this.store.dispatch(new UsersRolesSetChanges(changes));
+  }
 }

--- a/src/frontend/packages/cloud-foundry/src/user-permissions/cf-current-user-roles-signal.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/user-permissions/cf-current-user-roles-signal.service.ts
@@ -1,56 +1,49 @@
 import { Injectable, inject } from '@angular/core';
-import { Store } from '@ngrx/store';
-import { EndpointsDataService, GeneralEntityAppState, PermissionValues } from '@stratosui/store';
+import { EndpointsDataService, PermissionValues } from '@stratosui/store';
 import { Observable, defer, from } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { CfCurrentUserRolesDataService } from '../services/cf-current-user-roles-data.service';
 import { CF_ENDPOINT_TYPE } from '../cf-types';
-import {
-  getCurrentUserCFEndpointHasScope,
-  getCurrentUserCFEndpointRolesState,
-  getCurrentUserCFGlobalState,
-} from '../store/selectors/cf-current-user-role.selectors';
 import { ICfRolesState } from '../store/types/cf-current-user-roles.types';
 import { CfScopeStrings } from './cf-user-permissions.types';
 
 /**
- * Signal-native bridge over the cf-side `currentUserRoles` selectors and
- * the `connectedEndpoints` projection.
+ * W36-C Wave 2 — thin facade over {@link CfCurrentUserRolesDataService}.
  *
- * `CfUserPermissionsChecker` previously injected `Store` directly to read
- * these selectors. Routing through this service moves the `Store`
- * dependency out of the checker so that component specs which only
- * transitively pull in `CurrentUserPermissionsService` (and never run a
- * permission check) don't need to provide `@ngrx/store` at all.
+ * Preserves the observable surface `CfUserPermissionsChecker` was written
+ * against. The single `Store` bridge moved into
+ * `CurrentUserRolesDataService` (in the store package); this service no
+ * longer touches `Store`.
  *
- * Wave 2 (W36-B): the connected-CF-endpoint enumeration now reads from
- * {@link EndpointsDataService} signals rather than
- * `connectedEndpointsSelector`. The observable surface is preserved for
- * the existing rxjs-shaped checker pipelines.
+ * The connected-CF-endpoint enumeration still reads from
+ * {@link EndpointsDataService} signals (since W36-B Wave 2), preserved
+ * here verbatim so the pipeline shape is unchanged.
  *
  * Returns `Observable<...>` rather than `Signal<...>` because the existing
  * checker pipelines (`combineLatest`, `switchMap`, `distinctUntilChanged`)
  * are observable-shaped and porting them piecewise would expand this
- * keystone slice well beyond its scope.
+ * keystone slice well beyond its scope. New code should inject
+ * {@link CfCurrentUserRolesDataService} directly for signal-shaped APIs.
  */
 @Injectable({ providedIn: 'root' })
 export class CfCurrentUserRolesSignalService {
-  private store = inject<Store<GeneralEntityAppState>>(Store);
+  private rolesData = inject(CfCurrentUserRolesDataService);
   private endpointsService = inject(EndpointsDataService);
 
   /** Whether the current user has the named scope on the given CF endpoint. */
   cfEndpointHasScope$(endpointGuid: string, scope: CfScopeStrings): Observable<boolean> {
-    return this.store.select(getCurrentUserCFEndpointHasScope(endpointGuid, scope));
+    return this.rolesData.cfEndpointHasScope$(endpointGuid, scope);
   }
 
   /** Whether the current user has the named global CF role on the endpoint. */
   cfGlobalState$(endpointGuid: string, permission: PermissionValues): Observable<boolean> {
-    return this.store.select(getCurrentUserCFGlobalState(endpointGuid, permission));
+    return this.rolesData.cfGlobalState$(endpointGuid, permission);
   }
 
   /** Full per-endpoint CF roles slice (orgs/spaces/global). */
   cfEndpointRolesState$(endpointGuid: string): Observable<ICfRolesState> {
-    return this.store.select(getCurrentUserCFEndpointRolesState(endpointGuid));
+    return this.rolesData.cfEndpointRolesState$(endpointGuid);
   }
 
   /** GUIDs of every connected CF endpoint. */

--- a/src/frontend/packages/core/src/app.module.ts
+++ b/src/frontend/packages/core/src/app.module.ts
@@ -261,9 +261,14 @@ export class AppModule {
           if (!backendErrors.length) {
             return res;
           }
-          const entityConfig = entityCatalog.getEntity(STRATOS_ENDPOINT_TYPE, endpointEntityType);
+          // The `stratos/endpoint` catalog entry no longer exists (the
+          // legacy ngrx slice + schema-only catalog placeholder were
+          // retired in W36-B/C Wave 5). The store still keys endpoints
+          // under the same deterministic entity key, so compute it
+          // directly via `buildEntityKey` rather than catalog lookup.
+          const endpointEntityKey = EntityCatalogHelpers.buildEntityKey(endpointEntityType, STRATOS_ENDPOINT_TYPE);
           res.push(new GlobalEventData(true, {
-            endpoint: selectEntity<EndpointModel>(entityConfig.entityKey, eventId)(state),
+            endpoint: selectEntity<EndpointModel>(endpointEntityKey, eventId)(state),
             count: backendErrors.length
           }));
           return res;

--- a/src/frontend/packages/core/src/core/signals/auth-signal.service.ts
+++ b/src/frontend/packages/core/src/core/signals/auth-signal.service.ts
@@ -1,33 +1,33 @@
-import { Injectable, Signal, computed, effect, inject, signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { Store } from '@ngrx/store';
-import { AppState, AuthState, RouterNav, RouterRedirect, SessionData, VerifySession } from '@stratosui/store';
+import { Injectable, Signal, effect, inject, signal } from '@angular/core';
+import { AuthDataService, AuthState, RouterRedirect, SessionData } from '@stratosui/store';
 
 /**
- * Signal-native projection of the `auth` ngrx slice.
+ * W36-C Wave 1 — thin signal-native facade over {@link AuthDataService}.
  *
- * Read-through wrapper over `Store.select(s => s.auth)`. Does not write to the
- * store and does not persist to localStorage — auth state rehydrates from
- * `verify-session` on app start, so no signal mirror is needed.
+ * Preserves the per-field signal API the existing consumer surface
+ * (session.service, endpoints, login/logout pages, profile, restore,
+ * about/diagnostics, wizards) was written against. New code should inject
+ * `AuthDataService` directly; the indirection here is only worth the
+ * compile-time stability for the dozen-plus call sites.
  *
- * Consumers will be flipped from the legacy SessionService / Actions stream
- * to these signals in a later wave-3 slice.
+ * The single bridge to `store.select(s => s.auth)` lives in
+ * `AuthDataService` now — this service does not touch `Store`.
  */
 @Injectable({ providedIn: 'root' })
 export class AuthSignalService {
-  private store = inject<Store<AppState>>(Store);
+  private authData = inject(AuthDataService);
 
-  /** Raw auth slice. `undefined` until the store emits its first value. */
-  readonly auth: Signal<AuthState | undefined> = toSignal(this.store.select(s => s.auth));
+  /** Raw auth slice. `undefined` until the data service mirrors its first value. */
+  readonly auth: Signal<AuthState | undefined> = this.authData.auth;
 
-  readonly loggedIn: Signal<boolean> = computed(() => !!this.auth()?.loggedIn);
-  readonly loggingIn: Signal<boolean> = computed(() => !!this.auth()?.loggingIn);
-  readonly verifying: Signal<boolean> = computed(() => !!this.auth()?.verifying);
-  readonly error: Signal<boolean> = computed(() => !!this.auth()?.error);
-  readonly errorResponse: Signal<unknown> = computed(() => this.auth()?.errorResponse);
-  readonly sessionData: Signal<SessionData | null> = computed(() => this.auth()?.sessionData ?? null);
-  readonly sessionValid: Signal<boolean> = computed(() => !!this.sessionData()?.valid);
-  readonly redirect: Signal<RouterRedirect | undefined> = computed(() => this.auth()?.redirect);
+  readonly loggedIn: Signal<boolean> = this.authData.loggedIn;
+  readonly loggingIn: Signal<boolean> = this.authData.loggingIn;
+  readonly verifying: Signal<boolean> = this.authData.verifying;
+  readonly error: Signal<boolean> = this.authData.error;
+  readonly errorResponse: Signal<unknown> = this.authData.errorResponse;
+  readonly sessionData: Signal<SessionData | null> = this.authData.sessionData;
+  readonly sessionValid: Signal<boolean> = this.authData.sessionValid;
+  readonly redirect: Signal<RouterRedirect | undefined> = this.authData.redirect;
 
   /**
    * Timestamp (ms since epoch) of the most recent transition into a logged-in
@@ -55,21 +55,22 @@ export class AuthSignalService {
   }
 
   /**
-   * Trigger a session-verification cycle. Wraps the legacy `VerifySession`
-   * action so callers can stay Store-free; the underlying ngrx effect remains
+   * Trigger a session-verification cycle. Delegates to {@link AuthDataService}
+   * so callers can stay Store-free; the underlying ngrx effect remains
    * responsible for the HTTP round-trip until session refresh is fully
    * signal-native.
    */
   verifySession(login: boolean = false, updateEndpoints: boolean = false): void {
-    this.store.dispatch(new VerifySession(login, updateEndpoints));
+    this.authData.verifySession(login, updateEndpoints);
   }
 
   /**
    * Navigate to `path` while remembering `redirect` as the post-login target.
-   * Wraps the legacy `RouterNav` action — the auth reducer captures the
-   * redirect into `auth.redirect` so the login page can replay it on success.
+   * Delegates to {@link AuthDataService}, which dispatches `RouterNav`; the
+   * auth reducer captures the redirect so the login page can replay it on
+   * success.
    */
   navigateAndRememberRedirect(path: string[] | string, redirect: RouterRedirect): void {
-    this.store.dispatch(new RouterNav({ path }, redirect));
+    this.authData.navigateAndRememberRedirect(path, redirect);
   }
 }

--- a/src/frontend/packages/core/src/core/signals/current-user-roles-signal.service.ts
+++ b/src/frontend/packages/core/src/core/signals/current-user-roles-signal.service.ts
@@ -1,49 +1,54 @@
 import { Injectable, inject } from '@angular/core';
-import { Store } from '@ngrx/store';
 import {
-  GeneralEntityAppState,
+  AuthDataService,
+  CurrentUserRolesDataService,
   PermissionValues,
   SessionData,
-  getCurrentUserStratosHasScope,
-  getCurrentUserStratosRole,
-  selectSessionData,
 } from '@stratosui/store';
-import { Observable } from 'rxjs';
+import { Observable, distinctUntilChanged } from 'rxjs';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 /**
- * Signal-native bridge over the stratos-side `currentUserRoles` selectors
- * and `selectSessionData()`.
+ * W36-C Wave 2 — thin facade over {@link CurrentUserRolesDataService}
+ * and {@link AuthDataService}.
  *
- * The `StratosUserPermissionsChecker` previously injected `Store` directly
- * to call `store.select(getCurrentUserStratosRole(...))` etc. Routing those
- * reads through this service moves the `Store` dependency out of the
- * checker, which (combined with lazy checker construction in
- * `CurrentUserPermissionsService`) lets component specs that pull in
- * `CurrentUserPermissionsService` transitively avoid providing `Store` until
- * a permission check actually runs.
+ * Preserves the existing observable surface the
+ * `StratosUserPermissionsChecker` (and any other checker importing this
+ * service) was written against. The single `Store` bridge moved into
+ * `CurrentUserRolesDataService` (for the `currentUserRoles` slice) and
+ * `AuthDataService` (for the `auth.sessionData` slice). This service no
+ * longer touches `Store`.
  *
  * Consumers receive `Observable<...>` return values to keep the existing
- * `combineLatest` / `switchMap` pipelines in the checkers untouched.
+ * `combineLatest` / `switchMap` pipelines in the checkers untouched. New
+ * code should inject the data services directly for signal-shaped APIs.
  */
 @Injectable({ providedIn: 'root' })
 export class CurrentUserRolesSignalService {
-  private store = inject<Store<GeneralEntityAppState>>(Store);
+  private rolesData = inject(CurrentUserRolesDataService);
+  private authData = inject(AuthDataService);
+
+  /**
+   * Bridge `AuthDataService.sessionData` (Signal) back to an Observable so
+   * the existing `apiKeyCheck` pipeline stays observable-shaped. Field-init
+   * runs in the injection context so `toObservable` works without an
+   * explicit injector.
+   */
+  private readonly sessionData$$: Observable<SessionData | null> =
+    toObservable(this.authData.sessionData);
 
   /** Whether the current user holds the named stratos role (e.g. `isAdmin`). */
   stratosRole$(role: PermissionValues): Observable<boolean> {
-    return this.store.select(getCurrentUserStratosRole(role));
+    return this.rolesData.stratosRole$(role);
   }
 
   /** Whether the current user's stratos scopes include the named scope. */
   stratosHasScope$(scope: string): Observable<boolean> {
-    // `getCurrentUserStratosHasScope` is typed `(scope: UserScopeStrings)` but
-    // accepts any string at runtime; the checker passes
-    // `StratosScopeStrings`-typed values which match the underlying storage.
-    return this.store.select(getCurrentUserStratosHasScope(scope as any));
+    return this.rolesData.stratosHasScope$(scope);
   }
 
   /** Raw session data slice (for `apiKeyCheck`-style flows). */
   sessionData$(): Observable<SessionData | null> {
-    return this.store.select(selectSessionData());
+    return this.sessionData$$.pipe(distinctUntilChanged());
   }
 }

--- a/src/frontend/packages/core/src/core/signals/session-signal.service.spec.ts
+++ b/src/frontend/packages/core/src/core/signals/session-signal.service.spec.ts
@@ -54,6 +54,32 @@ describe('SessionSignalService', () => {
     expect(service.userEndpointsNotDisabled()).toBe(true);
   });
 
+  it('projects the SessionDataConfig object verbatim onto config()', () => {
+    const config = {
+      enableTechPreview: true,
+      userEndpointsEnabled: UserEndpointsEnabled.ADMIN_ONLY,
+    };
+    stub.setSessionData({ valid: true, config } as unknown as SessionData);
+
+    const service = TestBed.inject(SessionSignalService);
+    expect(service.config()).toEqual(config);
+  });
+
+  it('reacts to upstream sessionData changes (signal pass-through)', () => {
+    const service = TestBed.inject(SessionSignalService);
+    expect(service.isTechPreview()).toBe(false);
+
+    stub.setSessionData({
+      valid: true,
+      config: { enableTechPreview: true },
+    } as unknown as SessionData);
+    expect(service.isTechPreview()).toBe(true);
+
+    stub.setSessionData(null);
+    expect(service.isTechPreview()).toBe(false);
+    expect(service.config()).toBeNull();
+  });
+
   it('treats DISABLED as both not-enabled and not-not-disabled', () => {
     stub.setSessionData({
       valid: true,

--- a/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-config.service.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-config.service.ts
@@ -88,14 +88,13 @@ export class ViewPipeline<T> {
   }
 }
 
-// Endpoints list config service — bridges the legacy ngrx endpoints store to the
-// signal-native list pattern. Unlike the per-CNSI services in cloud-foundry
-// (CfApps/Orgs/Spaces/Routes), endpoints have no parent CNSI: they're top-level
-// records under stratosEntityCatalog.endpoint.store. The data source is therefore
-// a direct toSignal() over endpointEntitiesSelector — no EndpointDataService /
-// registry indirection involved. Filter / sort / paging machinery is identical to
-// the CF analogs, so the visual / interaction language stays consistent across
-// signal-list pages.
+// Endpoints list config service — provides the signal-native list pattern
+// over `EndpointsDataService` (the W36-B replacement for the legacy
+// `stratosEntityCatalog.endpoint.store` slice). Unlike the per-CNSI
+// services in cloud-foundry (CfApps/Orgs/Spaces/Routes), endpoints have
+// no parent CNSI: they're top-level records owned by `EndpointsDataService`.
+// Filter / sort / paging machinery is identical to the CF analogs, so the
+// visual / interaction language stays consistent across signal-list pages.
 @Injectable({ providedIn: 'root' })
 export class EndpointsSignalConfigService {
   private readonly store = inject<Store<AppState>>(Store);

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/base-endpoints-data-source.ts
@@ -27,13 +27,17 @@ import { ListRowSateHelper } from '../../list.helper';
 import { EndpointRowStateSetUpManager } from '../endpoint/endpoint-data-source.helpers';
 
 /**
- * Wave 5 (W36-B): the legacy `GetAllEndpoints` ngrx action class is gone,
- * but `BaseEndpointsDataSource` (and subclasses) still feed the legacy
- * client-side pagination machinery, which keys off `EntityRequestAction`
- * shape (entityType, endpointType, schema, paginationKey, initialParams).
+ * Wave 5 (W36-B/C): the legacy `GetAllEndpoints` ngrx action class is
+ * gone, and the schema-only `stratos`/`endpoint` catalog entry that
+ * previously served lookups for this data source has been retired too.
+ * `BaseEndpointsDataSource` still feeds the legacy client-side
+ * pagination machinery, which keys off `EntityRequestAction` shape
+ * (entityType, endpointType, schema, paginationKey, initialParams).
+ *
  * `EndpointsListAction` is the value-only stand-in: never dispatched
- * (refresh now calls `EndpointsDataService.getAll()` directly), just used
- * to seed the pagination row.
+ * (refresh now calls `EndpointsDataService.getAll()` directly), just
+ * used to seed the pagination row. The schema lives on the action
+ * itself (`entity[0]`) — no catalog round-trip needed.
  */
 export class EndpointsListAction implements EntityRequestAction {
   public type = '[Endpoints] List';

--- a/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-name/table-cell-endpoint-name.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/list/list-types/endpoint/table-cell-endpoint-name/table-cell-endpoint-name.component.spec.ts
@@ -13,8 +13,12 @@ describe('TableCellEndpointNameComponent', () => {
   let fixture: ComponentFixture<TableCellEndpointNameComponent>;
 
   beforeEach(() => {
-    // Register stratos entities so stratosEntityCatalog.endpoint is populated
-    // before the component's row setter calls .endpoint.store.getEntityMonitor()
+    // Register stratos entities so `systemInfo`, `userFavorite`, etc. are
+    // available to any catalog lookups exercised during the row render.
+    // The endpoint schema itself no longer lives in the catalog — it ships
+    // on the data source's action — so registration is no longer
+    // load-bearing for endpoint lookups, but staying consistent with the
+    // rest of the suite avoids surprising drift.
     (entityCatalog as any).clear();
     generateStratosEntities().forEach(entity => entityCatalog.register(entity));
 

--- a/src/frontend/packages/core/src/shared/global-events.service.ts
+++ b/src/frontend/packages/core/src/shared/global-events.service.ts
@@ -4,7 +4,7 @@ import { Store } from '@ngrx/store';
 import {
   StratosStatus, GeneralEntityAppState,
   EndpointModel, endpointEntityType, STRATOS_ENDPOINT_TYPE,
-  selectEntity, entityCatalog,
+  selectEntity, EntityCatalogHelpers,
 } from '@stratosui/store';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { combineLatest, Observable, ReplaySubject } from 'rxjs';
@@ -152,9 +152,13 @@ export class GlobalEventService {
       return;
     }
     this.store.pipe(take(1)).subscribe((appState: GeneralEntityAppState) => {
-      const entityConfig = entityCatalog.getEntity(STRATOS_ENDPOINT_TYPE, endpointEntityType);
+      // The `stratos/endpoint` catalog entry no longer exists (retired in
+      // W36-B/C Wave 5). Endpoints remain keyed under the deterministic
+      // entity key produced by `buildEntityKey`, so derive it directly
+      // instead of looking it up via the catalog.
+      const endpointEntityKey = EntityCatalogHelpers.buildEntityKey(endpointEntityType, STRATOS_ENDPOINT_TYPE);
       for (const [cnsiGuid, err] of errors) {
-        const endpoint = selectEntity<EndpointModel>(entityConfig.entityKey, cnsiGuid)(appState);
+        const endpoint = selectEntity<EndpointModel>(endpointEntityKey, cnsiGuid)(appState);
         const name = endpoint?.name ?? cnsiGuid;
         const detail = formatEndpointErrorDetail(err);
         events.push({

--- a/src/frontend/packages/store/src/monitors/pagination-monitor.factory.ts
+++ b/src/frontend/packages/store/src/monitors/pagination-monitor.factory.ts
@@ -2,6 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import { AppState } from '../app-state';
+import { EntityCatalogHelpers } from '../entity-catalog/entity-catalog.helper';
 import type { IEntityCatalog } from '../entity-catalog/entity-catalog.interface';
 import { EntityCatalogEntityConfig } from '../entity-catalog/entity-catalog.types';
 import { ENTITY_CATALOG_TOKEN } from '../tokens/store-injection.tokens';
@@ -23,11 +24,16 @@ export class PaginationMonitorFactory {
     isLocal: boolean
   ) {
     const { endpointType, entityType } = entityConfig;
+    // Defensive: callers like `BaseEndpointsDataSource` carry their own
+    // schema on the action and no longer register a `stratos`/`endpoint`
+    // catalog entry (retired in W36-B/C Wave 5). Fall back to the
+    // deterministic `buildEntityKey` for the cache key when the catalog
+    // lookup misses, rather than throwing.
     const catalogEntity = this.entityCatalog.getEntity(endpointType, entityType);
-    if (!catalogEntity) {
-      throw new Error(`Could not find catalog entity for endpoint type '${endpointType}' and entity type '${entityType}'`);
-    }
-    const cacheKey = paginationKey + catalogEntity.entityKey;
+    const entityKey = catalogEntity ?
+      catalogEntity.entityKey :
+      EntityCatalogHelpers.buildEntityKey(entityType, endpointType);
+    const cacheKey = paginationKey + entityKey;
     if (this.monitorCache[cacheKey]) {
       return this.monitorCache[cacheKey] as PaginationMonitor<T>;
     } else {

--- a/src/frontend/packages/store/src/monitors/pagination-monitor.ts
+++ b/src/frontend/packages/store/src/monitors/pagination-monitor.ts
@@ -92,10 +92,22 @@ export class PaginationMonitor<T = any, Y extends AppState = GeneralEntityAppSta
   ) {
     const { endpointType, entityType, schemaKey } = entityConfig;
     const catalogEntity = entityCatalog.getEntity(endpointType, entityType);
-    if (!catalogEntity) {
-      throw new Error(`Could not find catalog entity for endpoint type '${endpointType}' and entity type '${entityType}'`);
+    if (catalogEntity) {
+      this.schema = catalogEntity.getSchema(schemaKey);
+    } else {
+      // Defensive: callers like `BaseEndpointsDataSource` carry their
+      // schema on the action itself (`entity[0]`) and no longer register
+      // a `stratos`/`endpoint` catalog entry (retired in W36-B/C Wave 5).
+      // Fall back to the action-borne schema rather than throwing.
+      const inlineEntity = (entityConfig as { entity?: EntitySchema[] }).entity;
+      const inlineSchema = inlineEntity && inlineEntity[0];
+      if (!inlineSchema) {
+        throw new Error(
+          `Could not find catalog entity for endpoint type '${endpointType}' and entity type '${entityType}', and no inline schema was supplied on the action.`
+        );
+      }
+      this.schema = inlineSchema;
     }
-    this.schema = entityCatalog.getEntity(endpointType, entityType).getSchema(schemaKey);
     this.init(store, paginationKey, this.schema);
   }
 

--- a/src/frontend/packages/store/src/public-api.ts
+++ b/src/frontend/packages/store/src/public-api.ts
@@ -265,3 +265,11 @@ export { EndpointDisconnectCleanupService } from './services/endpoint-disconnect
 // reads in `AuthSignalService` and consolidates `VerifySession` / `RouterNav`
 // dispatch into one place so downstream consumers stay Store-free.
 export { AuthDataService } from './services/auth-data.service';
+
+// W36-C Wave 2 — signal-native current-user-roles data service. Single
+// bridge over the legacy `currentUserRoles` ngrx slice. Replaces direct
+// `store.select(getCurrentUserStratosRole(...))` /
+// `store.select(getCurrentUserStratosHasScope(...))` reads in
+// `CurrentUserRolesSignalService` and underpins the cf-side
+// `CfCurrentUserRolesDataService` in the cloud-foundry package.
+export { CurrentUserRolesDataService } from './services/current-user-roles-data.service';

--- a/src/frontend/packages/store/src/public-api.ts
+++ b/src/frontend/packages/store/src/public-api.ts
@@ -259,3 +259,9 @@ export type {
   EndpointUpdateOptions,
 } from './services/endpoints-data.service';
 export { EndpointDisconnectCleanupService } from './services/endpoint-disconnect-cleanup.service';
+
+// W36-C Wave 1 — signal-native auth data service. Single bridge over the
+// legacy `auth` ngrx slice. Replaces direct `store.select(s => s.auth)`
+// reads in `AuthSignalService` and consolidates `VerifySession` / `RouterNav`
+// dispatch into one place so downstream consumers stay Store-free.
+export { AuthDataService } from './services/auth-data.service';

--- a/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
+++ b/src/frontend/packages/store/src/reducers/pagination-reducer/pagination-reducer.helper.ts
@@ -183,8 +183,13 @@ function getObservables<T = any>(
   const paginationSelect$ = store.select(selectPaginationState(entityKey, paginationKey));
   const pagination$: Observable<PaginationEntityState> = paginationSelect$.pipe(filter(pagination => !!pagination));
 
+  // Defensive: entity may be null when an action references an entity type
+  // not registered in the catalog (e.g. the legacy endpoint list, whose
+  // schema lives on the action itself rather than in the catalog now that
+  // the `endpoint` ngrx slice has been retired). Fall back to the default
+  // fetch handler and a no-op emit handler in that case.
   const entity = entityCatalog.getEntity(arrayAction[0]);
-  const entitiesFetchHandler = entity.getEntitiesFetchHandler();
+  const entitiesFetchHandler = entity ? entity.getEntitiesFetchHandler() : null;
   const fetchHandler = entitiesFetchHandler ?
     entitiesFetchHandler(store, arrayAction) :
     defaultEntitiesFetchHandler(store, arrayAction);
@@ -202,7 +207,7 @@ function getObservables<T = any>(
     map(([, newPag]) => newPag)
   );
 
-  const entitiesEmitHandlerBuilder = entity.getEntitiesEmitHandler();
+  const entitiesEmitHandlerBuilder = entity ? entity.getEntitiesEmitHandler() : null;
   const actionEmitHandler = entitiesEmitHandlerBuilder ? entitiesEmitHandlerBuilder(
     paginationAction, (action) => store.dispatch(action)
   ) : () => { };

--- a/src/frontend/packages/store/src/services/auth-data.service.spec.ts
+++ b/src/frontend/packages/store/src/services/auth-data.service.spec.ts
@@ -1,0 +1,92 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { BehaviorSubject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VerifySession } from '../actions/auth.actions';
+import { RouterNav } from '../actions/router.actions';
+import { AuthState } from '../reducers/auth.reducer';
+import { RouterRedirect } from '../reducers/routing.reducer';
+import { SessionData } from '../types/auth.types';
+import { AuthDataService } from './auth-data.service';
+
+function makeAuthState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    loggedIn: false,
+    loggingIn: false,
+    verifying: false,
+    error: false,
+    errorResponse: null,
+    user: null,
+    sessionData: null,
+    ...overrides,
+  } as AuthState;
+}
+
+describe('AuthDataService', () => {
+  let auth$: BehaviorSubject<AuthState>;
+  let dispatch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    auth$ = new BehaviorSubject<AuthState>(makeAuthState());
+    dispatch = vi.fn();
+    const stubStore = {
+      select: () => auth$.asObservable(),
+      dispatch,
+    };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: Store, useValue: stubStore },
+        AuthDataService,
+      ],
+    });
+  });
+
+  it('mirrors the default auth slice on construction', () => {
+    const svc = TestBed.inject(AuthDataService);
+    expect(svc.loggedIn()).toBe(false);
+    expect(svc.loggingIn()).toBe(false);
+    expect(svc.verifying()).toBe(false);
+    expect(svc.error()).toBe(false);
+    expect(svc.sessionData()).toBeNull();
+    expect(svc.sessionValid()).toBe(false);
+    expect(svc.redirect()).toBeUndefined();
+  });
+
+  it('reflects subsequent auth slice updates through projected signals', () => {
+    const svc = TestBed.inject(AuthDataService);
+    const sessionData = { valid: true } as unknown as SessionData;
+    const redirect: RouterRedirect = { path: '/post-login' };
+
+    auth$.next(makeAuthState({ loggedIn: true, sessionData, redirect }));
+
+    expect(svc.loggedIn()).toBe(true);
+    expect(svc.sessionData()).toBe(sessionData);
+    expect(svc.sessionValid()).toBe(true);
+    expect(svc.redirect()).toEqual(redirect);
+  });
+
+  it('dispatches VerifySession with login + updateEndpoints flags', () => {
+    const svc = TestBed.inject(AuthDataService);
+    svc.verifySession(true, true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const action = dispatch.mock.calls[0][0] as VerifySession;
+    expect(action).toBeInstanceOf(VerifySession);
+    expect(action.login).toBe(true);
+    expect(action.updateEndpoints).toBe(true);
+  });
+
+  it('dispatches RouterNav with the captured redirect', () => {
+    const svc = TestBed.inject(AuthDataService);
+    const redirect: RouterRedirect = { path: '/after' };
+    svc.navigateAndRememberRedirect(['/login'], redirect);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const action = dispatch.mock.calls[0][0] as RouterNav;
+    expect(action).toBeInstanceOf(RouterNav);
+    expect(action.payload).toEqual({ path: ['/login'] });
+    expect(action.redirect).toEqual(redirect);
+  });
+});

--- a/src/frontend/packages/store/src/services/auth-data.service.ts
+++ b/src/frontend/packages/store/src/services/auth-data.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, Signal, computed, inject, signal } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Subscription } from 'rxjs';
+
+import { RouterNav } from '../actions/router.actions';
+import { VerifySession } from '../actions/auth.actions';
+import { AppState } from '../app-state';
+import { AuthState } from '../reducers/auth.reducer';
+import { RouterRedirect } from '../reducers/routing.reducer';
+import { SessionData } from '../types/auth.types';
+
+/**
+ * W36-C Wave 1 signal-native facade over the legacy `auth` ngrx slice.
+ *
+ * The auth reducer remains the canonical store of truth — it's still driven
+ * by `auth.effects.ts` (verify-session HTTP, login/logout transitions) and
+ * `system.actions.ts` (GET_SYSTEM_INFO_SUCCESS folds endpoints into
+ * sessionData). This service is the single bridge point: it subscribes to
+ * `store.select(s => s.auth)` ONCE on construction and mirrors the slice
+ * into signals so downstream consumers can stay Store-free.
+ *
+ * Mutations that previously dispatched ngrx actions (`VerifySession`,
+ * `RouterNav` with redirect) are exposed as service methods. New consumers
+ * inject this service (or {@link AuthSignalService} for the legacy
+ * per-field signal API) and never touch `Store` directly.
+ *
+ * When the reducer eventually migrates into this service, the `Store` bridge
+ * is the only piece that has to go — the public signal API stays put.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthDataService {
+  private store = inject<Store<AppState>>(Store);
+
+  /** Mirror of the `auth` slice. `undefined` until the store emits. */
+  private readonly _auth = signal<AuthState | undefined>(undefined);
+
+  readonly auth: Signal<AuthState | undefined> = this._auth.asReadonly();
+
+  readonly loggedIn: Signal<boolean> = computed(() => !!this._auth()?.loggedIn);
+  readonly loggingIn: Signal<boolean> = computed(() => !!this._auth()?.loggingIn);
+  readonly verifying: Signal<boolean> = computed(() => !!this._auth()?.verifying);
+  readonly error: Signal<boolean> = computed(() => !!this._auth()?.error);
+  readonly errorResponse: Signal<unknown> = computed(() => this._auth()?.errorResponse);
+  readonly sessionData: Signal<SessionData | null> = computed(
+    () => this._auth()?.sessionData ?? null,
+  );
+  readonly sessionValid: Signal<boolean> = computed(() => !!this.sessionData()?.valid);
+  readonly redirect: Signal<RouterRedirect | undefined> = computed(
+    () => this._auth()?.redirect,
+  );
+
+  private subscription: Subscription;
+
+  constructor() {
+    // Single bridge subscription. Long-lived (service is providedIn root)
+    // so we don't need to manage teardown — the subscription dies with the
+    // app. Reading via `subscribe` rather than `toSignal` keeps the data
+    // service usable from non-injection contexts (e.g. effects that
+    // construct it lazily) and avoids the rxjs-interop dependency here.
+    this.subscription = this.store.select(s => s.auth).subscribe(next => {
+      this._auth.set(next);
+    });
+  }
+
+  /**
+   * Trigger a session-verification cycle. Wraps the legacy `VerifySession`
+   * action — `auth.effects.ts` still owns the HTTP round-trip.
+   */
+  verifySession(login: boolean = false, updateEndpoints: boolean = false): void {
+    this.store.dispatch(new VerifySession(login, updateEndpoints));
+  }
+
+  /**
+   * Navigate to `path` while remembering `redirect` as the post-login
+   * target. The auth reducer captures the redirect into `auth.redirect`
+   * via the `RouterActions.GO` case so the login page can replay it on
+   * success.
+   */
+  navigateAndRememberRedirect(path: string[] | string, redirect: RouterRedirect): void {
+    this.store.dispatch(new RouterNav({ path }, redirect));
+  }
+}

--- a/src/frontend/packages/store/src/services/current-user-roles-data.service.spec.ts
+++ b/src/frontend/packages/store/src/services/current-user-roles-data.service.spec.ts
@@ -1,0 +1,98 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ICurrentUserRolesState,
+  IStratosRolesState,
+} from '../types/current-user-roles.types';
+import { UserScopeStrings } from '../types/endpoint.types';
+import { CurrentUserRolesDataService } from './current-user-roles-data.service';
+
+function makeStratos(overrides: Partial<IStratosRolesState> = {}): IStratosRolesState {
+  return {
+    isAdmin: false,
+    scopes: [],
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<ICurrentUserRolesState> = {}): ICurrentUserRolesState {
+  return {
+    internal: makeStratos(),
+    endpoints: {},
+    state: { initialised: false, fetching: false, error: false },
+    ...overrides,
+  };
+}
+
+describe('CurrentUserRolesDataService', () => {
+  let slice$: BehaviorSubject<ICurrentUserRolesState>;
+
+  beforeEach(() => {
+    slice$ = new BehaviorSubject<ICurrentUserRolesState>(makeState());
+    const stubStore = {
+      select: () => slice$.asObservable(),
+      dispatch: () => undefined,
+    };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: Store, useValue: stubStore },
+        CurrentUserRolesDataService,
+      ],
+    });
+  });
+
+  it('mirrors the initial currentUserRoles slice on construction', () => {
+    const svc = TestBed.inject(CurrentUserRolesDataService);
+    expect(svc.state()).toBeDefined();
+    expect(svc.stratos()?.isAdmin).toBe(false);
+    expect(svc.stratosRole('isAdmin')()).toBe(false);
+    expect(svc.stratosHasScope('any.scope' as UserScopeStrings)()).toBe(false);
+  });
+
+  it('reflects subsequent slice updates through stratosRole + stratosHasScope', () => {
+    const svc = TestBed.inject(CurrentUserRolesDataService);
+    const isAdminSig = svc.stratosRole('isAdmin');
+    const hasScopeSig = svc.stratosHasScope('cloud_controller.admin' as UserScopeStrings);
+
+    slice$.next(makeState({
+      internal: makeStratos({
+        isAdmin: true,
+        scopes: ['cloud_controller.admin' as UserScopeStrings],
+      }),
+    }));
+
+    expect(isAdminSig()).toBe(true);
+    expect(hasScopeSig()).toBe(true);
+    expect(svc.stratosHasScope('something.else' as UserScopeStrings)()).toBe(false);
+  });
+
+  it('exposes observable variants for legacy rxjs-shaped pipelines', async () => {
+    const svc = TestBed.inject(CurrentUserRolesDataService);
+    slice$.next(makeState({
+      internal: makeStratos({
+        isAdmin: true,
+        scopes: ['scope.a' as UserScopeStrings],
+      }),
+    }));
+    await expect(firstValueFrom(svc.stratosRole$('isAdmin'))).resolves.toBe(true);
+    await expect(
+      firstValueFrom(svc.stratosHasScope$('scope.a' as UserScopeStrings)),
+    ).resolves.toBe(true);
+    await expect(
+      firstValueFrom(svc.stratosHasScope$('scope.b' as UserScopeStrings)),
+    ).resolves.toBe(false);
+  });
+
+  it('returns false for stratosRole when state is undefined', () => {
+    const svc = TestBed.inject(CurrentUserRolesDataService);
+    slice$.next(undefined as unknown as ICurrentUserRolesState);
+    expect(svc.stratosRole('isAdmin')()).toBe(false);
+    expect(svc.stratosHasScope('scope.x' as UserScopeStrings)()).toBe(false);
+  });
+});

--- a/src/frontend/packages/store/src/services/current-user-roles-data.service.ts
+++ b/src/frontend/packages/store/src/services/current-user-roles-data.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, Signal, computed, inject, signal } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Observable, Subscription, distinctUntilChanged, map } from 'rxjs';
+
+import { CurrentUserRolesAppState } from '../app-state';
+import { PermissionValues } from '../selectors/current-user-role.selectors';
+import {
+  ICurrentUserRolesState,
+  IStratosRolesState,
+} from '../types/current-user-roles.types';
+import { UserScopeStrings } from '../types/endpoint.types';
+
+/**
+ * W36-C Wave 2 signal-native facade over the legacy `currentUserRoles`
+ * ngrx slice.
+ *
+ * The reducer (`current-user-roles.reducer.ts` plus per-endpoint reducers
+ * such as `permission.reducer.ts`) remains the canonical store of truth —
+ * it's still driven by `permission-fetcher.service` and the auth
+ * `VerifySession` cycle. This service is the single bridge point: it
+ * subscribes to `store.select(s => s.currentUserRoles)` ONCE on
+ * construction and mirrors the slice into signals so downstream consumers
+ * (the stratos + cf permission checkers, the cf-side data service in the
+ * cloud-foundry package, list config helpers, etc.) can stay Store-free.
+ *
+ * Mirrors the W36-C Wave 1 `AuthDataService` shape:
+ *   - signal-out for new consumers
+ *   - parametric `*$` observable getters preserved so the legacy
+ *     rxjs-shaped checker pipelines (`combineLatest`, `switchMap`,
+ *     `distinctUntilChanged`) keep compiling unchanged through the
+ *     facade in {@link CurrentUserRolesSignalService}
+ *
+ * When the underlying reducer eventually migrates into a future wave's
+ * data service, the `Store` bridge is the only piece that has to go —
+ * the public signal + observable API stays put.
+ */
+@Injectable({ providedIn: 'root' })
+export class CurrentUserRolesDataService {
+  private store = inject<Store<CurrentUserRolesAppState>>(Store);
+
+  /** Mirror of the `currentUserRoles` slice. `undefined` until the store emits. */
+  private readonly _state = signal<ICurrentUserRolesState | undefined>(undefined);
+
+  readonly state: Signal<ICurrentUserRolesState | undefined> = this._state.asReadonly();
+
+  readonly stratos: Signal<IStratosRolesState | undefined> = computed(
+    () => this._state()?.internal,
+  );
+
+  /** Long-lived source observable; data services in dependent packages reuse it. */
+  readonly state$: Observable<ICurrentUserRolesState | undefined>;
+
+  private subscription: Subscription;
+
+  constructor() {
+    // Single bridge subscription. Long-lived (service is providedIn root)
+    // so we don't need to manage teardown.
+    this.state$ = this.store
+      .select((s: CurrentUserRolesAppState) => s.currentUserRoles)
+      .pipe(distinctUntilChanged());
+    this.subscription = this.state$.subscribe(next => {
+      this._state.set(next);
+    });
+  }
+
+  /** Per-role boolean signal — replaces `getCurrentUserStratosRole(role)`. */
+  stratosRole(role: PermissionValues): Signal<boolean> {
+    return computed(() => {
+      const internal = this._state()?.internal as Record<string, any> | undefined;
+      if (!internal) {
+        return false;
+      }
+      // Mirrors `selectCurrentUserStratosRoles`: scopes is handled separately.
+      return !!internal[role];
+    });
+  }
+
+  /** Per-scope boolean signal — replaces `getCurrentUserStratosHasScope(scope)`. */
+  stratosHasScope(scope: UserScopeStrings | string): Signal<boolean> {
+    return computed(() => {
+      const scopes = this._state()?.internal?.scopes;
+      return !!scopes?.includes(scope as UserScopeStrings);
+    });
+  }
+
+  /** Observable boolean — keeps legacy `combineLatest`/`switchMap` pipelines simple. */
+  stratosRole$(role: PermissionValues): Observable<boolean> {
+    return this.state$.pipe(
+      map(state => {
+        const internal = state?.internal as Record<string, any> | undefined;
+        return internal ? !!internal[role] : false;
+      }),
+      distinctUntilChanged(),
+    );
+  }
+
+  /** Observable boolean — keeps legacy `combineLatest`/`switchMap` pipelines simple. */
+  stratosHasScope$(scope: UserScopeStrings | string): Observable<boolean> {
+    return this.state$.pipe(
+      map(state => !!state?.internal?.scopes?.includes(scope as UserScopeStrings)),
+      distinctUntilChanged(),
+    );
+  }
+}

--- a/src/frontend/packages/store/src/stratos-entity-generator.ts
+++ b/src/frontend/packages/store/src/stratos-entity-generator.ts
@@ -7,13 +7,12 @@ import {
 import { IStratosEntityDefinition } from './entity-catalog/entity-catalog.types';
 import {
   apiKeyEntityType,
-  endpointEntityType,
   STRATOS_ENDPOINT_TYPE,
   systemInfoEntityType,
   userFavouritesEntityType,
   userProfileEntityType,
 } from './helpers/stratos-entity-factory';
-import { EndpointModel, stratosEntityFactory } from './public-api';
+import { stratosEntityFactory } from './public-api';
 import { addOrUpdateUserFavoriteMetadataReducer, deleteUserFavoriteMetadataReducer } from './reducers/favorite.reducer';
 import {
   ApiKeyActionBuilder,
@@ -41,33 +40,12 @@ export function generateStratosEntities(): StratosBaseCatalogEntity[] {
     schema: null as any
   };
   return [
-    generateEndpointSchemaEntry(stratosType),
     generateSystemInfo(stratosType),
     generateUserFavorite(stratosType),
     generateUserProfile(stratosType),
     generateMetricsEndpoint(),
     generateAPIKeys(stratosType)
   ];
-}
-
-/**
- * Wave 5 (W36-B): the `endpoint` slice's actions, effects, reducers, and
- * action builders are gone — EndpointsDataService owns the endpoint
- * lifecycle end-to-end. But the legacy `BaseEndpointsDataSource` (and
- * subclasses) still feed the client-side pagination/list machinery
- * (stratos pagination reducer, monitors, schema-driven row IDs) keyed on
- * the `stratos`/`endpoint` catalog entry. Register a no-action,
- * no-reducer schema-only entry here so those lookups resolve. The entry
- * is unreachable from any action dispatch path — there are no action
- * builders + nothing dispatches.
- */
-function generateEndpointSchemaEntry(stratosType: any) {
-  const definition: IStratosEntityDefinition = {
-    schema: stratosEntityFactory(endpointEntityType),
-    type: endpointEntityType,
-    endpoint: stratosType,
-  };
-  return new StratosCatalogEntity<undefined, EndpointModel>(definition);
 }
 
 function generateSystemInfo(stratosType: any) {


### PR DESCRIPTION
## Summary
Follow-up to #5332 (W36-B, merged). Re-filed from closed #5333 to clear
dismissed-review history; branch HEAD unchanged at `8587a629cc`.

Retires the internal `@stratosui/store` reads from the remaining four
W36-x signal services (Auth, CurrentUserRoles, CfCurrentUserRoles,
Session) by introducing new data services that own the bridge.
Migrates `cf-pagination-maxed-state.ts` and `CfRolesService` off direct
`store.select` / `store.dispatch` to the new data services. Retires the
schema-only `stratos/endpoint` catalog entry left as a transitional
artefact by #5332's Wave 5, by making three pagination chokepoints
(`PaginationMonitor`, `PaginationMonitorFactory`,
`getPaginationObservables`) defensive against missing catalog entries.

5 waves landed as separate atomic / merge-commits to preserve slice
identity:
- C-W1: `AuthDataService` + thin `AuthSignalService` facade
- C-W2: `CurrentUserRolesDataService` + `CfCurrentUserRolesDataService`
        + thin facades on both signal services
- C-W3a: `cf-pagination-maxed-state` routes session data via `AuthDataService`
- C-W3b: `CfRolesService` dispatch via `CfUsersRolesDataService`
- C-W4: `SessionSignalService` projection test coverage
        (already signal-native via C-W1 chain)
- C-W5: retire schema-only `stratos/endpoint` catalog entry
        + defensive pagination fallbacks

Net change: +871 / -140 (25 files).

**Merge strategy**: please use "Create a merge commit" to preserve the
wave-by-wave slice identity.

## Test plan
- [x] `make check gate` green on the integrated W36-C umbrella
      (vitest 636+ files / 2228+ tests, production build OK, Go suite PASS)
- [x] Per-slice gates verified independently for C-W1 and C-W5; gates
      trusted for C-W2/W3/W4 with the umbrella gate covering integration
- [ ] Local smoke: login → session → logout flows post AuthDataService rewire
- [ ] Local smoke: CF user roles tab reflects current-user permissions
      after reconnect
- [ ] Local smoke: list pagination respects `listMaxSize` from session
      config (cf-pagination-maxed-state path)