### PR TITLE
chore(deps): bump containerd 1.7.30 → 1.7.32 in /src/jetstream (re-do of #5359)

### DIFF
--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/cloudfoundry/bosh-cli v6.4.1+incompatible // indirect
 	github.com/cloudfoundry/bosh-utils v0.0.385 // indirect
-	github.com/containerd/containerd v1.7.30 // indirect
+	github.com/containerd/containerd v1.7.32 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -102,8 +102,8 @@ github.com/cloudfoundry/noaa/v2 v2.5.0/go.mod h1:R33q73MnTXa549YPMHupTdQuKL3QqKQ
 github.com/cloudfoundry/sonde-go v0.0.0-20250505082611-517434ece96d h1:zFEOGvCZYR7QrZ94C7r2dqsLNw/BYMr0QYyuwlMAhrY=
 github.com/cloudfoundry/sonde-go v0.0.0-20250505082611-517434ece96d/go.mod h1:n3NQkJyrQPZ/pq+mjECQL7sLjL/U3rmTwyWMwpGxcXQ=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
-github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
-github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
+github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
+github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=


### PR DESCRIPTION
## Summary

Clean replay of #5359. The original dependabot commit stripped `github.com/containerd/containerd` from `go.mod`/`go.sum` without adding v1.7.32 — Backend Tests failed with `go.mod needs tidy`, and the bot also incorrectly removed the four in-repo replace-managed `require` entries (`plugins/cfapppush`, `plugins/kubernetes`, `plugins/monocular`, `plugins/kubernetes/auth`).

This PR is a surgical replacement branched off current `develop`:

```bash
cd src/jetstream
go get github.com/containerd/containerd@v1.7.32
go mod tidy
```

Net diff: 1 line in `go.mod`, 2 lines in `go.sum`. No transitive deps moved. The in-repo replace targets stay intact.

## Test plan

- [x] `go build ./...` clean in `src/jetstream/`
- [ ] CI gate (Backend Tests + frontend matrix + lint + quality gate)

If this lands, #5359 can be closed by a maintainer.