### PR TITLE
chore(capi): bump to upstream fivetwenty-io/capi/v3 v3.216.5

### DIFF
--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/kubernetes/auth v0.0.0-20250312201517-2a076063346f
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/monocular v0.0.0-00010101000000-000000000000
 	github.com/domodwyer/mailyak v3.1.1+incompatible
-	github.com/fivetwenty-io/capi/v3 v3.216.4-fix-apps-delete.3
+	github.com/fivetwenty-io/capi/v3 v3.216.5
 	github.com/go-sql-driver/mysql v1.9.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
@@ -242,12 +242,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-// Temporary fork reference — stratos needs a patched AppsClient.Delete
-// that returns (*Job, error) so consumers can poll CF v3's async job.
-// The /v3 path suffix plus the v3.216.4-fix-apps-delete.1 tag lets Go's
-// module resolver accept the fork as a v3 replacement; Go falls back to
-// the fork's go.mod declaration (which still says fivetwenty-io/capi/v3)
-// during resolution. Retire this once the fix lands upstream in
-// fivetwenty-io/capi and a tagged release is cut.
-replace github.com/fivetwenty-io/capi/v3 => github.com/norman-abramovitz/fw-capi/v3 v3.216.4-fix-apps-delete.11

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -156,6 +156,8 @@ github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fivetwenty-io/capi/v3 v3.216.5 h1:KyqF5/Eo8Efh62d9Oc05iZU6hDTlLjl5nz2AjJPBaBg=
+github.com/fivetwenty-io/capi/v3 v3.216.5/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/foxcpp/go-mockdns v1.2.0 h1:omK3OrHRD1IWJz1FuFBCFquhXslXoF17OvBS6JPzZF0=
 github.com/foxcpp/go-mockdns v1.2.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -366,8 +368,6 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/norman-abramovitz/fw-capi/v3 v3.216.4-fix-apps-delete.11 h1:56q2EoD8ApSpVo+zksz0fEloD/yepeBaD9z2Wu/kPos=
-github.com/norman-abramovitz/fw-capi/v3 v3.216.4-fix-apps-delete.11/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=


### PR DESCRIPTION
## Summary

Drops the temporary `norman-abramovitz/fw-capi` fork in favor of
upstream `fivetwenty-io/capi/v3` `v3.216.5`. The fork carried four
patches that just landed upstream:

- `fix(async): return *Job from Location header for v3 lifecycle deletes/scales/restarts` — 9 clients
- `fix(routes): omitempty on RouteDestination.GUID`
- `feat(capi): add Link.Meta map for per-link sub-objects`
- `feat(capi): ListResponse[T].Included for the v3 \`included\` block` — unblocks future include-chain handler reworks (offerings/instances/plans/brokers/bindings) so they collapse N+1 \`?guids=<csv>\` fanouts into a single CAPI call

Removes the `replace` directive entirely; the go.mod `require` now
points straight at the upstream tag.

## Test plan

- [x] \`go build ./...\` clean on the new dependency
- [x] \`go test ./...\` passes — full backend suite
- [ ] Smoke deploy verification on adepttech once a build is cut