### PR TITLE
Fix endpoint register: surface new guid for connect step

### DIFF
--- a/src/frontend/packages/store/src/services/endpoints-data.service.ts
+++ b/src/frontend/packages/store/src/services/endpoints-data.service.ts
@@ -294,7 +294,8 @@ export class EndpointsDataService {
     }
 
     const stagingGuid = '<New Endpoint>' + opts.name;
-    return this.runMutation(stagingGuid, 'POST', ENDPOINTS_URL, body, e => {
+    let registeredGuid = '';
+    const result = await this.runMutation(stagingGuid, 'POST', ENDPOINTS_URL, body, e => {
       const message = 'There was a problem creating the endpoint. Please ensure the endpoint address is correct and try again. ' +
         httpErrorResponseToSafeString(e);
       if (e?.status === 403) {
@@ -302,10 +303,17 @@ export class EndpointsDataService {
       }
       return message;
     }, async endpoint => {
+      // The POST response body is the new CNSIRecord — capture its guid so the
+      // caller (create-endpoint stepper) can carry it into the connect step.
+      registeredGuid = endpoint?.guid || '';
       // Refresh full endpoint set so the new entry shows up keyed by real guid.
       await this.getAll(false).catch(() => {/* surfaced on _error */});
       return endpoint;
     });
+    if (!result.error && registeredGuid) {
+      result.message = registeredGuid;
+    }
+    return result;
   }
 
   async connect(guid: string, opts: EndpointConnectOptions): Promise<ActionState> {


### PR DESCRIPTION
## Summary

After registering a new endpoint, the create-endpoint stepper advances to the connect step and POSTs to `/api/v1/tokens` with the new endpoint's `cnsi_guid`. Currently the guid is always empty, so the backend rejects with `400 "Missing target endpoint"` and connect always fails.

**Cause:** W36-B Wave 1 (`2b544de0f0`) rewrote `EndpointsDataService.register()` to use `runMutation`, which returns `{ busy, error, message }` and discards the HTTP response body. On success `message` was `''`, so `create-endpoint-cf-step-1.component.ts` built its `ConnectEndpointConfig` with `guid: ''`.

**Fix:** Capture the new endpoint's guid in the `onSuccess` closure (the POST response body is the new `CNSIRecord`) and assign it to `result.message` on success before returning. No signature change to `runMutation`, no impact on other callers.

## Test plan

- [x] Register a new Cloud Foundry endpoint via Endpoints → Register
- [x] Verify the second step (Connect) succeeds when credentials are correct (previously: always 400)
- [x] Verify the first step still completes successfully when the connect checkbox is unchecked (Finish path)
- [x] Verify error path: bad credentials still surface the backend error, not a guid-missing error