### PR TITLE
build(cf-package): widen SESSION_STORE_EXPIRY to 4 hours

### DIFF
--- a/build/release-cf.sh
+++ b/build/release-cf.sh
@@ -102,6 +102,7 @@ applications:
     command: ./jetstream
     env:
       ENCRYPTION_KEY: B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF
+      SESSION_STORE_EXPIRY: "240"
 # Override CF API endpoint URL inferred from VCAP_APPLICATION env
 #       CF_API_URL: https://CLOUD_FOUNDRY_API_ENDPOINT
 # Force the console to use secured communication with the Cloud Foundry API endpoint


### PR DESCRIPTION
## Summary

- `build/release-cf.sh` heredoc gains `SESSION_STORE_EXPIRY: "240"` (minutes) under the cf-package manifest's `env:` block.
- Default jetstream session expiry is 20 minutes (`src/jetstream/main.go:74`), read at line 239 with the same default when the env var is unset.
- This widens the window to 4 hours so long verification / Playwright re-test sessions against a deployed instance don't get interrupted by mid-run cookie expiry.
- No code-side behavior change — only the cf-package manifest emitted by `make release cf` carries the new env var.

## Test plan

- [ ] `make build release cf` and inspect `dist/cf-package/manifest.yml` for the new line under `env:`
- [ ] `make deploy cf` to a test foundation and verify with `cf env console | grep SESSION_STORE_EXPIRY`
- [ ] Log in and confirm session survives past the 20-minute default (smoke check; full 4-hour observation optional)

## Related

- The original feature request to make this env-configurable was triaged today as fixed (closed during issue-backlog cleanup) — this PR is the cf-package deploy-side wiring.