### PR TITLE
EndpointDataService: drain all pages for apps/orgs/spaces

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
@@ -166,6 +166,53 @@ describe('EndpointDataService', () => {
     );
   });
 
+  it('loadDetails() drains all pages when pagination.totalPages > 1', async () => {
+    // Regression guard: the previous implementation capped at ?page=1
+    // (silently truncating to 500 rows on large CFs). The drain fetches
+    // page 1 inline, then pages 2..N in parallel via the totalPages
+    // metadata from the StratosPagedResponse envelope.
+    const orgsPage1 = [
+      { guid: 'org-1', name: 'Org One', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '' },
+    ];
+    const orgsPage2 = [
+      { guid: 'org-2', name: 'Org Two', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '' },
+    ];
+    const orgsPage3 = [
+      { guid: 'org-3', name: 'Org Three', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '' },
+    ];
+
+    service.loadDetails().subscribe();
+
+    // Page 1 fires for all three resources; apps + spaces report single-
+    // page totalPages so they don't drain further.
+    httpMock.expectOne(ORGS_FULL_URL).flush({
+      resources: orgsPage1,
+      pagination: { totalResults: 3, totalPages: 3 },
+    });
+    httpMock.expectOne(APPS_FULL_URL).flush({
+      resources: [], pagination: { totalResults: 0, totalPages: 1 },
+    });
+    httpMock.expectOne(SPACES_FULL_URL).flush({
+      resources: [], pagination: { totalResults: 0, totalPages: 1 },
+    });
+
+    // After page 1 lands, the orgs drain triggers pages 2 + 3 in parallel.
+    httpMock.expectOne('/pp/v1/cf/orgs/test-cnsi-guid?per_page=500&page=2').flush({
+      resources: orgsPage2,
+      pagination: { totalResults: 3, totalPages: 3 },
+    });
+    httpMock.expectOne('/pp/v1/cf/orgs/test-cnsi-guid?per_page=500&page=3').flush({
+      resources: orgsPage3,
+      pagination: { totalResults: 3, totalPages: 3 },
+    });
+
+    await Promise.resolve();
+
+    expect(service.orgs().length).toBe(3);
+    expect(service.orgs().map(o => o.guid)).toEqual(['org-1', 'org-2', 'org-3']);
+    expect(service.orgCount()).toBe(3);
+  });
+
   it('loadDetails() reads totalResults from the StratosPagedResponse pagination envelope', async () => {
     // Regression: the bounded ?per_page passthrough wraps responses in
     // StratosPagedResponse — totals live under pagination.totalResults rather

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { signal, Signal } from '@angular/core';
-import { EMPTY, firstValueFrom, merge, Observable, of, ReplaySubject } from 'rxjs';
-import { catchError, finalize, shareReplay, tap, timeout } from 'rxjs/operators';
+import { EMPTY, firstValueFrom, from, merge, Observable, of, ReplaySubject } from 'rxjs';
+import { catchError, finalize, map, mergeMap, reduce, shareReplay, switchMap, tap, timeout } from 'rxjs/operators';
 import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
 import { EndpointDataShim } from './endpoint-data.shim';
 import {
@@ -176,42 +176,32 @@ export class EndpointDataService {
     this.diagnostics?.emitCounter('cache-miss', { service: 'EndpointDataService', method: 'loadDetails' });
     this._isLoadingDetails.set(true);
 
-    // Use the bounded ?per_page passthrough so each list call is one CAPI
-    // page rather than a full-drain. On slow CFs the unbounded path could
-    // hit gorouter's 30 s ceiling; even where it doesn't, a single bounded
-    // page of 500 typically completes in well under 12 s. 500 covers most
-    // CFs in one page; if a CF has more rows the home card shows the first
-    // 500, accepted trade-off pending a guid-batch consolidation pattern.
+    // Full-drain pagination: fetch page 1, then pages 2..N in parallel with
+    // bounded concurrency. Replaces the previous ?page=1 single-page cap
+    // that silently truncated lists to 500 rows on CFs with more orgs /
+    // apps / spaces than fit in one page — that was a live regression on
+    // the prod orgs list page (CloudFoundryOrganizationsSignalComponent),
+    // not just the home card.
     //
-    // The bounded backend wraps results in StratosPagedResponse with totals
-    // under `pagination.totalResults`. Tap reads either shape so a future
-    // tightening of the backend wire contract doesn't silently zero out the
-    // count signals.
-    const detailPerPage = 500;
-    type Paged<T> = { resources: T[]; totalResults?: number; pagination?: { totalResults?: number } };
-    const totalOf = <T>(r: Paged<T>): number => r.pagination?.totalResults ?? r.totalResults ?? r.resources.length;
+    // 500 per page balances per-request latency vs round-trip count.
+    // Concurrency cap of 4 keeps parallel page fetches from saturating
+    // the connection or hitting gorouter back-pressure on slow CFs.
     this._inFlightLoadDetails = merge(
-      this.http.get<Paged<StOrg>>(
-        `/pp/v1/cf/orgs/${this.guid}?per_page=${detailPerPage}&page=1`,
-      ).pipe(
+      this.drainPages<StOrg>(`/pp/v1/cf/orgs/${this.guid}`).pipe(
         tap(resp => {
           this._orgs.set(resp.resources.map(org => ({ ...org, cnsiGuid: this.guid })));
-          this._orgCount.set(totalOf(resp));
+          this._orgCount.set(resp.totalResults);
         }),
         catchError(err => { this.addError('orgs-full', err); return EMPTY; }),
       ),
-      this.http.get<Paged<StApp>>(
-        `/pp/v1/cf/apps/${this.guid}?per_page=${detailPerPage}&page=1`,
-      ).pipe(
+      this.drainPages<StApp>(`/pp/v1/cf/apps/${this.guid}`).pipe(
         tap(resp => {
           this._apps.set(resp.resources.map(app => ({ ...app, cnsiGuid: this.guid })));
-          this._appCount.set(totalOf(resp));
+          this._appCount.set(resp.totalResults);
         }),
         catchError(err => { this.addError('apps-full', err); return EMPTY; }),
       ),
-      this.http.get<Paged<StSpace>>(
-        `/pp/v1/cf/spaces/${this.guid}?per_page=${detailPerPage}&page=1`,
-      ).pipe(
+      this.drainPages<StSpace>(`/pp/v1/cf/spaces/${this.guid}`).pipe(
         tap(resp => this._spaces.set(resp.resources.map(space => ({ ...space, cnsiGuid: this.guid })))),
         catchError(err => { this.addError('spaces-full', err); return EMPTY; }),
       ),
@@ -227,6 +217,38 @@ export class EndpointDataService {
       shareReplay({ bufferSize: 1, refCount: false }),
     ) as Observable<void>;
     return this._inFlightLoadDetails;
+  }
+
+  // Drain all pages for a Stratos-shape list endpoint. Page 1 inline,
+  // pages 2..N in parallel (concurrency=4). Reads totalPages from the
+  // StratosPagedResponse pagination meta (stratos_paging.go:68). Reduces
+  // to a single {resources, totalResults, totalPages} envelope so the
+  // caller can populate count signals from page-1 metadata without an
+  // extra fetch. Tolerates both StratosPagedResponse and the older
+  // flat-envelope shape (totalResults at the top level) — the backend
+  // PR #5337 era still has handlers in transition.
+  private drainPages<T>(urlBase: string): Observable<{ resources: T[]; totalResults: number; totalPages: number }> {
+    const perPage = 500;
+    type Paged<U> = { resources: U[]; totalResults?: number; pagination?: { totalResults?: number; totalPages?: number } };
+    const totalResultsOf = <U>(r: Paged<U>): number => r.pagination?.totalResults ?? r.totalResults ?? r.resources.length;
+    const fetchPage = (page: number) =>
+      this.http.get<Paged<T>>(`${urlBase}?per_page=${perPage}&page=${page}`);
+    return fetchPage(1).pipe(
+      switchMap(firstResp => {
+        const totalResults = totalResultsOf(firstResp);
+        const totalPages = firstResp.pagination?.totalPages ?? 1;
+        const firstResources = firstResp.resources;
+        if (totalPages <= 1) {
+          return of({ resources: firstResources, totalResults, totalPages });
+        }
+        const remainingPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
+        return from(remainingPages).pipe(
+          mergeMap(p => fetchPage(p).pipe(map(r => r.resources)), 4 /* concurrency */),
+          reduce((acc, resources) => [...acc, ...resources], [...firstResources]),
+          map(allResources => ({ resources: allResources, totalResults, totalPages })),
+        );
+      }),
+    );
   }
 
   // loadServicesCounts() fetches the four cnsi-scoped services-domain counts


### PR DESCRIPTION
## Summary

- **Removes the per_page=500 single-page cap** on \`EndpointDataService.loadDetails()\`. Previously the orgs/apps/spaces signals truncated at 500 rows on the first page — a live regression for any CF endpoint with more rows than fit in one page. Affected the home card AND the routed signal list pages (\`CloudFoundryOrganizationsSignalComponent\`, the apps/spaces signal-list configs) which all read these signals as their primary source.
- **Adds a \`drainPages()\` helper** that fetches page 1 inline, reads \`pagination.totalPages\` from the \`StratosPagedResponse\` envelope (\`stratos_paging.go:68\`), then fetches pages 2..N in parallel via \`mergeMap\` with concurrency=4 to avoid saturating the connection or hitting gorouter back-pressure on slow CFs.
- **Tolerates both response shapes** (the \`StratosPagedResponse\` pagination meta and the older flat envelope) since backend handlers are still mid-transition.

## Why now

Surfaced while planning the V2 URL removal triage (see PR #5337's follow-on workstream). The orgs path was about to be migrated from the legacy V2 \`?include-relations=\` URL to read \`endpointDataService.orgs()\` — that uncovered the pre-existing cap. Fixing the drain first unblocks every signal-native list page consumer (org list, app wall, space list) and keeps the migration's \"no regression\" bar honest.

## Live verify

Walked Kevin 4 / the validation target with \`perPage=10\` temporarily set to force drain on the existing 56-org dataset. Network trace confirmed:

| Resource | Pages fired | Total rendered |
|---|---|---|
| orgs | page=1..6 (200 OK each) | 56 orgs (matches CF) |
| apps | page=1..5 (200 OK each) | 48 apps (matches CF) |
| spaces | page=1..45+ (concurrency-capped) | thousands (CF has 56 orgs × ~50 spaces) |

Reverted to \`perPage=500\` before commit; spec coverage exercises the multi-page path with \`pagination.totalPages > 1\`.

## Test plan

- [x] \`make check gate\` (lint + vitest + go tests) green
- [x] Focused vitest: \`endpoint-data.service.spec.ts\` 19/19 pass (new test: \`loadDetails() drains all pages when pagination.totalPages > 1\`)
- [x] Browser verify on Kevin 4 with perPage=10 forced — apps/orgs/spaces all drain to completion
- [ ] Browser verify on a production-scale CF with >500 orgs/apps/spaces (no such fixture in the local sqlite seed; relies post-deploy deploy or similar large fixture)

## Notes

- Concurrency cap of 4 is conservative — the \`reduce\` accumulates resources in arrival order, which is fine because consumers re-sort via the signal-list \`ViewPipeline\` anyway.
- 500-per-page is unchanged from the previous behavior (only the cap that kicked in afterward is gone). For a CF with ≤500 of each resource type, this PR is a no-op — single page-1 fetch, no additional pages.
- Unblocks the next WS#1 step (V2 \`?include-relations=\` URL removal from \`cloud-foundry-endpoint.service\`); that work is currently stashed pending this merge.
