### PR TITLE
feat(signal-list): add bulkActions slot for selection-driven actions

### DIFF
--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -160,6 +160,45 @@
       </button>
     }
   </div>
+
+  <!-- Bulk-action bar: appears between the toolbar and the table when a
+       `kind: 'checkbox'` column has 1+ rows selected and bulkActions is
+       configured. Restores the legacy IMultiListAction surface. -->
+  @if (showBulkBar()) {
+    <div data-test="bulk-action-bar"
+         class="flex items-center gap-3 px-4 py-2 border-b border-content-border bg-primary-shade-50 dark:bg-primary-shade-900/30 flex-wrap">
+      <span data-test="bulk-selected-count" class="text-sm text-content-text font-medium">
+        {{ selectedCount() }} selected
+      </span>
+      <button
+        data-test="bulk-clear"
+        type="button"
+        (click)="clearBulkSelection()"
+        title="Clear selection"
+        class="px-2 py-1 text-sm text-content-muted hover:text-content-text underline">
+        Clear
+      </button>
+      <div class="flex-1"></div>
+      @for (act of config.bulkActions; track act.label) {
+        <button
+          type="button"
+          (click)="invokeBulkAction(act)"
+          [disabled]="act.disabled ? act.disabled() : false"
+          [title]="act.title ?? act.label"
+          [attr.data-test]="act.dataTest ?? ('bulk-action-' + act.label)"
+          [class]="'flex items-center gap-1 px-3 py-1 text-sm border rounded disabled:opacity-40 disabled:cursor-not-allowed ' +
+            (act.danger
+              ? 'border-red-600 bg-red-600 text-white hover:bg-red-700'
+              : 'border-content-border bg-content-bg text-content-text hover:bg-gray-100 dark:hover:bg-gray-700')">
+          @if (act.icon) {
+            <span class="material-icons text-base leading-5">{{ act.icon }}</span>
+          }
+          <span>{{ act.label }}</span>
+        </button>
+      }
+    </div>
+  }
+
   @if (config.errorsByCnsi().size > 0) {
     <div data-test="errors" class="px-4 py-1 text-sm text-danger-shade-700 bg-danger-shade-50 border-b border-content-border">
       @for (entry of config.errorsByCnsi() | keyvalue; track entry.key) {

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -679,4 +679,110 @@ describe('SignalListComponent', () => {
       expect(fixture.nativeElement.querySelectorAll('[data-test="custom-cell"]').length).toBe(0);
     });
   });
+
+  describe('bulk-action bar (bulkActions slot)', () => {
+    @Component({
+      standalone: true,
+      imports: [SignalListComponent],
+      template: `<app-signal-list [config]="config" />`
+    })
+    class BulkHost {
+      items = signal([{ name: 'one' }, { name: 'two' }, { name: 'three' }]);
+      selected = signal<ReadonlySet<string>>(new Set<string>());
+      pageIndex = signal(0);
+      pageSize = signal(10);
+      runSpy = vi.fn();
+      config: SignalListConfig<{ name: string }> = {
+        pagedItems: this.items.asReadonly(),
+        totalFilteredResults: signal(3).asReadonly(),
+        totalPages: signal(1).asReadonly(),
+        pageIndex: this.pageIndex,
+        pageSize: this.pageSize,
+        isAnyLoading: signal(false).asReadonly(),
+        errorsByCnsi: signal(new Map<string, unknown>()).asReadonly(),
+        columns: [
+          { header: 'Pick', key: 'pick', kind: 'checkbox', render: () => '',
+            checkbox: { selectedKeys: this.selected } },
+          { header: 'Name', render: r => r.name },
+        ],
+        getRowKey: r => r.name,
+        bulkActions: [
+          { label: 'Delete', icon: 'delete', danger: true, run: this.runSpy },
+        ],
+      };
+    }
+
+    it('does not render the bar when selection is empty', () => {
+      const fixture = TestBed.createComponent(BulkHost);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-test="bulk-action-bar"]')).toBeNull();
+    });
+
+    it('renders the bar with count and action when 1+ rows are selected', () => {
+      const fixture = TestBed.createComponent(BulkHost);
+      fixture.componentInstance.selected.set(new Set(['one', 'two']));
+      fixture.detectChanges();
+      const bar = fixture.nativeElement.querySelector('[data-test="bulk-action-bar"]');
+      expect(bar).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-test="bulk-selected-count"]').textContent).toContain('2 selected');
+      expect(fixture.nativeElement.querySelector('[data-test="bulk-action-Delete"]')).not.toBeNull();
+    });
+
+    it('clicking a bulk action invokes run with the selection snapshot', async () => {
+      const fixture = TestBed.createComponent(BulkHost);
+      fixture.componentInstance.selected.set(new Set(['one', 'three']));
+      fixture.detectChanges();
+      const btn = fixture.nativeElement.querySelector('[data-test="bulk-action-Delete"]') as HTMLButtonElement;
+      btn.click();
+      await fixture.whenStable();
+      expect(fixture.componentInstance.runSpy).toHaveBeenCalledTimes(1);
+      const passed = fixture.componentInstance.runSpy.mock.calls[0][0] as ReadonlySet<string>;
+      expect(passed.has('one')).toBe(true);
+      expect(passed.has('three')).toBe(true);
+      expect(passed.size).toBe(2);
+    });
+
+    it('Clear button empties the selection', () => {
+      const fixture = TestBed.createComponent(BulkHost);
+      fixture.componentInstance.selected.set(new Set(['one', 'two']));
+      fixture.detectChanges();
+      const clear = fixture.nativeElement.querySelector('[data-test="bulk-clear"]') as HTMLButtonElement;
+      clear.click();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.selected().size).toBe(0);
+      expect(fixture.nativeElement.querySelector('[data-test="bulk-action-bar"]')).toBeNull();
+    });
+
+    it('bar stays hidden when bulkActions is undefined even with selection', () => {
+      const fixture = TestBed.createComponent(BulkHost);
+      fixture.componentInstance.config = { ...fixture.componentInstance.config, bulkActions: undefined };
+      fixture.componentInstance.selected.set(new Set(['one']));
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-test="bulk-action-bar"]')).toBeNull();
+    });
+
+    it('bar stays hidden when bulkActions is empty array', () => {
+      const fixture = TestBed.createComponent(BulkHost);
+      fixture.componentInstance.config = { ...fixture.componentInstance.config, bulkActions: [] };
+      fixture.componentInstance.selected.set(new Set(['one']));
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-test="bulk-action-bar"]')).toBeNull();
+    });
+
+    it('disabled action does not invoke run', async () => {
+      const fixture = TestBed.createComponent(BulkHost);
+      const spy = vi.fn();
+      fixture.componentInstance.config = {
+        ...fixture.componentInstance.config,
+        bulkActions: [{ label: 'Delete', run: spy, disabled: signal(true).asReadonly() }],
+      };
+      fixture.componentInstance.selected.set(new Set(['one']));
+      fixture.detectChanges();
+      const btn = fixture.nativeElement.querySelector('[data-test="bulk-action-Delete"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      btn.click();
+      await fixture.whenStable();
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -231,6 +231,36 @@ export interface SignalListHeaderAction {
   readonly primary?: boolean;
 }
 
+/**
+ * Bulk action button rendered in the selection bar that appears above the
+ * table when a `kind: 'checkbox'` column has 1+ rows selected. Operates on
+ * the set of selected row keys; the consumer resolves keys → rows from its
+ * own data source (the framework doesn't keep an index by key, and pageable
+ * lists may not have every selected row in memory at action time).
+ *
+ * Restores the legacy `IMultiListAction` slot that V2 list-configs used for
+ * bulk Delete / Unmap / Manage Users. The signal-list framework had a
+ * `kind: 'checkbox'` selection column from the start but never grew a slot
+ * to act on the selection — leaving bulk operations unmigratable. This is
+ * the slot, no consumers wired by this commit.
+ */
+export interface SignalListBulkAction<T> {
+  /** Display label inside the button. */
+  readonly label: string;
+  /** Optional Material icon name rendered to the left of the label. */
+  readonly icon?: string;
+  /** Invoked with a snapshot of the currently-selected row keys. */
+  readonly run: (selectedKeys: ReadonlySet<string>) => void | Promise<void>;
+  /** Optional reactive disabled state — e.g. permission-gated actions. */
+  readonly disabled?: Signal<boolean>;
+  /** Optional destructive styling (red) — for Delete-style entries. */
+  readonly danger?: boolean;
+  /** Optional tooltip / aria title. */
+  readonly title?: string;
+  /** Optional `data-test` attribute for E2E selectors. */
+  readonly dataTest?: string;
+}
+
 export interface SignalListConfig<T> {
   readonly pagedItems: Signal<T[]>;
   readonly totalFilteredResults: Signal<number>;
@@ -296,6 +326,13 @@ export interface SignalListConfig<T> {
   // operate on the list as a whole (Invite User / Manage Users / Create
   // Org) — not per-row actions, which still go via `kind: 'actions'`.
   readonly headerActions?: readonly SignalListHeaderAction[];
+  // Optional — bulk-action buttons rendered in a selection bar above the
+  // table when a `kind: 'checkbox'` column has 1+ rows selected. Restores
+  // the legacy `IMultiListAction` slot for bulk Delete / Unmap / Manage.
+  // Bar is hidden when no checkbox column exists, selection is empty, or
+  // this field is undefined/empty — no visual impact on lists that don't
+  // opt in.
+  readonly bulkActions?: readonly SignalListBulkAction<T>[];
 }
 
 @Component({
@@ -556,6 +593,54 @@ export class SignalListComponent<T> implements AfterViewInit {
   // column doesn't render as a label:value detail line.
   actionsColumn(): SignalListColumn<T> | null {
     return this.config.columns.find(c => c.kind === 'actions' && !!c.actions) ?? null;
+  }
+
+  // Bulk-action bar helpers --------------------------------------------
+
+  // Returns the first column configured as kind === 'checkbox'; the
+  // bulk-action bar reads its selectedKeys signal to drive count and
+  // pass-through to action handlers.
+  checkboxColumn(): SignalListColumn<T> | null {
+    return this.config.columns.find(c => c.kind === 'checkbox' && !!c.checkbox) ?? null;
+  }
+
+  // Number of rows currently selected via the checkbox column. 0 when no
+  // checkbox column is configured.
+  selectedCount(): number {
+    return this.checkboxColumn()?.checkbox?.selectedKeys().size ?? 0;
+  }
+
+  // True when the bulk-action bar should render: bulkActions is non-empty,
+  // a checkbox column exists, and at least one row is selected.
+  showBulkBar(): boolean {
+    const acts = this.config.bulkActions;
+    if (!acts || acts.length === 0) return false;
+    return this.selectedCount() > 0;
+  }
+
+  // Clears the checkbox column's selection. Used by the "Clear" button in
+  // the bulk-action bar and is the recommended path for consumers to call
+  // after a bulk action completes (delete-style actions especially).
+  clearBulkSelection(): void {
+    const col = this.checkboxColumn();
+    col?.checkbox?.selectedKeys.set(new Set());
+  }
+
+  // Invokes a bulk action, passing the current selection snapshot. Errors
+  // from the handler are caught and logged — the bar stays open so the
+  // user can retry or clear manually. Selection is NOT auto-cleared; the
+  // consumer decides whether the action invalidates the selection (delete:
+  // yes; mark-favorite: no).
+  async invokeBulkAction(act: SignalListBulkAction<T>): Promise<void> {
+    if (act.disabled?.()) return;
+    const col = this.checkboxColumn();
+    const keys = col?.checkbox?.selectedKeys() ?? new Set<string>();
+    if (keys.size === 0) return;
+    try {
+      await act.run(keys);
+    } catch (err) {
+      console.error(`Bulk action "${act.label}" failed:`, err);
+    }
   }
 
   // Resolves the row-level link target — used to make the whole card /


### PR DESCRIPTION
## Summary

Adds `SignalListBulkAction<T>` interface and `bulkActions` slot on `SignalListConfig`. Restores the action surface that legacy V2 list-configs exposed via `IMultiListAction` — bulk Delete / Unmap / Manage Users that operate on the set of currently-checkbox-selected rows.

`SignalListComponent` grew the `kind: 'checkbox'` selection column on day one but never had a slot to act on the selection, so bulk-operation consumers (cf-routes bulk Delete/Unmap, cf-users bulk Manage Users, etc.) had nowhere to land during the signal-native migration. This PR adds the slot only — no consumer wirings.

## Behavior

When `bulkActions` is configured AND a `kind: 'checkbox'` column has 1+ rows selected:

- A bar renders between the toolbar and the table
- Shows `"N selected"` + `Clear` button + action buttons (one per `SignalListBulkAction`)
- Action handlers receive a `ReadonlySet<string>` of currently-selected row keys
- Consumer resolves keys → rows from its own data source (pageable lists can't keep an index by key)
- `danger: true` actions render in red (delete-style)
- `disabled: Signal<boolean>` supports reactive permission gating

When `bulkActions` is undefined OR empty: bar never renders. Zero visual change for existing list pages.

## Out of scope

- Wiring any actual bulk-action consumers (cf-routes / cf-users restorations) — separate follow-up PR
- Adding selection state plumbing — `kind: 'checkbox'` already produces it

## Test plan

- [x] Vitest: 7 new tests covering bar visibility, selection count text, action invocation with snapshot, Clear button behavior, undefined / empty bulkActions, disabled action no-op (`signal-list.component.spec.ts`)
- [x] All 34 SignalList specs pass (27 existing + 7 new)
- [x] Full `make check gate` ran; 2340 passed, 1 vitest worker-spawn flake on an unrelated store reducer spec (passes in isolation), 2 skipped — no logic regression from this change