### PR TITLE
fix(per-cf-tabs): restore Add affordances lost during signal migration

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.html
@@ -1,5 +1,8 @@
 <div class="cf-applications h-full flex flex-col">
   @if (listConfig(); as config) {
+    <app-list-sub-nav title="Total Applications"
+                      [count]="totalApplications"
+                      [addAction]="createApplicationAction"></app-list-sub-nav>
     <app-signal-list [config]="config" class="flex-1 min-h-0"></app-signal-list>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -1,12 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, OnInit, Signal, WritableSignal, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { map } from 'rxjs/operators';
 
 import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
+  CurrentUserPermissionsService,
+  ListSubNavAddAction,
+  ListSubNavComponent,
   SignalListComponent,
   SignalListConfig,
   SignalListDropdown,
@@ -21,6 +24,7 @@ import {
 
 import { applicationEntityType } from '../../../../cf-entity-types';
 import { CfAppsSignalConfigService } from '../../../../shared/components/list/list-types/app/cf-apps-signal-config.service';
+import { CfCurrentUserPermissions } from '../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import type { StApp } from '../../../../services/endpoint-data/stratos-types';
 
@@ -37,6 +41,7 @@ import type { StApp } from '../../../../services/endpoint-data/stratos-types';
   imports: [
     CommonModule,
     RouterModule,
+    ListSubNavComponent,
     SignalListComponent,
   ],
 })
@@ -46,6 +51,26 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
   private userFavoriteManager = inject(UserFavoriteManager);
   private confirmDialog = inject(ConfirmationDialogService);
   private snackBar = inject(TailwindSnackBarService);
+  private router = inject(Router);
+  private permissionsService = inject(CurrentUserPermissionsService);
+
+  /** Total app count for the L5 sub-nav. */
+  public totalApplications!: Signal<number>;
+  /** Reactive permission flag for the Create Application button. Built
+   *  in the constructor (injection context) so toSignal() resolves. */
+  public readonly canCreateApplication: Signal<boolean> = toSignal(
+    this.permissionsService.can(CfCurrentUserPermissions.APPLICATION_CREATE, this.cfEndpointService.cfGuid),
+    { initialValue: false },
+  );
+  /** L5 primary action — navigates to the deploy stepper with this CNSI
+   *  pre-selected via the `:endpointId` route param (the new-application
+   *  base step forwards it as `auto-select-endpoint`). */
+  public readonly createApplicationAction: ListSubNavAddAction = {
+    label: 'Create Application',
+    icon: 'add',
+    visible: this.canCreateApplication,
+    invoke: () => this.router.navigate(['/applications/new', this.cfEndpointService.cfGuid]),
+  };
 
   private readonly favoriteAppRowKeys: Signal<ReadonlySet<string>> = toSignal(
     this.userFavoriteManager.getAllFavorites().pipe(
@@ -76,6 +101,7 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
     // mount in the same session, then build a single-CNSI orchestrator.
     this.appsConfig.clearLockedSpace();
     this.appsConfig.initialize([cfGuid]);
+    this.totalApplications = this.appsConfig.view.totalItems;
     // CNSI is pre-chosen by the URL — pin the dropdown's selection to this
     // CF and disable it so the scope is visible (matching Org/Space framing
     // on per-org / per-space pages) but the user can't drift off this CF.

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-marketplace/cloud-foundry-marketplace-signal.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-marketplace/cloud-foundry-marketplace-signal.component.html
@@ -1,5 +1,8 @@
 <div class="cf-marketplace h-full flex flex-col">
   @if (listConfig(); as config) {
+    <app-list-sub-nav title="Total Service Offerings"
+                      [count]="totalServiceOfferings"
+                      [addAction]="createServiceInstanceAction"></app-list-sub-nav>
     <app-signal-list [config]="config" class="flex-1 min-h-0"></app-signal-list>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-marketplace/cloud-foundry-marketplace-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-marketplace/cloud-foundry-marketplace-signal.component.ts
@@ -1,10 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, OnInit, Signal, WritableSignal, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { map } from 'rxjs/operators';
 
 import {
+  CurrentUserPermissionsService,
+  ListSubNavAddAction,
+  ListSubNavComponent,
   SignalListComponent,
   SignalListConfig,
   SignalListDropdown,
@@ -15,6 +18,7 @@ import { serviceEntityType } from '../../../../cf-entity-types';
 import {
   CfServiceOfferingsSignalConfigService,
 } from '../../../../shared/components/list/list-types/service-offering/cf-service-offerings-signal-config.service';
+import { CfCurrentUserPermissions } from '../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import type { StServiceOffering } from '../../../../services/endpoint-data/stratos-types';
 
@@ -33,6 +37,7 @@ import type { StServiceOffering } from '../../../../services/endpoint-data/strat
   imports: [
     CommonModule,
     RouterModule,
+    ListSubNavComponent,
     SignalListComponent,
   ],
 })
@@ -40,6 +45,29 @@ export class CloudFoundryMarketplaceSignalComponent implements OnInit {
   cfEndpointService = inject(CloudFoundryEndpointService);
   private offeringsConfig = inject(CfServiceOfferingsSignalConfigService);
   private userFavoriteManager = inject(UserFavoriteManager);
+  private router = inject(Router);
+  private permissionsService = inject(CurrentUserPermissionsService);
+
+  /** Total offering count for the L5 sub-nav. */
+  public totalServiceOfferings!: Signal<number>;
+  /** Reactive permission flag for the Add Service Instance button. Built
+   *  in the constructor (injection context) so toSignal() resolves. */
+  public readonly canCreateServiceInstance: Signal<boolean> = toSignal(
+    this.permissionsService.can(CfCurrentUserPermissions.SERVICE_INSTANCE_CREATE, this.cfEndpointService.cfGuid),
+    { initialValue: false },
+  );
+  /** L5 primary action — navigates to the add-service-instance wizard
+   *  with the managed-service tile pre-selected (the marketplace context
+   *  already implies a managed-broker flow). Forwards the cnsi as an
+   *  `auto-select-endpoint` query param so the wizard can pre-select
+   *  this CF in its first step. */
+  public readonly createServiceInstanceAction: ListSubNavAddAction = {
+    label: 'Add Service Instance',
+    icon: 'add',
+    visible: this.canCreateServiceInstance,
+    invoke: () => this.router.navigate(['/services/new/service'],
+      { queryParams: { 'auto-select-endpoint': this.cfEndpointService.cfGuid } }),
+  };
 
   private readonly favoriteOfferingRowKeys: Signal<ReadonlySet<string>> = toSignal(
     this.userFavoriteManager.getAllFavorites().pipe(
@@ -72,6 +100,7 @@ export class CloudFoundryMarketplaceSignalComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     const cfGuid = this.cfEndpointService.cfGuid;
     this.offeringsConfig.initialize([cfGuid]);
+    this.totalServiceOfferings = this.offeringsConfig.view.totalItems;
     // CNSI is pre-chosen by the URL — show the dropdown but disable it so
     // the scope is visible and can't drift.
     this.offeringsConfig.selectedCnsi.set(cfGuid);

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.html
@@ -1,5 +1,8 @@
 <div class="space-apps h-full flex flex-col">
   @if (listConfig(); as config) {
+    <app-list-sub-nav title="Total Applications"
+                      [count]="totalApplications"
+                      [addAction]="createApplicationAction"></app-list-sub-nav>
     <app-signal-list [config]="config" class="flex-1 min-h-0"></app-signal-list>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
@@ -4,7 +4,8 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { TabNavService } from '@stratosui/core';
+import { CurrentUserPermissionsService, TabNavService } from '@stratosui/core';
+import { of } from 'rxjs';
 import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
 import { generateCfBaseTestModulesNoShared } from '@test-framework/cloud-foundry-endpoint-service.helper';
 
@@ -22,6 +23,7 @@ function makeStubAppsConfig() {
     pagedItems: signal([]).asReadonly(),
     totalFilteredResults: signal(0).asReadonly(),
     totalPages: signal(1).asReadonly(),
+    totalItems: signal(0).asReadonly(),
   };
   const orchestrator = {
     isAnyLoading: signal(false).asReadonly(),
@@ -71,6 +73,7 @@ describe('CloudFoundrySpaceAppsSignalComponent', () => {
         { provide: CfAppsSignalConfigService, useValue: stubAppsConfig },
         { provide: CloudFoundryEndpointService, useValue: stubEndpointService },
         { provide: CloudFoundrySpaceService, useValue: stubSpaceService },
+        { provide: CurrentUserPermissionsService, useValue: { can: () => of(true) } },
       ],
     }).compileComponents();
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
@@ -1,12 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, OnInit, Signal, WritableSignal, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { map } from 'rxjs/operators';
 
 import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
+  CurrentUserPermissionsService,
+  ListSubNavAddAction,
+  ListSubNavComponent,
   SignalListComponent,
   SignalListConfig,
   SignalListPillColor,
@@ -20,6 +23,7 @@ import {
 
 import { applicationEntityType } from '../../../../../../../cf-entity-types';
 import { CfAppsSignalConfigService } from '../../../../../../../shared/components/list/list-types/app/cf-apps-signal-config.service';
+import { CfCurrentUserPermissions } from '../../../../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundrySpaceService } from '../../../../../services/cloud-foundry-space.service';
 import type { StApp } from '../../../../../../../services/endpoint-data/stratos-types';
@@ -43,6 +47,7 @@ import type { StApp } from '../../../../../../../services/endpoint-data/stratos-
   imports: [
     CommonModule,
     RouterModule,
+    ListSubNavComponent,
     SignalListComponent,
   ],
 })
@@ -53,6 +58,32 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
   private userFavoriteManager = inject(UserFavoriteManager);
   private confirmDialog = inject(ConfirmationDialogService);
   private snackBar = inject(TailwindSnackBarService);
+  private router = inject(Router);
+  private permissionsService = inject(CurrentUserPermissionsService);
+
+  /** Total app count in this space for the L5 sub-nav. */
+  public totalApplications!: Signal<number>;
+  /** Reactive permission flag for the Create Application button — scoped
+   *  to this space (APPLICATION_CREATE checks SPACE_DEVELOPER role). Built
+   *  in the constructor (injection context) so toSignal() resolves. */
+  public readonly canCreateApplication: Signal<boolean> = toSignal(
+    this.permissionsService.can(
+      CfCurrentUserPermissions.APPLICATION_CREATE,
+      this.cfEndpointService.cfGuid,
+      this.cfSpaceService.spaceGuid,
+    ),
+    { initialValue: false },
+  );
+  /** L5 primary action — navigates to the deploy stepper with the CNSI
+   *  pre-selected via the `:endpointId` route param. Org/space pre-fill
+   *  is a follow-up enhancement; today the user picks org/space inside
+   *  the wizard. */
+  public readonly createApplicationAction: ListSubNavAddAction = {
+    label: 'Create Application',
+    icon: 'add',
+    visible: this.canCreateApplication,
+    invoke: () => this.router.navigate(['/applications/new', this.cfEndpointService.cfGuid]),
+  };
 
   // Row keys (${cnsiGuid}:${appGuid}) for apps the user has favorited.
   // Mirrors the application-wall pattern so favorites carry across the
@@ -87,6 +118,7 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
     // initializeForSpace() also flips a benign signal so the constructor
     // effect re-derives the filter predicate against the new lock.
     this.appsConfig.initializeForSpace(cfGuid, spaceGuid);
+    this.totalApplications = this.appsConfig.view.totalItems;
 
     const stateColor = (app: StApp): SignalListPillColor => {
       const s = (app.state ?? '').toUpperCase();

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.html
@@ -1,5 +1,8 @@
 <div class="cf-services h-full flex flex-col">
   @if (listConfig(); as config) {
+    <app-list-sub-nav title="Total Service Instances"
+                      [count]="totalServiceInstances"
+                      [addAction]="createServiceInstanceAction"></app-list-sub-nav>
     <app-signal-list [config]="config" class="flex-1 min-h-0"></app-signal-list>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
@@ -1,12 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, OnInit, Signal, WritableSignal, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { map } from 'rxjs/operators';
 
 import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
+  CurrentUserPermissionsService,
+  ListSubNavAddAction,
+  ListSubNavComponent,
   SignalListComponent,
   SignalListConfig,
   SignalListDropdown,
@@ -23,6 +26,7 @@ import {
 import {
   CfServiceInstancesSignalConfigService,
 } from '../../../../shared/components/list/list-types/service-instance/cf-service-instances-signal-config.service';
+import { CfCurrentUserPermissions } from '../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import type { StServiceInstance } from '../../../../services/endpoint-data/stratos-types';
 
@@ -38,6 +42,7 @@ import type { StServiceInstance } from '../../../../services/endpoint-data/strat
   imports: [
     CommonModule,
     RouterModule,
+    ListSubNavComponent,
     SignalListComponent,
   ],
 })
@@ -47,6 +52,27 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
   private userFavoriteManager = inject(UserFavoriteManager);
   private confirmDialog = inject(ConfirmationDialogService);
   private snackBar = inject(TailwindSnackBarService);
+  private router = inject(Router);
+  private permissionsService = inject(CurrentUserPermissionsService);
+
+  /** Total service-instance count for the L5 sub-nav. */
+  public totalServiceInstances!: Signal<number>;
+  /** Reactive permission flag for the Add Service Instance button. Built
+   *  in the constructor (injection context) so toSignal() resolves. */
+  public readonly canCreateServiceInstance: Signal<boolean> = toSignal(
+    this.permissionsService.can(CfCurrentUserPermissions.SERVICE_INSTANCE_CREATE, this.cfEndpointService.cfGuid),
+    { initialValue: false },
+  );
+  /** L5 primary action — navigates to the add-service-instance wizard's
+   *  type selector (Managed Service vs User Provided). Forwards the cnsi
+   *  as `auto-select-endpoint` so the wizard can pre-select this CF. */
+  public readonly createServiceInstanceAction: ListSubNavAddAction = {
+    label: 'Add Service Instance',
+    icon: 'add',
+    visible: this.canCreateServiceInstance,
+    invoke: () => this.router.navigate(['/services/new'],
+      { queryParams: { 'auto-select-endpoint': this.cfEndpointService.cfGuid } }),
+  };
 
   private readonly favoriteInstanceRowKeys: Signal<ReadonlySet<string>> = toSignal(
     this.userFavoriteManager.getAllFavorites().pipe(
@@ -84,6 +110,7 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     const cfGuid = this.cfEndpointService.cfGuid;
     this.instancesConfig.initialize([cfGuid]);
+    this.totalServiceInstances = this.instancesConfig.view.totalItems;
     // CNSI is pre-chosen by the URL — show the dropdown but disable it so
     // the scope is visible and can't drift.
     this.instancesConfig.selectedCnsi.set(cfGuid);

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.ts
@@ -5,6 +5,7 @@ import { Store } from '@stratosui/store';
 import { CFAppState } from '../../../../../../cloud-foundry/src/cf-app-state';
 import { getIdFromRoute } from '../../../../../../core/src/core/utils.service';
 import { BASE_REDIRECT_QUERY } from '../../../../../../core/src/shared/components/stepper/stepper.types';
+import { AUTO_SELECT_CF_URL_PARAM } from '../../../../features/applications/new-application-base-step/new-application-base-step.component';
 import { TileConfigManager } from '../../../../../../core/src/shared/components/tile/tile-selector.helpers';
 import { ITileConfig, ITileData } from '../../../../../../core/src/shared/components/tile/tile-selector.types';
 import { RouterNav } from '../../../../../../store/src/actions/router.actions';
@@ -62,12 +63,21 @@ export class AddServiceInstanceBaseStepComponent {
     this.pSelectedTile = tile;
     if (tile) {
       const baseUrl = this.createServiceTileUrl();
+      // Forward the per-CF-tab Add affordance's `?auto-select-endpoint=`
+      // hint to the next step. Per-CF Marketplace / Services tabs include
+      // this when launching the wizard; carrying it through the tile-pick
+      // step lets the actual wizard pre-select the CF in step 1.
+      const autoSelectCf = this.route.snapshot.queryParams[AUTO_SELECT_CF_URL_PARAM];
+      const query: { [key: string]: string } = {
+        [BASE_REDIRECT_QUERY]: baseUrl,
+        [CSI_CANCEL_URL]: this.cancelUrl,
+      };
+      if (autoSelectCf) {
+        query[AUTO_SELECT_CF_URL_PARAM] = autoSelectCf;
+      }
       this.store.dispatch(new RouterNav({
         path: `${baseUrl}/${this.serviceType}`,
-        query: {
-          [BASE_REDIRECT_QUERY]: baseUrl, // 'previous' destination
-          [CSI_CANCEL_URL]: this.cancelUrl // 'cancel' + 'success' destination
-        }
+        query,
       }));
     }
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -45,6 +45,7 @@ import { SpaceDataRegistry } from '../../../../services/endpoint-data/space-data
 import { StApp, StServiceInstance, StSpace } from '../../../../services/endpoint-data/stratos-types';
 import { CreateApplicationStep1Component } from '../../create-application/create-application-step1/create-application-step1.component';
 import { SelectServiceComponent } from '../../select-service/select-service.component';
+import { AUTO_SELECT_CF_URL_PARAM } from '../../../../features/applications/new-application-base-step/new-application-base-step.component';
 import { SERVICE_INSTANCE_TYPES } from '../add-service-instance-base-step/add-service-instance.types';
 import { BindAppsStepComponent } from '../bind-apps-step/bind-apps-step.component';
 import { CreateServiceInstanceHelperServiceFactory } from '../create-service-instance-helper-service-factory.service';
@@ -434,6 +435,17 @@ export class AddServiceInstanceComponent implements OnInit, OnDestroy {
     );
     this.inMarketplaceMode = this.modeService.isMarketplaceMode();
     this.serviceType = route.snapshot.params.type || SERVICE_INSTANCE_TYPES.SERVICE;
+
+    // Honor the per-CF-tab Add affordance: when a per-CF Marketplace /
+    // Services tab navigates here, it forwards its CNSI via the
+    // `auto-select-endpoint` query param (the same convention the app
+    // deploy wizard uses). Pre-select the CF in the org/space picker so
+    // step 1 lands on the right context — no re-pick required when the
+    // user clearly came from a CF-scoped surface.
+    const autoSelectCf = route.snapshot.queryParams[AUTO_SELECT_CF_URL_PARAM];
+    if (autoSelectCf) {
+      this.cfOrgSpaceService.cf.select.set(autoSelectCf);
+    }
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary

Per-CF Apps / Marketplace / Services tabs and the Space Apps tab all lost their Add affordances during the 2026-05-13 signal-native introduction of per-CF tabs (`6ec12c3ff3`). The walls grew or already had Add buttons; the per-CF tabs were cloned as bare list bodies with no L5 sub-nav.

Stratos's design intent is **per-endpoint Add affordances** — the walls aggregate across CNSIs, and clicking Add there forces the user to re-pick CF/org/space they already chose by navigating into a per-CF tab. The per-CF tabs are the natural home for these actions, not the walls.

## What it does

Wires `<app-list-sub-nav>` with an `addAction` on all four tabs, mirroring the pattern the Organizations tab already established:

| Tab | Button | Target |
|---|---|---|
| Per-CF Apps `/cloud-foundry/{cnsi}/applications` | Create Application | `/applications/new/{cfGuid}` |
| Per-CF Marketplace `/cloud-foundry/{cnsi}/marketplace` | Add Service Instance | `/services/new/service?auto-select-endpoint={cfGuid}` |
| Per-CF Services `/cloud-foundry/{cnsi}/services` | Add Service Instance | `/services/new?auto-select-endpoint={cfGuid}` |
| Space Apps `/cloud-foundry/{cnsi}/organizations/{org}/spaces/{space}/apps` | Create Application | `/applications/new/{cfGuid}` (org/space pre-fill deferred to follow-up) |

Permission gates reuse existing `CfCurrentUserPermissions` checks (`APPLICATION_CREATE` for the two Apps tabs, `SERVICE_INSTANCE_CREATE` for Marketplace/Services). Buttons hide for users without the role.

## Wizard plumbing

Plumbs the existing `AUTO_SELECT_CF_URL_PARAM` (`auto-select-endpoint`) contract through the add-service-instance wizard so the per-CF Marketplace and Services tabs can pre-select the CF:

- `AddServiceInstanceBaseStepComponent` forwards the query param when navigating from the tile selector to the typed wizard step
- `AddServiceInstanceComponent` reads the param on init and calls `cfOrgSpaceService.cf.select.set(cnsi)` — mirroring the existing `DeployApplicationComponent` handling — so the org/space picker step lands on the right CF without re-pick

## Out of scope (follow-ups)

- Space Apps Add: org + space pre-fill via additional query params (e.g. `?auto-select-org=&auto-select-space=`). Today the user picks them in the wizard — matches wall behavior, no worse than the regression we're fixing.
- Per-row action surface restoration on tabs whose actions column has fewer entries than legacy V2 (cf-services Edit/Detach, etc.) — separate audit.

## Test plan

- [x] Vitest: `cloud-foundry-space-apps-signal.component.spec.ts` updated (added `view.totalItems` to stub + `CurrentUserPermissionsService` mock) and passes
- [x] CSI wizard specs (`add-service-instance.component.spec.ts`, `add-service-instance-base-step.component.spec.ts`) unchanged + pass
- [x] Full `make check gate` ran clean (exit 0)
- [ ] Smoke in adepttech browser: each of the four tabs shows the Add affordance; click navigates to the wizard with CF context pre-filled