### PR TITLE
fix(deploy-application): restore file-upload deploy + drop deployer ngrx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,9 +280,14 @@ define dev.backend
 		echo "Building backend for host platform..."; \
 		$(MAKE) build backend PLATFORM=$($(_HIDE)HOST_OS)/$($(_HIDE)HOST_ARCH); \
 	fi
-	cd src/jetstream && CONSOLE_PROXY_TLS_ADDRESS=:$(BACKEND_PORT) ../../$($(_HIDE)BIN_DIR)/jetstream
+	cd src/jetstream && CONSOLE_PROXY_TLS_ADDRESS=:$(BACKEND_PORT) SESSION_STORE_EXPIRY=$(SESSION_STORE_EXPIRY) ../../$($(_HIDE)BIN_DIR)/jetstream
 endef
 $(call register, dev, backend)
+
+# Local dev session expiry. Mirrors the cf-package deploy default
+# (`build/release-cf.sh`) so long Playwright drives don't get bounced
+# back to /login mid-session. Override on the make line if needed.
+SESSION_STORE_EXPIRY ?= 240
 
 # ── E2E variables (consumed by test.e2e and check.e2e) ──
 # These are recipe-local, not cross-cutting. DRYRUN=yes is the

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-deployer.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-deployer.ts
@@ -1,13 +1,9 @@
 import { Injector, signal, WritableSignal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { Store } from '@ngrx/store';
-import { Observable, of as observableOf, Subject, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import websocketConnect from 'rxjs-websockets';
-import { take, catchError, combineLatest, filter, map, mergeMap, share, switchMap, tap } from 'rxjs/operators';
+import { take, catchError, filter, map, share, switchMap, tap } from 'rxjs/operators';
 
-import { CFAppState } from '../../../../../cloud-foundry/src/cf-app-state';
-import { organizationEntityType, spaceEntityType } from '../../../../../cloud-foundry/src/cf-entity-types';
-import { selectCfEntity } from '../../../../../cloud-foundry/src/store/selectors/api.selectors';
 import {
   AppData,
   DeployApplicationSource,
@@ -143,7 +139,6 @@ export class DeployApplicationDeployer {
   private currentFileTransfer: any;
 
   constructor(
-    private store: Store<CFAppState>,
     public cfOrgSpaceService: CfOrgSpaceDataService,
     private injector: Injector,
   ) {
@@ -202,24 +197,27 @@ export class DeployApplicationDeployer {
     const deployState$ = toObservable(deployData.state, { injector: this.injector });
     this.connectSub = deployState$.pipe(
       filter((appDetail): appDetail is DeployApplicationState => !!appDetail && !!appDetail.cloudFoundryDetails && readyFilter(appDetail)),
-      mergeMap(appDetails => {
-        const orgSubscription = this.store.select(selectCfEntity(organizationEntityType, appDetails.cloudFoundryDetails.org));
-        const spaceSubscription = this.store.select(selectCfEntity(spaceEntityType, appDetails.cloudFoundryDetails.space));
-        return observableOf(appDetails).pipe(combineLatest(orgSubscription, spaceSubscription));
-      }),
       take(1),
-      tap(([appDetail, org, space]) => {
+      tap((appDetail) => {
         this.cfGuid = appDetail.cloudFoundryDetails.cloudFoundry;
         this.orgGuid = appDetail.cloudFoundryDetails.org;
         this.spaceGuid = appDetail.cloudFoundryDetails.space;
         this.applicationSource = appDetail.applicationSource;
         this.applicationOverrides = appDetail.applicationOverrides;
+        // Resolve org / space names from the signal-native picker — it
+        // already loaded both lists when the user made their selection,
+        // so the lookup is synchronous. Replaces the legacy ngrx
+        // `selectCfEntity` selectors that the V3 signal-native cutover
+        // stopped populating for org / space, which was causing the
+        // deployer to crash here on `undefined.entity.name`.
+        const orgName = this.cfOrgSpaceService.orgList().find(o => o.guid === this.orgGuid)?.name ?? '';
+        const spaceName = this.cfOrgSpaceService.spaceList().find(s => s.guid === this.spaceGuid)?.name ?? '';
         const host = window.location.host;
         const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
         const appId = this.isRedeploy ? `&app=${this.isRedeploy}` : '';
         const streamUrl = (
           `${protocol}://${host}/pp/${this.proxyAPIVersion}/${this.cfGuid}/${this.orgGuid}/${this.spaceGuid}/deploy` +
-          `?org=${org.entity.name}&space=${space.entity.name}${appId}`
+          `?org=${encodeURIComponent(orgName)}&space=${encodeURIComponent(spaceName)}${appId}`
         );
 
         this.inputStream = new Subject<string>();

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.ts
@@ -1,10 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { Component, Injector, OnDestroy, ChangeDetectionStrategy, inject } from '@angular/core';
-import { Store } from '@stratosui/store';
 import { Observable, of as observableOf } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
-import { CFAppState } from '../../../../../../cloud-foundry/src/cf-app-state';
 import { BytesToHumanSize, StepOnNextFunction, UploadProgressIndicatorComponent } from '@stratosui/core';
 import { CfOrgSpaceDataService } from '../../../../shared/data-services/cf-org-space-service.service';
 import { DeployApplicationDeployer, FileTransferStatus } from '../deploy-application-deployer';
@@ -33,11 +31,10 @@ export class DeployApplicationStepSourceUploadComponent implements OnDestroy {
   public valid$: Observable<boolean>;
 
   constructor() {
-    const store = inject<Store<CFAppState>>(Store);
     const cfOrgSpaceService = this.cfOrgSpaceService;
     const injector = this.injector;
 
-    this.deployer = new DeployApplicationDeployer(store, cfOrgSpaceService, injector);
+    this.deployer = new DeployApplicationDeployer(cfOrgSpaceService, injector);
     this.valid$ = this.deployer.fileTransferStatus$.asObservable().pipe(
       filter(status => !!status),
       map((status: FileTransferStatus) => status.filesSent === status.totalFiles),

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
@@ -226,7 +226,7 @@ export class DeployApplicationStep3Component implements OnDestroy {
     if (fsDeployer) {
       this.deployer = fsDeployer;
     } else {
-      this.deployer = new DeployApplicationDeployer(this.store, this.cfOrgSpaceService, this.injector);
+      this.deployer = new DeployApplicationDeployer(this.cfOrgSpaceService, this.injector);
     }
 
     this.initDeployer();

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
@@ -87,21 +87,45 @@ describe('DeployApplicationComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  // Regression guard for the FWT-959 Part 2 file-upload deploy fix.
-  // step2's onNext returns the FileScannerInfo as result.data; the
-  // signal-handle submit() contract has no data channel, so the parent
-  // captures into pendingFsFileInfo and forwards via the step2_2
-  // ViewChild setter. Without this, deployer.fsFileInfo stays unset
-  // and the file-upload deploy throws at deployer.fsFileInfo.root.
-  it('forwards FileScannerInfo from step2 submit to step2_2.onEnter', async () => {
+  // Regression guard for the FWT-959 Part 2 file-upload deploy fix
+  // (GH #5045). step2's onNext returns the FileScannerInfo as
+  // result.data; the signal-handle submit() contract has no data
+  // channel, so the parent captures into pendingFsFileInfo and
+  // forwards via `step2_2Handle.onEnter` — which the stepper fires
+  // on activation, after step 2's submit has already run.
+  //
+  // Earlier versions of this test forwarded via the @ViewChild setter
+  // and asserted `step2_2Ref = mock` *after* submit. That order never
+  // occurs in real Angular: @ViewChild for projected content fires at
+  // parent view-init, before any submit. The old test silently passed
+  // against broken production code because it mocked an order the
+  // framework never produces. See KS doc
+  // 2026-05-26-deploy-application-ngrx-removal for the postmortem.
+  it('forwards FileScannerInfo from step2 submit to step2_2.onEnter via step2_2Handle.onEnter', async () => {
     const fakeFileInfo = { root: 'mock-root', total: 100 };
     const mockStep2 = { onNext: vi.fn().mockReturnValue(of({ success: true, data: fakeFileInfo })) };
     const mockStep2_2 = { onEnter: vi.fn(), valid$: of(true) };
 
+    // ViewChild fires at parent view-init before any step submit. The
+    // setter must NOT forward at this point — pendingFsFileInfo is
+    // still undefined, so a forward here would prime the deployer
+    // with garbage and the file-upload path's readyFilter would never
+    // open the deploy WebSocket.
+    (component as any).step2_2Ref = mockStep2_2;
+    expect(mockStep2_2.onEnter).not.toHaveBeenCalled();
+
+    // Step 2 submits — handle.submit captures result.data into
+    // pendingFsFileInfo, mirroring the legacy `enterData` channel
+    // the framework no longer provides for signal-handle steps.
     (component as any)._step2 = mockStep2;
     await component.step2Handle.submit!();
-    (component as any).step2_2Ref = mockStep2_2;
+    expect((component as any).pendingFsFileInfo).toBe(fakeFileInfo);
 
+    // Stepper activates step 2_2 → fires handle.onEnter → the parent
+    // forwards pendingFsFileInfo to the child component and clears
+    // the holding field.
+    component.step2_2Handle.onEnter!();
     expect(mockStep2_2.onEnter).toHaveBeenCalledWith(fakeFileInfo);
+    expect((component as any).pendingFsFileInfo).toBeUndefined();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.ts
@@ -134,13 +134,14 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
   // `enterData` between step.onNext.data → next step.onEnter(enterData);
   // signal-handle submit() drops the `data` channel, so the parent
   // captures it explicitly here. step2_2's submit stores the deployer,
-  // step3's ViewChild setter forwards it to step3.onEnter on activation.
+  // step3Handle.onEnter forwards it to step3.onEnter on activation.
   private pendingDeployer?: unknown;
   // FileScannerInfo from step2's source-select onNext, consumed by
-  // step2_2's onEnter to prime deployer.fsFileInfo. Without this, the
-  // file-upload deploy path throws at deployer.fsFileInfo.root because
-  // the field never gets set (the legacy stepper relayed step2's
-  // onNext.data into step2_2.onEnter via enterData).
+  // step2_2Handle.onEnter to prime deployer.fsFileInfo. Without this,
+  // the file-upload deploy path never opens the deploy WebSocket because
+  // deployer.open()'s readyFilter falls into the git/docker branch (which
+  // requires gitDetails or dockerDetails). The legacy stepper relayed
+  // step2's onNext.data into step2_2.onEnter via enterData.
   private pendingFsFileInfo?: unknown;
 
   private isLoadingSignal = this.cfOrgSpaceService.isLoading;
@@ -199,12 +200,13 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
     this.step2_2Sub?.unsubscribe();
     this.step2_2Sub = undefined;
     if (v) {
-      // The legacy [onEnter]="step2_2.onEnter" received the FileScannerInfo
-      // emitted by step 2's onNext data result. Forward the captured
-      // pendingFsFileInfo so deployer.fsFileInfo gets primed — the
-      // file-upload deploy path reads .root and .total off it later.
-      v.onEnter(this.pendingFsFileInfo as any);
-      this.pendingFsFileInfo = undefined;
+      // Subscription wiring only. The activation-time `onEnter` call that
+      // primes `deployer.fsFileInfo` lives on `step2_2Handle.onEnter` — it
+      // fires when the stepper navigates *into* this step, after step 2's
+      // submit has populated `pendingFsFileInfo`. Calling `v.onEnter` here
+      // (on view-init) would run with `pendingFsFileInfo === undefined`
+      // because `<app-step [hidden]>` keeps step 2_2 instantiated up-front,
+      // so the setter fires before step 2 ever submits.
       this.step2_2Sub = v.valid$.subscribe(valid => {
         this.step2_2Valid.set(!!valid);
         this.cdr.markForCheck();
@@ -244,13 +246,10 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
     this.step3CloseableSub = undefined;
     this.step3DisablePrevSub = undefined;
     if (v) {
-      // Forward the captured deployer (if any) to step3.onEnter so the
-      // file-upload path's deployer is reused. Source types that don't
-      // populate a deployer (giturl, docker-image) leave pendingDeployer
-      // undefined, in which case step3 instantiates a fresh deployer.
-      const deployer = this.pendingDeployer;
-      this.pendingDeployer = undefined;
-      v.onEnter(deployer as any);
+      // Subscription wiring only. The activation-time `onEnter` call that
+      // forwards `pendingDeployer` lives on `step3Handle.onEnter` — see the
+      // `step2_2Ref` comment above for why the ViewChild-time call was the
+      // wrong hook.
       this.step3ValidSub = v.valid$.subscribe(valid => {
         this.step3Valid.set(!!valid);
         this.cdr.markForCheck();
@@ -312,6 +311,15 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
 
   step2_2Handle: SignalStepHandle = {
     valid: this.step2_2Valid.asReadonly(),
+    // Activation-time hand-off of step 2's captured FileScannerInfo into
+    // the source-upload component. Has to run on each entry (not just on
+    // ViewChild init) so re-entries after a Previous click also re-prime
+    // the freshly-constructed deployer. See `step2_2Ref` comment for the
+    // ViewChild-fires-once trap this avoids.
+    onEnter: () => {
+      this._step2_2?.onEnter(this.pendingFsFileInfo as any);
+      this.pendingFsFileInfo = undefined;
+    },
     onLeave: (isNext?: boolean) => this._step2_2?.onLeave(!!isNext),
     submit: async () => {
       const result = await firstValueFrom(this._step2_2!.onNext(0, null as any));
@@ -338,6 +346,16 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
 
   step3Handle: SignalStepHandle = {
     valid: this.step3Valid.asReadonly(),
+    // Activation-time hand-off of step 2_2's deployer. Same rationale as
+    // `step2_2Handle.onEnter` — ViewChild-time would run with
+    // `pendingDeployer === undefined`. Source types that bypass step 2_2
+    // (git-url, docker-image) leave pendingDeployer undefined and step 3
+    // instantiates a fresh deployer.
+    onEnter: () => {
+      const deployer = this.pendingDeployer;
+      this.pendingDeployer = undefined;
+      this._step3?.onEnter(deployer as any);
+    },
     canClose: this.step3Closeable.asReadonly(),
     disablePrevious: this.step3DisablePrevious.asReadonly(),
     // step3.busy and step3.disablePrevious$ are both fed by the same


### PR DESCRIPTION
## Summary

- **Stepper hand-off fix.** Move the step 2 → step 2_2 (FileScannerInfo) and step 2_2 → step 3 (deployer) data forwards out of the `@ViewChild` setters and into `step2_2Handle.onEnter` / `step3Handle.onEnter`. ViewChild fires at parent view-init (before any step submit), which left `pendingFsFileInfo` / `pendingDeployer` undefined at forward time and the deploy WebSocket never opened.
- **Deployer ngrx removal.** `DeployApplicationDeployer.open()` looked up org and space names via `selectCfEntity` ngrx selectors that the V3 signal-native cutover stopped populating, crashing the URL construction on `undefined.entity.name`. Switch to `CfOrgSpaceDataService.orgList()` / `.spaceList()` — the same signal-native picker the wizard already uses. Drops the `store` constructor parameter from `DeployApplicationDeployer` and updates the two call sites.
- **Local dev session expiry.** Wire `SESSION_STORE_EXPIRY=240` into `make dev backend` so local dev matches the cf-package deploy default — long Playwright drives no longer get bounced to /login mid-session.

Closes #5045.

## Why the original fix didn't hold

The earlier fix attempt (commit `85612fb87f`) added the `pendingFsFileInfo` capture but forwarded via the `@ViewChild('step2_2')` setter. The companion regression test (`e8743db968`) asserted that order by mocking `step2_2Ref = mock` *after* `submit` — an order real Angular never produces. The test passed against broken production code; the deploy stayed broken. Updated test in this PR asserts the activation-time behavior instead.

## Test plan

- [x] Unit: updated `deploy-application.component.spec.ts` regression-guard now asserts handle.onEnter activation-time forwarding + pendingFsFileInfo clearing. 18/18 deploy-application area tests pass.
- [x] Manual (Playwright MCP, local stratos against a real CF endpoint):
  - Deploy via Application Folder with `{ index.html, Staticfile, manifest.yml }` bundle, org=e2e, space=e2e
  - WS opens: `wss://localhost:5440/pp/v1/{cf}/{org}/{space}/deploy?org=e2e&space=e2e`
  - All 3 files upload (258 B)
  - Backend pushes app — staticfile buildpack, nginx install, droplet upload, container start — clean
- [ ] CI gate