### PR TITLE
Org/space detail: signal-native migration + count-probe dedup

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/cli-info-cloud-foundry/cli-info-cloud-foundry.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cli-info-cloud-foundry/cli-info-cloud-foundry.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, Injector, inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 import { CustomTooltipDirective } from '@stratosui/core';
 import { Store } from '@stratosui/store';
@@ -13,7 +14,8 @@ import { getFullEndpointApiUrl } from '../../../../../store/src/endpoint-utils';
 import { APIResource, EntityInfo } from '../../../../../store/src/types/api.types';
 import { EndpointModel } from '../../../../../store/src/types/endpoint.types';
 import { getPreviousRoutingState } from '../../../../../store/src/types/routing.type';
-import { IOrganization, ISpace } from '../../../cf-api.types';
+import { ISpace } from '../../../cf-api.types';
+import { StOrgDetail } from '../../../services/endpoint-data/stratos-types';
 import { CFAppState } from '../../../cf-app-state';
 import { CliCommandComponent } from '../../../shared/components/cli-info/cli-command/cli-command.component';
 import { CFAppCLIInfoContext, CliInfoComponent } from '../../../shared/components/cli-info/cli-info.component';
@@ -56,6 +58,7 @@ export class CliInfoCloudFoundryComponent implements OnInit {
   private cfEndpointService = inject(CloudFoundryEndpointService);
   private cfOrgService = inject(CloudFoundryOrganizationService, { optional: true });
   private cfSpaceService = inject(CloudFoundrySpaceService, { optional: true });
+  private injector = inject(Injector);
 
 
   permsOrgEdit = CfCurrentUserPermissions.ORGANIZATION_EDIT;
@@ -76,7 +79,7 @@ export class CliInfoCloudFoundryComponent implements OnInit {
 
   public endpointOrgSpace$!: Observable<[
     EntityInfo<EndpointModel>,
-    EntityInfo<APIResource<IOrganization>>,
+    StOrgDetail | null,
     EntityInfo<APIResource<ISpace>>
   ]>;
 
@@ -127,7 +130,11 @@ export class CliInfoCloudFoundryComponent implements OnInit {
 
   private setupObservables() {
     const { orgGuid, spaceGuid } = this.activeRouteCfOrgSpace;
-    const org$ = orgGuid ? this.cfOrgService.org$ : observableOf(null);
+    // V3-native org snapshot from OrgDataService signal; space$ still envelope-
+    // shaped pending Phase B migration.
+    const org$ = orgGuid && this.cfOrgService
+      ? toObservable(this.cfOrgService.orgDataService.org, { injector: this.injector })
+      : observableOf(null);
     const space$ = spaceGuid ? this.cfSpaceService.space$ : observableOf(null);
     this.endpointOrgSpace$ = combineLatest(
       this.cfEndpointService.endpoint$,
@@ -138,7 +145,7 @@ export class CliInfoCloudFoundryComponent implements OnInit {
     this.context$ = this.endpointOrgSpace$.pipe(
       map(([cf, org, space]) => {
         return {
-          orgName: org ? org.entity.entity.name : null,
+          orgName: org ? org.name : null,
           spaceName: space ? space.entity.entity.name : null,
           apiEndpoint: getFullEndpointApiUrl(cf.entity),
           username: cf.entity.user ? cf.entity.user.name : ''
@@ -157,13 +164,13 @@ export class CliInfoCloudFoundryComponent implements OnInit {
         }];
         if (org) {
           breadcrumbs.push({
-            value: org.entity.entity.name,
-            routerLink: `/cloud-foundry/${cf.entity.guid}/organizations/${org.entity.metadata.guid}`
+            value: org.name,
+            routerLink: `/cloud-foundry/${cf.entity.guid}/organizations/${org.guid}`
           });
           if (space) {
             breadcrumbs.push({
               value: space.entity.entity.name,
-              routerLink: `/cloud-foundry/${cf.entity.guid}/organizations/${org.entity.metadata.guid}/spaces/${space.entity.metadata.guid}`
+              routerLink: `/cloud-foundry/${cf.entity.guid}/organizations/${org.guid}/spaces/${space.entity.metadata.guid}`
             });
           }
         }

--- a/src/frontend/packages/cloud-foundry/src/features/cf/cli-info-cloud-foundry/cli-info-cloud-foundry.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cli-info-cloud-foundry/cli-info-cloud-foundry.component.ts
@@ -11,11 +11,10 @@ import { PageHeaderComponent } from '../../../../../core/src/shared/components/p
 import { IHeaderBreadcrumb } from '../../../../../core/src/shared/components/page-header/page-header.types';
 import { RouterNav } from '../../../../../store/src/actions/router.actions';
 import { getFullEndpointApiUrl } from '../../../../../store/src/endpoint-utils';
-import { APIResource, EntityInfo } from '../../../../../store/src/types/api.types';
+import { EntityInfo } from '../../../../../store/src/types/api.types';
 import { EndpointModel } from '../../../../../store/src/types/endpoint.types';
 import { getPreviousRoutingState } from '../../../../../store/src/types/routing.type';
-import { ISpace } from '../../../cf-api.types';
-import { StOrgDetail } from '../../../services/endpoint-data/stratos-types';
+import { StOrgDetail, StSpace } from '../../../services/endpoint-data/stratos-types';
 import { CFAppState } from '../../../cf-app-state';
 import { CliCommandComponent } from '../../../shared/components/cli-info/cli-command/cli-command.component';
 import { CFAppCLIInfoContext, CliInfoComponent } from '../../../shared/components/cli-info/cli-info.component';
@@ -80,7 +79,7 @@ export class CliInfoCloudFoundryComponent implements OnInit {
   public endpointOrgSpace$!: Observable<[
     EntityInfo<EndpointModel>,
     StOrgDetail | null,
-    EntityInfo<APIResource<ISpace>>
+    StSpace | null
   ]>;
 
   constructor() {
@@ -130,12 +129,14 @@ export class CliInfoCloudFoundryComponent implements OnInit {
 
   private setupObservables() {
     const { orgGuid, spaceGuid } = this.activeRouteCfOrgSpace;
-    // V3-native org snapshot from OrgDataService signal; space$ still envelope-
-    // shaped pending Phase B migration.
+    // V3-native org + space snapshots from the OrgDataService /
+    // SpaceDataService signals.
     const org$ = orgGuid && this.cfOrgService
       ? toObservable(this.cfOrgService.orgDataService.org, { injector: this.injector })
       : observableOf(null);
-    const space$ = spaceGuid ? this.cfSpaceService.space$ : observableOf(null);
+    const space$ = spaceGuid && this.cfSpaceService
+      ? toObservable(this.cfSpaceService.spaceDataService.space, { injector: this.injector })
+      : observableOf(null);
     this.endpointOrgSpace$ = combineLatest(
       this.cfEndpointService.endpoint$,
       org$,
@@ -146,7 +147,7 @@ export class CliInfoCloudFoundryComponent implements OnInit {
       map(([cf, org, space]) => {
         return {
           orgName: org ? org.name : null,
-          spaceName: space ? space.entity.entity.name : null,
+          spaceName: space ? space.name : null,
           apiEndpoint: getFullEndpointApiUrl(cf.entity),
           username: cf.entity.user ? cf.entity.user.name : ''
         };
@@ -169,8 +170,8 @@ export class CliInfoCloudFoundryComponent implements OnInit {
           });
           if (space) {
             breadcrumbs.push({
-              value: space.entity.entity.name,
-              routerLink: `/cloud-foundry/${cf.entity.guid}/organizations/${org.guid}/spaces/${space.entity.metadata.guid}`
+              value: space.name,
+              routerLink: `/cloud-foundry/${cf.entity.guid}/organizations/${org.guid}/spaces/${space.guid}`
             });
           }
         }

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization-step/edit-organization-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization-step/edit-organization-step.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, inject, signal, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, Injector, inject, signal, Input } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { AbstractControl, ReactiveFormsModule, ValidatorFn, Validators, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store } from '@stratosui/store';
@@ -57,6 +58,7 @@ export class EditOrganizationStepComponent implements OnInit, OnDestroy {
   private store = inject<Store<CFAppState>>(Store);
   private paginationMonitorFactory = inject(PaginationMonitorFactory);
   private cfOrgService = inject(CloudFoundryOrganizationService);
+  private injector = inject(Injector);
   private fb = inject(FormBuilder);
   private router = inject(Router);
 
@@ -121,8 +123,15 @@ export class EditOrganizationStepComponent implements OnInit, OnDestroy {
       orgName: new FormControl('', { nonNullable: true, validators: [Validators.required, this.nameTakenValidator()] }),
       quotaDefinition: new FormControl<string | null>(null),
     });
-    this.org$ = this.cfOrgService.org$.pipe(
-      map(o => o.entity.entity),
+    // Source the form-prefill from the V3-native OrgDataService signal. Wait
+    // for the first non-null snapshot (filter), then patch the form once.
+    this.org$ = toObservable(this.cfOrgService.orgDataService.org, { injector: this.injector }).pipe(
+      filter((o): o is NonNullable<typeof o> => !!o),
+      map(o => ({
+        name: o.name,
+        status: o.status,
+        quota_definition_guid: o.quotaGuid || undefined,
+      })),
       take(1),
       tap(n => {
         this.originalName = n.name;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space-step/edit-space-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space-step/edit-space-step.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, inject, signal, Input } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, Injector, inject, signal, Input } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { FormsModule, ReactiveFormsModule, FormControl, FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@stratosui/store';
@@ -50,6 +51,7 @@ interface EditSpaceForm {
 })
 export class EditSpaceStepComponent extends AddEditSpaceStepBase implements OnInit, OnDestroy {
   private cfSpaceService = inject(CloudFoundrySpaceService);
+  private injector = inject(Injector);
   private router = inject(Router);
 
   /** See QuotaDefinitionFormComponent for rationale. */
@@ -104,8 +106,17 @@ export class EditSpaceStepComponent extends AddEditSpaceStepBase implements OnIn
       toggleSsh: new FormControl(false, { nonNullable: true }),
       quotaDefinition: new FormControl<string | number | null>(null),
     });
-    this.space$ = this.cfSpaceService.space$.pipe(
-      map(o => o.entity.entity),
+    // V3-native: source the form-prefill from the SpaceDataService signal.
+    // Map V3 field names (allowSsh, quotaGuid) back onto the form's V2 keys
+    // (allow_ssh, space_quota_definition_guid) so the rest of the form
+    // pipeline stays unchanged.
+    this.space$ = toObservable(this.cfSpaceService.spaceDataService.space, { injector: this.injector }).pipe(
+      filter((o): o is NonNullable<typeof o> => !!o),
+      map(o => ({
+        name: o.name,
+        allow_ssh: o.allowSsh,
+        space_quota_definition_guid: o.quotaGuid || undefined,
+      })),
       take(1),
       tap(n => {
         this.originalName = n.name;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space.component.spec.ts
@@ -27,15 +27,12 @@ describe('EditSpaceComponent', () => {
     cfGuid: 'test-cf-guid',
     orgGuid: 'test-org-guid',
     spaceGuid: 'test-space-guid',
-    space$: of({
-      entity: {
-        entity: {
-          name: 'test-space',
-          allow_ssh: true,
-          space_quota_definition_guid: null
-        }
-      }
-    })
+    spaceDataService: {
+      space: () => null,
+      isLoading: () => false,
+      errors: () => [],
+      load: () => of(undefined),
+    },
   };
 
   beforeEach(() => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space.component.ts
@@ -1,7 +1,8 @@
 import { CommonModule } from '@angular/common';
-import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Injector, inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 
 import { PageHeaderComponent, StepComponent, SteppersComponent } from '@stratosui/core';
 import { CfUserService } from '../../../shared/data-services/cf-user.service';
@@ -41,14 +42,15 @@ export class EditSpaceComponent {
 
   constructor() {
     const cfSpaceService = inject(CloudFoundrySpaceService);
-
+    const injector = inject(Injector);
 
     this.spaceUrl = '/cloud-foundry/' +
       `${cfSpaceService.cfGuid}/organizations/` +
       `${cfSpaceService.orgGuid}/spaces/` +
       `${cfSpaceService.spaceGuid}/summary`;
-    this.spaceName$ = cfSpaceService.space$.pipe(
-      map(s => s.entity.entity.name)
+    this.spaceName$ = toObservable(cfSpaceService.spaceDataService.space, { injector }).pipe(
+      filter(s => !!s),
+      map(s => s!.name),
     );
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-organization.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-organization.service.ts
@@ -3,7 +3,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { Route } from '@angular/router';
 import { Store } from '@stratosui/store';
 import { combineLatest, Observable } from 'rxjs';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { filter, map, shareReplay, switchMap } from 'rxjs/operators';
 
 import { CnsiUsersSnapshotService } from '../../../services/endpoint-data/cnsi-users-snapshot.service';
 import { OrgDataRegistry } from '../../../services/endpoint-data/org-data.registry';
@@ -238,13 +238,19 @@ export class CloudFoundryOrganizationService {
     const orgSnapshot$ = toObservable(this.orgDataService.org, { injector: this.injector }).pipe(
       filter((o): o is StOrgDetail => !!o),
     );
+    // shareReplay so the 4 subscribers on space-detail summary (template
+    // quotaDefinition$ async-pipe, quotaLink$ combineLatest, plus space-
+    // service.spaceQuotaDefinition$ fallback chain) share one
+    // getEntityService(...) subscription instead of each dispatching a
+    // separate /organization_quotas/{guid} fetch.
     this.quotaDefinition$ = orgSnapshot$.pipe(
       map(o => o.quotaGuid),
       filter(quotaGuid => !!quotaGuid),
       switchMap(quotaGuid =>
         cfEntityCatalog.quotaDefinition.store.getEntityService(quotaGuid, this.cfGuid, {}).waitForEntity$
       ),
-      map(qe => qe.entity.entity)
+      map(qe => qe.entity.entity),
+      shareReplay({ bufferSize: 1, refCount: false }),
     );
 
     this.quotaLink$ = orgSnapshot$.pipe(map(o => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-organization.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-organization.service.ts
@@ -3,17 +3,18 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { Route } from '@angular/router';
 import { Store } from '@stratosui/store';
 import { combineLatest, Observable } from 'rxjs';
-import { filter, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap } from 'rxjs/operators';
 
 import { CnsiUsersSnapshotService } from '../../../services/endpoint-data/cnsi-users-snapshot.service';
+import { OrgDataRegistry } from '../../../services/endpoint-data/org-data.registry';
+import { StOrgDetail } from '../../../services/endpoint-data/stratos-types';
 import { createUserRoleInOrg } from '../../../store/types/cf-user.types';
 
 import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
-import { APIResource, EntityInfo } from '../../../../../store/src/types/api.types';
+import { APIResource } from '../../../../../store/src/types/api.types';
 import {
   IApp,
   IDomain,
-  IOrganization,
   IOrgQuotaDefinition,
   ISpace,
   ISpaceQuotaDefinition,
@@ -21,22 +22,13 @@ import {
 import { CFAppState } from '../../../cf-app-state';
 import { cfEntityCatalog } from '../../../cf-entity-catalog';
 import {
-  domainEntityType,
   organizationEntityType,
-  privateDomainsEntityType,
-  quotaDefinitionEntityType,
-  spaceEntityType,
 } from '../../../cf-entity-types';
 import { getEntityFlattenedList, getStartedAppInstanceCount } from '../../../cf.helpers';
-import {
-  createEntityRelationKey,
-  createEntityRelationPaginationKey,
-} from '../../../entity-relations/entity-relations.types';
-import { CfUserService } from '../../../shared/data-services/cf-user.service';
+import { createEntityRelationPaginationKey } from '../../../entity-relations/entity-relations.types';
 import {
   CloudFoundryUserProvidedServicesService,
 } from '../../../shared/services/cloud-foundry-user-provided-services.service';
-import { OrgUserRoleNames } from '../../../store/types/cf-user.types';
 import { fetchServiceInstancesCount } from '../../service-catalog/services-helper';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { getOrgRolesString } from '../cf.helpers';
@@ -74,12 +66,19 @@ export const createSpaceQuotaDefinition = (orgGuid: string): ISpaceQuotaDefiniti
 export class CloudFoundryOrganizationService {
   activeRouteCfOrgSpace = inject(ActiveRouteCfOrgSpace);
   private store = inject<Store<CFAppState>>(Store);
-  private cfUserService = inject(CfUserService);
   private paginationMonitorFactory = inject(PaginationMonitorFactory);
   private cfEndpointService = inject(CloudFoundryEndpointService);
   private cfUserProvidedServicesService = inject(CloudFoundryUserProvidedServicesService);
   private cnsiUsers = inject(CnsiUsersSnapshotService);
+  private orgDataRegistry = inject(OrgDataRegistry);
   private injector = inject(Injector);
+
+  // Registry returns the same instance as the org-base component's provider,
+  // so reads here hit the shared, in-flight-deduped signal — no extra HTTP.
+  readonly orgDataService = this.orgDataRegistry.acquire(
+    this.activeRouteCfOrgSpace.cfGuid,
+    this.activeRouteCfOrgSpace.orgGuid,
+  );
 
   orgGuid: string;
   cfGuid: string;
@@ -100,7 +99,6 @@ export class CloudFoundryOrganizationService {
   apps$!: Observable<APIResource<IApp>[]>;
   appCount$!: Observable<number>;
   loadingApps$!: Observable<boolean>;
-  org$!: Observable<EntityInfo<APIResource<IOrganization>>>;
   usersCount$!: Observable<number | null>;
 
   constructor() {
@@ -121,31 +119,6 @@ export class CloudFoundryOrganizationService {
   }
 
   private initialiseObservables() {
-    this.org$ = this.cfUserService.isConnectedUserAdmin(this.cfGuid).pipe(
-      switchMap(isAdmin => {
-        const relations = [
-          createEntityRelationKey(organizationEntityType, spaceEntityType),
-          createEntityRelationKey(organizationEntityType, domainEntityType),
-          createEntityRelationKey(organizationEntityType, quotaDefinitionEntityType),
-          createEntityRelationKey(organizationEntityType, privateDomainsEntityType),
-        ];
-        if (!isAdmin) {
-          // We're only interested in fetching org roles via the org request for non-admins.
-          // Non-admins cannot fetch missing roles via the users entity as the `<x>_url` is invalid
-          // #2902 Scaling Orgs/Spaces Inline --> individual capped requests & handling
-          relations.push(
-            createEntityRelationKey(organizationEntityType, OrgUserRoleNames.USER),
-            createEntityRelationKey(organizationEntityType, OrgUserRoleNames.MANAGER),
-            createEntityRelationKey(organizationEntityType, OrgUserRoleNames.BILLING_MANAGERS),
-            createEntityRelationKey(organizationEntityType, OrgUserRoleNames.AUDITOR),
-          );
-        }
-        return cfEntityCatalog.org.store.getEntityService(this.orgGuid, this.cfGuid, { includeRelations: relations }).waitForEntity$;
-      }),
-      publishReplay(1),
-      refCount()
-    );
-
     this.initialiseOrgObservables();
 
     this.initialiseAppObservables();
@@ -259,11 +232,14 @@ export class CloudFoundryOrganizationService {
     ).entities$.pipe(filter(domains => !!domains));
 
     // V3-native: org no longer carries inline quota_definition. The
-    // quota_definition_guid field (mapped from V3 relationships.quota.data.guid
-    // by v3-native rename) drives a separate cfEntityCatalog fetch — same
+    // quotaGuid field (mapped from V3 relationships.quota.data.guid by the
+    // native handler) drives a separate cfEntityCatalog fetch — same
     // pattern as features/cf/quota-definition/quota-definition.component.ts.
-    this.quotaDefinition$ = this.org$.pipe(
-      map(o => o.entity.entity.quota_definition_guid),
+    const orgSnapshot$ = toObservable(this.orgDataService.org, { injector: this.injector }).pipe(
+      filter((o): o is StOrgDetail => !!o),
+    );
+    this.quotaDefinition$ = orgSnapshot$.pipe(
+      map(o => o.quotaGuid),
       filter(quotaGuid => !!quotaGuid),
       switchMap(quotaGuid =>
         cfEntityCatalog.quotaDefinition.store.getEntityService(quotaGuid, this.cfGuid, {}).waitForEntity$
@@ -271,8 +247,8 @@ export class CloudFoundryOrganizationService {
       map(qe => qe.entity.entity)
     );
 
-    this.quotaLink$ = this.org$.pipe(map(o => {
-      const quotaDefinitionGuid = o.entity.entity.quota_definition_guid;
+    this.quotaLink$ = orgSnapshot$.pipe(map(o => {
+      const quotaDefinitionGuid = o.quotaGuid;
       return quotaDefinitionGuid && [
         '/cloud-foundry',
         this.cfGuid,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-space.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-space.service.ts
@@ -2,31 +2,22 @@ import { Injectable, Injector, inject } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Store } from '@stratosui/store';
 import { combineLatest, Observable, of } from 'rxjs';
-import { filter, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
+import { filter, map, shareReplay, switchMap } from 'rxjs/operators';
 
 import { CnsiUsersSnapshotService } from '../../../services/endpoint-data/cnsi-users-snapshot.service';
+import { SpaceDataRegistry } from '../../../services/endpoint-data/space-data.registry';
+import { StSpace } from '../../../services/endpoint-data/stratos-types';
 import { createUserRoleInSpace } from '../../../store/types/cf-user.types';
 
 import { PaginationMonitorFactory } from '../../../../../store/src/monitors/pagination-monitor.factory';
-import { APIResource, EntityInfo } from '../../../../../store/src/types/api.types';
-import { IApp, IOrgQuotaDefinition, IRoute, ISpace, ISpaceQuotaDefinition } from '../../../cf-api.types';
+import { APIResource } from '../../../../../store/src/types/api.types';
+import { IApp, IOrgQuotaDefinition, IRoute, ISpaceQuotaDefinition } from '../../../cf-api.types';
 import { CFAppState } from '../../../cf-app-state';
 import { cfEntityCatalog } from '../../../cf-entity-catalog';
-import {
-  applicationEntityType,
-  routeEntityType,
-  serviceBindingEntityType,
-  serviceInstancesEntityType,
-  spaceEntityType,
-  spaceQuotaEntityType,
-} from '../../../cf-entity-types';
 import { getStartedAppInstanceCount } from '../../../cf.helpers';
-import { createEntityRelationKey } from '../../../entity-relations/entity-relations.types';
-import { CfUserService } from '../../../shared/data-services/cf-user.service';
 import {
   CloudFoundryUserProvidedServicesService,
 } from '../../../shared/services/cloud-foundry-user-provided-services.service';
-import { SpaceUserRoleNames } from '../../../store/types/cf-user.types';
 import { fetchServiceInstancesCount } from '../../service-catalog/services-helper';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { getSpaceRolesString } from '../cf.helpers';
@@ -39,14 +30,20 @@ import { CloudFoundryOrganizationService, createOrgQuotaDefinition } from './clo
 export class CloudFoundrySpaceService {
   activeRouteCfOrgSpace = inject(ActiveRouteCfOrgSpace);
   private store = inject<Store<CFAppState>>(Store);
-  private cfUserService = inject(CfUserService);
   private paginationMonitorFactory = inject(PaginationMonitorFactory);
   private cfEndpointService = inject(CloudFoundryEndpointService);
   private cfUserProvidedServicesService = inject(CloudFoundryUserProvidedServicesService);
   private cfOrgService = inject(CloudFoundryOrganizationService);
   private cnsiUsers = inject(CnsiUsersSnapshotService);
+  private spaceDataRegistry = inject(SpaceDataRegistry);
   private injector = inject(Injector);
 
+  // Registry returns the same instance as the space-base component's provider,
+  // so reads here hit the shared, in-flight-deduped signal — no extra HTTP.
+  readonly spaceDataService = this.spaceDataRegistry.acquire(
+    this.activeRouteCfOrgSpace.cfGuid,
+    this.activeRouteCfOrgSpace.spaceGuid,
+  );
 
   cfGuid: string;
   orgGuid: string;
@@ -63,20 +60,22 @@ export class CloudFoundrySpaceService {
   spaceQuotaDefinition$!: Observable<ISpaceQuotaDefinition | null>;
   allowSsh$!: Observable<string>;
   totalMem$!: Observable<number>;
-  routes$!: Observable<APIResource<IRoute>[]>;
+  // Route count derived from the V3-native StSpace.routeCount aggregate
+  // (server-side fill). The full route list is loaded by the routes-tab
+  // data source separately — this stream exists for the summary tile's
+  // "Routes" card only.
+  routesCount$!: Observable<number>;
   serviceInstancesCount$!: Observable<number>;
   userProvidedServiceInstancesCount$!: Observable<number>;
   appInstances$!: Observable<number>;
   apps$!: Observable<APIResource<IApp>[]>;
   appCount$!: Observable<number>;
   loadingApps$!: Observable<boolean>;
-  space$!: Observable<EntityInfo<APIResource<ISpace>>>;
   usersCount$!: Observable<number | null>;
   quotaLink$!: Observable<string[]>;
 
   constructor() {
     const activeRouteCfOrgSpace = this.activeRouteCfOrgSpace;
-
 
     this.spaceGuid = activeRouteCfOrgSpace.spaceGuid;
     this.orgGuid = activeRouteCfOrgSpace.orgGuid;
@@ -119,29 +118,8 @@ export class CloudFoundrySpaceService {
   }
 
   private initialiseSpaceObservables() {
-    this.space$ = this.cfUserService.isConnectedUserAdmin(this.cfGuid).pipe(
-      switchMap(isAdmin => {
-        const relations = [
-          createEntityRelationKey(spaceEntityType, spaceQuotaEntityType),
-          createEntityRelationKey(serviceInstancesEntityType, serviceBindingEntityType),
-          createEntityRelationKey(serviceBindingEntityType, applicationEntityType),
-          createEntityRelationKey(spaceEntityType, routeEntityType),
-        ];
-        if (!isAdmin) {
-          // We're only interested in fetching space roles via the space request for non-admins.
-          // Non-admins cannot fetch missing roles via the users entity as the `<x>_url` is invalid
-          // #2902 Scaling Orgs/Spaces Inline --> individual capped requests & handling
-          relations.push(
-            createEntityRelationKey(spaceEntityType, SpaceUserRoleNames.DEVELOPER),
-            createEntityRelationKey(spaceEntityType, SpaceUserRoleNames.MANAGER),
-            createEntityRelationKey(spaceEntityType, SpaceUserRoleNames.AUDITOR),
-          );
-        }
-        return cfEntityCatalog.space.store.getEntityService(this.spaceGuid, this.cfGuid, { includeRelations: relations })
-          .entityObs$.pipe(filter(o => !!o && !!o.entity));
-      }),
-      publishReplay(1),
-      refCount()
+    const space$ = toObservable(this.spaceDataService.space, { injector: this.injector }).pipe(
+      filter((s): s is StSpace => !!s),
     );
 
     this.serviceInstancesCount$ = fetchServiceInstancesCount(
@@ -152,10 +130,19 @@ export class CloudFoundrySpaceService {
       this.paginationMonitorFactory);
     this.userProvidedServiceInstancesCount$ =
       this.cfUserProvidedServicesService.fetchUserProvidedServiceInstancesCount(this.cfGuid, this.orgGuid, this.spaceGuid);
-    this.routes$ = this.space$.pipe(map(o => o.entity.entity.routes));
-    this.allowSsh$ = this.space$.pipe(map(o => o.entity.entity.allow_ssh ? 'true' : 'false'));
-    this.spaceQuotaDefinition$ = this.space$.pipe(
-      map(q => q.entity.entity.space_quota_definition ? q.entity.entity.space_quota_definition.entity : null)
+    this.routesCount$ = space$.pipe(map(s => s.routeCount ?? 0));
+    this.allowSsh$ = space$.pipe(map(s => s.allowSsh ? 'true' : 'false'));
+    // V3-native space-quota lookup. quotaGuid mapped from V3
+    // relationships.quota.data.guid by getNativeSpaceDetail. cfEntityCatalog
+    // already serves space-quota entities; just hand it the guid.
+    this.spaceQuotaDefinition$ = space$.pipe(
+      map(s => s.quotaGuid || null),
+      switchMap(quotaGuid => quotaGuid
+        ? cfEntityCatalog.spaceQuota.store.getEntityService(quotaGuid, this.cfGuid, {}).waitForEntity$.pipe(
+          map(qe => qe.entity.entity as ISpaceQuotaDefinition),
+        )
+        : of(null as ISpaceQuotaDefinition | null)),
+      shareReplay({ bufferSize: 1, refCount: false }),
     );
     this.quotaDefinition$ = this.spaceQuotaDefinition$.pipe(
       switchMap(def => def ? of(def) : this.cfOrgService.quotaDefinition$),
@@ -194,8 +181,13 @@ export class CloudFoundrySpaceService {
   }
 
   private initialiseAppObservables() {
-    this.apps$ = this.space$.pipe(
-      switchMap(space => this.cfEndpointService.getAppsInSpaceViaAllApps(space.entity))
+    // V3-native: derive apps for this space from the foundation-wide apps
+    // stream filtered by space_guid (mirrors the cf-org-service pattern).
+    // Old getAppsInSpaceViaAllApps required an APIResource<ISpace> envelope
+    // which we no longer carry.
+    this.apps$ = this.cfEndpointService.apps$.pipe(
+      filter(apps => !!apps),
+      map(allApps => allApps.filter(a => a.entity.space_guid === this.spaceGuid)),
     );
 
     this.appInstances$ = this.apps$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.html
@@ -1,6 +1,6 @@
 <app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks" tabsHeader="Organization"
-  [favorite]="favorite$ | async">
-  <h1>{{ orgDataService?.org()?.name ?? (name$ | async) }}</h1>
+  [favorite]="favorite()">
+  <h1>{{ orgDataService.org()?.name }}</h1>
 </app-page-header>
 <app-loading-page [entityId]="cfOrgService.orgGuid" [entitySchema]="schema" deleteText="Deleting organization"
   [text]="'Retrieving organization'">

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.spec.ts
@@ -15,6 +15,7 @@ import { cfCurrentUserPermissionsService } from '@stratosui/cloud-foundry';
 import { EntityCatalogTestModule, TEST_CATALOGUE_ENTITIES, generateStratosEntities, EntityCatalogHelper, EntityCatalogHelpers } from '@stratosui/store';
 import { createEmptyStoreModule, STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
 import { generateCFEntities } from '../../../../../cf-entity-generator';
+import { OrgDataService } from '../../../../../services/endpoint-data/org-data.service';
 import { ActiveRouteCfOrgSpace } from '../../../cf-page.types';
 import { CloudFoundryOrganizationService } from '../../../services/cloud-foundry-organization.service';
 import { CloudFoundryEndpointService } from '../../../services/cloud-foundry-endpoint.service';
@@ -64,6 +65,14 @@ describe('CloudFoundryOrganizationBaseComponent', () => {
     spaceGuid: 'space-guid'
   };
 
+  // Minimal OrgDataService stand-in: only the methods the base component
+  // touches (load() in ngOnInit, org() in template). Bypasses the registry
+  // so the test doesn't need to wire HttpClient against the native handler.
+  const mockOrgDataService = {
+    org: () => null,
+    load: () => of(undefined),
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -99,6 +108,7 @@ describe('CloudFoundryOrganizationBaseComponent', () => {
         providers: [
           { provide: CloudFoundryOrganizationService, useValue: mockOrgService },
           { provide: CloudFoundryEndpointService, useValue: mockEndpointService },
+          { provide: OrgDataService, useValue: mockOrgDataService },
         ]
       }
     });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.ts
@@ -1,9 +1,9 @@
-import { Component, ChangeDetectionStrategy, inject, OnInit } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { Component, ChangeDetectionStrategy, computed, inject, OnInit, Signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 import { take, map } from 'rxjs/operators';
+import { OrgDataRegistry } from '../../../../../services/endpoint-data/org-data.registry';
 import { OrgDataService } from '../../../../../services/endpoint-data/org-data.service';
 
 import {
@@ -26,6 +26,7 @@ import { CF_ENDPOINT_TYPE } from '../../../../../cf-types';
 import { CfUserService } from '../../../../../shared/data-services/cf-user.service';
 import {
   CloudFoundryUserProvidedServicesService } from '../../../../../shared/services/cloud-foundry-user-provided-services.service';
+import { ActiveRouteCfOrgSpace } from '../../../cf-page.types';
 import { getActiveRouteCfOrgSpaceProvider } from '../../../cf.helpers';
 import { CloudFoundryEndpointService } from '../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryOrganizationService } from '../../../services/cloud-foundry-organization.service';
@@ -38,7 +39,17 @@ import { CloudFoundryOrganizationService } from '../../../services/cloud-foundry
     CfUserService,
     CloudFoundryEndpointService,
     CloudFoundryOrganizationService,
-    CloudFoundryUserProvidedServicesService
+    CloudFoundryUserProvidedServicesService,
+    // Provide a single OrgDataService instance for this org-detail subtree,
+    // acquired from the registry so navigation away and back returns a hot
+    // cached signal instead of refiring HTTP. Children inject(OrgDataService)
+    // directly — no per-component acquire boilerplate.
+    {
+      provide: OrgDataService,
+      useFactory: (registry: OrgDataRegistry, route: ActiveRouteCfOrgSpace) =>
+        registry.acquire(route.cfGuid, route.orgGuid),
+      deps: [OrgDataRegistry, ActiveRouteCfOrgSpace],
+    },
   ],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -52,8 +63,7 @@ import { CloudFoundryOrganizationService } from '../../../services/cloud-foundry
 export class CloudFoundryOrganizationBaseComponent implements OnInit {
   cfEndpointService = inject(CloudFoundryEndpointService);
   cfOrgService = inject(CloudFoundryOrganizationService);
-  private http = inject(HttpClient);
-  orgDataService: OrgDataService | null = null;
+  orgDataService = inject(OrgDataService);
 
 
   tabLinks: IPageSideNavTab[] = [
@@ -94,9 +104,6 @@ export class CloudFoundryOrganizationBaseComponent implements OnInit {
   ];
   public breadcrumbs$: Observable<IHeaderBreadcrumb[]>;
 
-  /** @deprecated Use orgDataService.org()?.name — kept for backward compatibility with favorite$ */
-  public name$: Observable<string>;
-
   // Used to hide tab that is not yet implemented when in production
   public isDevEnvironment = !environment.production;
 
@@ -104,21 +111,22 @@ export class CloudFoundryOrganizationBaseComponent implements OnInit {
 
   public extensionActions: StratosActionMetadata[] = getActionsFromExtensions(StratosActionType.CloudFoundryOrg);
 
-  public favorite$: Observable<UserFavorite<IFavoriteMetadata>>;
+  // Favorite recomputes when the org signal lands. Built from the V3-native
+  // org-detail snapshot — getMetadata reads `entity.name`, getGuid reads
+  // `metadata.guid`, getEndpointIdFromEntity reads `entity.cfGuid`, so we
+  // synthesise the minimal APIResource-shape favorites expect.
+  public favorite: Signal<UserFavorite<IFavoriteMetadata> | null>;
 
   constructor() {
-    const cfOrgService = this.cfOrgService;
     const userFavoriteManager = inject(UserFavoriteManager);
 
     this.schema = cfEntityFactory(organizationEntityType);
-    this.favorite$ = cfOrgService.org$.pipe(
-      take(1),
-      map(org => userFavoriteManager.getFavorite<IFavoriteMetadata>(org.entity, organizationEntityType, CF_ENDPOINT_TYPE))
-    );
-    this.name$ = cfOrgService.org$.pipe(
-      map(org => org.entity.entity.name),
-      take(1)
-    );
+    this.favorite = computed(() => {
+      const org = this.orgDataService.org();
+      if (!org) return null;
+      const favEntity = { entity: { name: org.name, cfGuid: org.cnsiGuid }, metadata: { guid: org.guid } };
+      return userFavoriteManager.getFavorite<IFavoriteMetadata>(favEntity, organizationEntityType, CF_ENDPOINT_TYPE);
+    });
     this.breadcrumbs$ = this.getBreadcrumbs();
 
     // Add any tabs from extensions
@@ -126,9 +134,9 @@ export class CloudFoundryOrganizationBaseComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    const cnsiGuid = this.cfOrgService.cfGuid;
-    const orgGuid = this.cfOrgService.orgGuid;
-    this.orgDataService = new OrgDataService(this.http, cnsiGuid, orgGuid);
+    // Trigger initial load. The registry-acquired instance dedupes concurrent
+    // load() calls and short-circuits once warm, so re-entry on tab nav is a
+    // no-op.
     this.orgDataService.load().subscribe({ error: () => {} });
   }
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.html
@@ -1,6 +1,6 @@
 <app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks" tabsHeader="Space"
-  [favorite]="favorite$ | async">
-  <h1>{{ name$ | async }}</h1>
+  [favorite]="favorite()">
+  <h1>{{ spaceDataService.space()?.name }}</h1>
 </app-page-header>
 <app-loading-page [entityId]="cfSpaceService.spaceGuid" [entitySchema]="schema" deleteText="Deleting space"
   text="Retrieving space">

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
@@ -1,10 +1,9 @@
-import { Component, OnDestroy, ChangeDetectionStrategy, Injector, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, Injector, OnInit, Signal, inject } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { Store } from '@stratosui/store';
-import { combineLatest, Observable, of, Subscription } from 'rxjs';
-import { filter, take, map, tap } from 'rxjs/operators';
+import { combineLatest, Observable, of } from 'rxjs';
+import { filter, take, map } from 'rxjs/operators';
 
 import {
   getActionsFromExtensions,
@@ -15,22 +14,22 @@ import {
 } from '../../../../../../../../core/src/core/extension/extension-service';
 import { environment } from '../../../../../../../../core/src/environments/environment.prod';
 import { IPageSideNavTab } from '../../../../../../../../core/src/features/dashboard/page-side-nav/page-side-nav.component';
-import { ConfirmationDialogService } from '../../../../../../../../core/src/shared/components/confirmation-dialog.service';
 import { PageHeaderComponent } from '../../../../../../../../core/src/shared/components/page-header/page-header.component';
 import { IHeaderBreadcrumb } from '../../../../../../../../core/src/shared/components/page-header/page-header.types';
 import { LoadingPageComponent } from '../../../../../../../../core/src/shared/components/loading-page/loading-page.component';
-import { RouterNav } from '../../../../../../../../store/src/actions/router.actions';
 import { UserFavorite } from '../../../../../../../../store/src/types/user-favorites.types';
 import { UserFavoriteManager } from '../../../../../../../../store/src/user-favorite-manager';
-import { CFAppState } from '../../../../../../cf-app-state';
 import { cfEntityFactory } from '../../../../../../cf-entity-factory';
 import { spaceEntityType } from '../../../../../../cf-entity-types';
 import { ISpaceFavMetadata } from '../../../../../../cf-metadata-types';
+import { SpaceDataRegistry } from '../../../../../../services/endpoint-data/space-data.registry';
+import { SpaceDataService } from '../../../../../../services/endpoint-data/space-data.service';
 import { CF_ENDPOINT_TYPE } from '../../../../../../cf-types';
 import { CfUserService } from '../../../../../../shared/data-services/cf-user.service';
 import {
   CloudFoundryUserProvidedServicesService,
 } from '../../../../../../shared/services/cloud-foundry-user-provided-services.service';
+import { ActiveRouteCfOrgSpace } from '../../../../cf-page.types';
 import { getActiveRouteCfOrgSpaceProvider } from '../../../../cf.helpers';
 import { CloudFoundryEndpointService } from '../../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryOrganizationService } from '../../../../services/cloud-foundry-organization.service';
@@ -52,15 +51,22 @@ import { CloudFoundrySpaceService } from '../../../../services/cloud-foundry-spa
     CfUserService,
     CloudFoundrySpaceService,
     CloudFoundryOrganizationService,
-    CloudFoundryUserProvidedServicesService
+    CloudFoundryUserProvidedServicesService,
+    // Provide a single SpaceDataService instance for this space-detail subtree
+    // (mirrors the OrgDataService factory on cloud-foundry-organization-base).
+    {
+      provide: SpaceDataService,
+      useFactory: (registry: SpaceDataRegistry, route: ActiveRouteCfOrgSpace) =>
+        registry.acquire(route.cfGuid, route.spaceGuid),
+      deps: [SpaceDataRegistry, ActiveRouteCfOrgSpace],
+    },
   ]
 })
-export class CloudFoundrySpaceBaseComponent implements OnDestroy {
+export class CloudFoundrySpaceBaseComponent implements OnInit {
   cfEndpointService = inject(CloudFoundryEndpointService);
   cfSpaceService = inject(CloudFoundrySpaceService);
   cfOrgService = inject(CloudFoundryOrganizationService);
-  private store = inject<Store<CFAppState>>(Store);
-  private confirmDialog = inject(ConfirmationDialogService);
+  spaceDataService = inject(SpaceDataService);
   private injector = inject(Injector);
 
 
@@ -108,73 +114,55 @@ export class CloudFoundrySpaceBaseComponent implements OnDestroy {
 
   public breadcrumbs$!: Observable<IHeaderBreadcrumb[]>;
 
-  public name$: Observable<string>;
-
-  public isFetching$: Observable<boolean>;
-
   // Used to hide tab that is not yet implemented when in production
   public isDevEnvironment = !environment.production;
 
   public schema = cfEntityFactory(spaceEntityType);
 
-  private deleteRedirectSub: Subscription;
-
-  private quotaLinkSub!: Subscription;
-
   public extensionActions: StratosActionMetadata[] = getActionsFromExtensions(StratosActionType.CloudFoundryOrg);
-  public favorite$: Observable<UserFavorite<ISpaceFavMetadata>>;
+
+  // Favorite recomputes when the SpaceDataService signal lands. Synthesises
+  // the minimal entity shape favorites expect: getMetadata reads name +
+  // organization_guid, getGuid reads metadata.guid, getEndpointIdFromEntity
+  // reads entity.cfGuid.
+  public favorite: Signal<UserFavorite<ISpaceFavMetadata> | null>;
 
   constructor() {
-    const cfEndpointService = this.cfEndpointService;
-    const cfSpaceService = this.cfSpaceService;
-    const cfOrgService = this.cfOrgService;
     const userFavoriteManager = inject(UserFavoriteManager);
 
-    this.favorite$ = cfSpaceService.space$.pipe(
-      map(space => userFavoriteManager.getFavorite<ISpaceFavMetadata>(space.entity, spaceEntityType, CF_ENDPOINT_TYPE))
-    );
-    this.isFetching$ = cfSpaceService.space$.pipe(
-      map(space => space.entityRequestInfo.fetching)
-    );
-    this.name$ = cfSpaceService.space$.pipe(
-      map(space => space.entity.entity.name),
-      take(1)
-    );
+    this.favorite = computed(() => {
+      const space = this.spaceDataService.space();
+      if (!space) return null;
+      const favEntity = {
+        entity: { name: space.name, organization_guid: space.orgGuid, cfGuid: space.cnsiGuid },
+        metadata: { guid: space.guid },
+      };
+      return userFavoriteManager.getFavorite<ISpaceFavMetadata>(favEntity, spaceEntityType, CF_ENDPOINT_TYPE);
+    });
 
-    this.setUpBreadcrumbs(cfEndpointService, cfOrgService);
+    this.setUpBreadcrumbs(this.cfEndpointService, this.cfOrgService);
 
-    this.deleteRedirectSub = this.cfSpaceService.space$.pipe(
-      tap(({ entityRequestInfo }) => {
-        if (entityRequestInfo.deleting.deleted) {
-          this.store.dispatch(new RouterNav({
-            path: [
-              'cloud-foundry',
-              this.cfSpaceService.cfGuid,
-              'organizations',
-              this.cfSpaceService.orgGuid,
-              'spaces']
-          }));
-        }
-      })
-    ).subscribe();
-
-    // Add any tabs from extensions
-    this.setupLinks();
+    // Add the Quota tab once the space snapshot lands — only show it if a
+    // space-specific quota is linked (quotaGuid set). Extension tabs are
+    // appended unconditionally to match the legacy ordering.
+    toObservable(this.spaceDataService.space, { injector: this.injector }).pipe(
+      filter(s => !!s),
+      take(1),
+    ).subscribe(space => {
+      this.tabLinks.push({
+        link: 'space-quota',
+        label: 'Quota',
+        icon: 'data_usage',
+        hidden$: of(!space!.quotaGuid),
+      });
+      this.tabLinks = this.tabLinks.concat(getTabsFromExtensions(StratosTabType.CloudFoundrySpace));
+    });
   }
 
-  private setupLinks() {
-    this.quotaLinkSub = this.cfSpaceService.space$.pipe(
-      tap((space) => {
-        this.tabLinks.push({
-          link: 'space-quota',
-          label: 'Quota',
-          icon: 'data_usage',
-          hidden$: of(!space.entity.entity.space_quota_definition)
-        });
-        this.tabLinks = this.tabLinks.concat(getTabsFromExtensions(StratosTabType.CloudFoundrySpace));
-      }),
-      take(1)
-    ).subscribe();
+  ngOnInit(): void {
+    // Trigger initial load. The registry-acquired instance dedupes concurrent
+    // load() calls and short-circuits once warm.
+    this.spaceDataService.load().subscribe({ error: () => {} });
   }
 
   private setUpBreadcrumbs(
@@ -214,8 +202,4 @@ export class CloudFoundrySpaceBaseComponent implements OnDestroy {
     );
   }
 
-  ngOnDestroy() {
-    this.deleteRedirectSub.unsubscribe();
-    this.quotaLinkSub.unsubscribe();
-  }
 }

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnDestroy, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, OnDestroy, ChangeDetectionStrategy, Injector, inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { Store } from '@stratosui/store';
 import { combineLatest, Observable, of, Subscription } from 'rxjs';
-import { take, map, tap } from 'rxjs/operators';
+import { filter, take, map, tap } from 'rxjs/operators';
 
 import {
   getActionsFromExtensions,
@@ -60,6 +61,7 @@ export class CloudFoundrySpaceBaseComponent implements OnDestroy {
   cfOrgService = inject(CloudFoundryOrganizationService);
   private store = inject<Store<CFAppState>>(Store);
   private confirmDialog = inject(ConfirmationDialogService);
+  private injector = inject(Injector);
 
 
   tabLinks: IPageSideNavTab[] = [
@@ -179,9 +181,14 @@ export class CloudFoundrySpaceBaseComponent implements OnDestroy {
     cfEndpointService: CloudFoundryEndpointService,
     cfOrgService: CloudFoundryOrganizationService
   ) {
+    // Org name comes from the V3-native OrgDataService signal; bridge into the
+    // existing breadcrumb pipeline via toObservable so the rest of the chain
+    // stays the same shape. take(1) preserves the original "freeze first
+    // populated value" behaviour.
+    const orgSignal$ = toObservable(cfOrgService.orgDataService.org, { injector: this.injector });
     this.breadcrumbs$ = combineLatest(
       cfEndpointService.endpoint$,
-      cfOrgService.org$
+      orgSignal$.pipe(filter(org => !!org)),
     ).pipe(
       map(([endpoint, org]) => ([
         {
@@ -191,8 +198,8 @@ export class CloudFoundrySpaceBaseComponent implements OnDestroy {
               routerLink: `/cloud-foundry/${endpoint.entity.guid}/organizations`
             },
             {
-              value: org.entity.entity.name,
-              routerLink: `/cloud-foundry/${endpoint.entity.guid}/organizations/${org.entity.metadata.guid}/spaces`
+              value: org.name,
+              routerLink: `/cloud-foundry/${endpoint.entity.guid}/organizations/${org.guid}/spaces`
             }
           ]
         },

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
@@ -49,7 +49,7 @@
           <app-card-number-metric
             link="/cloud-foundry/{{cfSpaceService.cfGuid}}/organizations/{{cfSpaceService.orgGuid}}/spaces/{{cfSpaceService.spaceGuid}}/routes"
             iconFont="stratos-icons" icon="route" label="Routes"
-            value="{{ (cfSpaceService.routes$ | async)?.length }}"
+            value="{{ (cfSpaceService.routesCount$ | async) }}"
           limit="{{ (cfSpaceService.quotaDefinition$ | async)?.total_routes}}"></app-card-number-metric>
         </app-tile>
       </app-tile-group>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.ts
@@ -4,7 +4,7 @@ import { Router, RouterModule } from '@angular/router';
 
 import { CustomTooltipDirective, TailwindSnackBarService } from '@stratosui/core';
 import { combineLatest, Observable } from 'rxjs';
-import { take, filter, map, startWith } from 'rxjs/operators';
+import { filter, map, startWith } from 'rxjs/operators';
 
 import { ConfirmationDialogConfig, ConfirmationDialogService } from '@stratosui/core';
 import { CfCurrentUserPermissions } from '../../../../../../../user-permissions/cf-user-permissions-checkers';
@@ -74,26 +74,18 @@ export class CloudFoundrySpaceSummaryComponent {
       map(() => false),
       startWith(true)
     );
-    this.name$ = cfSpaceService.space$.pipe(
-      map(space => space.entity.entity.name),
-      take(1)
-    );
   }
 
   deleteSpaceWarn = () => {
-    this.name$.pipe(
-      take(1)
-    ).subscribe(name => {
-      const confirmation = new ConfirmationDialogConfig(
-        'Delete Space',
-        {
-          textToMatch: name
-        },
-        'Delete',
-        true,
-      );
-      this.confirmDialog.open(confirmation, this.deleteSpace);
-    });
+    const name = this.cfSpaceService.spaceDataService.space()?.name;
+    if (!name) return;
+    const confirmation = new ConfirmationDialogConfig(
+      'Delete Space',
+      { textToMatch: name },
+      'Delete',
+      true,
+    );
+    this.confirmDialog.open(confirmation, this.deleteSpace);
   }
 
   // Signal-native delete: drives the native DELETE

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.spec.ts
@@ -29,23 +29,13 @@ describe('CloudFoundryOrganizationSummaryComponent', () => {
   const mockOrgService = {
     cfGuid: 'cf-guid',
     orgGuid: 'org-guid',
-    org$: of({
-      entity: {
-        entity: {
-          name: 'test-org',
-          guid: 'org-guid',
-          spaces: []
-        },
-        metadata: {
-          guid: 'org-guid'
-        }
-      },
-      entityRequestInfo: {
-        fetching: false,
-        error: false,
-        deleting: { busy: false, deleted: false }
-      }
-    }),
+    orgDataService: {
+      org: () => null,
+      spaces: () => [],
+      isLoading: () => false,
+      errors: () => [],
+      load: () => of(undefined),
+    },
     userProvidedServiceInstancesCount$: of(0)
   };
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.ts
@@ -4,7 +4,7 @@ import { CustomTooltipDirective, TailwindSnackBarService } from '@stratosui/core
 import { Router, RouterModule } from '@angular/router';
 import { Store } from '@stratosui/store';
 import { combineLatest, Observable } from 'rxjs';
-import { take, filter, map, startWith } from 'rxjs/operators';
+import { filter, map, startWith } from 'rxjs/operators';
 
 import { ConfirmationDialogConfig } from '../../../../../../../core/src/shared/components/confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../../../../../core/src/shared/components/confirmation-dialog.service';
@@ -82,28 +82,23 @@ export class CloudFoundryOrganizationSummaryComponent {
   }
 
   deleteOrgWarn() {
-    this.cfOrgService.org$.pipe(
-      map(org => org.entity.entity.name),
-      take(1)
-    ).subscribe(name => {
-      const confirmation = new ConfirmationDialogConfig(
-        'Delete Organization',
-        {
-          textToMatch: name
-        },
-        'Delete',
-        true,
-      );
-      this.confirmDialog.open(confirmation, async () => {
-        const cfGuid = this.cfOrgService.cfGuid;
-        const orgGuid = this.cfOrgService.orgGuid;
-        try {
-          await this.orgsConfig.deleteOrg(cfGuid, orgGuid);
-          this.router.navigate(['/cloud-foundry', cfGuid, 'organizations']);
-        } catch (err: any) {
-          this.snackBar.error(`Failed to delete organization: ${err?.message ?? err}`, 'Close');
-        }
-      });
+    const name = this.cfOrgService.orgDataService.org()?.name;
+    if (!name) return;
+    const confirmation = new ConfirmationDialogConfig(
+      'Delete Organization',
+      { textToMatch: name },
+      'Delete',
+      true,
+    );
+    this.confirmDialog.open(confirmation, async () => {
+      const cfGuid = this.cfOrgService.cfGuid;
+      const orgGuid = this.cfOrgService.orgGuid;
+      try {
+        await this.orgsConfig.deleteOrg(cfGuid, orgGuid);
+        this.router.navigate(['/cloud-foundry', cfGuid, 'organizations']);
+      } catch (err: any) {
+        this.snackBar.error(`Failed to delete organization: ${err?.message ?? err}`, 'Close');
+      }
     });
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.registry.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.registry.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OrgDataRegistry } from './org-data.registry';
+
+describe('OrgDataRegistry', () => {
+  let registry: OrgDataRegistry;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        OrgDataRegistry,
+      ],
+    });
+    registry = TestBed.inject(OrgDataRegistry);
+  });
+
+  it('returns same service instance on repeated acquire() for same (cnsi,org)', () => {
+    const svc1 = registry.acquire('cnsi-1', 'org-a');
+    const svc2 = registry.acquire('cnsi-1', 'org-a');
+    expect(svc1).toBe(svc2);
+    registry.release('cnsi-1', 'org-a');
+    registry.release('cnsi-1', 'org-a');
+  });
+
+  it('returns different instances for different orgs in same cnsi', () => {
+    const a = registry.acquire('cnsi-1', 'org-a');
+    const b = registry.acquire('cnsi-1', 'org-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('returns different instances for same org guid across cnsis', () => {
+    const a = registry.acquire('cnsi-1', 'org-a');
+    const b = registry.acquire('cnsi-2', 'org-a');
+    expect(a).not.toBe(b);
+  });
+
+  it('retains instance after full release (sticky data)', () => {
+    const svc = registry.acquire('cnsi-1', 'org-a');
+    registry.release('cnsi-1', 'org-a');
+    const svcAgain = registry.acquire('cnsi-1', 'org-a');
+    expect(svc).toBe(svcAgain);
+  });
+
+  it('evict() removes the instance', () => {
+    const svc = registry.acquire('cnsi-1', 'org-a');
+    registry.evict('cnsi-1', 'org-a');
+    const svcAfter = registry.acquire('cnsi-1', 'org-a');
+    expect(svc).not.toBe(svcAfter);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.registry.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.registry.ts
@@ -1,0 +1,47 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
+import { OrgDataService } from './org-data.service';
+
+interface RegistryEntry {
+  service: OrgDataService;
+  refCount: number;
+}
+
+// Caches OrgDataService instances per (cnsiGuid, orgGuid). Mirrors
+// EndpointDataRegistry — keeps state warm across navigation away and back to
+// the same org-detail page, and gives every consumer in the org-detail tree a
+// shared instance (so in-flight dedup + cached signals actually take effect).
+@Injectable({ providedIn: 'root' })
+export class OrgDataRegistry {
+  private readonly http = inject(HttpClient);
+  private readonly diagnostics = inject(StratosDiagnostics);
+  private readonly instances = new Map<string, RegistryEntry>();
+
+  acquire(cnsiGuid: string, orgGuid: string): OrgDataService {
+    const key = this.key(cnsiGuid, orgGuid);
+    const existing = this.instances.get(key);
+    if (existing) {
+      existing.refCount++;
+      return existing.service;
+    }
+    const service = new OrgDataService(this.http, cnsiGuid, orgGuid, this.diagnostics);
+    this.instances.set(key, { service, refCount: 1 });
+    return service;
+  }
+
+  release(cnsiGuid: string, orgGuid: string): void {
+    const entry = this.instances.get(this.key(cnsiGuid, orgGuid));
+    if (!entry) { return; }
+    entry.refCount = Math.max(0, entry.refCount - 1);
+    // Instance stays in map sticky — only removed on explicit evict.
+  }
+
+  evict(cnsiGuid: string, orgGuid: string): void {
+    this.instances.delete(this.key(cnsiGuid, orgGuid));
+  }
+
+  private key(cnsiGuid: string, orgGuid: string): string {
+    return `${cnsiGuid}:${orgGuid}`;
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.service.spec.ts
@@ -28,6 +28,7 @@ describe('OrgDataService', () => {
     expect(service.spaces()).toEqual([]);
     expect(service.isLoading()).toBeFalsy();
     expect(service.errors()).toEqual([]);
+    expect(service.lastFetched()).toBeNull();
   });
 
   it('fetches org detail and spaces in parallel', async () => {
@@ -43,6 +44,7 @@ describe('OrgDataService', () => {
     expect(service.spaces().length).toBe(1);
     expect(service.spaceCount()).toBe(1);
     expect(service.isLoading()).toBeFalsy();
+    expect(service.lastFetched()).not.toBeNull();
   });
 
   it('retains org when spaces fetch fails', async () => {
@@ -57,5 +59,36 @@ describe('OrgDataService', () => {
     expect(service.errors().length).toBe(1);
     expect(service.errors()[0].resource).toBe('spaces');
     expect(service.isLoading()).toBeFalsy();
+  });
+
+  it('dedupes concurrent load() calls into a single HTTP fan-out', async () => {
+    const mockOrg = { guid: 'org-1', name: 'My Org', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '', spaces: [] };
+    const mockSpaces: any[] = [];
+
+    service.load().subscribe();
+    service.load().subscribe();
+    service.load().subscribe();
+
+    // Concurrent callers must share one HTTP fan-out — expectOne would fail if
+    // any caller spawned its own request.
+    httpMock.expectOne('/pp/v1/cf/org/cnsi-1/org-1').flush(mockOrg);
+    httpMock.expectOne('/pp/v1/cf/org/cnsi-1/org-1/spaces').flush({ resources: mockSpaces, totalResults: 0 });
+    await Promise.resolve();
+
+    expect(service.org()?.name).toBe('My Org');
+  });
+
+  it('short-circuits load() once warm (no HTTP on second call)', async () => {
+    const mockOrg = { guid: 'org-1', name: 'My Org', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '', spaces: [] };
+
+    service.load().subscribe();
+    httpMock.expectOne('/pp/v1/cf/org/cnsi-1/org-1').flush(mockOrg);
+    httpMock.expectOne('/pp/v1/cf/org/cnsi-1/org-1/spaces').flush({ resources: [], totalResults: 0 });
+    await Promise.resolve();
+
+    // Second call: cache is hot — expectNone for both URLs.
+    service.load().subscribe();
+    httpMock.expectNone('/pp/v1/cf/org/cnsi-1/org-1');
+    httpMock.expectNone('/pp/v1/cf/org/cnsi-1/org-1/spaces');
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/org-data.service.ts
@@ -1,7 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { computed, signal, Signal } from '@angular/core';
-import { EMPTY, merge, Observable } from 'rxjs';
-import { catchError, finalize, tap, timeout } from 'rxjs/operators';
+import { EMPTY, merge, Observable, of, ReplaySubject } from 'rxjs';
+import { catchError, finalize, shareReplay, tap, timeout } from 'rxjs/operators';
+import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
 import { StError, StOrgDetail, StSpace } from './stratos-types';
 
 export class OrgDataService {
@@ -9,24 +10,47 @@ export class OrgDataService {
   private readonly _spaces = signal<StSpace[]>([]);
   private readonly _isLoading = signal<boolean>(false);
   private readonly _errors = signal<StError[]>([]);
+  private readonly _lastFetched = signal<Date | null>(null);
 
   readonly org: Signal<StOrgDetail | null> = this._org.asReadonly();
   readonly spaces: Signal<StSpace[]> = this._spaces.asReadonly();
   readonly spaceCount = computed(() => this._spaces().length);
   readonly isLoading: Signal<boolean> = this._isLoading.asReadonly();
   readonly errors: Signal<StError[]> = this._errors.asReadonly();
+  readonly lastFetched: Signal<Date | null> = this._lastFetched.asReadonly();
+
+  // ReplaySubject so late subscribers see the last completion immediately
+  // (matches EndpointDataService convention).
+  readonly loaded$ = new ReplaySubject<void>(1);
+
+  // In-flight dedup. Concurrent callers before the first HTTP completes share
+  // the same Observable instead of each firing their own fan-out — mirrors
+  // EndpointDataService.load(), which exists for the same reason.
+  private _inFlightLoad: Observable<void> | null = null;
 
   constructor(
     private readonly http: HttpClient,
     readonly cnsiGuid: string,
     readonly orgGuid: string,
+    private readonly diagnostics?: StratosDiagnostics,
   ) {}
 
   load(): Observable<void> {
+    this.diagnostics?.emitCounter('service-call-count', { service: 'OrgDataService', method: 'load' });
+    // Warm-cache short-circuit: signals already populated, no network needed.
+    if (this._lastFetched() !== null && this._org() !== null) {
+      this.diagnostics?.emitCounter('cache-hit', { service: 'OrgDataService', method: 'load' });
+      return of(undefined);
+    }
+    if (this._inFlightLoad) {
+      this.diagnostics?.emitCounter('in-flight-hit', { service: 'OrgDataService', method: 'load' });
+      return this._inFlightLoad;
+    }
+    this.diagnostics?.emitCounter('cache-miss', { service: 'OrgDataService', method: 'load' });
     this._isLoading.set(true);
     this._errors.set([]);
 
-    return merge(
+    this._inFlightLoad = merge(
       this.http.get<StOrgDetail>(`/pp/v1/cf/org/${this.cnsiGuid}/${this.orgGuid}`).pipe(
         tap(org => this._org.set({
           ...org,
@@ -43,8 +67,15 @@ export class OrgDataService {
       ),
     ).pipe(
       timeout(60_000),
-      finalize(() => this._isLoading.set(false)),
+      finalize(() => {
+        this._isLoading.set(false);
+        this._lastFetched.set(new Date());
+        this.loaded$.next();
+        this._inFlightLoad = null;
+      }),
+      shareReplay({ bufferSize: 1, refCount: false }),
     ) as Observable<void>;
+    return this._inFlightLoad;
   }
 
   private addError(resource: string, err: unknown): void {

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.registry.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.registry.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SpaceDataRegistry } from './space-data.registry';
+
+describe('SpaceDataRegistry', () => {
+  let registry: SpaceDataRegistry;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        SpaceDataRegistry,
+      ],
+    });
+    registry = TestBed.inject(SpaceDataRegistry);
+  });
+
+  it('returns same instance for same (cnsi,space)', () => {
+    const a = registry.acquire('cnsi-1', 'sp-1');
+    const b = registry.acquire('cnsi-1', 'sp-1');
+    expect(a).toBe(b);
+  });
+
+  it('returns different instances for different spaces', () => {
+    const a = registry.acquire('cnsi-1', 'sp-1');
+    const b = registry.acquire('cnsi-1', 'sp-2');
+    expect(a).not.toBe(b);
+  });
+
+  it('different cnsi same space → different instances', () => {
+    const a = registry.acquire('cnsi-1', 'sp-1');
+    const b = registry.acquire('cnsi-2', 'sp-1');
+    expect(a).not.toBe(b);
+  });
+
+  it('retains instance after release (sticky)', () => {
+    const svc = registry.acquire('cnsi-1', 'sp-1');
+    registry.release('cnsi-1', 'sp-1');
+    expect(registry.acquire('cnsi-1', 'sp-1')).toBe(svc);
+  });
+
+  it('evict() removes the instance', () => {
+    const svc = registry.acquire('cnsi-1', 'sp-1');
+    registry.evict('cnsi-1', 'sp-1');
+    expect(registry.acquire('cnsi-1', 'sp-1')).not.toBe(svc);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.registry.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.registry.ts
@@ -1,0 +1,45 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
+import { SpaceDataService } from './space-data.service';
+
+interface RegistryEntry {
+  service: SpaceDataService;
+  refCount: number;
+}
+
+// Caches SpaceDataService instances per (cnsiGuid, spaceGuid). Mirrors
+// OrgDataRegistry — sticky across navigation away and back, so the
+// space-detail subtree shares one warm signal across all consumers.
+@Injectable({ providedIn: 'root' })
+export class SpaceDataRegistry {
+  private readonly http = inject(HttpClient);
+  private readonly diagnostics = inject(StratosDiagnostics);
+  private readonly instances = new Map<string, RegistryEntry>();
+
+  acquire(cnsiGuid: string, spaceGuid: string): SpaceDataService {
+    const key = this.key(cnsiGuid, spaceGuid);
+    const existing = this.instances.get(key);
+    if (existing) {
+      existing.refCount++;
+      return existing.service;
+    }
+    const service = new SpaceDataService(this.http, cnsiGuid, spaceGuid, this.diagnostics);
+    this.instances.set(key, { service, refCount: 1 });
+    return service;
+  }
+
+  release(cnsiGuid: string, spaceGuid: string): void {
+    const entry = this.instances.get(this.key(cnsiGuid, spaceGuid));
+    if (!entry) { return; }
+    entry.refCount = Math.max(0, entry.refCount - 1);
+  }
+
+  evict(cnsiGuid: string, spaceGuid: string): void {
+    this.instances.delete(this.key(cnsiGuid, spaceGuid));
+  }
+
+  private key(cnsiGuid: string, spaceGuid: string): string {
+    return `${cnsiGuid}:${spaceGuid}`;
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.service.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SpaceDataService } from './space-data.service';
+
+describe('SpaceDataService', () => {
+  let httpMock: HttpTestingController;
+  let service: SpaceDataService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    service = new SpaceDataService(TestBed.inject(HttpClient), 'cnsi-1', 'sp-1');
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('starts empty', () => {
+    expect(service.space()).toBeNull();
+    expect(service.isLoading()).toBeFalsy();
+    expect(service.errors()).toEqual([]);
+    expect(service.lastFetched()).toBeNull();
+  });
+
+  it('fetches space detail and stamps cnsiGuid', async () => {
+    const mockSpace = {
+      guid: 'sp-1', name: 'Space One', orgGuid: 'org-1',
+      createdAt: '', updatedAt: '', cnsiGuid: '',
+      appCount: 3, routeCount: 5, allowSsh: true, quotaGuid: 'q-1',
+    };
+
+    service.load().subscribe();
+    httpMock.expectOne('/pp/v1/cf/spaces/cnsi-1/sp-1').flush(mockSpace);
+    await Promise.resolve();
+
+    expect(service.space()?.name).toBe('Space One');
+    expect(service.space()?.cnsiGuid).toBe('cnsi-1');
+    expect(service.space()?.quotaGuid).toBe('q-1');
+    expect(service.isLoading()).toBeFalsy();
+  });
+
+  it('records error on fetch failure', async () => {
+    service.load().subscribe({ error: () => {} });
+    httpMock.expectOne('/pp/v1/cf/spaces/cnsi-1/sp-1').error(new ErrorEvent('Network error'));
+    await Promise.resolve();
+
+    expect(service.space()).toBeNull();
+    expect(service.errors().length).toBe(1);
+    expect(service.errors()[0].resource).toBe('space');
+  });
+
+  it('dedupes concurrent load() calls into one HTTP fan-out', async () => {
+    const mockSpace = {
+      guid: 'sp-1', name: 'X', orgGuid: 'org-1',
+      createdAt: '', updatedAt: '', cnsiGuid: '',
+      appCount: 0, routeCount: 0, allowSsh: false,
+    };
+
+    service.load().subscribe();
+    service.load().subscribe();
+    service.load().subscribe();
+
+    httpMock.expectOne('/pp/v1/cf/spaces/cnsi-1/sp-1').flush(mockSpace);
+    await Promise.resolve();
+
+    expect(service.space()?.name).toBe('X');
+  });
+
+  it('short-circuits load() once warm', async () => {
+    const mockSpace = {
+      guid: 'sp-1', name: 'X', orgGuid: 'org-1',
+      createdAt: '', updatedAt: '', cnsiGuid: '',
+      appCount: 0, routeCount: 0, allowSsh: false,
+    };
+
+    service.load().subscribe();
+    httpMock.expectOne('/pp/v1/cf/spaces/cnsi-1/sp-1').flush(mockSpace);
+    await Promise.resolve();
+
+    service.load().subscribe();
+    httpMock.expectNone('/pp/v1/cf/spaces/cnsi-1/sp-1');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/space-data.service.ts
@@ -1,0 +1,73 @@
+import { HttpClient } from '@angular/common/http';
+import { signal, Signal } from '@angular/core';
+import { EMPTY, Observable, of, ReplaySubject } from 'rxjs';
+import { catchError, finalize, shareReplay, tap, timeout } from 'rxjs/operators';
+import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
+import { StError, StSpace } from './stratos-types';
+
+// V3-native space-detail data source. Backs CloudFoundrySpaceService.space$
+// once the V2-includes URL path is retired (Phase B of the
+// v2-includes-migration). Mirrors OrgDataService — same in-flight dedup +
+// warm-cache short-circuit pattern so concurrent callers share one HTTP
+// fan-out.
+export class SpaceDataService {
+  private readonly _space = signal<StSpace | null>(null);
+  private readonly _isLoading = signal<boolean>(false);
+  private readonly _errors = signal<StError[]>([]);
+  private readonly _lastFetched = signal<Date | null>(null);
+
+  readonly space: Signal<StSpace | null> = this._space.asReadonly();
+  readonly isLoading: Signal<boolean> = this._isLoading.asReadonly();
+  readonly errors: Signal<StError[]> = this._errors.asReadonly();
+  readonly lastFetched: Signal<Date | null> = this._lastFetched.asReadonly();
+
+  readonly loaded$ = new ReplaySubject<void>(1);
+
+  private _inFlightLoad: Observable<void> | null = null;
+
+  constructor(
+    private readonly http: HttpClient,
+    readonly cnsiGuid: string,
+    readonly spaceGuid: string,
+    private readonly diagnostics?: StratosDiagnostics,
+  ) {}
+
+  load(): Observable<void> {
+    this.diagnostics?.emitCounter('service-call-count', { service: 'SpaceDataService', method: 'load' });
+    if (this._lastFetched() !== null && this._space() !== null) {
+      this.diagnostics?.emitCounter('cache-hit', { service: 'SpaceDataService', method: 'load' });
+      return of(undefined);
+    }
+    if (this._inFlightLoad) {
+      this.diagnostics?.emitCounter('in-flight-hit', { service: 'SpaceDataService', method: 'load' });
+      return this._inFlightLoad;
+    }
+    this.diagnostics?.emitCounter('cache-miss', { service: 'SpaceDataService', method: 'load' });
+    this._isLoading.set(true);
+    this._errors.set([]);
+
+    this._inFlightLoad = this.http.get<StSpace>(`/pp/v1/cf/spaces/${this.cnsiGuid}/${this.spaceGuid}`).pipe(
+      tap(space => this._space.set({ ...space, cnsiGuid: this.cnsiGuid })),
+      catchError(err => { this.addError('space', err); return EMPTY; }),
+      timeout(60_000),
+      finalize(() => {
+        this._isLoading.set(false);
+        this._lastFetched.set(new Date());
+        this.loaded$.next();
+        this._inFlightLoad = null;
+      }),
+      shareReplay({ bufferSize: 1, refCount: false }),
+    ) as Observable<void>;
+    return this._inFlightLoad;
+  }
+
+  private addError(resource: string, err: unknown): void {
+    this._errors.update(errors => [...errors, {
+      resource,
+      severity: 'error' as const,
+      message: err instanceof Error ? err.message : String(err),
+      recoverable: true,
+      detail: err,
+    }]);
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
@@ -235,6 +235,11 @@ export interface StSpace {
   // (getNativeSpaceDetail). List handlers leave it `false` to avoid
   // an N+1 /v3/spaces/{guid}/features/ssh fetch per space.
   allowSsh: boolean;
+  // V3 relationships.quota.data.guid — empty when no space-specific
+  // quota is linked (org quota is the effective limit then). Drives
+  // cf-space-service.spaceQuotaDefinition$ — replaces the V2 inline
+  // space_quota_definition that used to ride on the includes envelope.
+  quotaGuid?: string;
 }
 
 export interface StOrgDetail extends StOrg {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.html
@@ -22,13 +22,13 @@
 
         <div class="app-metadata__two-cols">
           <app-metadata-item label="Org Status">
-            {{ ((cfOrgService.org$ | async)?.entity?.entity?.status) | capitalizeFirst}}
+            {{ cfOrgService.orgDataService.org()?.status | capitalizeFirst }}
           </app-metadata-item>
           <app-metadata-item label="Created At">
-            {{ ((cfOrgService.org$ | async)?.entity?.metadata?.created_at) | date:'medium' }}
+            {{ cfOrgService.orgDataService.org()?.createdAt | date:'medium' }}
           </app-metadata-item>
           <app-metadata-item label="Updated At">
-            {{ ((cfOrgService.org$ | async)?.entity?.metadata?.updated_at) | date:'medium' }}
+            {{ cfOrgService.orgDataService.org()?.updatedAt | date:'medium' }}
           </app-metadata-item>
         </div>
       </div>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.html
@@ -34,10 +34,10 @@
           {{ allowSshStatus$ | async }}
         </app-metadata-item>
         <app-metadata-item label="Created At">
-          {{ ((cfSpaceService.space$ | async)?.entity?.metadata?.created_at) | date: 'medium' }}
+          {{ cfSpaceService.spaceDataService.space()?.createdAt | date: 'medium' }}
         </app-metadata-item>
         <app-metadata-item label="Updated At">
-          {{ ((cfSpaceService.space$ | async)?.entity?.metadata?.updated_at) | date: 'medium' }}
+          {{ cfSpaceService.spaceDataService.space()?.updatedAt | date: 'medium' }}
         </app-metadata-item>
       </div>
     </div>

--- a/src/frontend/packages/cloud-foundry/src/shared/services/cloud-foundry-user-provided-services.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/cloud-foundry-user-provided-services.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, shareReplay } from 'rxjs/operators';
 
 import { IUserProvidedServiceInstanceData } from '../../actions/user-provided-service.actions';
 import { StServiceInstance } from '../../services/endpoint-data/stratos-types';
@@ -125,9 +125,17 @@ export class CloudFoundryUserProvidedServicesService {
         params = params.set('space_guids', spaceGuid);
       }
     }
+    // shareReplay so multiple template async-pipes on the same field share
+    // one HTTP fan-out. Without it, space-detail Summary fires this count
+    // probe ~3-5× per page nav (detailsLoading$ combineLatest + the
+    // template's @if condition + value display), with the early teardown
+    // showing up as ERR_ABORTED in DevTools. refCount:false keeps the
+    // cached emission warm across mid-stream resubscribes — matches the
+    // dedup pattern in EndpointDataService.load() / OrgDataService.load().
     return this.http.get<PagedServiceInstances>(path, { params }).pipe(
       map(resp => totalOf(resp)),
       catchError(() => of(0)),
+      shareReplay({ bufferSize: 1, refCount: false }),
     );
   }
 

--- a/src/frontend/packages/cloud-foundry/test-framework/cloud-foundry-organization.service.mock.ts
+++ b/src/frontend/packages/cloud-foundry/test-framework/cloud-foundry-organization.service.mock.ts
@@ -14,6 +14,16 @@ export class CloudFoundryOrganizationServiceMock {
       },
       entityRequestInfo: getDefaultRequestState()
     });
+  // Signal-native shim: card-cf-org-user-details and other org-detail consumers
+  // read scalar fields off cfOrgService.orgDataService.org() directly. Returns
+  // null so templates render their `?` chains as empty.
+  orgDataService = {
+    org: () => null,
+    spaces: () => [],
+    isLoading: () => false,
+    errors: () => [],
+    load: () => observableOf(undefined),
+  };
   apps$ = observableOf([]);
   appCount$ = observableOf(0);
   serviceInstancesCount$ = observableOf(0);

--- a/src/frontend/packages/cloud-foundry/test-framework/cloud-foundry-space.service.mock.ts
+++ b/src/frontend/packages/cloud-foundry/test-framework/cloud-foundry-space.service.mock.ts
@@ -44,7 +44,15 @@ export class CloudFoundrySpaceServiceMock {
   appCount$ = observableOf(0);
   serviceInstancesCount$ = observableOf(0);
   userProvidedServiceInstancesCount$ = observableOf(0);
-
+  routesCount$ = observableOf(0);
+  // Signal-native shim: card-cf-space-details and other space-detail consumers
+  // read scalar fields off cfSpaceService.spaceDataService.space() directly.
+  spaceDataService = {
+    space: () => null,
+    isLoading: () => false,
+    errors: () => [],
+    load: () => observableOf(undefined),
+  };
 }
 
 export const getCfSpaceServiceMock = {

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -247,12 +247,17 @@ func toStApp(r capi.App) StApp {
 }
 
 func toStSpace(r capi.Space) StSpace {
+	quotaGUID := ""
+	if r.Relationships.Quota != nil {
+		quotaGUID = relationshipGUID(*r.Relationships.Quota)
+	}
 	return StSpace{
 		GUID:      r.GUID,
 		Name:      r.Name,
 		OrgGUID:   relationshipGUID(r.Relationships.Organization),
 		CreatedAt: r.CreatedAt.Format(time.RFC3339),
 		UpdatedAt: r.UpdatedAt.Format(time.RFC3339),
+		QuotaGUID: quotaGUID,
 	}
 }
 

--- a/src/jetstream/plugins/cloudfoundry/native_types.go
+++ b/src/jetstream/plugins/cloudfoundry/native_types.go
@@ -81,6 +81,11 @@ type StSpace struct {
 	// by detail handlers (getNativeSpaceDetail); list handlers leave it at
 	// the default `false` to avoid an N+1 feature fetch per space.
 	AllowSSH bool `json:"allowSsh"`
+	// QuotaGUID mirrors V3 relationships.quota.data.guid. Empty when no
+	// space-specific quota is linked (the org quota is the effective limit
+	// in that case). Always-emit (omitempty) so the wire shape stays
+	// predictable; consumers fall back to the org quota when this is "".
+	QuotaGUID string `json:"quotaGuid,omitempty"`
 }
 
 type StOrgDetail struct {


### PR DESCRIPTION
## Summary

- **Kills the V2 \`?include-relations=...\` URLs** that fired on every org-detail and space-detail page load. Backend native handlers already returned the data Stratos needed; the \`cfEntityCatalog.{org,space}.store.getEntityService(..., {includeRelations})\` path was a V2-only no-op against the V3 backend that still cost a round-trip per page nav.
- **Org and space services now signal-native end-to-end.** \`CloudFoundryOrganizationService.org\$\` and \`CloudFoundrySpaceService.space\$\` are gone. Consumers read \`StOrgDetail\` / \`StSpace\` directly off \`OrgDataService.org\` and \`SpaceDataService.space\` signals — no \`EntityInfo<APIResource<…>>\` envelope. Backed by sticky per-(cnsi,key) registries with in-flight dedup + warm-cache short-circuit (same pattern as \`EndpointDataService\`).
- **Two count-probe fanouts fixed.** \`organization_quotas/{guid}\` was firing 4× on space-detail Summary and \`service_instances/{cnsi}?return=counts&type=user-provided\` was firing 3-5× with ABORTED noise — both because cold pipes with multiple template async-pipe subscribers; \`shareReplay({bufferSize:1, refCount:false})\` at each source dedupes.

### Commit map

1. \`OrgDataService\`: in-flight dedup + \`OrgDataRegistry\`
2. Org-detail base: \`inject(OrgDataService)\` via registry factory
3. Org service signal-native; \`org\$\` + bridge gone (5 consumers migrated)
4. Native space detail: expose V3 quota relationship as \`quotaGuid\`
5. \`SpaceDataService\`: in-flight dedup + \`SpaceDataRegistry\`
6. Space-detail base: \`inject(SpaceDataService)\` via registry factory
7. Space service signal-native; \`space\$\` + bridge gone (5 consumers migrated)
8. Org \`quotaDefinition\$\`: shareReplay to dedup 4× quota fetch
9. UPS count probe: shareReplay to dedup space-summary fanout

## Test plan

- [x] \`make check gate\` (lint + vitest + go tests)
- [x] Focused vitest sweep: \`cf-organizations\` (35), \`endpoint-data\` (20+), \`edit-space\` (4), \`cli-info-cloud-foundry\`, \`cards/card-cf-{org,space}-details\`, \`cloud-foundry-user-provided-services\` (12) — all green
- [x] Browser walk on Kevin 4 / e2e: confirm zero \`?inline-relations-depth=…\` URLs on org-detail and space-detail pages; \`organization_quotas\` + UPS count fire once per page nav
- [x] Confirm org/space favorite + breadcrumb + quota tile + name still render correctly post-deploy

## Notes

- Backend change is additive: \`StSpace.QuotaGUID\` with \`omitempty\` — older clients ignore it.
- \`fetchServiceInstancesCount\` in \`services-helper.ts\` already deduped via NGRX store (\`fetchTotalResults\` → \`store.select\`); the shareReplay fix is only needed on the UPS helper which is a bare \`http.get(...).pipe(...)\` chain.
