### PR TITLE
Post-A21 regressions: favicon, CF sort, drain dedup, null guards, CAPI status

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -88,7 +88,11 @@
                 "input": "src/frontend/packages/core/assets",
                 "output": "/core/assets"
               },
-              "src/frontend/packages/core/src/favicon.ico",
+              {
+                "glob": "favicon.ico",
+                "input": "src/frontend/packages/core/src",
+                "output": "/"
+              },
               {
                 "glob": "**/*",
                 "input": "custom-src/frontend/assets/custom",

--- a/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.ts
@@ -16,6 +16,7 @@ import {
   PageHeaderComponent,
   SignalListComponent,
   SignalListConfig,
+  SignalListSort,
 } from '@stratosui/core';
 import type { EndpointModel } from '@stratosui/store';
 
@@ -63,10 +64,29 @@ export class CloudFoundryComponent {
       if (!q) return all;
       return all.filter(e => (e.name ?? '').toLowerCase().includes(q));
     });
+    const sortState: WritableSignal<SignalListSort> = signal({ field: 'name', direction: 'asc' });
+    const sortExtractors: Record<string, (e: EndpointModel) => unknown> = {
+      name: e => e.name ?? '',
+      address: e => e.api_endpoint?.Host ?? '',
+      user: e => e.user?.name ?? '',
+    };
+    const sorted: Signal<EndpointModel[]> = computed(() => {
+      const items = filtered();
+      const { field, direction } = sortState();
+      const extract = sortExtractors[field] ?? sortExtractors.name;
+      const dir = direction === 'desc' ? -1 : 1;
+      return [...items].sort((a, b) => {
+        const av = extract(a), bv = extract(b);
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        return av < bv ? -1 * dir : av > bv ? 1 * dir : 0;
+      });
+    });
     const pageSize: WritableSignal<number> = signal(24);
     const pageIndex: WritableSignal<number> = signal(0);
     const paged: Signal<EndpointModel[]> = computed(() => {
-      const items = filtered();
+      const items = sorted();
       const sz = pageSize();
       const i = pageIndex();
       return items.slice(i * sz, (i + 1) * sz);
@@ -108,6 +128,7 @@ export class CloudFoundryComponent {
       nameFilter,
       filterColumns: ['name'],
       viewMode: signal('card'),
+      sort: sortState,
     });
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/services/diagnostics/diagnostics.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/diagnostics/diagnostics.types.ts
@@ -8,6 +8,7 @@ export const DIAGNOSTIC_CODE_FAMILIES = [
   'service-call-count',
   'cache-hit',
   'cache-miss',
+  'in-flight-hit',
   'buffer-overflow',
 ] as const;
 

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { signal, Signal } from '@angular/core';
 import { EMPTY, firstValueFrom, merge, Observable, of, ReplaySubject } from 'rxjs';
-import { catchError, finalize, tap, timeout } from 'rxjs/operators';
+import { catchError, finalize, shareReplay, tap, timeout } from 'rxjs/operators';
 import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
 import { EndpointDataShim } from './endpoint-data.shim';
 import {
@@ -90,6 +90,14 @@ export class EndpointDataService {
   readonly loaded$ = new ReplaySubject<void>(1);
   readonly detailsLoaded$ = new ReplaySubject<void>(1);
 
+  // In-flight dedup. Concurrent callers before the first HTTP completes share
+  // the same Observable instead of each firing their own fan-out — without
+  // this, multiple subscribers (org-list + endpoint summary + recents) each
+  // start fresh requests; teardown of the first subscriber aborts its in-
+  // flight requests (ERR_ABORTED), leaving only the last to complete.
+  private _inFlightLoad: Observable<void> | null = null;
+  private _inFlightLoadDetails: Observable<void> | null = null;
+
   constructor(
     private readonly http: HttpClient,
     private readonly shim: EndpointDataShim,
@@ -109,11 +117,15 @@ export class EndpointDataService {
       this.diagnostics?.emitCounter('cache-hit', { service: 'EndpointDataService', method: 'load' });
       return of(undefined);
     }
+    if (this._inFlightLoad) {
+      this.diagnostics?.emitCounter('in-flight-hit', { service: 'EndpointDataService', method: 'load' });
+      return this._inFlightLoad;
+    }
     this.diagnostics?.emitCounter('cache-miss', { service: 'EndpointDataService', method: 'load' });
     this._isLoading.set(true);
     this._errors.set([]);
 
-    return merge(
+    this._inFlightLoad = merge(
       this.http.get<{ resources: StOrg[]; totalResults: number }>(`/pp/v1/cf/orgs/${this.guid}?return=counts`).pipe(
         tap(resp => this._orgCount.set(resp.totalResults)),
         catchError(err => { this.addError('orgs', err); return EMPTY; }),
@@ -142,8 +154,11 @@ export class EndpointDataService {
         // pagination store only needs the full lists, which loadDetails()
         // dispatches via shim.write() in its own finalize().
         this.loaded$.next();
+        this._inFlightLoad = null;
       }),
+      shareReplay({ bufferSize: 1, refCount: false }),
     ) as Observable<void>;
+    return this._inFlightLoad;
   }
 
   // loadDetails() fetches the full orgs/apps/spaces lists (paginated
@@ -153,6 +168,10 @@ export class EndpointDataService {
     if (this._detailsLastFetched() !== null && this._orgs().length > 0) {
       this.diagnostics?.emitCounter('cache-hit', { service: 'EndpointDataService', method: 'loadDetails' });
       return of(undefined);
+    }
+    if (this._inFlightLoadDetails) {
+      this.diagnostics?.emitCounter('in-flight-hit', { service: 'EndpointDataService', method: 'loadDetails' });
+      return this._inFlightLoadDetails;
     }
     this.diagnostics?.emitCounter('cache-miss', { service: 'EndpointDataService', method: 'loadDetails' });
     this._isLoadingDetails.set(true);
@@ -171,7 +190,7 @@ export class EndpointDataService {
     const detailPerPage = 500;
     type Paged<T> = { resources: T[]; totalResults?: number; pagination?: { totalResults?: number } };
     const totalOf = <T>(r: Paged<T>): number => r.pagination?.totalResults ?? r.totalResults ?? r.resources.length;
-    return merge(
+    this._inFlightLoadDetails = merge(
       this.http.get<Paged<StOrg>>(
         `/pp/v1/cf/orgs/${this.guid}?per_page=${detailPerPage}&page=1`,
       ).pipe(
@@ -203,8 +222,11 @@ export class EndpointDataService {
         this._detailsLastFetched.set(new Date());
         this.shim.write(this.guid, this.currentData());
         this.detailsLoaded$.next();
+        this._inFlightLoadDetails = null;
       }),
+      shareReplay({ bufferSize: 1, refCount: false }),
     ) as Observable<void>;
+    return this._inFlightLoadDetails;
   }
 
   // loadServicesCounts() fetches the four cnsi-scoped services-domain counts

--- a/src/frontend/packages/core/src/shared/global-events.service.ts
+++ b/src/frontend/packages/core/src/shared/global-events.service.ts
@@ -220,9 +220,26 @@ export class GlobalEventService {
 
   // Get the event from the event config and event data.
   private getEvent(eventData: any, config: IGlobalEventConfig<any>, appState: GeneralEntityAppState): IGlobalEvent {
-    const message = typeof config.message === 'function' ? config.message(eventData, appState) : config.message;
-    const link = typeof config.link === 'function' ? config.link(eventData, appState) : config.link;
-    const key = typeof config.key === 'function' ? config.key(eventData, appState) : config.key || config.message;
+    // User-supplied callbacks can crash when eventData is undefined — e.g.
+    // an endpoint-error event whose entity never resolved. Treat any
+    // throw as "no link/message" so the event still emits its key/type
+    // and the row template's `@if (event.link)` guard hides the View
+    // button cleanly.
+    const safe = <T>(fn: () => T, fallback: T): T => {
+      try { return fn(); } catch { return fallback; }
+    };
+    const messageFn = config.message;
+    const linkFn = config.link;
+    const keyFn = config.key;
+    const message = typeof messageFn === 'function'
+      ? safe(() => messageFn(eventData, appState), '')
+      : messageFn;
+    const link = typeof linkFn === 'function'
+      ? safe(() => linkFn(eventData, appState), '')
+      : linkFn;
+    const key = typeof keyFn === 'function'
+      ? safe(() => keyFn(eventData, appState), '')
+      : keyFn || config.message;
     const type = config.type || 'warning';
     return {
       message,

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -800,7 +800,7 @@ func (c *CloudFoundrySpecification) getNativeOrgDetail(ctx echo.Context) error {
 
 	r, err := cfClient.Organizations().Get(ctx.Request().Context(), orgGUID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+		return echo.NewHTTPError(statusFromCapiError(err), err.Error())
 	}
 
 	detail := StOrgDetail{
@@ -834,7 +834,7 @@ func (c *CloudFoundrySpecification) getNativeSpaceDetail(ctx echo.Context) error
 
 	r, err := cfClient.Spaces().Get(ctx.Request().Context(), spaceGUID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+		return echo.NewHTTPError(statusFromCapiError(err), err.Error())
 	}
 
 	detail := StSpaceDetail{


### PR DESCRIPTION
## Summary

Five regression fixes surfaced by a dev.83 walk of the major pages after PR #5335 / the Angular 21 ship:

- **Favicon 404** — the Angular 21 `application` builder copied `favicon.ico` to `/core/src/favicon.ico` instead of dist root; switched to the explicit object form so it lands at `/favicon.ico`.
- **CF picker sort missing** — PR #5335 migrated `/cloud-foundry` to SignalList but didn't wire the `sort` writable signal, so the card-mode sort dropdown was hidden. Restored Name/Address/User sort defaulting to Name asc.
- **EndpointDataService drain double-fire** — concurrent callers of `load()` / `loadDetails()` each fanned out their own HTTP requests; teardown of one subscriber aborted its in-flight requests (`ERR_ABORTED` noise). Added in-flight Observable cache + `shareReplay` so the underlying drain fires exactly once regardless of subscriber count.
- **GlobalEventService link/message/key TypeError** — user-supplied callbacks crashed when `eventData` was undefined (e.g. an endpoint-error event for an entity that never resolved). Wrapped each callback in a try/catch with `''` fallback; row template's `@if (event.link)` guard hides the View button cleanly.
- **Native org/space detail 502 → 404 mapping** — `getNativeOrgDetail` / `getNativeSpaceDetail` blanket-mapped all CAPI errors to `502 Bad Gateway`. Switched to `statusFromCapiError` (already used by writes) so `capi.ErrNotFound` surfaces as `404`, `ErrUnauthorized` as `401`, etc.

## Test plan
- [x] `make check gate` green
- [x] Local dev: favicon renders at `/login`
- [x] Local dev: `/cloud-foundry` shows Sort dropdown (Name/Address/User) and reorders cards
- [x] Local dev: org-detail loads cleanly on a real org (Kevin 4 / `e2e`) — no `ERR_ABORTED`, no TypeError
- [ ] Deploy verify post-deploy
