### PR TITLE
fix(picker): UX polish for CF/Org/Space pickers + walls

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
@@ -277,12 +277,14 @@ export class ApplicationWallComponent implements OnInit {
         options: this.appsConfig.orgOptions,
         selected: this.appsConfig.selectedOrg,
         onOpen: onDropdownOpen,
+        loading: this.appsConfig.isLoadingOrgs,
       },
       {
         label: 'Space',
         options: this.appsConfig.spaceOptions,
         selected: this.appsConfig.selectedSpace,
         onOpen: onDropdownOpen,
+        loading: this.appsConfig.isLoadingSpaces,
       },
     ];
     const stateColor = (app: StApp): SignalListPillColor => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -92,11 +92,13 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
         label: 'Organization',
         options: this.appsConfig.orgOptions,
         selected: this.appsConfig.selectedOrg,
+        loading: this.appsConfig.isLoadingOrgs,
       },
       {
         label: 'Space',
         options: this.appsConfig.spaceOptions,
         selected: this.appsConfig.selectedSpace,
+        loading: this.appsConfig.isLoadingSpaces,
       },
     ];
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-routes/cloud-foundry-routes-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-routes/cloud-foundry-routes-signal.component.ts
@@ -174,11 +174,13 @@ export class CloudFoundryRoutesSignalComponent {
         label: 'Organization',
         options: this.routesConfig.orgOptions,
         selected: this.routesConfig.selectedOrg,
+        loading: this.routesConfig.isLoadingOrgs,
       },
       {
         label: 'Space',
         options: this.routesConfig.spaceOptions,
         selected: this.routesConfig.selectedSpace,
+        loading: this.routesConfig.isLoadingSpaces,
       },
     ];
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
@@ -99,11 +99,13 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
         label: 'Organization',
         options: this.instancesConfig.orgOptions,
         selected: this.instancesConfig.selectedOrg,
+        loading: this.instancesConfig.isLoadingOrgs,
       },
       {
         label: 'Space',
         options: this.instancesConfig.spaceOptions,
         selected: this.instancesConfig.selectedSpace,
+        loading: this.instancesConfig.isLoadingSpaces,
       },
     ];
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.ts
@@ -223,11 +223,13 @@ export class CloudFoundryUsersComponent {
           label: 'Organization',
           options: this.usersConfig.orgOptions,
           selected: this.usersConfig.selectedOrg,
+          loading: this.usersConfig.isLoadingOrgs,
         },
         {
           label: 'Space',
           options: this.usersConfig.spaceOptions,
           selected: this.usersConfig.selectedSpace,
+          loading: this.usersConfig.isLoadingSpaces,
         },
       ] as SignalListDropdown[],
       onRefresh: () => this.usersConfig.refresh(),

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.html
@@ -16,6 +16,9 @@
 @if ((cloudFoundryService.hasRegisteredCFEndpoints$ | async) && (cloudFoundryService.hasConnectedCFEndpoints$ | async)) {
   <app-duplicate-url-banner nounPlural="Service offerings"></app-duplicate-url-banner>
   @if (listConfig(); as cfg) {
+    <app-list-sub-nav title="Total Service Offerings"
+                      [count]="totalServiceOfferings"
+                      [addAction]="createServiceInstanceAction"></app-list-sub-nav>
     <div class="flex-1 min-h-0 p-4 flex flex-col">
       <app-signal-list [config]="cfg"></app-signal-list>
     </div>

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.ts
@@ -2,7 +2,7 @@ import { animate, query, style, transition, trigger } from '@angular/animations'
 import { CommonModule, DatePipe } from '@angular/common';
 import { Component, OnInit, ChangeDetectionStrategy, Signal, inject, signal, WritableSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { Observable, firstValueFrom } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 
@@ -59,6 +59,7 @@ export class ServiceCatalogPageComponent implements OnInit {
   cloudFoundryService = inject(CloudFoundryService);
   private offeringsConfig = inject(CfServiceOfferingsSignalConfigService);
   private userFavoriteManager = inject(UserFavoriteManager);
+  private router = inject(Router);
 
   public cfIds$: Observable<string[]>;
   public haveConnectedCf$: Observable<boolean>;
@@ -205,6 +206,18 @@ export class ServiceCatalogPageComponent implements OnInit {
       filterColumns: ['name', 'description', 'tags', 'broker'],
       filterField: this.offeringsConfig.filterField,
       filterDropdowns: dropdowns,
+      headerActions: [
+        {
+          label: 'Add Service Instance',
+          icon: 'add',
+          primary: true,
+          dataTest: 'add-service-instance',
+          // Marketplace lists managed offerings, so default to the managed
+          // path. The tile chooser at /services/new offers UPS too if the
+          // user navigates back, but skipping it on this page shaves a step.
+          run: () => this.router.navigateByUrl('/services/new/service'),
+        },
+      ],
       onRefresh: () => this.offeringsConfig.refresh(),
       onClear: () => this.offeringsConfig.clearFilters(),
       viewMode: this.offeringsConfig.viewMode,

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.ts
@@ -7,6 +7,8 @@ import { Observable, firstValueFrom } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 
 import {
+  ListSubNavAddAction,
+  ListSubNavComponent,
   PageHeaderComponent,
   SignalListComponent,
   SignalListConfig,
@@ -38,6 +40,7 @@ import type { StServiceOffering } from '../../../services/endpoint-data/stratos-
     RouterModule,
     PageHeaderComponent,
     SignalListComponent,
+    ListSubNavComponent,
     CfEndpointsMissingComponent,
     DuplicateUrlBannerComponent,
   ],
@@ -100,6 +103,17 @@ export class ServiceCatalogPageComponent implements OnInit {
   // config has been initialized with the connected CF guids. Using a
   // WritableSignal so assignment triggers change detection under OnPush.
   public listConfig: WritableSignal<SignalListConfig<StServiceOffering> | undefined> = signal(undefined);
+  // L5 sub-nav: unfiltered offering count + primary add action. Total is
+  // bound post-initialize() once offeringsConfig.view exists.
+  public totalServiceOfferings!: Signal<number>;
+  public readonly createServiceInstanceAction: ListSubNavAddAction = {
+    label: 'Add Service Instance',
+    // Marketplace lists managed offerings, so default to the managed path —
+    // skips the tile chooser at /services/new since UPS isn't a marketplace
+    // construct.
+    icon: 'add',
+    invoke: () => this.router.navigateByUrl('/services/new/service'),
+  };
 
   constructor() {
     this.cfIds$ = this.cloudFoundryService.cFEndpoints$.pipe(
@@ -122,6 +136,8 @@ export class ServiceCatalogPageComponent implements OnInit {
     );
     const cnsiGuids = (connected ?? []).map(ep => ep.guid);
     this.offeringsConfig.initialize(cnsiGuids);
+    // Bind the L5 sub-nav count — view exists only after initialize().
+    this.totalServiceOfferings = this.offeringsConfig.view.totalItems;
 
     const dropdowns: SignalListDropdown[] = [
       {
@@ -206,18 +222,6 @@ export class ServiceCatalogPageComponent implements OnInit {
       filterColumns: ['name', 'description', 'tags', 'broker'],
       filterField: this.offeringsConfig.filterField,
       filterDropdowns: dropdowns,
-      headerActions: [
-        {
-          label: 'Add Service Instance',
-          icon: 'add',
-          primary: true,
-          dataTest: 'add-service-instance',
-          // Marketplace lists managed offerings, so default to the managed
-          // path. The tile chooser at /services/new offers UPS too if the
-          // user navigates back, but skipping it on this page shaves a step.
-          run: () => this.router.navigateByUrl('/services/new/service'),
-        },
-      ],
       onRefresh: () => this.offeringsConfig.refresh(),
       onClear: () => this.offeringsConfig.clearFilters(),
       viewMode: this.offeringsConfig.viewMode,

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.html
@@ -16,6 +16,9 @@
 @if ((cloudFoundryService.hasRegisteredCFEndpoints$ | async) && (cloudFoundryService.hasConnectedCFEndpoints$ | async)) {
   <app-duplicate-url-banner nounPlural="Service instances"></app-duplicate-url-banner>
   @if (listConfig(); as cfg) {
+    <app-list-sub-nav title="Total Service Instances"
+                      [count]="totalServiceInstances"
+                      [addAction]="createServiceInstanceAction"></app-list-sub-nav>
     <div class="flex-1 min-h-0 p-4 flex flex-col">
       <app-signal-list [config]="cfg"></app-signal-list>
     </div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -2,7 +2,7 @@ import { animate, query, style, transition, trigger } from '@angular/animations'
 import { CommonModule, DatePipe } from '@angular/common';
 import { Component, OnInit, ChangeDetectionStrategy, Signal, inject, signal, WritableSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { Observable, firstValueFrom } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 
@@ -72,6 +72,7 @@ export class ServicesWallComponent implements OnInit {
   private userFavoriteManager = inject(UserFavoriteManager);
   private confirmDialog = inject(ConfirmationDialogService);
   private snackBar = inject(TailwindSnackBarService);
+  private router = inject(Router);
 
   public cfIds$: Observable<string[]>;
   public haveConnectedCf$: Observable<boolean>;
@@ -286,6 +287,15 @@ export class ServicesWallComponent implements OnInit {
       filterColumns: ['name', 'service', 'tags'],
       filterField: this.instancesConfig.filterField,
       filterDropdowns: dropdowns,
+      headerActions: [
+        {
+          label: 'Add Service Instance',
+          icon: 'add',
+          primary: true,
+          dataTest: 'add-service-instance',
+          run: () => this.router.navigateByUrl('/services/new'),
+        },
+      ],
       onRefresh: () => this.instancesConfig.refresh(),
       onClear: () => this.instancesConfig.clearFilters(),
       viewMode: this.instancesConfig.viewMode,

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -150,11 +150,13 @@ export class ServicesWallComponent implements OnInit {
         label: 'Organization',
         options: this.instancesConfig.orgOptions,
         selected: this.instancesConfig.selectedOrg,
+        loading: this.instancesConfig.isLoadingOrgs,
       },
       {
         label: 'Space',
         options: this.instancesConfig.spaceOptions,
         selected: this.instancesConfig.selectedSpace,
+        loading: this.instancesConfig.isLoadingSpaces,
       },
     ];
 

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -9,6 +9,8 @@ import { filter, map, take } from 'rxjs/operators';
 import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
+  ListSubNavAddAction,
+  ListSubNavComponent,
   PageHeaderComponent,
   SignalListComponent,
   SignalListConfig,
@@ -49,6 +51,7 @@ import type { StServiceInstance } from '../../../services/endpoint-data/stratos-
     RouterModule,
     PageHeaderComponent,
     SignalListComponent,
+    ListSubNavComponent,
     CfEndpointsMissingComponent,
     DuplicateUrlBannerComponent,
   ],
@@ -118,6 +121,14 @@ export class ServicesWallComponent implements OnInit {
   // Config for <app-signal-list>. Populated in ngOnInit once the signal
   // config has been initialized with the connected CF guids.
   public listConfig: WritableSignal<SignalListConfig<StServiceInstance> | undefined> = signal(undefined);
+  // L5 sub-nav: unfiltered total + primary add action. Total is bound
+  // post-initialize() once instancesConfig.view exists.
+  public totalServiceInstances!: Signal<number>;
+  public readonly createServiceInstanceAction: ListSubNavAddAction = {
+    label: 'Add Service Instance',
+    icon: 'add',
+    invoke: () => this.router.navigateByUrl('/services/new'),
+  };
 
   constructor() {
     this.cfIds$ = this.cloudFoundryService.cFEndpoints$.pipe(
@@ -140,6 +151,8 @@ export class ServicesWallComponent implements OnInit {
     );
     const cnsiGuids = (connected ?? []).map(ep => ep.guid);
     this.instancesConfig.initialize(cnsiGuids);
+    // Bind the L5 sub-nav count — view exists only after initialize().
+    this.totalServiceInstances = this.instancesConfig.view.totalItems;
 
     const dropdowns: SignalListDropdown[] = [
       {
@@ -287,15 +300,6 @@ export class ServicesWallComponent implements OnInit {
       filterColumns: ['name', 'service', 'tags'],
       filterField: this.instancesConfig.filterField,
       filterDropdowns: dropdowns,
-      headerActions: [
-        {
-          label: 'Add Service Instance',
-          icon: 'add',
-          primary: true,
-          dataTest: 'add-service-instance',
-          run: () => this.router.navigateByUrl('/services/new'),
-        },
-      ],
       onRefresh: () => this.instancesConfig.refresh(),
       onClear: () => this.instancesConfig.clearFilters(),
       viewMode: this.instancesConfig.viewMode,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
@@ -2,8 +2,12 @@
   {{ title$ | async }}
 </app-page-header>
 @if (initialisedService(); as inited) {
+  <ng-template #contextSummaryTpl>
+    <span><span class="font-medium text-content-text">Creating in:</span> {{ contextSummaryParts().join(' / ') }}</span>
+  </ng-template>
   <div class="h-full">
-    <app-steppers [cancel]="modeService.cancelUrl">
+    <app-steppers [cancel]="modeService.cancelUrl"
+      [contextSummary]="contextSummaryParts().length > 0 ? contextSummaryTpl : null">
       @if (serviceType === serviceTypes.SERVICE) {
         @if (modeService.viewDetail.showSelectCf && !isSpaceScoped()) {
           <app-step title="Cloud Foundry" [signalHandle]="selectCFHandle">

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -103,6 +103,36 @@ export class AddServiceInstanceComponent implements OnInit, OnDestroy {
   // Use signal for imperative title updates without change detection errors
   private _title = signal<string>('');
   title$ = toObservable(this._title);
+  // Service offering name resolved by the helper, used both for the
+  // page title and the stepper context summary. Updated alongside _title.
+  private _serviceName = signal<string>('');
+  // Stepper context summary parts — "what am I creating, where" — surfaced
+  // above the step headers via the new <app-steppers [contextSummary]>.
+  // CF / Org / Space come from the picker selections; service / instance
+  // name come from csiState as the user advances.
+  readonly contextSummaryParts: Signal<string[]> = computed(() => {
+    const parts: string[] = [];
+    const cfGuid = this.cfOrgSpaceService.cf.select();
+    const orgGuid = this.cfOrgSpaceService.org.select();
+    const spaceGuid = this.cfOrgSpaceService.space.select();
+    if (cfGuid) {
+      const cf = this.cfOrgSpaceService.cf.list().find(c => c.guid === cfGuid);
+      if (cf?.name) parts.push(cf.name);
+    }
+    if (orgGuid) {
+      const org = this.cfOrgSpaceService.org.list().find(o => o.guid === orgGuid);
+      if (org?.name) parts.push(org.name);
+    }
+    if (spaceGuid) {
+      const space = this.cfOrgSpaceService.space.list().find(s => s.guid === spaceGuid);
+      if (space?.name) parts.push(space.name);
+    }
+    const svc = this._serviceName();
+    if (svc) parts.push(svc);
+    const instanceName = this.csiState.state().name;
+    if (instanceName) parts.push(`"${instanceName}"`);
+    return parts;
+  });
   servicesWallCreateInstance = false;
   stepperText = 'Select a Cloud Foundry instance, organization and space for the service instance.';
   bindAppStepperText = 'Bind App (Optional)';
@@ -831,18 +861,21 @@ export class AddServiceInstanceComponent implements OnInit, OnDestroy {
     // setTimeout pushes each update past the current change-detection
     // cycle to avoid ExpressionChangedAfterItHasBeenChecked.
     this.cSIHelperService.serviceName$.pipe(
-      map(label => `Create Instance: ${label || 'Service'}`),
       catchError(error => {
         console.error('initialiseForMarketplaceMode: Failed to fetch service name', {
           serviceId,
           endpointId,
           error
         });
-        return observableOf('Create Service Instance');
+        return observableOf('');
       }),
       takeUntil(this.destroyed$)
-    ).subscribe(title => {
-      setTimeout(() => this._title.set(title), 0);
+    ).subscribe(label => {
+      const title = `Create Instance: ${label || 'Service'}`;
+      setTimeout(() => {
+        this._title.set(title);
+        this._serviceName.set(label || '');
+      }, 0);
     });
     this.marketPlaceMode = true;
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.ts
@@ -69,11 +69,13 @@ export class CloudFoundryEventsListComponent implements OnInit, OnChanges {
           label: 'Organization',
           options: this.eventsConfig.orgOptions,
           selected: this.eventsConfig.selectedOrg,
+          loading: this.eventsConfig.isLoadingOrgs,
         },
         {
           label: 'Space',
           options: this.eventsConfig.spaceOptions,
           selected: this.eventsConfig.selectedSpace,
+          loading: this.eventsConfig.isLoadingSpaces,
         },
       ]
       : [];

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
@@ -30,7 +30,7 @@
         </app-option>
       }
     </app-select>
-    @if (!hasOrgs()) {
+    @if (cfOrgSpaceService.cf.select() && !cfOrgSpaceService.org.loading() && !hasOrgs()) {
       <app-error>There are no organizations in this Cloud Foundry</app-error>
     }
   </app-form-field>
@@ -47,7 +47,7 @@
         </app-option>
       }
     </app-select>
-    @if ((hasSpaces$ | async) === false) {
+    @if (cfOrgSpaceService.org.select() && !cfOrgSpaceService.space.loading() && (hasSpaces$ | async) === false) {
       <app-error>There are no spaces in this organization</app-error>
     }
   </app-form-field>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
@@ -4,6 +4,7 @@
     <app-form-field>
       <app-select id="cf" #cfSelect="ngModel" placeholder="Cloud Foundry" [autoSelectSingleOption]="false"
         [disabled]="cfOrgSpaceService.cf.loading() || isRedeploy"
+        [loading]="cfOrgSpaceService.cf.loading()"
         [ngModel]="cfOrgSpaceService.cf.select()"
         (selectionChange)="onCfChange($event.value)" required name="cf"
         [appFocus]="!cfOrgSpaceService.cf.loading()">
@@ -19,6 +20,7 @@
   <app-form-field>
     <app-select id="org" #orgSelect="ngModel" placeholder="Organization" [autoSelectSingleOption]="false"
       [disabled]="!cfOrgSpaceService.cf.select() || cfOrgSpaceService.org.loading() || isRedeploy"
+      [loading]="cfOrgSpaceService.org.loading()"
       [ngModel]="cfOrgSpaceService.org.select()"
       (selectionChange)="onOrgChange($event.value)" required name="org"
       [appFocus]="isMarketplaceMode && !(!cfOrgSpaceService.cf.select() || cfOrgSpaceService.org.loading() || isRedeploy)">
@@ -36,6 +38,7 @@
   <app-form-field>
     <app-select id="space" #spaceSelect="ngModel" placeholder="Space" [autoSelectSingleOption]="false"
       [disabled]="!cfOrgSpaceService.org.select() || cfOrgSpaceService.space.loading() || isRedeploy"
+      [loading]="cfOrgSpaceService.space.loading()"
       [ngModel]="cfOrgSpaceService.space.select()"
       (selectionChange)="onSpaceChange($event.value)" required name="space">
       <app-option [value]="null">None</app-option>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
@@ -4,7 +4,6 @@
     <app-form-field>
       <app-select id="cf" #cfSelect="ngModel" placeholder="Cloud Foundry" [autoSelectSingleOption]="false"
         [disabled]="cfOrgSpaceService.cf.loading() || isRedeploy"
-        [loading]="cfOrgSpaceService.cf.loading()"
         [ngModel]="cfOrgSpaceService.cf.select()"
         (selectionChange)="onCfChange($event.value)" required name="cf"
         [appFocus]="!cfOrgSpaceService.cf.loading()">

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/app/cf-apps-signal-config.service.ts
@@ -104,6 +104,14 @@ export class CfAppsSignalConfigService {
   // is the expected visual cue.
   private readonly _orgsByCnsi = signal<Map<string, StOrg[]>>(new Map());
   private readonly _spacesByCnsi = signal<Map<string, StSpace[]>>(new Map());
+  // Loading flags for the Org / Space toolbar dropdowns — set true while
+  // loadNames() is fetching and cleared once the relevant map is populated.
+  // Drives the SignalListDropdown spinner so users see "loading" rather
+  // than an empty list.
+  private readonly _isLoadingOrgs = signal(false);
+  private readonly _isLoadingSpaces = signal(false);
+  readonly isLoadingOrgs: Signal<boolean> = this._isLoadingOrgs.asReadonly();
+  readonly isLoadingSpaces: Signal<boolean> = this._isLoadingSpaces.asReadonly();
   // Visible-row resolver overlay: space names looked up by guid for rows
   // currently visible in the view but whose guid wasn't in the bounded
   // /pp/v1/cf/spaces catalog page (which caps at ~500 resources to avoid
@@ -436,12 +444,15 @@ export class CfAppsSignalConfigService {
         .then(r => ({ guid, orgs: r.resources as StOrg[] }))
         .catch(() => ({ guid, orgs: [] as StOrg[] }));
 
+    this._isLoadingOrgs.set(true);
+    this._isLoadingSpaces.set(true);
     const orgResults = await Promise.all(cnsiGuids.map(fetchOrgs));
-    if (gen !== this._initGen) return;
+    if (gen !== this._initGen) { this._isLoadingOrgs.set(false); this._isLoadingSpaces.set(false); return; }
 
     const orgMap = new Map<string, StOrg[]>();
     for (const { guid, orgs } of orgResults) orgMap.set(guid, orgs);
     this._orgsByCnsi.set(orgMap);
+    this._isLoadingOrgs.set(false);
 
     // Reset the spaces map up-front so a re-initialize() doesn't render
     // last mount's stale list while the new drain is still in flight.
@@ -463,6 +474,7 @@ export class CfAppsSignalConfigService {
     // returning. A failure of one CF's drain shouldn't block the others,
     // hence allSettled.
     await Promise.allSettled(drainPromises);
+    this._isLoadingSpaces.set(false);
   }
 
   // Returns the cnsi's orgs ordered with "priority" orgs first (those

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-events/cf-audit-events-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/cf-events/cf-audit-events-signal-config.service.ts
@@ -53,6 +53,15 @@ export class CfAuditEventsSignalConfigService {
   // restrict the foundation-wide event stream to their entity.
   readonly basePredicate: WritableSignal<(e: StAuditEvent) => boolean> = signal(() => true);
 
+  // Loading flags for the Org / Space toolbar dropdowns — surface a
+  // spinner while the per-CF EndpointDataService drains orgs / spaces.
+  readonly isLoadingOrgs: Signal<boolean> = computed(() =>
+    this.endpointDataService?.isLoadingOrgs() ?? false
+  );
+  readonly isLoadingSpaces: Signal<boolean> = computed(() =>
+    this.endpointDataService?.isLoadingSpaces() ?? false
+  );
+
   // Org options for the toolbar. Sourced from EDS.orgs(); "All"
   // prepended. Natural-sort (numeric-aware). Sub-pages (per-org, per-
   // space, per-app) ignore this dropdown.

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/route/cf-routes-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/route/cf-routes-signal-config.service.ts
@@ -173,6 +173,15 @@ export class CfRoutesSignalConfigService {
     return map;
   });
 
+  // Loading flags for the Org / Space toolbar dropdowns — surface a
+  // spinner while the per-CF EndpointDataService drains orgs / spaces.
+  readonly isLoadingOrgs: Signal<boolean> = computed(() =>
+    this.endpointDataService?.isLoadingOrgs() ?? false
+  );
+  readonly isLoadingSpaces: Signal<boolean> = computed(() =>
+    this.endpointDataService?.isLoadingSpaces() ?? false
+  );
+
   // Org options for the CF-level page's Organization filter dropdown.
   // "All" is prepended as the null-value option. Sorted natural-order
   // (numeric-aware) so "org-2" comes before "org-10".

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instance/cf-service-instances-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/service-instance/cf-service-instances-signal-config.service.ts
@@ -97,6 +97,10 @@ export class CfServiceInstancesSignalConfigService {
   // (scope is already pinned).
   readonly orgOptions: Signal<SignalListDropdownOption[]>;
   readonly spaceOptions: Signal<SignalListDropdownOption[]>;
+  // Loading flags for the Org / Space filter dropdowns. True while any
+  // in-scope EndpointDataService is draining orgs / spaces.
+  readonly isLoadingOrgs!: Signal<boolean>;
+  readonly isLoadingSpaces!: Signal<boolean>;
   // endpoint guid → endpoint name, for rendering the CF column without
   // forcing each row to look it up.
   readonly endpointNames: Signal<Map<string, string>>;
@@ -218,6 +222,27 @@ export class CfServiceInstancesSignalConfigService {
         opts.push({ label: `${spaceName} - ${orgName}`, value: guid });
       }
       return opts;
+    });
+
+    // Org / Space dropdown loading flags — unioned across the in-scope
+    // EndpointDataServices. Lets the SignalListDropdown surface a spinner
+    // while the per-CNSI orgs/spaces drain is in flight, so a momentarily
+    // empty list reads as "loading" rather than "no items available."
+    this.isLoadingOrgs = computed(() => {
+      const byCnsi = this._edsByCnsi();
+      const selected = this.selectedCnsi();
+      const edsList: EndpointDataService[] = selected
+        ? (byCnsi.get(selected) ? [byCnsi.get(selected) as EndpointDataService] : [])
+        : Array.from(byCnsi.values());
+      return edsList.some(eds => eds.isLoadingOrgs());
+    });
+    this.isLoadingSpaces = computed(() => {
+      const byCnsi = this._edsByCnsi();
+      const selected = this.selectedCnsi();
+      const edsList: EndpointDataService[] = selected
+        ? (byCnsi.get(selected) ? [byCnsi.get(selected) as EndpointDataService] : [])
+        : Array.from(byCnsi.values());
+      return edsList.some(eds => eds.isLoadingSpaces());
     });
 
     // Flattened space → org map for the filter predicate. StServiceInstance

--- a/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/user/cf-users-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/list/list-types/user/cf-users-signal-config.service.ts
@@ -126,6 +126,15 @@ export class CfUsersSignalConfigService {
     return map;
   });
 
+  // Loading flags for the Org / Space toolbar dropdowns — surface a
+  // spinner while the per-CF EndpointDataService drains orgs / spaces.
+  readonly isLoadingOrgs: Signal<boolean> = computed(() =>
+    this.endpointDataService?.isLoadingOrgs() ?? false
+  );
+  readonly isLoadingSpaces: Signal<boolean> = computed(() =>
+    this.endpointDataService?.isLoadingSpaces() ?? false
+  );
+
   // Org options for the CF-level Users toolbar. Natural-sort (numeric-
   // aware); "All" prepended. The per-org tab pins `_lockedOrgGuid` and
   // elects not to render this dropdown.

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal, WritableSignal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
@@ -19,6 +19,48 @@ import { createBasicStoreModule, STORE_TEST_PROVIDERS } from '@stratosui/store/t
 import { generateCFEntities } from '../../cf-entity-generator';
 import { IOrganization, ISpace } from '../../cf-api.types';
 import { CfOrgSpaceDataService } from './cf-org-space-service.service';
+import { EndpointDataRegistry } from '../../services/endpoint-data/endpoint-data.registry';
+import type { StOrg, StSpace } from '../../services/endpoint-data/stratos-types';
+
+/**
+ * Fake EndpointDataRegistry for spec scenarios that need to drive
+ * orgs/spaces data into the picker without booting the real
+ * registry + drain stack. Each `acquire(cnsi)` returns a per-cnsi
+ * stub EDS whose `orgs` / `spaces` / loading flags are WritableSignals
+ * the test can mutate to simulate the drain landing.
+ */
+interface FakeEDS {
+  orgs: WritableSignal<StOrg[]>;
+  spaces: WritableSignal<StSpace[]>;
+  isLoadingOrgs: WritableSignal<boolean>;
+  isLoadingSpaces: WritableSignal<boolean>;
+}
+
+function makeFakeRegistry() {
+  const byCnsi = new Map<string, FakeEDS>();
+  const get = (cnsi: string): FakeEDS => {
+    let eds = byCnsi.get(cnsi);
+    if (!eds) {
+      eds = {
+        orgs: signal<StOrg[]>([]),
+        spaces: signal<StSpace[]>([]),
+        isLoadingOrgs: signal(false),
+        isLoadingSpaces: signal(false),
+      };
+      byCnsi.set(cnsi, eds);
+    }
+    return eds;
+  };
+  return {
+    acquire: (cnsi: string) => get(cnsi),
+    release: (_cnsi: string) => { /* no-op */ },
+    setOrgs: (cnsi: string, orgs: { guid: string; name: string }[]) =>
+      get(cnsi).orgs.set(orgs as StOrg[]),
+    setSpaces: (cnsi: string, spaces: { guid: string; name: string; orgGuid: string }[]) =>
+      get(cnsi).spaces.set(spaces as StSpace[]),
+  };
+}
+type FakeRegistry = ReturnType<typeof makeFakeRegistry>;
 
 /**
  * Helper to build an APIResource<IOrganization> with spaces for testing.
@@ -408,17 +450,25 @@ describe('FWT-917 auto-selector loading gate', () => {
 });
 
 /**
- * V3-native data sourcing.
+ * V3-native data sourcing via EndpointDataService.
  *
- * Org/space data must come from per-cnsi V3 native handlers
- * (`/pp/v1/cf/orgs/{cnsiGuid}`, etc.), not from a cross-endpoint
- * v2 ngrx pagination action. The cross-endpoint path collapses
- * entities sharing duplicate URL endpoints and stamps them with one
- * winner cfGuid, dropping the rest from the downstream filter.
+ * Org/space data is sourced from the per-CNSI EndpointDataService handle
+ * the picker acquires through EndpointDataRegistry on CF selection. The
+ * registry-driven drain (used by home cards / walls) already hydrates
+ * orgs/spaces; the picker just reads off the cached signals. Tests drive
+ * a FakeRegistry stub directly — no HTTP traffic, no real drain — and
+ * mutate the per-CNSI orgs/spaces signals to simulate the drain landing.
+ *
+ * Replaces the prior HTTP-driven coverage of the v3 `/pp/v1/cf/orgs/...`
+ * and `/pp/v1/cf/org/.../spaces` handlers, which moved out of the
+ * picker when CfOrgSpaceDataService stopped issuing its own fetches.
  */
 describe('V3-native org sourcing', () => {
 
+  let fakeRegistry: FakeRegistry;
+
   beforeEach(() => {
+    fakeRegistry = makeFakeRegistry();
     TestBed.configureTestingModule({
       imports: [
         createBasicStoreModule(),
@@ -434,6 +484,7 @@ describe('V3-native org sourcing', () => {
             ...generateCFEntities(),
           ],
         },
+        { provide: EndpointDataRegistry, useValue: fakeRegistry },
         provideZonelessChangeDetection(),
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -443,44 +494,29 @@ describe('V3-native org sourcing', () => {
     EntityCatalogHelpers.SetEntityCatalogHelper(helper);
   });
 
-  it('fetches orgs from /pp/v1/cf/orgs/{cnsiGuid} when cf is selected', () => {
+  it('acquires an EndpointDataService for the selected cnsi', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
+    const spy = vi.spyOn(fakeRegistry, 'acquire');
 
     service.cf.select.set('cf-A');
     TestBed.tick();
 
-    const req = httpMock.expectOne(
-      r => r.url.startsWith('/pp/v1/cf/orgs/cf-A'),
-      'V3 native orgs handler should be called for the selected cnsi',
-    );
-    expect(req.request.method).toBe('GET');
-    req.flush({ resources: [], totalResults: 0 });
-
-    httpMock.verify();
+    expect(spy).toHaveBeenCalledWith('cf-A');
   });
 
-  it('populates the orgList signal from the V3 response', async () => {
+  it('populates the orgList signal from the EDS orgs signal', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     service.cf.select.set('cf-A');
     TestBed.tick();
 
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [
-        { guid: 'org-1', name: 'alpha' },
-        { guid: 'org-2', name: 'bravo' },
-      ],
-      totalResults: 2,
-    });
-
-    await Promise.resolve();
+    fakeRegistry.setOrgs('cf-A', [
+      { guid: 'org-1', name: 'alpha' },
+      { guid: 'org-2', name: 'bravo' },
+    ]);
     TestBed.tick();
 
-    const orgs = service.orgList();
-    expect(orgs.map(o => o.guid)).toEqual(['org-1', 'org-2']);
-    httpMock.verify();
+    expect(service.orgList().map(o => o.guid)).toEqual(['org-1', 'org-2']);
   });
 
   /**
@@ -490,98 +526,72 @@ describe('V3-native org sourcing', () => {
    * cross-endpoint pagination collapsed entities by GUID across the
    * three responses and stamped all of them with one winner cfGuid,
    * causing the downstream filter (entity.cfGuid === selectedCF) to
-   * drop most orgs. The V3 native path is per-cnsi by URL —
-   * `/pp/v1/cf/orgs/{cnsiGuid}` — so each endpoint's orgs are
-   * independently sourced and never collapsed.
-   *
-   * The orgs in this test even share GUIDs across endpoints (the
-   * worst case in the duplicate-URL scenario, where the same CF is
-   * registered three times). orgList must scope to the selected cnsi
-   * regardless of GUID overlap.
+   * drop most orgs. The EDS-per-CNSI path is keyed by cnsi guid, so
+   * each endpoint's orgs are independently held even when they share
+   * GUIDs across endpoints — orgList must scope to the selected cnsi.
    */
-  it('scopes orgList to the selected cnsi even with duplicate-URL endpoints', async () => {
+  it('scopes orgList to the selected cnsi even with duplicate-URL endpoints', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
+
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'shared-org-1', name: 'org-on-A' }]);
+    fakeRegistry.setOrgs('cf-B', [{ guid: 'shared-org-1', name: 'org-on-B' }]);
 
     service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'shared-org-1', name: 'org-on-A' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
     TestBed.tick();
     expect(service.orgList().map(o => o.name)).toEqual(['org-on-A']);
 
     service.cf.select.set('cf-B');
     TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-B')).flush({
-      resources: [{ guid: 'shared-org-1', name: 'org-on-B' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
-    TestBed.tick();
     expect(service.orgList().map(o => o.name)).toEqual(['org-on-B']);
-
-    httpMock.verify();
   });
 
   it('cascade-clears orgSelected and spaceSelected when cfSelected changes', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     service.cf.select.set('cf-A');
     service.org.select.set('org-1');
     service.space.select.set('space-1');
     TestBed.tick();
 
-    // Drain any in-flight requests so verify() is clean.
-    httpMock.match(() => true).forEach(req => req.flush({ resources: [], totalResults: 0 }));
-
     service.cf.select.set('cf-B');
     TestBed.tick();
 
     expect(service.org.select()).toBeFalsy();
     expect(service.space.select()).toBeFalsy();
-
-    httpMock.match(() => true).forEach(req => req.flush({ resources: [], totalResults: 0 }));
-    httpMock.verify();
   });
 
   it('exposes orgList contents through the legacy org.list$ observable', async () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     const emissions: { guid: string }[][] = [];
     const sub = service.org.list$.subscribe(list => emissions.push(list as any));
 
     service.cf.select.set('cf-A');
     TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'org-1', name: 'alpha' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'org-1', name: 'alpha' }]);
     TestBed.tick();
+    await Promise.resolve();
 
     const last = emissions[emissions.length - 1];
     expect(last.map(o => o.guid)).toEqual(['org-1']);
 
     sub.unsubscribe();
-    httpMock.verify();
   });
 });
 
 /**
- * V3-native space sourcing.
+ * V3-native space sourcing via EndpointDataService.
  *
- * Spaces narrowed to a single org come from `/pp/v1/cf/org/{cnsiGuid}/{orgGuid}/spaces`
- * — per-cnsi, per-org. Same structural cure as orgs: no cross-endpoint
- * fan-out, no duplicate-URL collision.
+ * Spaces are filtered out of the per-CNSI EDS spaces signal by orgGuid
+ * once an org is selected. Same structural cure as orgs — no
+ * cross-endpoint fan-out, no duplicate-URL collision.
  */
 describe('V3-native space sourcing', () => {
 
+  let fakeRegistry: FakeRegistry;
+
   beforeEach(() => {
+    fakeRegistry = makeFakeRegistry();
     TestBed.configureTestingModule({
       imports: [
         createBasicStoreModule(),
@@ -597,6 +607,7 @@ describe('V3-native space sourcing', () => {
             ...generateCFEntities(),
           ],
         },
+        { provide: EndpointDataRegistry, useValue: fakeRegistry },
         provideZonelessChangeDetection(),
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -606,127 +617,97 @@ describe('V3-native space sourcing', () => {
     EntityCatalogHelpers.SetEntityCatalogHelper(helper);
   });
 
-  it('fetches spaces from /pp/v1/cf/org/{cnsi}/{org}/spaces when an org is selected', () => {
+  it('populates the spaceList signal from the EDS spaces signal filtered by orgGuid', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
+
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'org-1', name: 'alpha' }]);
+    fakeRegistry.setSpaces('cf-A', [
+      { guid: 'space-a', name: 'development', orgGuid: 'org-1' },
+      { guid: 'space-b', name: 'production', orgGuid: 'org-1' },
+    ]);
 
     service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'org-1', name: 'alpha' }],
-      totalResults: 1,
-    });
-
     service.org.select.set('org-1');
     TestBed.tick();
 
-    const req = httpMock.expectOne(
-      r => r.url.startsWith('/pp/v1/cf/org/cf-A/org-1/spaces'),
-      'V3 native per-org spaces handler should be called',
-    );
-    expect(req.request.method).toBe('GET');
-    req.flush({ resources: [], totalResults: 0 });
-
-    httpMock.verify();
+    expect(service.spaceList().map(s => s.guid)).toEqual(['space-a', 'space-b']);
   });
 
-  it('populates the spaceList signal from the V3 per-org response', async () => {
+  it('filters out spaces belonging to other orgs', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
+
+    fakeRegistry.setOrgs('cf-A', [
+      { guid: 'org-1', name: 'alpha' },
+      { guid: 'org-2', name: 'bravo' },
+    ]);
+    fakeRegistry.setSpaces('cf-A', [
+      { guid: 'space-a', name: 'a-space', orgGuid: 'org-1' },
+      { guid: 'space-b', name: 'b-space', orgGuid: 'org-2' },
+    ]);
 
     service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'org-1', name: 'alpha' }],
-      totalResults: 1,
-    });
-
     service.org.select.set('org-1');
     TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/org/cf-A/org-1/spaces')).flush({
-      resources: [
-        { guid: 'space-a', name: 'development' },
-        { guid: 'space-b', name: 'production' },
-      ],
-      totalResults: 2,
-    });
 
-    await Promise.resolve();
-    TestBed.tick();
-
-    const spaces = service.spaceList();
-    expect(spaces.map(s => s.guid)).toEqual(['space-a', 'space-b']);
-    httpMock.verify();
+    expect(service.spaceList().map(s => s.guid)).toEqual(['space-a']);
   });
 
-  it('cascade-clears spaceSelected when org changes', async () => {
+  it('cascade-clears spaceSelected when org changes', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
+
+    fakeRegistry.setOrgs('cf-A', [
+      { guid: 'org-1', name: 'alpha' },
+      { guid: 'org-2', name: 'bravo' },
+    ]);
 
     service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.match(() => true).forEach(req => req.flush({ resources: [], totalResults: 0 }));
-
     service.org.select.set('org-1');
     service.space.select.set('space-1');
     TestBed.tick();
-    httpMock.match(() => true).forEach(req => req.flush({ resources: [], totalResults: 0 }));
 
     service.org.select.set('org-2');
     TestBed.tick();
     expect(service.space.select()).toBeFalsy();
-
-    httpMock.match(() => true).forEach(req => req.flush({ resources: [], totalResults: 0 }));
-    httpMock.verify();
   });
 
   it('exposes spaceList contents through the legacy space.list$ observable', async () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     const emissions: { guid: string }[][] = [];
     const sub = service.space.list$.subscribe(list => emissions.push(list as any));
 
-    service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'org-1', name: 'alpha' }],
-      totalResults: 1,
-    });
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'org-1', name: 'alpha' }]);
+    fakeRegistry.setSpaces('cf-A', [
+      { guid: 'space-a', name: 'development', orgGuid: 'org-1' },
+    ]);
 
+    service.cf.select.set('cf-A');
     service.org.select.set('org-1');
     TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/org/cf-A/org-1/spaces')).flush({
-      resources: [{ guid: 'space-a', name: 'development' }],
-      totalResults: 1,
-    });
-
     await Promise.resolve();
-    TestBed.tick();
 
     const last = emissions[emissions.length - 1];
     expect(last.map(s => s.guid)).toEqual(['space-a']);
 
     sub.unsubscribe();
-    httpMock.verify();
   });
 });
 
 /**
- * V3-native auto-selectors.
+ * V3-native auto-selectors over EDS-sourced data.
  *
  * `enableAutoSelectors()` is opt-in (create-application calls it; the wizard
  * does not). When enabled, a singleton org or space — count exactly 1 and
- * nothing currently selected — is auto-picked off the V3 fetch result. This
- * replaces the v2 ngrx pagination-based `setupAutoSelectors` machinery that
- * was entangled with the duplicate-URL collision path.
- *
- * Default (no enableAutoSelectors call) must do no auto-pick: the wizard
- * relies on this so the user always picks org/space explicitly.
+ * nothing currently selected — is auto-picked off the EDS-sourced orgList /
+ * spaceList. Default (no enableAutoSelectors call) must do no auto-pick:
+ * the wizard relies on this so the user always picks org/space explicitly.
  */
 describe('V3-native auto-selectors', () => {
 
+  let fakeRegistry: FakeRegistry;
+
   beforeEach(() => {
+    fakeRegistry = makeFakeRegistry();
     TestBed.configureTestingModule({
       imports: [
         createBasicStoreModule(),
@@ -742,6 +723,7 @@ describe('V3-native auto-selectors', () => {
             ...generateCFEntities(),
           ],
         },
+        { provide: EndpointDataRegistry, useValue: fakeRegistry },
         provideZonelessChangeDetection(),
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -751,115 +733,75 @@ describe('V3-native auto-selectors', () => {
     EntityCatalogHelpers.SetEntityCatalogHelper(helper);
   });
 
-  it('auto-picks the single org when enableAutoSelectors is called and one org is fetched', async () => {
+  it('auto-picks the single org when enableAutoSelectors is called and EDS holds one org', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     service.enableAutoSelectors();
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'only-org', name: 'solo' }]);
+
     service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'only-org', name: 'solo' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
     TestBed.tick();
 
     expect(service.org.select()).toBe('only-org');
-    httpMock.match(() => true).forEach(req => req.flush({ resources: [], totalResults: 0 }));
-    httpMock.verify();
   });
 
-  it('does NOT auto-pick when more than one org is fetched', async () => {
+  it('does NOT auto-pick when EDS holds more than one org', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     service.enableAutoSelectors();
+    fakeRegistry.setOrgs('cf-A', [
+      { guid: 'org-1', name: 'a' },
+      { guid: 'org-2', name: 'b' },
+    ]);
+
     service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [
-        { guid: 'org-1', name: 'a' },
-        { guid: 'org-2', name: 'b' },
-      ],
-      totalResults: 2,
-    });
-    await Promise.resolve();
     TestBed.tick();
 
     expect(service.org.select()).toBeFalsy();
-    httpMock.verify();
   });
 
-  it('does NOT auto-pick when enableAutoSelectors was never called (default)', async () => {
+  it('does NOT auto-pick when enableAutoSelectors was never called (default)', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     // Note: no service.enableAutoSelectors() call.
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'only-org', name: 'solo' }]);
+
     service.cf.select.set('cf-A');
-    TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'only-org', name: 'solo' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
     TestBed.tick();
 
     expect(service.org.select()).toBeFalsy();
-    httpMock.verify();
   });
 
-  it('auto-picks the single space when enableAutoSelectors and the org has one space', async () => {
+  it('auto-picks the single space when enableAutoSelectors and EDS holds one space for the org', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     service.enableAutoSelectors();
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'only-org', name: 'solo' }]);
+    fakeRegistry.setSpaces('cf-A', [
+      { guid: 'only-space', name: 'dev', orgGuid: 'only-org' },
+    ]);
+
     service.cf.select.set('cf-A');
     TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'only-org', name: 'solo' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
-    TestBed.tick();
 
-    // Org auto-picked → spaces fetch fires
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/org/cf-A/only-org/spaces')).flush({
-      resources: [{ guid: 'only-space', name: 'dev' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
-    TestBed.tick();
-
+    expect(service.org.select()).toBe('only-org');
     expect(service.space.select()).toBe('only-space');
-    httpMock.verify();
   });
 
-  it('does NOT auto-pick space when org has multiple spaces', async () => {
+  it('does NOT auto-pick space when EDS holds multiple spaces for the org', () => {
     const service = TestBed.inject(CfOrgSpaceDataService);
-    const httpMock = TestBed.inject(HttpTestingController);
 
     service.enableAutoSelectors();
+    fakeRegistry.setOrgs('cf-A', [{ guid: 'only-org', name: 'solo' }]);
+    fakeRegistry.setSpaces('cf-A', [
+      { guid: 'sp-1', name: 'dev', orgGuid: 'only-org' },
+      { guid: 'sp-2', name: 'prod', orgGuid: 'only-org' },
+    ]);
+
     service.cf.select.set('cf-A');
     TestBed.tick();
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/orgs/cf-A')).flush({
-      resources: [{ guid: 'only-org', name: 'solo' }],
-      totalResults: 1,
-    });
-    await Promise.resolve();
-    TestBed.tick();
 
-    httpMock.expectOne(r => r.url.startsWith('/pp/v1/cf/org/cf-A/only-org/spaces')).flush({
-      resources: [
-        { guid: 'sp-1', name: 'dev' },
-        { guid: 'sp-2', name: 'prod' },
-      ],
-      totalResults: 2,
-    });
-    await Promise.resolve();
-    TestBed.tick();
-
+    expect(service.org.select()).toBe('only-org');
     expect(service.space.select()).toBeFalsy();
-    httpMock.verify();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-org-space-service.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, OnDestroy, Signal, WritableSignal, computed, effect, inject, signal, untracked } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Observable } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
@@ -20,6 +19,8 @@ import { CFAppState } from '../../cf-app-state';
 import { cfEntityFactory } from '../../cf-entity-factory';
 import { IOrganization, ISpace } from '../../cf-api.types';
 import { CF_ENDPOINT_TYPE } from '../../cf-types';
+import { EndpointDataRegistry } from '../../services/endpoint-data/endpoint-data.registry';
+import type { EndpointDataService } from '../../services/endpoint-data/endpoint-data.service';
 import { QParam, QParamJoiners } from '../q-param';
 import { CfOrgSpaceDebug, createCfOrgSpaceDebug } from './cf-org-space-debug';
 
@@ -137,13 +138,15 @@ interface InitialValues { cf: string; org: string; space: string; }
  * Signal-native cf/org/space picker store.
  *
  * State of the world:
- * - Selection (`_cfSelected`, `_orgSelected`, `_spaceSelected`) and data
- *   (`_orgsByCnsi`, `_spacesByOrg`) are WritableSignals — single source of
- *   truth.
- * - Cascade (cf change clears org+space, org change clears space), HTTP
- *   fetches against V3 native handlers, and singleton auto-pick are all
- *   `effect()` reactions to those signals. No rxjs operators in the
- *   control flow.
+ * - Selection (`_cfSelected`, `_orgSelected`, `_spaceSelected`) are
+ *   WritableSignals — single source of truth.
+ * - Org and space lists are sourced from the per-CNSI
+ *   `EndpointDataService` (acquired through `EndpointDataRegistry`),
+ *   not fetched directly. The registry already drains orgs+spaces on
+ *   home / wall navigation, so the picker reuses the warmed cache.
+ * - Cascade (cf change clears org+space, org change clears space) and
+ *   singleton auto-pick are `effect()` reactions to the selection
+ *   signals. No rxjs operators in the control flow.
  * - The legacy `cf/org/space.{list$, loading$, select}` shape is kept as
  *   a thin shim — `list$`/`loading$` are `toObservable(signal)` and
  *   `select` is a BehaviorSubject backed by the underlying signal so
@@ -165,9 +168,14 @@ interface InitialValues { cf: string; org: string; space: string; }
 })
 export class CfOrgSpaceDataService implements OnDestroy {
   private store = inject<Store<CFAppState>>(Store);
-  private http = inject(HttpClient);
   private endpointsService = inject(EndpointsDataService);
+  private endpointRegistry = inject(EndpointDataRegistry);
   paginationMonitorFactory = inject(PaginationMonitorFactory);
+
+  // Per-CNSI acquired EndpointDataService handles. Each handle is
+  // released on destroy. The registry refcounts so multiple acquirers
+  // (this picker + a wall page + the home cards) share one drain.
+  private _edsByCnsi = signal<Map<string, EndpointDataService>>(new Map());
 
   private debug: CfOrgSpaceDebug = createCfOrgSpaceDebug();
 
@@ -177,12 +185,13 @@ export class CfOrgSpaceDataService implements OnDestroy {
   private _spaceSelected = signal<string | null>(null);
 
   // === Data state ===
-  private _orgsByCnsi = signal<Record<string, { guid: string; name: string }[]>>({});
-  private _spacesByOrg = signal<Record<string, { guid: string; name: string }[]>>({});
+  // org and space lists are now sourced from EndpointDataService via the
+  // `_edsByCnsi` handle map (declared earlier). _orgFetching /
+  // _spaceFetching mirror EDS.isLoadingOrgs / isLoadingSpaces for the
+  // currently selected CF / org pair so consumers keep their existing
+  // org.loading / space.loading API surface.
   private _orgFetching = signal(false);
   private _spaceFetching = signal(false);
-  private fetchedCnsis = new Set<string>();
-  private fetchedOrgKeys = new Set<string>();
 
   private _autoSelectEnabled = signal(false);
 
@@ -198,24 +207,29 @@ export class CfOrgSpaceDataService implements OnDestroy {
   );
 
   // === Public derived signals ===
-  /** Orgs for the currently-selected cnsi. Empty until fetch resolves.
-   *  Sorted by name (natural compare) so org_2 lands between org_1 and
-   *  org_3, not after org_19. CAPI returns creation order by default
-   *  which is not useful for users scanning a long list. */
+  /** Orgs for the currently-selected cnsi. Reads from EndpointDataService
+   *  via the per-CNSI handle (already drained by the registry). Empty
+   *  until the drain lands. Sorted by name (natural compare) so org_2
+   *  lands between org_1 and org_3, not after org_19 — CAPI returns
+   *  creation order by default which isn't useful for scanning. */
   public orgList: Signal<{ guid: string; name: string }[]> = computed(() => {
     const cnsi = this._cfSelected();
-    if (!cnsi) { return []; }
-    const list = this._orgsByCnsi()[cnsi] ?? [];
+    if (!cnsi) return [];
+    const eds = this._edsByCnsi().get(cnsi);
+    const list = eds ? eds.orgs() : [];
     return [...list].sort((a, b) => naturalCompare(a.name, b.name));
   });
 
-  /** Spaces for the currently-selected (cnsi, org). Empty until fetch
-   *  resolves. Sorted by name for the same reason as orgList. */
+  /** Spaces for the currently-selected (cnsi, org). Reads from EDS too —
+   *  filters EDS.spaces() by orgGuid. Sorted by name for the same reason
+   *  as orgList. */
   public spaceList: Signal<{ guid: string; name: string }[]> = computed(() => {
     const cnsi = this._cfSelected();
     const org = this._orgSelected();
-    if (!cnsi || !org) { return []; }
-    const list = this._spacesByOrg()[`${cnsi}:${org}`] ?? [];
+    if (!cnsi || !org) return [];
+    const eds = this._edsByCnsi().get(cnsi);
+    if (!eds) return [];
+    const list = eds.spaces().filter(s => s.orgGuid === org);
     return [...list].sort((a, b) => naturalCompare(a.name, b.name));
   });
 
@@ -266,41 +280,42 @@ export class CfOrgSpaceDataService implements OnDestroy {
 
     // === Effects ===
 
-    // V3 orgs fetch on cf change. Each cnsi is fetched once.
+    // Acquire an EndpointDataService for the selected CNSI. The registry
+    // refcounts and drives the orgs+spaces drain via its own card/details
+    // queue. Reading EDS.orgs() / EDS.spaces() is reactive — the picker's
+    // orgList / spaceList computeds (below) re-evaluate as soon as the
+    // drain lands. Eliminates the previous duplicate `/pp/v1/cf/orgs/...`
+    // and `/pp/v1/cf/org/.../spaces` fetches that were redundant with the
+    // home-card / wall hydration the registry already drives.
     effect(() => {
       const cnsi = this._cfSelected();
-      if (!cnsi || this.fetchedCnsis.has(cnsi)) { return; }
-      this.fetchedCnsis.add(cnsi);
-      untracked(() => this._orgFetching.set(true));
-      this.http.get<{ resources: { guid: string; name: string }[] }>(
-        `/pp/v1/cf/orgs/${cnsi}?per_page=500&page=1`,
-      ).subscribe({
-        next: resp => {
-          this._orgsByCnsi.update(m => ({ ...m, [cnsi]: resp.resources ?? [] }));
-          this._orgFetching.set(false);
-        },
-        error: () => this._orgFetching.set(false),
-      });
+      if (!cnsi) return;
+      const cur = untracked(() => this._edsByCnsi());
+      if (cur.has(cnsi)) return;
+      const eds = this.endpointRegistry.acquire(cnsi);
+      untracked(() => this._edsByCnsi.update(m => {
+        const n = new Map(m);
+        n.set(cnsi, eds);
+        return n;
+      }));
     });
 
-    // V3 spaces fetch on org change. Each (cnsi, org) is fetched once.
+    // Mirror EDS loading flags into the picker's loading signals so
+    // consumers don't have to know about the EDS handle layer.
+    effect(() => {
+      const cnsi = this._cfSelected();
+      if (!cnsi) { untracked(() => this._orgFetching.set(false)); return; }
+      const eds = this._edsByCnsi().get(cnsi);
+      const loading = eds ? eds.isLoadingOrgs() : false;
+      untracked(() => this._orgFetching.set(loading));
+    });
     effect(() => {
       const cnsi = this._cfSelected();
       const orgGuid = this._orgSelected();
-      if (!cnsi || !orgGuid) { return; }
-      const key = `${cnsi}:${orgGuid}`;
-      if (this.fetchedOrgKeys.has(key)) { return; }
-      this.fetchedOrgKeys.add(key);
-      untracked(() => this._spaceFetching.set(true));
-      this.http.get<{ resources: { guid: string; name: string }[] }>(
-        `/pp/v1/cf/org/${cnsi}/${orgGuid}/spaces?per_page=500&page=1`,
-      ).subscribe({
-        next: resp => {
-          this._spacesByOrg.update(m => ({ ...m, [key]: resp.resources ?? [] }));
-          this._spaceFetching.set(false);
-        },
-        error: () => this._spaceFetching.set(false),
-      });
+      if (!cnsi || !orgGuid) { untracked(() => this._spaceFetching.set(false)); return; }
+      const eds = this._edsByCnsi().get(cnsi);
+      const loading = eds ? eds.isLoadingSpaces() : false;
+      untracked(() => this._spaceFetching.set(loading));
     });
 
     // Cascade: cf change clears org and space — but skip on null→non-null
@@ -439,6 +454,13 @@ export class CfOrgSpaceDataService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    // Release acquired EndpointDataService handles. The registry refcounts —
+    // other acquirers keep the drain alive; if we were the last, the
+    // registry tears the EDS down.
+    for (const cnsi of this._edsByCnsi().keys()) {
+      this.endpointRegistry.release(cnsi);
+    }
+    this._edsByCnsi.set(new Map());
     this.destroy();
   }
 

--- a/src/frontend/packages/core/src/shared/components/custom-select/custom-select.component.html
+++ b/src/frontend/packages/core/src/shared/components/custom-select/custom-select.component.html
@@ -1,6 +1,6 @@
 <div class="custom-select relative inline-block w-full min-w-[100px] font-inherit bg-[var(--input-bg)] text-[var(--input-text)] border-none rounded-md"
   [ngClass]="{
-    'opacity-60 pointer-events-none cursor-not-allowed': disabled,
+    'disabled opacity-60 pointer-events-none cursor-not-allowed': disabled,
     'open': isOpen,
     'invalid': invalid
   }"
@@ -33,12 +33,21 @@
       </span>
     </span>
     <div class="flex items-center gap-1 ml-2">
-      <div class="text-[var(--text-muted,#666)] flex items-center transition-transform duration-200"
-        [class.rotate-180]="isOpen">
-        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </div>
+      @if (loading) {
+        <div class="text-[var(--text-muted,#666)] flex items-center" aria-label="Loading">
+          <svg class="animate-spin" width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-opacity="0.25"/>
+            <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+          </svg>
+        </div>
+      } @else {
+        <div class="text-[var(--text-muted,#666)] flex items-center transition-transform duration-200"
+          [class.rotate-180]="isOpen">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+      }
     </div>
   </div>
 

--- a/src/frontend/packages/core/src/shared/components/custom-select/custom-select.component.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-select/custom-select.component.ts
@@ -78,6 +78,7 @@ export class CustomSelectComponent implements ControlValueAccessor, AfterContent
   @Input() invalid = false;
   @Input() errorMessage = '';
   @Input() autoSelectSingleOption = true; // Auto-select when only one option exists
+  @Input({ transform: booleanAttribute }) loading = false;
 
   @Input()
   get value(): any {

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -18,6 +18,12 @@
               <option [value]="opt.value ?? ''" [selected]="(opt.value ?? '') === (dd.selected() ?? '')">{{ opt.label }}</option>
             }
           </select>
+          @if (dd.loading?.()) {
+            <svg class="animate-spin text-content-muted" width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Loading">
+              <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-opacity="0.25"/>
+              <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+          }
         </label>
       }
     }

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -195,6 +195,10 @@ export interface SignalListDropdown {
   // Lets the host service defer expensive option-population work until the user
   // actually opens the menu — paint-fast pages, populate-on-demand dropdowns.
   onOpen?: () => void;
+  // When true, render a small spinner next to the dropdown label so the user
+  // sees that option population is in-flight rather than mistaking an empty
+  // list for "no items available."
+  loading?: Signal<boolean>;
 }
 
 export type SignalListViewMode = 'table' | 'card';

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html
@@ -2,6 +2,14 @@
   @if (steps && steps.length) {
     <div class="steppers">
       <div class="steppers-inner">
+        <!-- Context summary — surfaces in-progress selections (e.g.
+             "Creating service instance in {CF} / {Org} / {Space}") so
+             later steps don't lose track of what's being built. -->
+        @if (contextSummary) {
+          <div class="steppers-context-summary mb-4 px-3 py-2 rounded border border-content-border bg-content-bg-alt text-sm text-content-muted">
+            <ng-container *ngTemplateOutlet="contextSummary"></ng-container>
+          </div>
+        }
         <!-- Step headers -->
         @if (steps.length > 1) {
           <div class="steppers-headers flex flex-wrap sm:flex-nowrap items-center justify-center mb-8 gap-2 overflow-x-auto">

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, AfterContentInit, Component, ContentChildren, Input, OnDestroy, OnInit, QueryList, ViewEncapsulation, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, AfterContentInit, Component, ContentChildren, Input, OnDestroy, OnInit, QueryList, TemplateRef, ViewEncapsulation, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { TailwindSnackBarService, TailwindSnackBarRef } from '../../../services/tailwind-snackbar.service';
@@ -50,6 +50,11 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
   @Input() basePreviousRedirect: IRouterNavPayload = this.route.snapshot.queryParams[BASE_REDIRECT_QUERY] ? {
     path: this.route.snapshot.queryParams[BASE_REDIRECT_QUERY]
   } : null;
+  // Optional context summary rendered above the step headers. Hosts pass
+  // a TemplateRef that surfaces the user's in-progress selections (CF /
+  // Org / Space / offering / plan / name) so the wizard always shows
+  // "what am I creating?" as later steps navigate away from the picker.
+  @Input() contextSummary?: TemplateRef<unknown>;
 
   steps: StepComponent[] = [];
   allSteps: StepComponent[] = [];


### PR DESCRIPTION
## Summary

UX polish pass on the CF/Org/Space picker flow and the Services /
Marketplace walls. Eight focused commits, each independently
reviewable.

### Picker (Create App / Deploy App / Add Service Instance step 1)

- **Disabled-tint fix** — `app-select` had a dead
  `.custom-select.disabled .select-trigger` CSS rule that never fired
  because the ngClass binding only added the three Tailwind utilities,
  not the `.disabled` hook the CSS expected. Enabled-empty and disabled
  dropdowns now have clearly distinct backgrounds instead of looking
  visually identical.
- **Loading spinner** — new `[loading]` Input on `app-select` swaps
  the caret for a small animate-spin SVG. Wired through Org and Space
  picker dropdowns so the user sees "loading" rather than "no items
  available" during the data drain.
- **Eliminate redundant orgs/spaces fetch** — `CfOrgSpaceDataService`
  was issuing its own `/pp/v1/cf/orgs/{cnsi}` and
  `/pp/v1/cf/org/.../spaces` calls on every CF / org selection,
  ignoring the per-CNSI `EndpointDataService` cache the registry already
  drains. Refactored to acquire EDS via the registry and read
  `orgs() / spaces()` directly — pickers hit instantly on already-warm
  CFs and stop double-loading CAPI.
- **Drop CF dropdown spinner** — the CF list is local (sourced from
  `EndpointsDataService`), no fetch involved, so spinner there was
  misleading.
- **Gate empty-list errors** — "There are no organizations / spaces"
  no longer fires before a selection is made or while the drain is in
  flight; only shows when there is a real empty result to report.

### Signal-list filter dropdowns

- Adds optional `loading: Signal<boolean>` to `SignalListDropdown`
  and renders a small spinner next to the dropdown label when truthy.
- Wired through every wall + per-CF tab Org / Space filter rail:
  service-instances, apps, users, routes, audit-events.

### Wizard stepper context summary

- New optional `[contextSummary]` TemplateRef Input on `<app-steppers>`
  rendered above the step headers. Hosts pass a template surfacing
  in-progress selections so later wizard steps don't lose track of
  "what am I creating, where."
- Wired into Add Service Instance: composes
  `CF / Org / Space / offering / "instance-name"` as those land. The
  slot stays hidden until at least one part is selected. Framework-
  level change — Create App and Deploy App can adopt it in a follow-up
  without re-engineering.

### Services + Marketplace walls

- Closes a UX gap: neither wall had an entry point to the unscoped
  Add Service Instance picker, so users had to either drill into a
  specific Marketplace offering (which pre-pins CF) or type
  `/services/new` directly.
- Adds an L5 sub-nav row above the filter toolbar — same pattern the
  Applications wall already uses (`<app-list-sub-nav>`): "Total <Thing>:
  <N>" on the left, blue **[+ Add Service Instance]** button on the
  right.
- Services wall → `/services/new` (tile chooser, managed or UPS).
- Marketplace wall → `/services/new/service` (managed only, since the
  Marketplace lists managed offerings).

## Test plan

- [x] Local dev server (`make dev backend` + `make dev frontend`):
      drive `/services/new/service`, pick CF → Org enables, no
      spurious "no orgs" error, context summary updates as selections
      land.
- [x] Verified Phase 3 perf win — Org dropdown populates 0ms-perceived
      on warm CFs (vs ~RTT-bound previously).
- [x] Verified spinner appears on Org/Space when EDS drain is in
      flight (forced via Angular debug API; on local with warm cache
      the natural window is too short to catch).
- [x] Verified disabled-tint distinguishes Space from enabled-empty Org
      visually.
- [ ] Smoke on adepttech after deploy — confirm CAPI-latency-bound
      spinner is actually visible during a fresh CF select.
- [ ] Browser smoke through Create App step 1 + Deploy App step 1 —
      both reuse `<app-create-application-step1>` so the picker fix
      applies; verify they still validate cleanly.

## Follow-ups (filed separately, not in this PR)

- #5370 — Service instance detail/summary page (managed + UPS) so
  both card link targets unify.