### PR TITLE
Common delete mechanism: route all CF entity deletes through one chokepoint

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/cloud-foundry-package.module.ts
+++ b/src/frontend/packages/cloud-foundry/src/cloud-foundry-package.module.ts
@@ -5,6 +5,8 @@ import { MDAppModule } from '../../core/src/core/md.module';
 import { SharedModule } from '@stratosui/core';
 import { EntityCatalogModule } from '../../store/src/entity-catalog.module';
 import { generateCFEntities } from './cf-entity-generator';
+import { registerCfRelationDescriptors } from './entity-relations/signal/cf-relation-registrations';
+import { SignalRelationFetcherService } from './entity-relations/signal/signal-relation-fetcher.service';
 import { setCfInfoHelperInjector } from './services/endpoint-data/cf-info-helper';
 import { CloudFoundryService } from './shared/data-services/cloud-foundry.service';
 import { LongRunningCfOperationsService } from './shared/data-services/long-running-cf-op.service';
@@ -34,5 +36,10 @@ export class CloudFoundryPackageModule {
     // Angular injection context) can resolve CfInfoDataRegistry and trigger
     // a signal-native refresh. Replaces the deleted GetCFInfo ngrx effect.
     setCfInfoHelperInjector(inject(Injector));
+
+    // Register the CF parent→child relation graph so the entity-delete
+    // chokepoint can derive a complete invalidation closure (affectedSlices).
+    // One source of truth for both fetch (wave β) and delete invalidation.
+    registerCfRelationDescriptors(inject(SignalRelationFetcherService));
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/cloud-foundry-package.module.ts
+++ b/src/frontend/packages/cloud-foundry/src/cloud-foundry-package.module.ts
@@ -7,6 +7,8 @@ import { EntityCatalogModule } from '../../store/src/entity-catalog.module';
 import { generateCFEntities } from './cf-entity-generator';
 import { registerCfRelationDescriptors } from './entity-relations/signal/cf-relation-registrations';
 import { SignalRelationFetcherService } from './entity-relations/signal/signal-relation-fetcher.service';
+import { EntityDeleteController } from './services/deletes/entity-delete.controller';
+import { FavoritesRecentsDeleteCleanup } from './services/deletes/favorites-recents-cleanup.service';
 import { setCfInfoHelperInjector } from './services/endpoint-data/cf-info-helper';
 import { CloudFoundryService } from './shared/data-services/cloud-foundry.service';
 import { LongRunningCfOperationsService } from './shared/data-services/long-running-cf-op.service';
@@ -41,5 +43,10 @@ export class CloudFoundryPackageModule {
     // chokepoint can derive a complete invalidation closure (affectedSlices).
     // One source of truth for both fetch (wave β) and delete invalidation.
     registerCfRelationDescriptors(inject(SignalRelationFetcherService));
+
+    // Restore the favorites + recents cleanup the signal-delete migration
+    // dropped: on a successful delete the controller fires this hook to remove
+    // any stranded favorite/recent for the gone entity.
+    inject(EntityDeleteController).registerCleanup(inject(FavoritesRecentsDeleteCleanup).hook);
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/signal/cf-relation-registrations.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/signal/cf-relation-registrations.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { affectedSlices } from '../../services/deletes/affected-slices';
+import { indexDescriptors } from './signal-relation-tree';
+import {
+  CF_RELATION_DESCRIPTORS,
+  registerCfRelationDescriptors,
+} from './cf-relation-registrations';
+
+// ---------------------------------------------------------------------------
+// These specs prove that the REAL CF relation descriptors, once registered,
+// derive a delete-invalidation closure that covers `routes` — the slice the
+// legacy hand-curated cascade-registry (org.delete) silently dropped.
+//
+// affectedSlices is pure, so we build the registry straight from the exported
+// descriptor list (the same `indexDescriptors` the fetcher uses internally).
+// ---------------------------------------------------------------------------
+
+const registry = indexDescriptors(CF_RELATION_DESCRIPTORS);
+
+describe('CF relation registrations — delete-invalidation closure', () => {
+  describe('organization root (the reproduced bug)', () => {
+    const slices = affectedSlices('organization', registry);
+
+    it('covers every server-side cascade of an org delete', () => {
+      expect(slices).toEqual(
+        expect.arrayContaining([
+          'spaces',
+          'apps',
+          'routes',
+          'serviceInstances',
+          'serviceCredentialBindings',
+        ]),
+      );
+    });
+
+    it('covers routes — the gap the old cascade-registry had', () => {
+      // cascade-registry org.delete was ['spaces','apps','serviceInstances',
+      // 'serviceCredentialBindings'] — routes was never invalidated, leaving
+      // stale per-space/app route lists after an org delete.
+      expect(slices).toContain('routes');
+    });
+
+    it('does not invalidate the org slice itself', () => {
+      expect(slices).not.toContain('orgs');
+    });
+
+    it('returns a de-duplicated set', () => {
+      expect(slices).toHaveLength(new Set(slices).size);
+    });
+  });
+
+  describe('space root', () => {
+    const slices = affectedSlices('space', registry);
+
+    it('covers apps, routes, serviceInstances, serviceCredentialBindings', () => {
+      expect(slices).toEqual(
+        expect.arrayContaining(['apps', 'routes', 'serviceInstances', 'serviceCredentialBindings']),
+      );
+    });
+
+    it('does not invalidate the space slice itself', () => {
+      expect(slices).not.toContain('spaces');
+    });
+  });
+
+  describe('application root', () => {
+    const slices = affectedSlices('application', registry);
+
+    it('covers routes and serviceCredentialBindings', () => {
+      expect(slices).toEqual(expect.arrayContaining(['routes', 'serviceCredentialBindings']));
+    });
+  });
+
+  describe('serviceInstance root', () => {
+    it('covers serviceCredentialBindings', () => {
+      expect(affectedSlices('serviceInstance', registry)).toContain('serviceCredentialBindings');
+    });
+  });
+});
+
+describe('registerCfRelationDescriptors', () => {
+  it('bulk-registers the descriptor set into a fetcher', () => {
+    const fetcher = { registerAll: vi.fn() };
+    registerCfRelationDescriptors(fetcher as any);
+    expect(fetcher.registerAll).toHaveBeenCalledWith(CF_RELATION_DESCRIPTORS);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/signal/cf-relation-registrations.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/signal/cf-relation-registrations.ts
@@ -1,0 +1,86 @@
+// Real CF parent→child relation descriptors for the signal-native
+// entity-relations substrate.
+//
+// PURPOSE (Increment 1, Task 3 of the common-delete mechanism): give the
+// delete chokepoint a *complete* invalidation graph. `affectedSlices()` walks
+// these edges to decide which EndpointDataService slices a delete must mark
+// stale. The legacy hand-curated `cascade-registry.ts` under-marked — it never
+// listed `routes` for an org/space delete — so the migration silently dropped
+// the route-list cleanup. Deriving the closure from the same descriptors that
+// (will) drive fetch makes the graph the single source of truth.
+//
+// SCOPE NOTE: these are registered for the *invalidation* graph today. The
+// `fetchChildren` impls are intentionally thin — nothing live-fetches through
+// SignalRelationFetcherService yet (wave β). They throw loudly rather than
+// returning [] so that the first consumer to wire live fetch can't get a
+// silent empty result; walkParent() records the throw as a per-relation error.
+//
+// ENTITY-TYPE VOCABULARY: child types match the keys in
+// `affected-slices.ts` ENTITY_TYPE_TO_SLICE. Most align 1:1 with the
+// cf-entity-types constants; the one exception is the service-binding edge —
+// the legacy constant is `serviceBinding` ('serviceBinding') but the delete
+// mechanism uses the CF V3 name `serviceCredentialBinding` (→ slice
+// `serviceCredentialBindings`), matching the already-committed slice map. The
+// `paramName`s are the legacy v2 CAPI include-relations keys, kept for when
+// fetch is wired.
+
+import {
+  applicationEntityType,
+  organizationEntityType,
+  routeEntityType,
+  serviceInstancesEntityType,
+  spaceEntityType,
+} from '../../cf-entity-types';
+import type { RelationDescriptor, RelationFetchContext } from './signal-relation-types';
+import type { SignalRelationFetcherService } from './signal-relation-fetcher.service';
+
+// CF V3 name for service bindings; no cf-entity-types constant carries this
+// value (the legacy `serviceBindingEntityType` is 'serviceBinding'). Keep it
+// in lockstep with ENTITY_TYPE_TO_SLICE in affected-slices.ts.
+export const serviceCredentialBindingEntityType = 'serviceCredentialBinding';
+
+/** Thin stub: invalidation needs only the parent→child edges, not live fetch. */
+const notWired =
+  (parentEntityType: string, childEntityType: string) =>
+  (_parent: unknown, _ctx: RelationFetchContext): Promise<never> => {
+    throw new Error(
+      `RelationDescriptor ${parentEntityType}->${childEntityType} is registered for ` +
+        `delete invalidation only; live fetchChildren is not wired yet (wave β).`,
+    );
+  };
+
+const edge = (
+  parentEntityType: string,
+  childEntityType: string,
+  paramName: string,
+): RelationDescriptor => ({
+  parentEntityType,
+  childEntityType,
+  paramName,
+  isArray: true,
+  inlineParentPath: `entity.${paramName}`,
+  fetchChildren: notWired(parentEntityType, childEntityType),
+});
+
+/**
+ * The CF relation graph used to derive delete-invalidation closures. Every
+ * server-side cascade of a delete is reachable from these edges:
+ *
+ *   organization → space → { application, route, serviceInstance }
+ *   application  → { route, serviceCredentialBinding }
+ *   serviceInstance → serviceCredentialBinding
+ */
+export const CF_RELATION_DESCRIPTORS: ReadonlyArray<RelationDescriptor> = [
+  edge(organizationEntityType, spaceEntityType, 'spaces'),
+  edge(spaceEntityType, applicationEntityType, 'apps'),
+  edge(spaceEntityType, routeEntityType, 'routes'),
+  edge(spaceEntityType, serviceInstancesEntityType, 'service_instances'),
+  edge(applicationEntityType, routeEntityType, 'routes'),
+  edge(applicationEntityType, serviceCredentialBindingEntityType, 'service_bindings'),
+  edge(serviceInstancesEntityType, serviceCredentialBindingEntityType, 'service_bindings'),
+];
+
+/** Bulk-register the CF relation descriptors into the fetcher (bootstrap hook). */
+export function registerCfRelationDescriptors(fetcher: SignalRelationFetcherService): void {
+  fetcher.registerAll(CF_RELATION_DESCRIPTORS);
+}

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/signal/signal-relation-fetcher.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/signal/signal-relation-fetcher.service.ts
@@ -174,7 +174,12 @@ export class SignalRelationFetcherService {
     this.inFlight.clear();
   }
 
-  private snapshotRegistry(): RelationDescriptorRegistry {
+  /**
+   * Snapshot the current descriptor set as a parent→children registry.
+   * Public so the entity-delete chokepoint can derive invalidation closures
+   * (affectedSlices) from the same descriptors that drive fetch.
+   */
+  snapshotRegistry(): RelationDescriptorRegistry {
     return indexDescriptors(this.descriptors);
   }
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.ts
@@ -94,7 +94,7 @@ export class CloudFoundryOrganizationSummaryComponent {
       const cfGuid = this.cfOrgService.cfGuid;
       const orgGuid = this.cfOrgService.orgGuid;
       try {
-        await this.orgsConfig.deleteOrg(cfGuid, orgGuid);
+        await this.orgsConfig.deleteOrg(cfGuid, orgGuid, name);
         this.router.navigate(['/cloud-foundry', cfGuid, 'organizations']);
       } catch (err: any) {
         this.snackBar.error(`Failed to delete organization: ${err?.message ?? err}`, 'Close');

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cloud-foundry-organizations-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cloud-foundry-organizations-signal.component.ts
@@ -233,7 +233,7 @@ export class CloudFoundryOrganizationsSignalComponent {
             true,
           );
           this.confirmDialog.open(confirm, async () => {
-            await runAction('Delete', () => this.orgsConfig.deleteOrg(org.cnsiGuid, org.guid));
+            await runAction('Delete', () => this.orgsConfig.deleteOrg(org.cnsiGuid, org.guid, org.name));
           });
         },
       },

--- a/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.ts
@@ -10,7 +10,9 @@ import {
   SteppersComponent,
 } from '@stratosui/core';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
-import { CnsiServiceBindingsSource } from '../../../services/data-sources/cnsi-service-bindings-source';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../../services/deletes/run-cf-delete';
+import { serviceCredentialBindingEntityType } from '../../../entity-relations/signal/cf-relation-registrations';
 import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
 import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
 import { StServiceCredentialBinding, StServiceInstance } from '../../../services/endpoint-data/stratos-types';
@@ -48,11 +50,7 @@ export class DetachServiceInstanceComponent implements OnDestroy {
   private http = inject(HttpClient);
   private serviceCatalog = inject(ServiceCatalogDataService);
   private endpointDataRegistry = inject(EndpointDataRegistry);
-
-  // Single source instance reused across the parallel delete calls; the
-  // EDS lookup happens once in the constructor so each delete patches the
-  // same canonical _serviceCredentialBindings list.
-  private bindingsSource!: CnsiServiceBindingsSource;
+  private deleteController = inject(EntityDeleteController);
 
 
   private _instanceSource!: SignalSource<StServiceInstance | null>;
@@ -119,8 +117,9 @@ export class DetachServiceInstanceComponent implements OnDestroy {
     this.cfGuid = activatedRoute.snapshot.params.endpointId;
     const serviceInstanceId = activatedRoute.snapshot.params.serviceInstanceId;
     this._instanceSource = this.serviceCatalog.serviceInstance(this.cfGuid, serviceInstanceId);
-    const eds = this.endpointDataRegistry.acquire(this.cfGuid);
-    this.bindingsSource = new CnsiServiceBindingsSource(this.cfGuid, this.http, eds);
+    // Hold a refcount on the endpoint's data service so the delete chokepoint
+    // can find (peek) it to invalidate the binding rollups after each detach.
+    this.endpointDataRegistry.acquire(this.cfGuid);
   }
 
   ngOnDestroy() {
@@ -133,11 +132,15 @@ export class DetachServiceInstanceComponent implements OnDestroy {
 
   private async detachOne(bindingGuid: string): Promise<void> {
     try {
-      // Route through CnsiServiceBindingsSource so the canonical
-      // EDS._serviceCredentialBindings list updates and the
-      // serviceBinding.delete cascade fires (apps/SI consumers
-      // re-fetch their binding rollups).
-      await this.bindingsSource.delete(bindingGuid);
+      // Route through the EntityDeleteController chokepoint so the canonical
+      // EDS._serviceCredentialBindings list updates and the graph-derived
+      // invalidation fires (bound apps/SI re-fetch their binding rollups).
+      await runCfDelete(this.deleteController, this.http, {
+        cnsiGuid: this.cfGuid,
+        entityKind: serviceCredentialBindingEntityType,
+        deleteGuid: bindingGuid,
+        path: `/pp/v1/cf/service_bindings/${this.cfGuid}/${bindingGuid}`,
+      });
       this.statusByGuid.update(prev => ({ ...prev, [bindingGuid]: 'success' }));
     } catch (err: unknown) {
       const message = err instanceof StratosJobError

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cascade-registry.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cascade-registry.spec.ts
@@ -2,29 +2,21 @@ import { describe, it, expect } from 'vitest';
 import { CASCADE_RULES, cascadeFor } from './cascade-registry';
 
 describe('cascade-registry', () => {
-  it('cascadeFor returns the registered entry', () => {
-    expect(cascadeFor('org.delete')).toEqual(['spaces', 'apps', 'serviceInstances', 'serviceCredentialBindings']);
-  });
+  // Entity-delete cascades moved to EntityDeleteController (relation-graph
+  // derived), so org/space/app/serviceInstance/serviceBinding `.delete` keys
+  // were removed. What remains: create/update cascades + route.delete (fired by
+  // route *unmap*) + the dormant serviceBroker.* pair.
 
   it('cascadeFor("org.create") returns empty (no cascade on create)', () => {
     expect(cascadeFor('org.create')).toEqual([]);
   });
 
-  it('cascadeFor("space.delete") cascades to apps + SI + bindings (not orgs/spaces)', () => {
-    const list = cascadeFor('space.delete');
-    expect(list).toContain('apps');
-    expect(list).toContain('serviceInstances');
-    expect(list).toContain('serviceCredentialBindings');
-    expect(list).not.toContain('orgs');
-    expect(list).not.toContain('spaces');
+  it('cascadeFor("route.delete") still cascades to apps (route unmap path)', () => {
+    expect(cascadeFor('route.delete')).toEqual(['apps']);
   });
 
-  it('cascadeFor("app.delete") drops only bindings (no cross-org cascade)', () => {
-    expect(cascadeFor('app.delete')).toEqual(['serviceCredentialBindings']);
-  });
-
-  it('cascadeFor("serviceBinding.delete") affects apps + serviceInstances', () => {
-    expect(cascadeFor('serviceBinding.delete')).toEqual(['apps', 'serviceInstances']);
+  it('cascadeFor("serviceBinding.create") affects apps + serviceInstances', () => {
+    expect(cascadeFor('serviceBinding.create')).toEqual(['apps', 'serviceInstances']);
   });
 
   it('cascadeFor("serviceBroker.delete") affects offerings + plans', () => {

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cascade-registry.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cascade-registry.ts
@@ -13,6 +13,7 @@ export type EntityKind =
   | 'orgs'
   | 'apps'
   | 'spaces'
+  | 'routes'
   | 'serviceInstances'
   | 'serviceOfferings'
   | 'servicePlans'

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cascade-registry.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cascade-registry.ts
@@ -20,55 +20,46 @@ export type EntityKind =
   | 'serviceBrokers'
   | 'serviceCredentialBindings';
 
+// NOTE: entity *delete* cascades now derive from the relation graph via
+// EntityDeleteController (affectedSlices ∪ referencingSlices), so the
+// org/space/app/serviceInstance/serviceBinding `.delete` keys were removed —
+// nothing dispatches them anymore. `route.delete` stays: it's still fired by
+// route *unmap* (CnsiRoutesSource.unmapApp), a relationship op that isn't an
+// entity delete. create/update cascades still flow through applyCascade.
+// (serviceBroker.* remain as dormant scaffolding for the parked broker UI.)
 export type CascadeKey =
-  | 'org.delete'
   | 'org.create'
   | 'org.update'
-  | 'space.delete'
   | 'space.create'
   | 'space.update'
-  | 'app.delete'
   | 'app.create'
   | 'app.update'
   | 'route.delete'
   | 'route.create'
-  | 'serviceInstance.delete'
   | 'serviceInstance.create'
   | 'serviceInstance.update'
-  | 'serviceBinding.delete'
   | 'serviceBinding.create'
   | 'serviceBroker.delete'
   | 'serviceBroker.create';
 
 export const CASCADE_RULES: Readonly<Record<CascadeKey, readonly EntityKind[]>> = {
-  // Deleting an org cascades server-side to its spaces, apps, routes,
-  // and service instances. All of those slices in EndpointDataService
-  // become potentially stale.
-  'org.delete': ['spaces', 'apps', 'serviceInstances', 'serviceCredentialBindings'],
   'org.create': [],
   'org.update': [],
 
-  // Deleting a space cascades to its apps, routes, service instances.
-  'space.delete': ['apps', 'serviceInstances', 'serviceCredentialBindings'],
   'space.create': [],
   'space.update': [],
 
-  // Apps own their service bindings; deleting an app drops bindings.
-  'app.delete': ['serviceCredentialBindings'],
   'app.create': [],
   'app.update': [],
 
-  // Routes attached to apps; deleting affects per-app route lists.
+  // Route unmap (relationship op) affects per-app route lists.
   'route.delete': ['apps'],
   'route.create': ['apps'],
 
-  // Service instance lifecycle affects bound apps.
-  'serviceInstance.delete': ['apps', 'serviceCredentialBindings'],
   'serviceInstance.create': [],
   'serviceInstance.update': [],
 
   // Service bindings link apps ↔ instances.
-  'serviceBinding.delete': ['apps', 'serviceInstances'],
   'serviceBinding.create': ['apps', 'serviceInstances'],
 
   // Broker mutations invalidate offerings + plans (broker catalog).

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.spec.ts
@@ -27,33 +27,8 @@ describe('CnsiAppsSource', () => {
     expect(src.items()).toHaveLength(1);
   });
 
-  it('delete hits DELETE /pp/v1/cf/apps/{cnsi}/{guid} and removes the row from items()', async () => {
-    const resp = {
-      resources: [{ guid: 'a', name: 'app-a' }, { guid: 'b', name: 'app-b' }] as unknown as StApp[],
-      pagination: { totalResults: 2, totalPages: 1, next: null, previous: null, first: { href: '' }, last: { href: '' } }
-    };
-    const http = makeHttp(resp);
-    const src = new CnsiAppsSource('cnsi-1', http);
-    await src.load();
-    await src.delete('a');
-    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/apps/cnsi-1/a', { observe: 'response' });
-    expect(src.items().map(i => (i as { guid?: string }).guid)).toEqual(['b']);
-  });
-
-  it('delete does not mutate items on HTTP error', async () => {
-    const resp = {
-      resources: [{ guid: 'a', name: 'app-a' }] as unknown as StApp[],
-      pagination: { totalResults: 1, totalPages: 1, next: null, previous: null, first: { href: '' }, last: { href: '' } }
-    };
-    const http = {
-      get: vi.fn(() => of(resp)),
-      delete: vi.fn(() => { throw new Error('forbidden'); }),
-    } as unknown as HttpClient;
-    const src = new CnsiAppsSource('cnsi-1', http);
-    await src.load();
-    await expect(src.delete('a')).rejects.toThrow('forbidden');
-    expect(src.items().map(i => (i as { guid?: string }).guid)).toEqual(['a']);
-  });
+  // app delete moved to EntityDeleteController (see cf-apps-signal-config
+  // deleteApp); create/update/action/deleteInstance stay here.
 
   it('update(guid, patch) issues PATCH and patches local items', async () => {
     const initial = {

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.ts
@@ -3,7 +3,6 @@ import { firstValueFrom } from 'rxjs';
 import { CnsiEntitySource } from './cnsi-entity-source';
 import type { StApp } from '../endpoint-data/stratos-types';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
-import { writeWithJob } from '../async-jobs/write-with-job';
 
 export class CnsiAppsSource extends CnsiEntitySource<StApp> {
   protected readonly entityName = 'apps';
@@ -21,17 +20,8 @@ export class CnsiAppsSource extends CnsiEntitySource<StApp> {
     super(cnsiGuid, http, pageSize);
   }
 
-  async delete(appGuid: string): Promise<void> {
-    // Route through writeWithJob so the Promise only resolves once CF's
-    // async delete job is terminal (COMPLETE or, via thrown error, FAILED).
-    // Callers that refresh the orchestrator immediately see a consistent
-    // post-delete state instead of racing the CF v3 job.
-    const call = this.http.delete(`/pp/v1/cf/apps/${this.cnsiGuid}/${appGuid}`, { observe: 'response' });
-    await writeWithJob(this.http, call);
-    this.patchItems(items => items.filter(a => (a as { guid?: string }).guid !== appGuid));
-    this.eds?.removeApp(appGuid);
-    this.eds?.applyCascade('app.delete');
-  }
+  // NOTE: app delete routes through EntityDeleteController (see
+  // CfAppsSignalConfigService.deleteApp); create/update/action stay here.
 
   async update(appGuid: string, patch: Partial<StApp> & Record<string, unknown>): Promise<void> {
     const updated = await firstValueFrom(this.http.patch<StApp>(`/pp/v1/cf/apps/${this.cnsiGuid}/${appGuid}`, patch));

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-orgs-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-orgs-source.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { CnsiOrgsSource } from './cnsi-orgs-source';
 import type { StOrg } from '../endpoint-data/stratos-types';
@@ -15,28 +15,8 @@ function makeEds(): EndpointDataService {
 }
 
 describe('CnsiOrgsSource', () => {
-  it('delete: DELETE + writeWithJob + removeOrg + cascade("org.delete")', async () => {
-    const http = {
-      delete: vi.fn(() => of(new HttpResponse({ status: 200, body: null }))),
-    } as unknown as HttpClient;
-    const eds = makeEds();
-    const src = new CnsiOrgsSource('cnsi-1', http, eds);
-    await src.delete('org-1');
-    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/orgs/cnsi-1/org-1', { observe: 'response' });
-    expect(eds.removeOrg).toHaveBeenCalledWith('org-1');
-    expect(eds.applyCascade).toHaveBeenCalledWith('org.delete');
-  });
-
-  it('delete: does not patch EDS on HTTP failure', async () => {
-    const http = {
-      delete: vi.fn(() => { throw new Error('forbidden'); }),
-    } as unknown as HttpClient;
-    const eds = makeEds();
-    const src = new CnsiOrgsSource('cnsi-1', http, eds);
-    await expect(src.delete('org-1')).rejects.toThrow('forbidden');
-    expect(eds.removeOrg).not.toHaveBeenCalled();
-    expect(eds.applyCascade).not.toHaveBeenCalled();
-  });
+  // Org delete moved to EntityDeleteController (see cf-orgs-signal-config
+  // deleteOrg + entity-delete.controller.spec). create/update stay here.
 
   it('create: POST + addOrg + cascade("org.create")', async () => {
     const newOrg: StOrg = { guid: 'org-2', name: 'new' } as unknown as StOrg;

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-orgs-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-orgs-source.ts
@@ -2,7 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import type { StOrg } from '../endpoint-data/stratos-types';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
-import { writeWithJob } from '../async-jobs/write-with-job';
 
 // Thin mutation surface for orgs. Org list state lives on
 // EndpointDataService._orgs (the per-CNSI cache), not in a CnsiEntitySource
@@ -12,19 +11,18 @@ import { writeWithJob } from '../async-jobs/write-with-job';
 // async job to terminate, patches EndpointDataService's local cache, and
 // fires the cascade marker so cross-entity slices (spaces / apps / SI /
 // bindings) get refetched the next time they're read.
+//
+// NOTE: org *delete* no longer lives here — it routes through
+// EntityDeleteController (see CfOrgsSignalConfigService.deleteOrg) so the
+// invalidation set is derived from the relation graph (and the cold/fallback
+// path is covered). create/update stay here until Increment 2 fans the rest
+// of the entities through the controller.
 export class CnsiOrgsSource {
   constructor(
     readonly cnsiGuid: string,
     private readonly http: HttpClient,
     private readonly eds: EndpointDataService,
   ) {}
-
-  async delete(orgGuid: string): Promise<void> {
-    const call = this.http.delete(`/pp/v1/cf/orgs/${this.cnsiGuid}/${orgGuid}`, { observe: 'response' });
-    await writeWithJob(this.http, call);
-    this.eds.removeOrg(orgGuid);
-    this.eds.applyCascade('org.delete');
-  }
 
   async create(payload: unknown): Promise<StOrg> {
     const created = await firstValueFrom(

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-routes-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-routes-source.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { CnsiRoutesSource } from './cnsi-routes-source';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
@@ -21,21 +21,6 @@ describe('CnsiRoutesSource', () => {
     expect(eds.applyCascade).toHaveBeenCalledWith('route.delete');
   });
 
-  it('delete(routeGuid) goes through writeWithJob + patches _items + cascade("route.delete")', async () => {
-    const resp = {
-      resources: [{ guid: 'route-1', host: 'foo' }],
-      pagination: { totalResults: 1, totalPages: 1, next: null, previous: null, first: { href: '' }, last: { href: '' } },
-    };
-    const http = {
-      get: vi.fn(() => of(resp)),
-      delete: vi.fn(() => of(new HttpResponse({ status: 200, body: null }))),
-    } as unknown as HttpClient;
-    const eds = makeEds();
-    const src = new CnsiRoutesSource('cnsi-1', http, eds);
-    await src.load();
-    await src.delete('route-1');
-    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/routes/cnsi-1/route-1', { observe: 'response' });
-    expect(src.items().map(r => r.guid)).toEqual([]);
-    expect(eds.applyCascade).toHaveBeenCalledWith('route.delete');
-  });
+  // route delete moved to EntityDeleteController (see cf-routes-signal-config
+  // + cf-apps-signal-config deleteRoute); create + unmapApp stay here.
 });

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-routes-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-routes-source.ts
@@ -2,7 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { CnsiEntitySource } from './cnsi-entity-source';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
-import { writeWithJob } from '../async-jobs/write-with-job';
 
 export interface StRoute {
   guid: string;
@@ -24,15 +23,9 @@ export class CnsiRoutesSource extends CnsiEntitySource<StRoute> {
     super(cnsiGuid, http, pageSize);
   }
 
-  async delete(routeGuid: string): Promise<void> {
-    const call = this.http.delete(
-      `/pp/v1/cf/routes/${this.cnsiGuid}/${routeGuid}`,
-      { observe: 'response' },
-    );
-    await writeWithJob(this.http, call);
-    this.patchItems(items => items.filter(r => r.guid !== routeGuid));
-    this.eds?.applyCascade('route.delete');
-  }
+  // NOTE: route delete routes through EntityDeleteController (see
+  // CfRoutesSignalConfigService.deleteRoute + CfAppsSignalConfigService.
+  // deleteRoute); create + unmapApp (relationship-only) stay here.
 
   async create(payload: unknown): Promise<StRoute> {
     const created = await firstValueFrom(this.http.post<StRoute>(`/pp/v1/cf/routes/${this.cnsiGuid}`, payload));

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-bindings-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-bindings-source.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { CnsiServiceBindingsSource } from './cnsi-service-bindings-source';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
@@ -28,26 +28,6 @@ describe('CnsiServiceBindingsSource', () => {
     expect(eds.applyCascade).toHaveBeenCalledWith('serviceBinding.create');
   });
 
-  it('delete(bindingGuid) goes through writeWithJob + patches items + cascade("serviceBinding.delete")', async () => {
-    const http = {
-      get: vi.fn(() => of({ resources: [], pagination: { totalResults: 0, totalPages: 0, next: null, previous: null, first: { href: '' }, last: { href: '' } } })),
-      delete: vi.fn(() => of(new HttpResponse({ status: 200, body: null }))),
-    } as unknown as HttpClient;
-    const eds = makeEds();
-    const src = new CnsiServiceBindingsSource('cnsi-1', http, eds);
-    await src.delete('b-1');
-    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/service_bindings/cnsi-1/b-1', { observe: 'response' });
-    expect(eds.removeServiceCredentialBinding).toHaveBeenCalledWith('b-1');
-    expect(eds.applyCascade).toHaveBeenCalledWith('serviceBinding.delete');
-  });
-
-  it('eds is optional — source still patches its own _items without it', async () => {
-    const http = {
-      get: vi.fn(() => of({ resources: [], pagination: { totalResults: 0, totalPages: 0, next: null, previous: null, first: { href: '' }, last: { href: '' } } })),
-      delete: vi.fn(() => of(new HttpResponse({ status: 200, body: null }))),
-    } as unknown as HttpClient;
-    const src = new CnsiServiceBindingsSource('cnsi-1', http);  // no eds
-    await src.delete('b-1');  // does not throw
-    expect(http.delete).toHaveBeenCalled();
-  });
+  // binding delete moved to EntityDeleteController (see cf-apps-signal-config
+  // deleteServiceBinding + the detach-service-instance stepper); create stays.
 });

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-bindings-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-bindings-source.ts
@@ -3,7 +3,6 @@ import { firstValueFrom } from 'rxjs';
 import { CnsiEntitySource } from './cnsi-entity-source';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
 import type { StServiceCredentialBinding } from '../endpoint-data/stratos-types';
-import { writeWithJob } from '../async-jobs/write-with-job';
 
 export class CnsiServiceBindingsSource extends CnsiEntitySource<StServiceCredentialBinding> {
   protected readonly entityName = 'service_bindings';
@@ -27,14 +26,7 @@ export class CnsiServiceBindingsSource extends CnsiEntitySource<StServiceCredent
     return created;
   }
 
-  async delete(bindingGuid: string): Promise<void> {
-    const call = this.http.delete(
-      `/pp/v1/cf/service_bindings/${this.cnsiGuid}/${bindingGuid}`,
-      { observe: 'response' },
-    );
-    await writeWithJob(this.http, call);
-    this.patchItems(items => items.filter(b => b.guid !== bindingGuid));
-    this.eds?.removeServiceCredentialBinding(bindingGuid);
-    this.eds?.applyCascade('serviceBinding.delete');
-  }
+  // NOTE: binding delete routes through EntityDeleteController (see
+  // CfAppsSignalConfigService.deleteServiceBinding + the detach-service-instance
+  // stepper); create stays here.
 }

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-instances-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-instances-source.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { CnsiServiceInstancesSource } from './cnsi-service-instances-source';
 import type { StServiceInstance } from '../endpoint-data/stratos-types';
@@ -15,24 +15,8 @@ function makeEds(): EndpointDataService {
 }
 
 describe('CnsiServiceInstancesSource mutations', () => {
-  it('delete: DELETE + writeWithJob + patchItems + removeServiceInstance + cascade("serviceInstance.delete")', async () => {
-    const resp = {
-      resources: [{ guid: 'si-1', name: 'mydb' }] as unknown as StServiceInstance[],
-      pagination: { totalResults: 1, totalPages: 1, next: null, previous: null, first: { href: '' }, last: { href: '' } },
-    };
-    const http = {
-      get: vi.fn(() => of(resp)),
-      delete: vi.fn(() => of(new HttpResponse({ status: 200, body: null }))),
-    } as unknown as HttpClient;
-    const eds = makeEds();
-    const src = new CnsiServiceInstancesSource('cnsi-1', http, eds);
-    await src.load();
-    await src.delete('si-1');
-    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/service_instances/cnsi-1/si-1', { observe: 'response' });
-    expect(src.items().map(s => s.guid)).toEqual([]);
-    expect(eds.removeServiceInstance).toHaveBeenCalledWith('si-1');
-    expect(eds.applyCascade).toHaveBeenCalledWith('serviceInstance.delete');
-  });
+  // SI delete moved to EntityDeleteController (see cf-service-instances-signal-
+  // config deleteServiceInstance). create/update stay here.
 
   it('create: POST + patchItems + addServiceInstance + cascade("serviceInstance.create")', async () => {
     const created = { guid: 'si-2', name: 'cache' } as unknown as StServiceInstance;
@@ -68,18 +52,15 @@ describe('CnsiServiceInstancesSource mutations', () => {
     expect(eds.applyCascade).toHaveBeenCalledWith('serviceInstance.update');
   });
 
-  it('eds optional — source still patches its own _items', async () => {
-    const resp = {
-      resources: [{ guid: 'si-1' }] as unknown as StServiceInstance[],
-      pagination: { totalResults: 1, totalPages: 1, next: null, previous: null, first: { href: '' }, last: { href: '' } },
-    };
+  it('eds optional — create still patches its own _items without an eds', async () => {
+    const created = { guid: 'si-2', name: 'cache' } as unknown as StServiceInstance;
     const http = {
-      get: vi.fn(() => of(resp)),
-      delete: vi.fn(() => of(new HttpResponse({ status: 200, body: null }))),
+      get: vi.fn(() => of({ resources: [], pagination: { totalResults: 0, totalPages: 0, next: null, previous: null, first: { href: '' }, last: { href: '' } } })),
+      post: vi.fn(() => of(created)),
     } as unknown as HttpClient;
     const src = new CnsiServiceInstancesSource('cnsi-1', http);  // no eds
     await src.load();
-    await src.delete('si-1');
-    expect(src.items().map(s => s.guid)).toEqual([]);
+    await src.create({ name: 'cache' });
+    expect(src.items().map(s => s.guid)).toEqual(['si-2']);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-instances-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-service-instances-source.ts
@@ -3,7 +3,6 @@ import { firstValueFrom } from 'rxjs';
 import { CnsiEntitySource } from './cnsi-entity-source';
 import type { StServiceInstance } from '../endpoint-data/stratos-types';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
-import { writeWithJob } from '../async-jobs/write-with-job';
 
 // Per-CNSI source for service instances. Reads
 // /pp/v1/cf/service_instances/{cnsi}, which now emits the nested-ref
@@ -52,14 +51,7 @@ export class CnsiServiceInstancesSource extends CnsiEntitySource<StServiceInstan
     return updated;
   }
 
-  async delete(siGuid: string): Promise<void> {
-    const call = this.http.delete(
-      `/pp/v1/cf/service_instances/${this.cnsiGuid}/${siGuid}`,
-      { observe: 'response' },
-    );
-    await writeWithJob(this.http, call);
-    this.patchItems(items => items.filter(si => si.guid !== siGuid));
-    this.eds?.removeServiceInstance(siGuid);
-    this.eds?.applyCascade('serviceInstance.delete');
-  }
+  // NOTE: service-instance delete routes through EntityDeleteController (see
+  // CfServiceInstancesSignalConfigService.deleteServiceInstance); create/update
+  // stay here.
 }

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-spaces-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-spaces-source.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { CnsiSpacesSource } from './cnsi-spaces-source';
 import type { StSpace } from '../endpoint-data/stratos-types';
@@ -15,17 +15,8 @@ function makeEds(): EndpointDataService {
 }
 
 describe('CnsiSpacesSource', () => {
-  it('delete: DELETE + writeWithJob + removeSpace + cascade("space.delete")', async () => {
-    const http = {
-      delete: vi.fn(() => of(new HttpResponse({ status: 200, body: null }))),
-    } as unknown as HttpClient;
-    const eds = makeEds();
-    const src = new CnsiSpacesSource('cnsi-1', http, eds);
-    await src.delete('sp-1');
-    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/spaces/cnsi-1/sp-1', { observe: 'response' });
-    expect(eds.removeSpace).toHaveBeenCalledWith('sp-1');
-    expect(eds.applyCascade).toHaveBeenCalledWith('space.delete');
-  });
+  // Space delete moved to EntityDeleteController (see cf-spaces-signal-config
+  // deleteSpace + entity-delete.controller.spec). create/update stay here.
 
   it('create: POST + addSpace + cascade("space.create")', async () => {
     const newSpace: StSpace = { guid: 'sp-2', name: 'new' } as unknown as StSpace;

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-spaces-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-spaces-source.ts
@@ -2,25 +2,20 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import type { StSpace } from '../endpoint-data/stratos-types';
 import { EndpointDataService } from '../endpoint-data/endpoint-data.service';
-import { writeWithJob } from '../async-jobs/write-with-job';
 
 // Thin mutation surface for spaces. Mirrors CnsiOrgsSource — see that
 // file for the architectural rationale. Spaces cache lives on
 // EndpointDataService._spaces; this class patches it on success and fires
 // the cascade marker for downstream slices (apps / SI / bindings).
+//
+// NOTE: space *delete* routes through EntityDeleteController (see
+// CfSpacesSignalConfigService.deleteSpace); create/update stay here.
 export class CnsiSpacesSource {
   constructor(
     readonly cnsiGuid: string,
     private readonly http: HttpClient,
     private readonly eds: EndpointDataService,
   ) {}
-
-  async delete(spaceGuid: string): Promise<void> {
-    const call = this.http.delete(`/pp/v1/cf/spaces/${this.cnsiGuid}/${spaceGuid}`, { observe: 'response' });
-    await writeWithJob(this.http, call);
-    this.eds.removeSpace(spaceGuid);
-    this.eds.applyCascade('space.delete');
-  }
 
   async create(payload: unknown): Promise<StSpace> {
     const created = await firstValueFrom(

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { indexDescriptors } from '../../entity-relations/signal/signal-relation-tree';
 import type { RelationDescriptor } from '../../entity-relations/signal/signal-relation-types';
-import { affectedSlices } from './affected-slices';
+import { affectedSlices, referencingSlices } from './affected-slices';
 
 // ---------------------------------------------------------------------------
 // Helpers — build a RelationDescriptorRegistry from an inline descriptor list.
@@ -115,5 +115,35 @@ describe('affectedSlices', () => {
     it('returns [] against an empty registry', () => {
       expect(affectedSlices('organization', indexDescriptors([]))).toEqual([]);
     });
+  });
+});
+
+describe('referencingSlices (reverse edges, one hop)', () => {
+  it('returns the parent slice that references the type (space → org)', () => {
+    expect(referencingSlices('space', testRegistry)).toContain('orgs');
+  });
+
+  it('returns every type that references the child (route ← space)', () => {
+    // testRegistry: space → route only references route.
+    expect(referencingSlices('route', testRegistry)).toEqual(expect.arrayContaining(['spaces']));
+  });
+
+  it('returns multiple referencers when several types point at the child', () => {
+    const reg = indexDescriptors([
+      makeDescriptor('application', 'serviceCredentialBinding', 'serviceCredentialBindings'),
+      makeDescriptor('serviceInstance', 'serviceCredentialBinding', 'serviceCredentialBindings'),
+    ]);
+    expect(referencingSlices('serviceCredentialBinding', reg).sort()).toEqual(
+      ['apps', 'serviceInstances'].sort(),
+    );
+  });
+
+  it('returns [] for a type nothing references (organization is a root)', () => {
+    expect(referencingSlices('organization', testRegistry)).toEqual([]);
+  });
+
+  it('de-duplicates referencer slices', () => {
+    const result = referencingSlices('route', testRegistry);
+    expect(result).toHaveLength(new Set(result).size);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { indexDescriptors } from '../../entity-relations/signal/signal-relation-tree';
+import type { RelationDescriptor } from '../../entity-relations/signal/signal-relation-types';
+import { affectedSlices } from './affected-slices';
+
+// ---------------------------------------------------------------------------
+// Helpers — build a RelationDescriptorRegistry from an inline descriptor list.
+// We use `indexDescriptors` from the substrate (same function the service
+// uses internally) so the registry shape is identical to production.
+// fetchChildren is a no-op stub: affectedSlices is pure/sync and never calls it.
+// ---------------------------------------------------------------------------
+
+const stub = (): never => { throw new Error('fetchChildren must not be called in affectedSlices'); };
+
+function makeDescriptor(
+  parentEntityType: string,
+  childEntityType: string,
+  paramName: string,
+): RelationDescriptor {
+  return { parentEntityType, childEntityType, paramName, isArray: true, fetchChildren: stub };
+}
+
+// ---------------------------------------------------------------------------
+// Test registry: org -> spaces, space -> apps, space -> routes,
+//                app -> serviceCredentialBindings
+// ---------------------------------------------------------------------------
+
+const ORG_SPACE   = makeDescriptor('organization', 'space',                     'spaces');
+const SPACE_APP   = makeDescriptor('space',        'application',               'apps');
+const SPACE_ROUTE = makeDescriptor('space',        'route',                     'routes');
+const APP_SCB     = makeDescriptor('application',  'serviceCredentialBinding',  'serviceCredentialBindings');
+
+const testRegistry = indexDescriptors([ORG_SPACE, SPACE_APP, SPACE_ROUTE, APP_SCB]);
+
+// ---------------------------------------------------------------------------
+// Specs
+// ---------------------------------------------------------------------------
+
+describe('affectedSlices', () => {
+  describe('organization root — full transitive closure', () => {
+    it('contains spaces (direct child)', () => {
+      expect(affectedSlices('organization', testRegistry)).toContain('spaces');
+    });
+
+    it('contains apps (org → space → app)', () => {
+      expect(affectedSlices('organization', testRegistry)).toContain('apps');
+    });
+
+    it('contains routes (org → space → route)', () => {
+      expect(affectedSlices('organization', testRegistry)).toContain('routes');
+    });
+
+    it('contains serviceCredentialBindings (org → space → app → scb)', () => {
+      expect(affectedSlices('organization', testRegistry)).toContain('serviceCredentialBindings');
+    });
+
+    it('does not contain the root type itself (organizations)', () => {
+      const result = affectedSlices('organization', testRegistry);
+      expect(result).not.toContain('orgs');
+    });
+
+    it('returns no duplicate slice names', () => {
+      const result = affectedSlices('organization', testRegistry);
+      expect(result).toHaveLength(new Set(result).size);
+    });
+  });
+
+  describe('space root — partial closure, no parent types', () => {
+    it('contains apps', () => {
+      expect(affectedSlices('space', testRegistry)).toContain('apps');
+    });
+
+    it('contains routes', () => {
+      expect(affectedSlices('space', testRegistry)).toContain('routes');
+    });
+
+    it('contains serviceCredentialBindings (space → app → scb)', () => {
+      expect(affectedSlices('space', testRegistry)).toContain('serviceCredentialBindings');
+    });
+
+    it('does NOT contain spaces (that is the root level)', () => {
+      expect(affectedSlices('space', testRegistry)).not.toContain('spaces');
+    });
+  });
+
+  describe('cycle safety', () => {
+    it('does not infinite-loop on a cyclic registry (org → space, space → org)', () => {
+      const cyclicRegistry = indexDescriptors([
+        makeDescriptor('organization', 'space', 'spaces'),
+        makeDescriptor('space', 'organization', 'orgs'),
+      ]);
+      // Must return a finite result without hanging.
+      const result = affectedSlices('organization', cyclicRegistry);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('returns a finite, de-duplicated set from a cyclic registry', () => {
+      const cyclicRegistry = indexDescriptors([
+        makeDescriptor('organization', 'space', 'spaces'),
+        makeDescriptor('space', 'organization', 'orgs'),
+      ]);
+      const result = affectedSlices('organization', cyclicRegistry);
+      expect(result).toHaveLength(new Set(result).size);
+      // Both reachable child types should appear.
+      expect(result).toContain('spaces');
+      expect(result).toContain('orgs');
+    });
+  });
+
+  describe('unknown root', () => {
+    it('returns [] when root has no registered descriptors', () => {
+      expect(affectedSlices('unknownType', testRegistry)).toEqual([]);
+    });
+
+    it('returns [] against an empty registry', () => {
+      expect(affectedSlices('organization', indexDescriptors([]))).toEqual([]);
+    });
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.ts
@@ -85,3 +85,37 @@ export function affectedSlices(
   walk(rootEntityType);
   return slices;
 }
+
+/**
+ * Return the EDS slice names of entity types that **reference**
+ * `rootEntityType` as a direct child in the relation graph (reverse edges,
+ * one hop).
+ *
+ * Deleting an entity changes the relationship lists/counts embedded in its
+ * parents' and siblings' list rows — e.g. deleting a space decrements the
+ * org's "spaces" count; deleting a service binding changes the bound-app and
+ * bound-instance lists. `affectedSlices` (descendants) cannot see these, so
+ * the delete chokepoint unions both. This is what preserves — and corrects —
+ * the non-containment cascades the legacy hand-curated `cascade-registry` had
+ * (route→apps, serviceBinding→apps+serviceInstances), without re-encoding them
+ * by hand: they fall straight out of the same descriptors, walked in reverse.
+ *
+ * Pure and synchronous.
+ */
+export function referencingSlices(
+  rootEntityType: string,
+  registry: RelationDescriptorRegistry,
+): string[] {
+  const slices: string[] = [];
+  for (const [parentEntityType, descriptors] of registry) {
+    const references = descriptors.some(d => d.childEntityType === rootEntityType);
+    if (!references) {
+      continue;
+    }
+    const slice = ENTITY_TYPE_TO_SLICE[parentEntityType];
+    if (slice && !slices.includes(slice)) {
+      slices.push(slice);
+    }
+  }
+  return slices;
+}

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/affected-slices.ts
@@ -1,0 +1,87 @@
+// Pure helper: derive the full transitive set of EDS slice names whose
+// lists can be invalidated by deleting an entity of `rootEntityType`.
+//
+// CLOSURE APPROACH: direct registry walk (not buildSignalRelationTree).
+//
+// buildSignalRelationTree filters by an `includeRelations` allowlist —
+// if we used it we would have to first enumerate all reachable relation
+// keys (a graph walk), then call buildSignalRelationTree with that set
+// (another graph walk). That's two passes over the same graph for no
+// benefit. Walking the registry directly in one DFS pass is simpler,
+// requires no external state, and is easier to follow. It also avoids
+// the tree cache side-effects which would pollute other tests if we
+// called buildSignalRelationTree here.
+//
+// Guard against cycles: track visited entity types in a Set<string>.
+// Because we only care about which types are reachable (not the relation
+// key path), a simple "have we started processing this type?" guard is
+// sufficient — we stop the DFS as soon as we see a type we've already
+// enqueued.
+
+import type { RelationDescriptorRegistry } from '../../entity-relations/signal/signal-relation-tree';
+
+// ---------------------------------------------------------------------------
+// entityType → EDS slice name map
+//
+// `childEntityType` in RelationDescriptor uses EntitySchema-style singular
+// names.  EDS slices in EndpointDataService / cascade-registry.ts use the
+// plural collection key.  This map is the single translation table; keep it
+// documented and complete.  `routes` is included even though EntityKind does
+// not yet list it — the graph tells the truth and the EDS gap is a downstream
+// task (see cascade-registry.ts TODO).
+// ---------------------------------------------------------------------------
+
+export const ENTITY_TYPE_TO_SLICE: Readonly<Record<string, string>> = {
+  organization:              'orgs',
+  space:                     'spaces',
+  application:               'apps',
+  route:                     'routes',
+  serviceInstance:           'serviceInstances',
+  serviceOffering:           'serviceOfferings',
+  servicePlan:               'servicePlans',
+  serviceBroker:             'serviceBrokers',
+  serviceCredentialBinding:  'serviceCredentialBindings',
+};
+
+/**
+ * Return the de-duplicated set of EDS slice names for every entity type
+ * transitively reachable as a **child** of `rootEntityType` in the
+ * registered relation graph.  These are the slices whose lists a delete
+ * of `rootEntityType` can invalidate.
+ *
+ * Pure and synchronous — no Angular, no HTTP, no signals.
+ */
+export function affectedSlices(
+  rootEntityType: string,
+  registry: RelationDescriptorRegistry,
+): string[] {
+  const slices: string[] = [];
+  // visited tracks entity types we have already started expanding so we
+  // terminate on cycles (org→space→org) and avoid duplicate expansions.
+  const visited = new Set<string>();
+
+  function walk(entityType: string): void {
+    if (visited.has(entityType)) {
+      return;
+    }
+    visited.add(entityType);
+
+    const children = registry.get(entityType);
+    if (!children) {
+      return;
+    }
+
+    for (const descriptor of children) {
+      const slice = ENTITY_TYPE_TO_SLICE[descriptor.childEntityType];
+      if (slice && !slices.includes(slice)) {
+        slices.push(slice);
+      }
+      // Recurse regardless of whether we know the slice name — the child
+      // may itself have further children we need to collect.
+      walk(descriptor.childEntityType);
+    }
+  }
+
+  walk(rootEntityType);
+  return slices;
+}

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/delete-event.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/delete-event.types.ts
@@ -1,0 +1,31 @@
+import { Observable } from 'rxjs';
+import { HttpResponse } from '@angular/common/http';
+
+export type DeleteState = 'start' | 'in-process' | 'success' | 'failure' | 'blocked';
+
+export type BlockReason = 'has-dependents' | 'operation-in-progress' | 'forbidden';
+
+export interface DeleteEvent {
+  state: DeleteState;
+  cnsiName: string;
+  cnsiGuid: string;
+  deleteName: string;
+  deleteGuid: string;
+  entityKind: string;
+  reason?: BlockReason;
+  error?: unknown;
+}
+
+export interface DeleteRequest {
+  cnsiGuid: string;
+  cnsiName: string;
+  entityKind: string;
+  deleteGuid: string;
+  deleteName: string;
+  call: () => Observable<HttpResponse<unknown>>;
+}
+
+export interface DeleteHandle {
+  events$: Observable<DeleteEvent>;
+  done: Promise<DeleteEvent>;
+}

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/delete-event.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/delete-event.types.ts
@@ -12,6 +12,7 @@ export interface DeleteEvent {
   deleteName: string;
   deleteGuid: string;
   entityKind: string;
+  /** Populated when state === 'blocked'. */
   reason?: BlockReason;
   error?: unknown;
 }

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/delete-event.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/delete-event.types.ts
@@ -30,3 +30,11 @@ export interface DeleteHandle {
   events$: Observable<DeleteEvent>;
   done: Promise<DeleteEvent>;
 }
+
+/**
+ * Hook invoked after a successful delete so subscribers (favorites, recents)
+ * can clean up references to the removed entity. Runs regardless of whether an
+ * EndpointDataService cache exists for the endpoint — favorites/recents live
+ * outside the per-cnsi cache.
+ */
+export type DeleteCleanupHook = (req: DeleteRequest) => void;

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
@@ -1,0 +1,143 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { AsyncJobResult } from '../async-jobs/async-job.types';
+import { StratosJobError } from '../async-jobs/async-job.types';
+import { EntityDeleteController, WRITE_WITH_JOB } from './entity-delete.controller';
+import type { DeleteRequest } from './delete-event.types';
+
+// ---------------------------------------------------------------------------
+// Shared request fixture
+// ---------------------------------------------------------------------------
+
+const makeRequest = (): DeleteRequest => ({
+  cnsiGuid: 'cnsi-guid-1',
+  cnsiName: 'My CF',
+  entityKind: 'app',
+  deleteGuid: 'app-guid-1',
+  deleteName: 'my-app',
+  call: () => of(new HttpResponse({ status: 200 })),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Drain the microtask queue so ReplaySubject emissions are synchronously visible. */
+const tick = async (): Promise<void> => {
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve();
+  }
+};
+
+/** Collect all events$ emissions into an array then return them. */
+const collectStates = async (ctrl: EntityDeleteController, req: DeleteRequest): Promise<string[]> => {
+  const states: string[] = [];
+  const handle = ctrl.delete(req);
+  // Subscribe before the done resolves.
+  handle.events$.subscribe(e => states.push(e.state));
+  await handle.done;
+  return states;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EntityDeleteController', () => {
+  describe('happy path — write resolves COMPLETE', () => {
+    let ctrl: EntityDeleteController;
+
+    beforeEach(() => {
+      const fakeWrite = async (): Promise<AsyncJobResult<void>> => ({ status: 'COMPLETE', state: undefined });
+
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          EntityDeleteController,
+          { provide: WRITE_WITH_JOB, useValue: fakeWrite },
+        ],
+      });
+      ctrl = TestBed.inject(EntityDeleteController);
+    });
+
+    it('emits states [start, success]', async () => {
+      const states = await collectStates(ctrl, makeRequest());
+      expect(states).toEqual(['start', 'success']);
+    });
+
+    it('done resolves with state success and request payload fields', async () => {
+      const req = makeRequest();
+      const handle = ctrl.delete(req);
+      const terminal = await handle.done;
+
+      expect(terminal.state).toBe('success');
+      expect(terminal.cnsiGuid).toBe(req.cnsiGuid);
+      expect(terminal.cnsiName).toBe(req.cnsiName);
+      expect(terminal.entityKind).toBe(req.entityKind);
+      expect(terminal.deleteGuid).toBe(req.deleteGuid);
+      expect(terminal.deleteName).toBe(req.deleteName);
+      expect(terminal.error).toBeUndefined();
+    });
+
+    it('a late subscriber still receives all events via ReplaySubject', async () => {
+      const req = makeRequest();
+      const handle = ctrl.delete(req);
+      await handle.done;
+
+      // Subscribe AFTER the stream has completed.
+      const states: string[] = [];
+      handle.events$.subscribe(e => states.push(e.state));
+      expect(states).toEqual(['start', 'success']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe('failure path — write throws', () => {
+    let ctrl: EntityDeleteController;
+    const writeError = new StratosJobError({
+      id: 'job-fail',
+      kind: 'cf.app.delete',
+      state: 'FAILED',
+      startedAt: '',
+      updatedAt: '',
+      errors: [{ code: 'cf.500', message: 'internal error' }],
+    });
+
+    beforeEach(() => {
+      const fakeWrite = async (): Promise<never> => { throw writeError; };
+
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          EntityDeleteController,
+          { provide: WRITE_WITH_JOB, useValue: fakeWrite },
+        ],
+      });
+      ctrl = TestBed.inject(EntityDeleteController);
+    });
+
+    it('emits states [start, failure]', async () => {
+      const states = await collectStates(ctrl, makeRequest());
+      expect(states).toEqual(['start', 'failure']);
+    });
+
+    it('done resolves with state failure and error attached', async () => {
+      const req = makeRequest();
+      const handle = ctrl.delete(req);
+      const terminal = await handle.done;
+
+      expect(terminal.state).toBe('failure');
+      expect(terminal.error).toBe(writeError);
+    });
+
+    it('done resolves (does not reject) even when write throws', async () => {
+      // The done promise must never reject — the caller reads the terminal event.
+      const req = makeRequest();
+      await expect(ctrl.delete(req).done).resolves.toBeDefined();
+    });
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
+import { config as rxjsConfig } from 'rxjs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { AsyncJobResult } from '../async-jobs/async-job.types';
 import { StratosJobError } from '../async-jobs/async-job.types';
@@ -24,13 +25,6 @@ const makeRequest = (): DeleteRequest => ({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Drain the microtask queue so ReplaySubject emissions are synchronously visible. */
-const tick = async (): Promise<void> => {
-  for (let i = 0; i < 4; i++) {
-    await Promise.resolve();
-  }
-};
 
 /** Collect all events$ emissions into an array then return them. */
 const collectStates = async (ctrl: EntityDeleteController, req: DeleteRequest): Promise<string[]> => {
@@ -91,6 +85,27 @@ describe('EntityDeleteController', () => {
       const states: string[] = [];
       handle.events$.subscribe(e => states.push(e.state));
       expect(states).toEqual(['start', 'success']);
+    });
+
+    it('done still resolves with success even when a subscriber next handler throws synchronously', async () => {
+      // RxJS v7 defers uncaught observer errors via setTimeout (reportUnhandledError).
+      // Install a no-op handler so that deliberate throws in this test don't leak
+      // as vitest "unhandled errors".  Drain the macrotask queue before restoring so
+      // the deferred setTimeout fires while the handler is still installed.
+      const prevHandler = rxjsConfig.onUnhandledError;
+      rxjsConfig.onUnhandledError = () => { /* expected: observer intentionally throws */ };
+
+      const req = makeRequest();
+      const handle = ctrl.delete(req);
+      // Subscribe with a handler that throws on every event.
+      handle.events$.subscribe(() => { throw new Error('observer exploded'); });
+      // done must settle and carry the success terminal — not hang or reject.
+      const terminal = await handle.done;
+      // Drain macrotasks so the RxJS-deferred rethrow fires before we restore.
+      await new Promise<void>(r => setTimeout(r, 0));
+
+      rxjsConfig.onUnhandledError = prevHandler;
+      expect(terminal.state).toBe('success');
     });
   });
 

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
@@ -3,9 +3,14 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
 import { config as rxjsConfig } from 'rxjs';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AsyncJobResult } from '../async-jobs/async-job.types';
 import { StratosJobError } from '../async-jobs/async-job.types';
+import { EndpointDataRegistry } from '../endpoint-data/endpoint-data.registry';
+import { SignalRelationFetcherService } from '../../entity-relations/signal/signal-relation-fetcher.service';
+import { indexDescriptors } from '../../entity-relations/signal/signal-relation-tree';
+import { CF_RELATION_DESCRIPTORS } from '../../entity-relations/signal/cf-relation-registrations';
+import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
 import { EntityDeleteController, WRITE_WITH_JOB } from './entity-delete.controller';
 import type { DeleteRequest } from './delete-event.types';
 
@@ -25,6 +30,17 @@ const makeRequest = (): DeleteRequest => ({
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// Lightweight fakes for the invalidation collaborators the controller injects.
+// The lifecycle-only describe blocks below don't exercise invalidation, but
+// the controller still resolves these at construction, so every TestBed needs
+// them. peek() → undefined keeps invalidation a no-op; an empty relation
+// registry yields no affected slices.
+const stubInvalidationProviders = () => [
+  { provide: EndpointDataRegistry, useValue: { peek: () => undefined } },
+  { provide: SignalRelationFetcherService, useValue: { snapshotRegistry: () => indexDescriptors([]) } },
+  { provide: StratosDiagnostics, useValue: { emitCounter: () => { /* noop */ } } },
+];
 
 /** Collect all events$ emissions into an array then return them. */
 const collectStates = async (ctrl: EntityDeleteController, req: DeleteRequest): Promise<string[]> => {
@@ -52,6 +68,7 @@ describe('EntityDeleteController', () => {
           provideZonelessChangeDetection(),
           EntityDeleteController,
           { provide: WRITE_WITH_JOB, useValue: fakeWrite },
+          ...stubInvalidationProviders(),
         ],
       });
       ctrl = TestBed.inject(EntityDeleteController);
@@ -130,6 +147,7 @@ describe('EntityDeleteController', () => {
           provideZonelessChangeDetection(),
           EntityDeleteController,
           { provide: WRITE_WITH_JOB, useValue: fakeWrite },
+          ...stubInvalidationProviders(),
         ],
       });
       ctrl = TestBed.inject(EntityDeleteController);
@@ -153,6 +171,122 @@ describe('EntityDeleteController', () => {
       // The done promise must never reject — the caller reads the terminal event.
       const req = makeRequest();
       await expect(ctrl.delete(req).done).resolves.toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Invalidation + cleanup on the success path (Task 4). The controller walks
+  // the relation graph for the deleted entity, marks every affected EDS slice
+  // stale, removes the deleted row, and fires registered cleanup hooks. This
+  // is the mechanism that closes the silently-dropped-delete bug.
+  // -------------------------------------------------------------------------
+
+  describe('invalidation + cleanup on success', () => {
+    const ORG_REQUEST: DeleteRequest = {
+      cnsiGuid: 'cnsi-guid-1',
+      cnsiName: 'My CF',
+      entityKind: 'organization',
+      deleteGuid: 'org-guid-1',
+      deleteName: 'demo-org',
+      call: () => of(new HttpResponse({ status: 200 })),
+    };
+
+    const makeEds = () => ({
+      markStale: vi.fn(),
+      removeOrg: vi.fn(),
+      removeSpace: vi.fn(),
+      removeApp: vi.fn(),
+      removeServiceInstance: vi.fn(),
+      removeServiceCredentialBinding: vi.fn(),
+    });
+
+    const configure = (opts: { eds: ReturnType<typeof makeEds> | undefined }) => {
+      const diag = { emitCounter: vi.fn() };
+      const registry = { peek: vi.fn(() => opts.eds) };
+      const relations = { snapshotRegistry: () => indexDescriptors(CF_RELATION_DESCRIPTORS) };
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          EntityDeleteController,
+          { provide: WRITE_WITH_JOB, useValue: async () => ({ status: 'COMPLETE', state: undefined } as AsyncJobResult<void>) },
+          { provide: EndpointDataRegistry, useValue: registry },
+          { provide: SignalRelationFetcherService, useValue: relations },
+          { provide: StratosDiagnostics, useValue: diag },
+        ],
+      });
+      return { ctrl: TestBed.inject(EntityDeleteController), diag, registry };
+    };
+
+    it('marks every relation-graph slice of the deleted org stale', async () => {
+      const eds = makeEds();
+      const { ctrl } = configure({ eds });
+      await ctrl.delete(ORG_REQUEST).done;
+
+      const marked = eds.markStale.mock.calls.map(c => c[0]);
+      expect(marked).toEqual(
+        expect.arrayContaining(['spaces', 'apps', 'routes', 'serviceInstances', 'serviceCredentialBindings']),
+      );
+    });
+
+    it('removes the deleted org row from the EDS cache', async () => {
+      const eds = makeEds();
+      const { ctrl } = configure({ eds });
+      await ctrl.delete(ORG_REQUEST).done;
+      expect(eds.removeOrg).toHaveBeenCalledWith('org-guid-1');
+    });
+
+    it('invokes registered cleanup hooks with the request', async () => {
+      const eds = makeEds();
+      const { ctrl } = configure({ eds });
+      const hook = vi.fn();
+      ctrl.registerCleanup(hook);
+      await ctrl.delete(ORG_REQUEST).done;
+      expect(hook).toHaveBeenCalledWith(ORG_REQUEST);
+    });
+
+    it('emits a delete-event success diagnostics counter', async () => {
+      const eds = makeEds();
+      const { ctrl, diag } = configure({ eds });
+      await ctrl.delete(ORG_REQUEST).done;
+      expect(diag.emitCounter).toHaveBeenCalledWith('delete-event', {
+        state: 'success',
+        entityKind: 'organization',
+      });
+    });
+
+    it('does not throw and still runs cleanup when no EDS instance is cached', async () => {
+      const { ctrl } = configure({ eds: undefined });
+      const hook = vi.fn();
+      ctrl.registerCleanup(hook);
+      const terminal = await ctrl.delete(ORG_REQUEST).done;
+      expect(terminal.state).toBe('success');
+      expect(hook).toHaveBeenCalledWith(ORG_REQUEST);
+    });
+
+    it('does not invalidate or run cleanup on the failure path', async () => {
+      const eds = makeEds();
+      const diag = { emitCounter: vi.fn() };
+      const registry = { peek: vi.fn(() => eds) };
+      const relations = { snapshotRegistry: () => indexDescriptors(CF_RELATION_DESCRIPTORS) };
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          EntityDeleteController,
+          { provide: WRITE_WITH_JOB, useValue: async () => { throw new Error('boom'); } },
+          { provide: EndpointDataRegistry, useValue: registry },
+          { provide: SignalRelationFetcherService, useValue: relations },
+          { provide: StratosDiagnostics, useValue: diag },
+        ],
+      });
+      const ctrl = TestBed.inject(EntityDeleteController);
+      const hook = vi.fn();
+      ctrl.registerCleanup(hook);
+      const terminal = await ctrl.delete(ORG_REQUEST).done;
+
+      expect(terminal.state).toBe('failure');
+      expect(eds.markStale).not.toHaveBeenCalled();
+      expect(eds.removeOrg).not.toHaveBeenCalled();
+      expect(hook).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
@@ -34,7 +34,7 @@ export class EntityDeleteController {
   private readonly writeFn = inject(WRITE_WITH_JOB);
 
   delete(req: DeleteRequest): DeleteHandle {
-    const subject = new ReplaySubject<DeleteEvent>();
+    const subject = new ReplaySubject<DeleteEvent>(3);
 
     // Base fields shared by every event in this lifecycle.
     const base: Omit<DeleteEvent, 'state'> = {
@@ -45,25 +45,25 @@ export class EntityDeleteController {
       deleteName: req.deleteName,
     };
 
-    const done = new Promise<DeleteEvent>((resolve) => {
-      // Kick off the async operation; subscription happens inside.
-      (async () => {
-        const startEvent: DeleteEvent = { ...base, state: 'start' };
-        subject.next(startEvent);
+    // Wrap subject.next so a synchronous observer throw cannot abort the
+    // lifecycle — the terminal event and done resolution must always happen.
+    const safeNext = (event: DeleteEvent): void => {
+      try { subject.next(event); } catch { /* observer threw */ }
+    };
 
-        let terminal: DeleteEvent;
-        try {
-          await this.writeFn(this.http, req.call());
-          terminal = { ...base, state: 'success' };
-        } catch (error: unknown) {
-          terminal = { ...base, state: 'failure', error };
-        }
-
-        subject.next(terminal);
-        subject.complete();
-        resolve(terminal);
-      })();
-    });
+    const done = (async (): Promise<DeleteEvent> => {
+      let terminal: DeleteEvent;
+      try {
+        safeNext({ ...base, state: 'start' });
+        await this.writeFn(this.http, req.call());
+        terminal = { ...base, state: 'success' };
+      } catch (error: unknown) {
+        terminal = { ...base, state: 'failure', error };
+      }
+      safeNext(terminal);
+      try { subject.complete(); } catch { /* observer threw */ }
+      return terminal;
+    })();
 
     return { events$: subject.asObservable(), done };
   }

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
@@ -1,0 +1,70 @@
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { inject, Injectable, InjectionToken } from '@angular/core';
+import { Observable, ReplaySubject } from 'rxjs';
+import type { AsyncJobResult } from '../async-jobs/async-job.types';
+import { writeWithJob } from '../async-jobs/write-with-job';
+import type { DeleteEvent, DeleteHandle, DeleteRequest } from './delete-event.types';
+
+// ---------------------------------------------------------------------------
+// Injection token — lets tests supply a fake without touching HttpClient.
+// The default factory delegates to the real writeWithJob import so the
+// production code path is unchanged.
+// ---------------------------------------------------------------------------
+
+export type WriteWithJobFn = (
+  http: HttpClient,
+  call$: Observable<HttpResponse<unknown>>,
+) => Promise<AsyncJobResult<unknown>>;
+
+export const WRITE_WITH_JOB = new InjectionToken<WriteWithJobFn>(
+  'WRITE_WITH_JOB',
+  {
+    providedIn: 'root',
+    factory: () => writeWithJob,
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------------
+
+@Injectable({ providedIn: 'root' })
+export class EntityDeleteController {
+  private readonly http = inject(HttpClient);
+  private readonly writeFn = inject(WRITE_WITH_JOB);
+
+  delete(req: DeleteRequest): DeleteHandle {
+    const subject = new ReplaySubject<DeleteEvent>();
+
+    // Base fields shared by every event in this lifecycle.
+    const base: Omit<DeleteEvent, 'state'> = {
+      cnsiGuid: req.cnsiGuid,
+      cnsiName: req.cnsiName,
+      entityKind: req.entityKind,
+      deleteGuid: req.deleteGuid,
+      deleteName: req.deleteName,
+    };
+
+    const done = new Promise<DeleteEvent>((resolve) => {
+      // Kick off the async operation; subscription happens inside.
+      (async () => {
+        const startEvent: DeleteEvent = { ...base, state: 'start' };
+        subject.next(startEvent);
+
+        let terminal: DeleteEvent;
+        try {
+          await this.writeFn(this.http, req.call());
+          terminal = { ...base, state: 'success' };
+        } catch (error: unknown) {
+          terminal = { ...base, state: 'failure', error };
+        }
+
+        subject.next(terminal);
+        subject.complete();
+        resolve(terminal);
+      })();
+    });
+
+    return { events$: subject.asObservable(), done };
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
@@ -8,7 +8,7 @@ import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
 import { EndpointDataRegistry } from '../endpoint-data/endpoint-data.registry';
 import type { EndpointDataService } from '../endpoint-data/endpoint-data.service';
 import { SignalRelationFetcherService } from '../../entity-relations/signal/signal-relation-fetcher.service';
-import { affectedSlices } from './affected-slices';
+import { affectedSlices, ENTITY_TYPE_TO_SLICE, referencingSlices } from './affected-slices';
 import type { DeleteCleanupHook, DeleteEvent, DeleteHandle, DeleteRequest } from './delete-event.types';
 
 // ---------------------------------------------------------------------------
@@ -108,22 +108,35 @@ export class EntityDeleteController {
     return { events$: subject.asObservable(), done };
   }
 
-  // On success: walk the relation graph for the deleted entity, mark every
-  // affected EDS slice stale, remove the deleted row, then fire cleanup hooks.
-  // Each step is isolated so one failure can't strand the others or reject the
-  // done promise. Cleanup hooks run even without a cached EDS — favorites and
-  // recents live outside the per-cnsi cache.
+  // On success: derive the full invalidation set from the relation graph —
+  // descendants (affectedSlices, containment) UNION referencing parents/siblings
+  // (referencingSlices, reverse edges, so parent count columns + sibling
+  // relationship lists refresh). Remove the deleted row, then fire cleanup
+  // hooks. Each step is isolated so one failure can't strand the others or
+  // reject the done promise. Cleanup hooks run even without a cached EDS —
+  // favorites and recents live outside the per-cnsi cache.
   private invalidateAndCleanup(req: DeleteRequest): void {
     const eds = this.endpoints.peek(req.cnsiGuid);
     if (eds) {
+      const remover = ROW_REMOVERS[req.entityKind];
+      const slices = new Set<string>();
       try {
-        for (const slice of affectedSlices(req.entityKind, this.relations.snapshotRegistry())) {
-          eds.markStale(slice as EntityKind);
-        }
+        const registry = this.relations.snapshotRegistry();
+        affectedSlices(req.entityKind, registry).forEach(s => slices.add(s));
+        referencingSlices(req.entityKind, registry).forEach(s => slices.add(s));
       } catch { /* invalidation is best-effort */ }
-      try {
-        ROW_REMOVERS[req.entityKind]?.(eds, req.deleteGuid);
-      } catch { /* row removal is best-effort */ }
+      // Count-only slices (e.g. routes) have no row list to patch, so there is
+      // no remover — mark the entity's own slice stale to refetch its count.
+      if (!remover) {
+        const ownSlice = ENTITY_TYPE_TO_SLICE[req.entityKind];
+        if (ownSlice) slices.add(ownSlice);
+      }
+      for (const slice of slices) {
+        try { eds.markStale(slice as EntityKind); } catch { /* per-slice best-effort */ }
+      }
+      if (remover) {
+        try { remover(eds, req.deleteGuid); } catch { /* row removal is best-effort */ }
+      }
     }
     for (const cleanup of this.cleanups) {
       try { cleanup(req); } catch { /* one bad hook can't block the rest */ }

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
@@ -3,7 +3,13 @@ import { inject, Injectable, InjectionToken } from '@angular/core';
 import { Observable, ReplaySubject } from 'rxjs';
 import type { AsyncJobResult } from '../async-jobs/async-job.types';
 import { writeWithJob } from '../async-jobs/write-with-job';
-import type { DeleteEvent, DeleteHandle, DeleteRequest } from './delete-event.types';
+import type { EntityKind } from '../data-sources/cascade-registry';
+import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
+import { EndpointDataRegistry } from '../endpoint-data/endpoint-data.registry';
+import type { EndpointDataService } from '../endpoint-data/endpoint-data.service';
+import { SignalRelationFetcherService } from '../../entity-relations/signal/signal-relation-fetcher.service';
+import { affectedSlices } from './affected-slices';
+import type { DeleteCleanupHook, DeleteEvent, DeleteHandle, DeleteRequest } from './delete-event.types';
 
 // ---------------------------------------------------------------------------
 // Injection token — lets tests supply a fake without touching HttpClient.
@@ -25,6 +31,22 @@ export const WRITE_WITH_JOB = new InjectionToken<WriteWithJobFn>(
 );
 
 // ---------------------------------------------------------------------------
+// entityKind → EndpointDataService row-remover. Removing the deleted row keeps
+// the originating slice consistent locally without a refetch; the *child*
+// slices (from affectedSlices) are marked stale instead. Routes are a
+// count-only slice with no row list, so they have no remover — they're handled
+// purely via markStale('routes').
+// ---------------------------------------------------------------------------
+
+const ROW_REMOVERS: Readonly<Record<string, (eds: EndpointDataService, guid: string) => void>> = {
+  organization: (eds, guid) => eds.removeOrg(guid),
+  space: (eds, guid) => eds.removeSpace(guid),
+  application: (eds, guid) => eds.removeApp(guid),
+  serviceInstance: (eds, guid) => eds.removeServiceInstance(guid),
+  serviceCredentialBinding: (eds, guid) => eds.removeServiceCredentialBinding(guid),
+};
+
+// ---------------------------------------------------------------------------
 // Controller
 // ---------------------------------------------------------------------------
 
@@ -32,6 +54,18 @@ export const WRITE_WITH_JOB = new InjectionToken<WriteWithJobFn>(
 export class EntityDeleteController {
   private readonly http = inject(HttpClient);
   private readonly writeFn = inject(WRITE_WITH_JOB);
+  private readonly endpoints = inject(EndpointDataRegistry);
+  private readonly relations = inject(SignalRelationFetcherService);
+  private readonly diagnostics = inject(StratosDiagnostics);
+
+  // Cleanup subscribers (favorites, recents). Registered once at bootstrap;
+  // invoked after every successful delete.
+  private readonly cleanups: DeleteCleanupHook[] = [];
+
+  /** Register a cleanup hook fired after each successful delete. */
+  registerCleanup(hook: DeleteCleanupHook): void {
+    this.cleanups.push(hook);
+  }
 
   delete(req: DeleteRequest): DeleteHandle {
     const subject = new ReplaySubject<DeleteEvent>(3);
@@ -49,6 +83,9 @@ export class EntityDeleteController {
     // lifecycle — the terminal event and done resolution must always happen.
     const safeNext = (event: DeleteEvent): void => {
       try { subject.next(event); } catch { /* observer threw */ }
+      try {
+        this.diagnostics.emitCounter('delete-event', { state: event.state, entityKind: event.entityKind });
+      } catch { /* diagnostics must never break the lifecycle */ }
     };
 
     const done = (async (): Promise<DeleteEvent> => {
@@ -56,6 +93,9 @@ export class EntityDeleteController {
       try {
         safeNext({ ...base, state: 'start' });
         await this.writeFn(this.http, req.call());
+        // Invalidate caches + run cleanup BEFORE emitting success so a
+        // success observer sees a consistent post-delete world.
+        this.invalidateAndCleanup(req);
         terminal = { ...base, state: 'success' };
       } catch (error: unknown) {
         terminal = { ...base, state: 'failure', error };
@@ -66,5 +106,27 @@ export class EntityDeleteController {
     })();
 
     return { events$: subject.asObservable(), done };
+  }
+
+  // On success: walk the relation graph for the deleted entity, mark every
+  // affected EDS slice stale, remove the deleted row, then fire cleanup hooks.
+  // Each step is isolated so one failure can't strand the others or reject the
+  // done promise. Cleanup hooks run even without a cached EDS — favorites and
+  // recents live outside the per-cnsi cache.
+  private invalidateAndCleanup(req: DeleteRequest): void {
+    const eds = this.endpoints.peek(req.cnsiGuid);
+    if (eds) {
+      try {
+        for (const slice of affectedSlices(req.entityKind, this.relations.snapshotRegistry())) {
+          eds.markStale(slice as EntityKind);
+        }
+      } catch { /* invalidation is best-effort */ }
+      try {
+        ROW_REMOVERS[req.entityKind]?.(eds, req.deleteGuid);
+      } catch { /* row removal is best-effort */ }
+    }
+    for (const cleanup of this.cleanups) {
+      try { cleanup(req); } catch { /* one bad hook can't block the rest */ }
+    }
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/favorites-recents-cleanup.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/favorites-recents-cleanup.service.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { RemoveRecentEntityAction, RemoveUserFavoriteAction, UserFavorite } from '@stratosui/store';
+import { FavoritesRecentsDeleteCleanup } from './favorites-recents-cleanup.service';
+import type { DeleteRequest } from './delete-event.types';
+
+const ORG_REQUEST: DeleteRequest = {
+  cnsiGuid: 'cnsi-1',
+  cnsiName: 'My CF',
+  entityKind: 'organization',
+  deleteGuid: 'org-1',
+  deleteName: 'demo-org',
+  call: () => undefined as never,
+};
+
+describe('FavoritesRecentsDeleteCleanup', () => {
+  let dispatch: ReturnType<typeof vi.fn>;
+  let service: FavoritesRecentsDeleteCleanup;
+
+  beforeEach(() => {
+    dispatch = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        FavoritesRecentsDeleteCleanup,
+        { provide: Store, useValue: { dispatch } },
+      ],
+    });
+    service = TestBed.inject(FavoritesRecentsDeleteCleanup);
+  });
+
+  it('dispatches RemoveUserFavoriteAction for the deleted entity', () => {
+    service.hook(ORG_REQUEST);
+    const fav = dispatch.mock.calls
+      .map(c => c[0])
+      .find(a => a instanceof RemoveUserFavoriteAction);
+    expect(fav).toBeInstanceOf(RemoveUserFavoriteAction);
+    // The favorite identity must match how the org was favorited.
+    const expected = new UserFavorite('cnsi-1', 'cf', 'organization', 'org-1');
+    expect((fav as RemoveUserFavoriteAction).guid).toBe(expected.guid);
+  });
+
+  it('dispatches RemoveRecentEntityAction with the matching favorite guid', () => {
+    service.hook(ORG_REQUEST);
+    const recent = dispatch.mock.calls
+      .map(c => c[0])
+      .find(a => a instanceof RemoveRecentEntityAction) as RemoveRecentEntityAction;
+    const expected = new UserFavorite('cnsi-1', 'cf', 'organization', 'org-1');
+    expect(recent).toBeInstanceOf(RemoveRecentEntityAction);
+    expect(recent.guid).toBe(expected.guid);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/favorites-recents-cleanup.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/favorites-recents-cleanup.service.ts
@@ -1,0 +1,32 @@
+import { inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { RemoveRecentEntityAction, RemoveUserFavoriteAction, UserFavorite } from '@stratosui/store';
+import { CF_ENDPOINT_TYPE } from '../../cf-types';
+import type { DeleteCleanupHook, DeleteRequest } from './delete-event.types';
+
+// Restores the favorites + recents cleanup the ngrx→signal delete migration
+// silently dropped. When a CF entity is deleted, the legacy ngrx delete
+// pipeline dispatched EntityDeleteCompleteAction, which the favorites and
+// recents reducers consumed to drop references to the gone entity. The
+// signal-native delete path never dispatched it, so favorites stranded on the
+// Home page (the reproduced bug) and recents kept dead deep-links.
+//
+// This hook rebuilds the same UserFavorite identity (guid = entityId +
+// endpointId + entityType + endpointType) the favorite/recent were stored
+// under and dispatches the existing remove actions. Favorites are still ngrx
+// today; when the favorites/roles island migrates to signals this becomes a
+// direct signal call (see island-currentuserroles-favorites-design).
+@Injectable({ providedIn: 'root' })
+export class FavoritesRecentsDeleteCleanup {
+  private readonly store = inject(Store);
+
+  /** Bound so it can be registered directly as a DeleteCleanupHook. */
+  readonly hook: DeleteCleanupHook = (req: DeleteRequest): void => {
+    // entityKind matches the favorite entityType for favoritable CF entities
+    // (organization/space/application); non-favoritable kinds (route, binding…)
+    // simply have no matching favorite/recent and the removes no-op.
+    const favorite = new UserFavorite(req.cnsiGuid, CF_ENDPOINT_TYPE, req.entityKind, req.deleteGuid);
+    this.store.dispatch(new RemoveUserFavoriteAction(favorite));
+    this.store.dispatch(new RemoveRecentEntityAction(favorite.guid));
+  };
+}

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { firstValueFrom, of } from 'rxjs';
+import { runCfDelete } from './run-cf-delete';
+import { EntityDeleteController } from './entity-delete.controller';
+import type { DeleteEvent, DeleteRequest } from './delete-event.types';
+
+function makeHttp(): HttpClient {
+  return { delete: vi.fn(() => of(new HttpResponse({ status: 200 }))) } as unknown as HttpClient;
+}
+
+function makeController(terminal: Partial<DeleteEvent>) {
+  return {
+    delete: vi.fn((req: DeleteRequest) => ({
+      events$: of(),
+      done: Promise.resolve({ ...req, state: 'success', ...terminal } as DeleteEvent),
+    })),
+  } as unknown as EntityDeleteController & { delete: ReturnType<typeof vi.fn> };
+}
+
+describe('runCfDelete', () => {
+  it('routes through the controller with the entity identity + DELETE path', async () => {
+    const http = makeHttp();
+    const controller = makeController({});
+    await runCfDelete(controller, http, {
+      cnsiGuid: 'c1', entityKind: 'space', deleteGuid: 's1', deleteName: 'demo-space',
+      path: '/pp/v1/cf/spaces/c1/s1',
+    });
+
+    const req = (controller.delete as any).mock.calls[0][0] as DeleteRequest;
+    expect(req.entityKind).toBe('space');
+    expect(req.cnsiGuid).toBe('c1');
+    expect(req.deleteGuid).toBe('s1');
+    expect(req.deleteName).toBe('demo-space');
+
+    await firstValueFrom(req.call());
+    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/spaces/c1/s1', { observe: 'response' });
+  });
+
+  it('defaults deleteName + cnsiName to the guid when omitted', async () => {
+    const controller = makeController({});
+    await runCfDelete(controller, makeHttp(), {
+      cnsiGuid: 'c1', entityKind: 'route', deleteGuid: 'r1', path: '/pp/v1/cf/routes/c1/r1',
+    });
+    const req = (controller.delete as any).mock.calls[0][0] as DeleteRequest;
+    expect(req.deleteName).toBe('r1');
+    expect(req.cnsiName).toBe('c1');
+  });
+
+  it('throws the terminal error when the delete fails', async () => {
+    const boom = new Error('association_not_empty');
+    const controller = makeController({ state: 'failure', error: boom });
+    await expect(
+      runCfDelete(controller, makeHttp(), {
+        cnsiGuid: 'c1', entityKind: 'space', deleteGuid: 's1', path: '/pp/v1/cf/spaces/c1/s1',
+      }),
+    ).rejects.toBe(boom);
+  });
+
+  it('resolves void on success', async () => {
+    const controller = makeController({});
+    await expect(
+      runCfDelete(controller, makeHttp(), {
+        cnsiGuid: 'c1', entityKind: 'space', deleteGuid: 's1', path: '/pp/v1/cf/spaces/c1/s1',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.ts
@@ -1,0 +1,40 @@
+import type { HttpClient } from '@angular/common/http';
+import type { EntityDeleteController } from './entity-delete.controller';
+
+/**
+ * Shared helper that routes a CF entity delete through the
+ * EntityDeleteController chokepoint. Builds the DeleteRequest (a CF v3
+ * DELETE with `observe: 'response'` so writeWithJob can read the 202 + job
+ * URL), awaits the terminal lifecycle event, and throws on failure so the
+ * calling component's catch can surface a snackbar.
+ *
+ * Every per-entity signal-config `deleteX` is a thin call to this so the
+ * delete-and-invalidate path has exactly one implementation.
+ */
+export async function runCfDelete(
+  controller: EntityDeleteController,
+  http: HttpClient,
+  req: {
+    cnsiGuid: string;
+    entityKind: string;
+    deleteGuid: string;
+    deleteName?: string;
+    /** Endpoint display name for the event stream; falls back to the guid. */
+    cnsiName?: string;
+    /** The CF v3 DELETE path, e.g. `/pp/v1/cf/spaces/{cnsi}/{guid}`. */
+    path: string;
+  },
+): Promise<void> {
+  const deleteName = req.deleteName ?? req.deleteGuid;
+  const result = await controller.delete({
+    cnsiGuid: req.cnsiGuid,
+    cnsiName: req.cnsiName ?? req.cnsiGuid,
+    entityKind: req.entityKind,
+    deleteGuid: req.deleteGuid,
+    deleteName,
+    call: () => http.delete(req.path, { observe: 'response' }),
+  }).done;
+  if (result.state === 'failure') {
+    throw result.error ?? new Error(`Failed to delete ${req.entityKind} "${deleteName}"`);
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/diagnostics/diagnostics.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/diagnostics/diagnostics.types.ts
@@ -11,6 +11,7 @@ export const DIAGNOSTIC_CODE_FAMILIES = [
   'in-flight-hit',
   'buffer-overflow',
   'cascade-apply',
+  'delete-event',
 ] as const;
 
 export type DiagnosticCode = typeof DIAGNOSTIC_CODE_FAMILIES[number];

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.registry.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.registry.ts
@@ -129,6 +129,16 @@ export class EndpointDataRegistry implements OnDestroy {
     return service;
   }
 
+  // Side-effect-free lookup of an already-acquired instance. Unlike acquire()
+  // this does NOT create an instance, bump refCount, or enqueue a load — it
+  // returns undefined when nothing is cached for the guid. Used by the
+  // entity-delete chokepoint to invalidate an endpoint's slices only when a
+  // cache actually exists (a delete against an un-visited endpoint has nothing
+  // to clean up).
+  peek(guid: string): EndpointDataService | undefined {
+    return this.instances.get(guid)?.service;
+  }
+
   release(guid: string): void {
     const entry = this.instances.get(guid);
     if (!entry) { return; }

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
@@ -468,23 +468,20 @@ describe('EndpointDataService', () => {
       expect(service.appsStale()).toBe(true);
     });
 
-    it('applyCascade("org.delete") marks spaces+apps+serviceInstances+bindings stale', () => {
-      service.applyCascade('org.delete');
-      expect(service.spacesStale()).toBe(true);
+    // Entity-delete cascades (org/space/app/serviceInstance/serviceBinding
+    // .delete) moved to EntityDeleteController (relation-graph derived) and are
+    // covered by entity-delete.controller.spec + affected-slices.spec. The
+    // applyCascade path still serves the surviving create/update + route-unmap
+    // cascades:
+    it('applyCascade("route.delete") marks apps stale (route unmap cascade)', () => {
+      service.applyCascade('route.delete');
       expect(service.appsStale()).toBe(true);
-      expect(service.serviceInstancesStale()).toBe(true);
-      expect(service.serviceCredentialBindingsStale()).toBe(true);
-      // Orgs itself is NOT in the cascade — the source patches its own slice
-      expect(service.orgsStale()).toBe(false);
     });
 
-    it('applyCascade("space.delete") marks apps+SI+bindings stale (no orgs/spaces)', () => {
-      service.applyCascade('space.delete');
+    it('applyCascade("serviceBinding.create") marks apps+serviceInstances stale', () => {
+      service.applyCascade('serviceBinding.create');
       expect(service.appsStale()).toBe(true);
       expect(service.serviceInstancesStale()).toBe(true);
-      expect(service.serviceCredentialBindingsStale()).toBe(true);
-      expect(service.orgsStale()).toBe(false);
-      expect(service.spacesStale()).toBe(false);
     });
 
     it('loadOrgs() refetches when stale even with warm cache', async () => {

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
@@ -81,6 +81,12 @@ export class EndpointDataService {
   private readonly _orgsStale = signal<boolean>(false);
   private readonly _appsStale = signal<boolean>(false);
   private readonly _spacesStale = signal<boolean>(false);
+  // Routes have no full-list signal here (only _routeCount, populated by
+  // load()'s home-card fast path). The stale flag busts that count's
+  // warm-cache short-circuit so a delete that cascades to routes forces the
+  // count to refetch. This is the slice the legacy cascade-registry never
+  // marked — the gap the relation-graph invalidation closes.
+  private readonly _routesStale = signal<boolean>(false);
   private readonly _serviceInstancesStale = signal<boolean>(false);
   private readonly _serviceOfferingsStale = signal<boolean>(false);
   private readonly _servicePlansStale = signal<boolean>(false);
@@ -123,6 +129,7 @@ export class EndpointDataService {
   readonly orgsStale: Signal<boolean> = this._orgsStale.asReadonly();
   readonly appsStale: Signal<boolean> = this._appsStale.asReadonly();
   readonly spacesStale: Signal<boolean> = this._spacesStale.asReadonly();
+  readonly routesStale: Signal<boolean> = this._routesStale.asReadonly();
   readonly serviceInstancesStale: Signal<boolean> = this._serviceInstancesStale.asReadonly();
   readonly serviceOfferingsStale: Signal<boolean> = this._serviceOfferingsStale.asReadonly();
   readonly servicePlansStale: Signal<boolean> = this._servicePlansStale.asReadonly();
@@ -160,8 +167,10 @@ export class EndpointDataService {
     this.diagnostics?.emitCounter('service-call-count', { service: 'EndpointDataService', method: 'load' });
     // Warm-cache short-circuit: signals already populated, no network needed.
     // Without this, every consumer that calls load() fires the full HTTP
-    // fan-out — measured as ~3-15s per endpoint on adepttech.
-    if (this._lastFetched() !== null && this._recentApps().length > 0) {
+    // fan-out — measured as ~3-15s per endpoint on adepttech. A stale routes
+    // flag (set when a delete cascades to routes) busts the short-circuit so
+    // the route count refetches.
+    if (!this._routesStale() && this._lastFetched() !== null && this._recentApps().length > 0) {
       this.diagnostics?.emitCounter('cache-hit', { service: 'EndpointDataService', method: 'load' });
       return of(undefined);
     }
@@ -198,6 +207,8 @@ export class EndpointDataService {
       finalize(() => {
         this._isLoading.set(false);
         this._lastFetched.set(new Date());
+        // Route count has just been refetched — clear the cascade stale flag.
+        this._routesStale.set(false);
         // Shim write-through is intentionally NOT called here. Counts + recent
         // apps populate service signals for the home card directly; the NGRX
         // pagination store only needs the full lists, which loadDetails()
@@ -455,6 +466,7 @@ export class EndpointDataService {
       case 'orgs': this._orgsStale.set(true); break;
       case 'apps': this._appsStale.set(true); break;
       case 'spaces': this._spacesStale.set(true); break;
+      case 'routes': this._routesStale.set(true); break;
       case 'serviceInstances': this._serviceInstancesStale.set(true); break;
       case 'serviceOfferings': this._serviceOfferingsStale.set(true); break;
       case 'servicePlans': this._servicePlansStale.set(true); break;

--- a/src/frontend/packages/cloud-foundry/src/shared/services/app-route-actions.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/app-route-actions.service.ts
@@ -4,7 +4,9 @@ import { firstValueFrom } from 'rxjs';
 
 import { ApplicationService } from '../../features/applications/application.service';
 import type { StRoute } from '../../services/endpoint-data/stratos-types';
-import { writeWithJob } from '../../services/async-jobs/write-with-job';
+import { EntityDeleteController } from '../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../services/deletes/run-cf-delete';
+import { routeEntityType } from '../../cf-entity-types';
 
 /**
  * Stratos-shape mirror of CF V3's `capi.RouteCreateRequest`. Sent as the
@@ -57,6 +59,7 @@ export interface CreateRouteRequest {
 export class AppRouteActionsService {
   private http = inject(HttpClient);
   private applicationService = inject(ApplicationService);
+  private deleteController = inject(EntityDeleteController);
 
   /** GUID of the route currently being unmapped/deleted; null when idle. */
   private readonly _transitioningRouteGuid = signal<string | null>(null);
@@ -99,13 +102,17 @@ export class AppRouteActionsService {
       throw new Error('Another route action is already in flight');
     }
     const { cfGuid } = this.applicationService;
-    const url = `/pp/v1/cf/routes/${cfGuid}/${routeGuid}`;
     this._transitioningRouteGuid.set(routeGuid);
     try {
-      // observe: 'response' so writeWithJob can discriminate 200 fast-path
-      // from 202 + Location handoff.
-      const call = this.http.delete(url, { observe: 'response' });
-      await writeWithJob(this.http, call);
+      // Route through the chokepoint so the route delete invalidates the
+      // routes count + reverse-edge slices (space/app lists) and fires cleanup
+      // — the tab still evicts its own row via removeRoute.
+      await runCfDelete(this.deleteController, this.http, {
+        cnsiGuid: cfGuid,
+        entityKind: routeEntityType,
+        deleteGuid: routeGuid,
+        path: `/pp/v1/cf/routes/${cfGuid}/${routeGuid}`,
+      });
     } finally {
       this._transitioningRouteGuid.set(null);
     }

--- a/src/frontend/packages/cloud-foundry/src/shared/services/app-service-binding-actions.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/app-service-binding-actions.service.ts
@@ -2,7 +2,9 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, computed, inject, signal } from '@angular/core';
 
 import { ApplicationService } from '../../features/applications/application.service';
-import { writeWithJob } from '../../services/async-jobs/write-with-job';
+import { EntityDeleteController } from '../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../services/deletes/run-cf-delete';
+import { serviceCredentialBindingEntityType } from '../../entity-relations/signal/cf-relation-registrations';
 
 /**
  * AppServiceBindingActionsService
@@ -31,6 +33,7 @@ import { writeWithJob } from '../../services/async-jobs/write-with-job';
 export class AppServiceBindingActionsService {
   private http = inject(HttpClient);
   private applicationService = inject(ApplicationService);
+  private deleteController = inject(EntityDeleteController);
 
   /** GUID of the binding currently being unbound; null when idle. */
   private readonly _transitioningBindingGuid = signal<string | null>(null);
@@ -52,11 +55,17 @@ export class AppServiceBindingActionsService {
       throw new Error('Another binding action is already in flight');
     }
     const { cfGuid } = this.applicationService;
-    const url = `/pp/v1/cf/service_bindings/${cfGuid}/${bindingGuid}`;
     this._transitioningBindingGuid.set(bindingGuid);
     try {
-      const call = this.http.delete(url, { observe: 'response' });
-      await writeWithJob(this.http, call);
+      // Route through the chokepoint so the binding delete also invalidates
+      // the EDS cache + reverse-edge slices (bound app/SI rollups) and fires
+      // cleanup hooks — the tab still evicts its own row via removeServiceBinding.
+      await runCfDelete(this.deleteController, this.http, {
+        cnsiGuid: cfGuid,
+        entityKind: serviceCredentialBindingEntityType,
+        deleteGuid: bindingGuid,
+        path: `/pp/v1/cf/service_bindings/${cfGuid}/${bindingGuid}`,
+      });
     } finally {
       this._transitioningBindingGuid.set(null);
     }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -4,10 +4,12 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import type { EndpointModel } from '@stratosui/store';
 import { CnsiAppsSource } from '../../../services/data-sources/cnsi-apps-source';
-import { CnsiRoutesSource } from '../../../services/data-sources/cnsi-routes-source';
-import { CnsiServiceBindingsSource } from '../../../services/data-sources/cnsi-service-bindings-source';
 import { MergeOrchestrator } from '../../../services/data-sources/merge-orchestrator';
 import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../../services/deletes/run-cf-delete';
+import { applicationEntityType, routeEntityType } from '../../../cf-entity-types';
+import { serviceCredentialBindingEntityType } from '../../../entity-relations/signal/cf-relation-registrations';
 import { ViewPipeline, SortSpec } from '../../../services/data-sources/view-pipeline';
 import type { StApp, StAppRoutesResponse, StOrg, StOrgsResponse, StRoute, StServiceCredentialBinding, StServiceCredentialBindingsResponse, StSpace, StSpacesResponse } from '../../../services/endpoint-data/stratos-types';
 import { CloudFoundryService } from '../../data-services/cloud-foundry.service';
@@ -162,6 +164,7 @@ export class CfAppsSignalConfigService {
   private _lockedSpaceGuid = '';
 
   private readonly endpointRegistry = inject(EndpointDataRegistry);
+  private readonly deleteController = inject(EntityDeleteController);
 
   constructor(private readonly http: HttpClient) {
     const cfService = inject(CloudFoundryService, { optional: true });
@@ -883,25 +886,34 @@ export class CfAppsSignalConfigService {
   // CnsiServiceBindingsSource so the binding row is dropped from
   // EndpointDataService._serviceCredentialBindings on success and the
   // serviceBinding.delete cascade fires (marks apps + SI stale).
+  // Deletes a service credential binding through the EntityDeleteController
+  // chokepoint. The controller removes the binding from
+  // EndpointDataService._serviceCredentialBindings and (via reverse edges)
+  // marks the bound app + service-instance lists stale.
   async deleteServiceBinding(cnsiGuid: string, bindingGuid: string): Promise<void> {
-    const eds = this.endpointRegistry.acquire(cnsiGuid);
-    const source = new CnsiServiceBindingsSource(cnsiGuid, this.http, eds);
-    await source.delete(bindingGuid);
+    await runCfDelete(this.deleteController, this.http, {
+      cnsiGuid,
+      entityKind: serviceCredentialBindingEntityType,
+      deleteGuid: bindingGuid,
+      path: `/pp/v1/cf/service_bindings/${cnsiGuid}/${bindingGuid}`,
+    });
   }
 
-  // Deletes a CF route through CnsiRoutesSource. The source handles
-  // writeWithJob, patches its own _items, and fires the route.delete
-  // cascade (marks apps stale so app-detail route lists refetch).
+  // Deletes a CF route through the EntityDeleteController chokepoint. Routes
+  // are a count-only EDS slice (no row list), so the controller marks the
+  // routes slice stale + the referencing space/app lists.
   //
   // Used by the signal-native delete stepper when the user opts to delete
-  // attached routes alongside the app. Throws StratosJobError on FAILED
-  // terminal state — callers should either surface the error or swallow it
-  // (the route may fail to delete because the app delete already cascaded
-  // through CF's reference checks).
+  // attached routes alongside the app. Throws on FAILED terminal state —
+  // callers should either surface the error or swallow it (the route may fail
+  // to delete because the app delete already cascaded through CF's checks).
   async deleteRoute(cnsiGuid: string, routeGuid: string): Promise<void> {
-    const eds = this.endpointRegistry.acquire(cnsiGuid);
-    const source = new CnsiRoutesSource(cnsiGuid, this.http, eds);
-    await source.delete(routeGuid);
+    await runCfDelete(this.deleteController, this.http, {
+      cnsiGuid,
+      entityKind: routeEntityType,
+      deleteGuid: routeGuid,
+      path: `/pp/v1/cf/routes/${cnsiGuid}/${routeGuid}`,
+    });
   }
 
   // Lifecycle actions. The CF v3 /v3/apps/{guid}/actions/{action} endpoints
@@ -957,22 +969,19 @@ export class CfAppsSignalConfigService {
     await writeWithJob(this.http, call);
   }
 
-  async deleteApp(cnsiGuid: string, appGuid: string): Promise<void> {
-    // Orchestrator-undefined fallback (cold bookmark / HMR): no source to
-    // update, but we still need to issue the delete and wait for CF's
-    // async job to terminate before the caller refreshes.
-    if (!this.orchestrator) {
-      const call = this.http.delete(`/pp/v1/cf/apps/${cnsiGuid}/${appGuid}`, { observe: 'response' });
-      await writeWithJob(this.http, call);
-      return;
-    }
-    const src = this.orchestrator.sourceFor(cnsiGuid) as CnsiAppsSource | undefined;
-    if (!src) {
-      const call = this.http.delete(`/pp/v1/cf/apps/${cnsiGuid}/${appGuid}`, { observe: 'response' });
-      await writeWithJob(this.http, call);
-      return;
-    }
-    // Source-aware path: waits for terminal state and updates local cache.
-    await src.delete(appGuid);
+  // Deletes an app through the EntityDeleteController chokepoint, then drops
+  // the row from the orchestrator's aggregated view (no-op when there is no
+  // orchestrator — the prior cold-fallback branch). The controller removes the
+  // app from the EDS cache and marks descendant routes/bindings + the space's
+  // app-count stale.
+  async deleteApp(cnsiGuid: string, appGuid: string, appName: string = appGuid): Promise<void> {
+    await runCfDelete(this.deleteController, this.http, {
+      cnsiGuid,
+      entityKind: applicationEntityType,
+      deleteGuid: appGuid,
+      deleteName: appName,
+      path: `/pp/v1/cf/apps/${cnsiGuid}/${appGuid}`,
+    });
+    this.orchestrator?.removeRow(cnsiGuid, appGuid);
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { firstValueFrom, of } from 'rxjs';
+import { TestBed } from '@angular/core/testing';
+import { CfOrgsSignalConfigService } from './cf-orgs-signal-config.service';
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import type { DeleteEvent, DeleteRequest } from '../../../services/deletes/delete-event.types';
+
+// Construct the service via TestBed so inject() in its field initializers has a
+// valid injection context. We stub the heavy collaborators — this spec only
+// covers deleteOrg's routing through the EntityDeleteController chokepoint.
+function makeSvc(opts: {
+  http?: HttpClient;
+  controller?: Partial<EntityDeleteController>;
+} = {}): { svc: CfOrgsSignalConfigService; controller: { delete: ReturnType<typeof vi.fn>; registerCleanup: ReturnType<typeof vi.fn> }; http: HttpClient } {
+  const http = opts.http ?? ({ delete: vi.fn(() => of(new HttpResponse({ status: 200 }))) } as unknown as HttpClient);
+  const controller = {
+    delete: vi.fn((req: DeleteRequest) => ({
+      events$: of(),
+      done: Promise.resolve({ ...req, state: 'success' } as DeleteEvent),
+    })),
+    registerCleanup: vi.fn(),
+    ...opts.controller,
+  };
+  const registry = { acquire: vi.fn(), peek: vi.fn(), release: vi.fn() } as unknown as EndpointDataRegistry;
+
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: HttpClient, useValue: http },
+      { provide: EndpointDataRegistry, useValue: registry },
+      { provide: EntityDeleteController, useValue: controller },
+      CfOrgsSignalConfigService,
+    ],
+  });
+  return { svc: TestBed.inject(CfOrgsSignalConfigService), controller: controller as never, http };
+}
+
+beforeEach(() => TestBed.resetTestingModule());
+
+describe('CfOrgsSignalConfigService.deleteOrg', () => {
+  it('routes the delete through EntityDeleteController with org identity', async () => {
+    const { svc, controller } = makeSvc();
+    await svc.deleteOrg('cnsi-1', 'org-1', 'demo-org');
+
+    expect(controller.delete).toHaveBeenCalledTimes(1);
+    const req = controller.delete.mock.calls[0][0] as DeleteRequest;
+    expect(req.entityKind).toBe('organization');
+    expect(req.cnsiGuid).toBe('cnsi-1');
+    expect(req.deleteGuid).toBe('org-1');
+    expect(req.deleteName).toBe('demo-org');
+  });
+
+  it('issues the org DELETE against the CF v3 path when the call thunk runs', async () => {
+    const { svc, controller, http } = makeSvc();
+    await svc.deleteOrg('cnsi-1', 'org-1');
+
+    const req = controller.delete.mock.calls[0][0] as DeleteRequest;
+    await firstValueFrom(req.call());
+    expect(http.delete).toHaveBeenCalledWith('/pp/v1/cf/orgs/cnsi-1/org-1', { observe: 'response' });
+  });
+
+  it('works on the cold path — no initialize() call required', async () => {
+    // The org summary page deep-links here without the org-list tab ever
+    // mounting (so initialize() never ran). The delete must still go through.
+    const { svc, controller } = makeSvc();
+    await expect(svc.deleteOrg('cnsi-1', 'org-1')).resolves.toBeUndefined();
+    expect(controller.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the controller reports a failure terminal', async () => {
+    const boom = new Error('forbidden');
+    const { svc } = makeSvc({
+      controller: {
+        delete: vi.fn((req: DeleteRequest) => ({
+          events$: of(),
+          done: Promise.resolve({ ...req, state: 'failure', error: boom } as DeleteEvent),
+        })),
+      } as never,
+    });
+    await expect(svc.deleteOrg('cnsi-1', 'org-1')).rejects.toBe(boom);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
@@ -6,6 +6,8 @@ import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-d
 import type { EndpointDataService } from '../../../services/endpoint-data/endpoint-data.service';
 import { ViewPipeline, SortSpec } from '../../../services/data-sources/view-pipeline';
 import { CnsiOrgsSource } from '../../../services/data-sources/cnsi-orgs-source';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { organizationEntityType } from '../../../cf-entity-types';
 import type { StOrg } from '../../../services/endpoint-data/stratos-types';
 
 // Orgs list config service — single-CNSI analog to CfAppsSignalConfigService.
@@ -19,6 +21,7 @@ export class CfOrgsSignalConfigService {
   private readonly registry = inject(EndpointDataRegistry);
   private readonly destroyRef = inject(DestroyRef);
   private readonly injector = inject(Injector);
+  private readonly deleteController = inject(EntityDeleteController);
 
   // Wrapped in a signal so the `orgs` / `spaces` computeds re-run when the
   // active CNSI swaps. With a plain field the computeds tracked only the
@@ -139,15 +142,31 @@ export class CfOrgsSignalConfigService {
     });
   }
 
-  // Delete an org via CnsiOrgsSource. The source handles writeWithJob,
-  // patches EndpointDataService._orgs in place, and fires the org.delete
-  // cascade so spaces/apps/SI/bindings get marked stale (for repaint when
-  // the user navigates to those tabs).
-  async deleteOrg(_cnsiGuid: string, orgGuid: string): Promise<void> {
-    if (!this.orgsSource) {
-      throw new Error('CfOrgsSignalConfigService: initialize() not called before deleteOrg');
+  // Delete an org through the EntityDeleteController chokepoint. The controller
+  // issues the DELETE via writeWithJob, then derives the *complete* set of
+  // affected EndpointDataService slices from the relation graph (spaces, apps,
+  // routes, serviceInstances, serviceCredentialBindings — note routes, which
+  // the old org.delete cascade omitted), removes the org row, and fires the
+  // favorites/recents cleanup hooks.
+  //
+  // Routing through the root-singleton controller (not orgsSource) means delete
+  // no longer depends on initialize() having run — fixing the cold/fallback
+  // path where the org summary page is deep-linked without the org list tab
+  // ever mounting, which previously left every cache stale (the reproduced bug).
+  async deleteOrg(cnsiGuid: string, orgGuid: string, orgName: string = orgGuid): Promise<void> {
+    const result = await this.deleteController.delete({
+      cnsiGuid,
+      // Display-only in the event/diagnostics stream; no endpoint-name source
+      // is wired into this service yet, so fall back to the guid.
+      cnsiName: cnsiGuid,
+      entityKind: organizationEntityType,
+      deleteGuid: orgGuid,
+      deleteName: orgName,
+      call: () => this.http.delete(`/pp/v1/cf/orgs/${cnsiGuid}/${orgGuid}`, { observe: 'response' }),
+    }).done;
+    if (result.state === 'failure') {
+      throw result.error ?? new Error(`Failed to delete organization "${orgName}"`);
     }
-    await this.orgsSource.delete(orgGuid);
   }
 
   // Create an org via CnsiOrgsSource. The source POSTs to /pp/v1/cf/orgs,

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
@@ -7,6 +7,7 @@ import type { EndpointDataService } from '../../../services/endpoint-data/endpoi
 import { ViewPipeline, SortSpec } from '../../../services/data-sources/view-pipeline';
 import { CnsiOrgsSource } from '../../../services/data-sources/cnsi-orgs-source';
 import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../../services/deletes/run-cf-delete';
 import { organizationEntityType } from '../../../cf-entity-types';
 import type { StOrg } from '../../../services/endpoint-data/stratos-types';
 
@@ -154,19 +155,13 @@ export class CfOrgsSignalConfigService {
   // path where the org summary page is deep-linked without the org list tab
   // ever mounting, which previously left every cache stale (the reproduced bug).
   async deleteOrg(cnsiGuid: string, orgGuid: string, orgName: string = orgGuid): Promise<void> {
-    const result = await this.deleteController.delete({
+    await runCfDelete(this.deleteController, this.http, {
       cnsiGuid,
-      // Display-only in the event/diagnostics stream; no endpoint-name source
-      // is wired into this service yet, so fall back to the guid.
-      cnsiName: cnsiGuid,
       entityKind: organizationEntityType,
       deleteGuid: orgGuid,
       deleteName: orgName,
-      call: () => this.http.delete(`/pp/v1/cf/orgs/${cnsiGuid}/${orgGuid}`, { observe: 'response' }),
-    }).done;
-    if (result.state === 'failure') {
-      throw result.error ?? new Error(`Failed to delete organization "${orgName}"`);
-    }
+      path: `/pp/v1/cf/orgs/${cnsiGuid}/${orgGuid}`,
+    });
   }
 
   // Create an org via CnsiOrgsSource. The source POSTs to /pp/v1/cf/orgs,

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.ts
@@ -6,7 +6,9 @@ import { ListStateStore, naturalCompare } from '@stratosui/core';
 import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
 import type { EndpointDataService } from '../../../services/endpoint-data/endpoint-data.service';
 import { ViewPipeline, SortSpec } from '../../../services/data-sources/view-pipeline';
-import { CnsiRoutesSource } from '../../../services/data-sources/cnsi-routes-source';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../../services/deletes/run-cf-delete';
+import { routeEntityType } from '../../../cf-entity-types';
 import type { StRoute, StRoutesResponse } from '../../../services/endpoint-data/stratos-types';
 
 // Routes list config service — single-CNSI, single-space. Analog of
@@ -26,6 +28,7 @@ export class CfRoutesSignalConfigService {
   private readonly registry = inject(EndpointDataRegistry);
   private readonly destroyRef = inject(DestroyRef);
   private readonly injector = inject(Injector);
+  private readonly deleteController = inject(EntityDeleteController);
 
   private endpointDataService?: EndpointDataService;
   private cnsiGuid = '';
@@ -272,13 +275,16 @@ export class CfRoutesSignalConfigService {
   }
 
   async deleteRoute(cnsiGuid: string, routeGuid: string): Promise<void> {
-    const eds = this.registry.acquire(cnsiGuid);
-    const source = new CnsiRoutesSource(cnsiGuid, this.http, eds);
-    await source.delete(routeGuid);
+    await runCfDelete(this.deleteController, this.http, {
+      cnsiGuid,
+      entityKind: routeEntityType,
+      deleteGuid: routeGuid,
+      path: `/pp/v1/cf/routes/${cnsiGuid}/${routeGuid}`,
+    });
     // The local _routes list lives on this config service (via fetchRoutes),
-    // not the source — the source's _items is discarded. Re-fetch the list
-    // so the just-deleted row leaves the view. The applyCascade in delete()
-    // also marks apps stale for the cross-tab UX.
+    // not on the EDS cache — re-fetch so the just-deleted row leaves the view.
+    // The controller has already marked the routes/space/app slices stale for
+    // the cross-tab UX.
     await this.fetchRoutes();
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.ts
@@ -7,6 +7,9 @@ import { MergeOrchestrator } from '../../../services/data-sources/merge-orchestr
 import { ViewPipeline, SortSpec } from '../../../services/data-sources/view-pipeline';
 import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
 import type { EndpointDataService } from '../../../services/endpoint-data/endpoint-data.service';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../../services/deletes/run-cf-delete';
+import { serviceInstancesEntityType } from '../../../cf-entity-types';
 import type { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 import { CloudFoundryService } from '../../data-services/cloud-foundry.service';
 import type { SignalListDropdownOption } from '@stratosui/core';
@@ -126,6 +129,7 @@ export class CfServiceInstancesSignalConfigService {
   private readonly _hasLoadedOnce: WritableSignal<boolean> = signal(false);
   private readonly injector = inject(Injector);
   private readonly http = inject(HttpClient);
+  private readonly deleteController = inject(EntityDeleteController);
   // Optional so unit tests don't have to provide it; the real app always
   // does (providedIn: 'root'). When present, used to short-circuit the
   // orchestrator's HTTP drain on revisit by pre-seeding each per-CNSI
@@ -511,28 +515,23 @@ export class CfServiceInstancesSignalConfigService {
     return runInInjectionContext(this.injector, fn);
   }
 
-  // Delete a service instance through CnsiServiceInstancesSource. The
-  // source handles writeWithJob (which waits for CF's async job to
-  // terminate), patches its own _items, patches EndpointDataService's
-  // serviceInstances signal, and fires the serviceInstance.delete cascade
-  // (marks apps + bindings stale). Replaces the previous
-  // optimistic-remove + refresh hybrid, which could leave server + local
-  // state out of sync if the trailing refresh's page-2 refetch failed.
-  async deleteServiceInstance(cnsiGuid: string, siGuid: string): Promise<void> {
-    const src = this.orchestrator?.sourceFor(cnsiGuid) as CnsiServiceInstancesSource | undefined;
-    if (src) {
-      await src.delete(siGuid);
-      // Mirror the orchestrator's aggregated view: even though the source
-      // patches its own _items, the orchestrator-level removeRow keeps
-      // the aggregated allItems Signal in sync for the merged-CNSI case.
-      this.orchestrator.removeRow(cnsiGuid, siGuid);
-      return;
-    }
-    // Orchestrator-undefined fallback (cold bookmark / HMR): instantiate
-    // a one-shot source for the delete. EDS is still threaded so the
-    // cascade fires.
-    const eds = this.registry.acquire(cnsiGuid);
-    const oneShot = new CnsiServiceInstancesSource(cnsiGuid, this.http, eds);
-    await oneShot.delete(siGuid);
+  // Delete a service instance through the EntityDeleteController chokepoint.
+  // The controller issues the DELETE via writeWithJob, derives the
+  // invalidation set from the relation graph (descendant bindings + the
+  // space's serviceInstance-count via reverse edge), removes the SI from the
+  // EDS cache, and fires cleanup hooks. We then drop the row from the list
+  // orchestrator's aggregated view so it disappears without a refresh.
+  // Routing through the root-singleton controller removes the prior
+  // orchestrator-undefined cold-fallback branch (removeRow no-ops when there
+  // is no orchestrator).
+  async deleteServiceInstance(cnsiGuid: string, siGuid: string, siName: string = siGuid): Promise<void> {
+    await runCfDelete(this.deleteController, this.http, {
+      cnsiGuid,
+      entityKind: serviceInstancesEntityType,
+      deleteGuid: siGuid,
+      deleteName: siName,
+      path: `/pp/v1/cf/service_instances/${cnsiGuid}/${siGuid}`,
+    });
+    this.orchestrator?.removeRow(cnsiGuid, siGuid);
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/space/cf-spaces-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/space/cf-spaces-signal-config.service.ts
@@ -5,8 +5,9 @@ import { firstValueFrom } from 'rxjs';
 import { ListStateStore } from '@stratosui/core';
 
 import { ViewPipeline, SortSpec } from '../../../services/data-sources/view-pipeline';
-import { CnsiSpacesSource } from '../../../services/data-sources/cnsi-spaces-source';
-import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../../services/deletes/run-cf-delete';
+import { spaceEntityType } from '../../../cf-entity-types';
 import type { StSpace } from '../../../services/endpoint-data/stratos-types';
 
 /**
@@ -39,7 +40,7 @@ interface PagedSpaces {
 export class CfSpacesSignalConfigService {
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
-  private readonly endpointRegistry = inject(EndpointDataRegistry);
+  private readonly deleteController = inject(EntityDeleteController);
 
   private cnsiGuid = '';
   private orgGuid = '';
@@ -122,10 +123,18 @@ export class CfSpacesSignalConfigService {
     });
   }
 
-  async deleteSpace(cnsiGuid: string, spaceGuid: string): Promise<void> {
-    const eds = this.endpointRegistry.acquire(cnsiGuid);
-    const source = new CnsiSpacesSource(cnsiGuid, this.http, eds);
-    await source.delete(spaceGuid);
+  // Delete a space through the EntityDeleteController chokepoint. The
+  // controller derives the full invalidation set from the relation graph
+  // (descendant apps/routes/serviceInstances/bindings + the org's space-count
+  // via reverse edge), removes the space row, and fires cleanup hooks.
+  async deleteSpace(cnsiGuid: string, spaceGuid: string, spaceName: string = spaceGuid): Promise<void> {
+    await runCfDelete(this.deleteController, this.http, {
+      cnsiGuid,
+      entityKind: spaceEntityType,
+      deleteGuid: spaceGuid,
+      deleteName: spaceName,
+      path: `/pp/v1/cf/spaces/${cnsiGuid}/${spaceGuid}`,
+    });
   }
 
   /**

--- a/src/frontend/packages/store/src/actions/recently-visited.actions.ts
+++ b/src/frontend/packages/store/src/actions/recently-visited.actions.ts
@@ -40,3 +40,17 @@ export class PruneRecentsToConnectedAction implements Action {
   constructor(public connectedEndpointGuids: string[]) { }
 }
 
+/**
+ * Remove a single recents entry by its favorite guid. Dispatched by the
+ * entity-delete cleanup hook when an entity is deleted, so a stale recent
+ * doesn't linger and deep-link to a 404. Replaces the recents-side effect of
+ * the legacy `EntityDeleteCompleteAction` (which the ngrx delete pipeline
+ * dispatched and which is being retired) without coupling to the
+ * RecursiveDelete machinery.
+ */
+export class RemoveRecentEntityAction implements Action {
+  static ACTION_TYPE = '[Recently visited] Remove entity';
+  public type = RemoveRecentEntityAction.ACTION_TYPE;
+  constructor(public guid: string) { }
+}
+

--- a/src/frontend/packages/store/src/public-api.ts
+++ b/src/frontend/packages/store/src/public-api.ts
@@ -116,7 +116,8 @@ export {
 export type { RoutingEvent } from './types/routing.type';
 export type { IFavoriteMetadata, IFavoritesInfo, UserFavoriteEndpoint, IEndpointFavMetadata, FavoriteIconData } from './types/user-favorites.types';
 export { UserFavorite } from './types/user-favorites.types';
-export { AddRecentlyVisitedEntityAction, SetRecentlyVisitedEntityAction } from './actions/recently-visited.actions';
+export { AddRecentlyVisitedEntityAction, SetRecentlyVisitedEntityAction, RemoveRecentEntityAction } from './actions/recently-visited.actions';
+export { RemoveUserFavoriteAction } from './actions/user-favourites.actions';
 export { UserFavoriteManager } from './user-favorite-manager';
 export { TestEntityCatalog, entityCatalog } from './entity-catalog/entity-catalog';
 export { ENTITY_CATALOG_TOKEN } from './tokens/store-injection.tokens';

--- a/src/frontend/packages/store/src/reducers/current-user-roles-reducer/recently-visited.reducer.spec.ts
+++ b/src/frontend/packages/store/src/reducers/current-user-roles-reducer/recently-visited.reducer.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+
+import { RemoveRecentEntityAction } from '../../actions/recently-visited.actions';
+import { IRecentlyVisitedEntity, IRecentlyVisitedState } from '../../types/recently-visited.types';
+import { recentlyVisitedReducer } from './recently-visited.reducer';
+
+const entry = (guid: string, endpointId: string): IRecentlyVisitedEntity => ({
+  guid,
+  entityId: guid,
+  endpointId,
+  entityType: 'organization',
+  endpointType: 'cf',
+  name: guid,
+  date: 1,
+} as IRecentlyVisitedEntity);
+
+describe('recentlyVisitedReducer — RemoveRecentEntityAction', () => {
+  const state: IRecentlyVisitedState = {
+    'org-1__cnsi-1': entry('org-1__cnsi-1', 'cnsi-1'),
+    'org-2__cnsi-1': entry('org-2__cnsi-1', 'cnsi-1'),
+  };
+
+  it('removes the matching recents entry by guid', () => {
+    const next = recentlyVisitedReducer(state, new RemoveRecentEntityAction('org-1__cnsi-1'));
+    expect(next['org-1__cnsi-1']).toBeUndefined();
+    expect(next['org-2__cnsi-1']).toBeDefined();
+  });
+
+  it('does not mutate the original state object', () => {
+    recentlyVisitedReducer(state, new RemoveRecentEntityAction('org-1__cnsi-1'));
+    expect(state['org-1__cnsi-1']).toBeDefined();
+  });
+
+  it('returns the same reference when the guid is absent (no-op)', () => {
+    const next = recentlyVisitedReducer(state, new RemoveRecentEntityAction('missing'));
+    expect(next).toBe(state);
+  });
+});

--- a/src/frontend/packages/store/src/reducers/current-user-roles-reducer/recently-visited.reducer.ts
+++ b/src/frontend/packages/store/src/reducers/current-user-roles-reducer/recently-visited.reducer.ts
@@ -5,6 +5,7 @@ import {
   AddRecentlyVisitedEntityAction,
   CleanRecentsForEndpointsAction,
   PruneRecentsToConnectedAction,
+  RemoveRecentEntityAction,
   SetRecentlyVisitedEntityAction,
 } from '../../actions/recently-visited.actions';
 import { IRecentlyVisitedState } from '../../types/recently-visited.types';
@@ -39,6 +40,15 @@ export function recentlyVisitedReducer(
     case PruneRecentsToConnectedAction.ACTION_TYPE: {
       const pruneAction = action as PruneRecentsToConnectedAction;
       return cleanRecentsList(state, pruneAction.connectedEndpointGuids, true);
+    }
+    case RemoveRecentEntityAction.ACTION_TYPE: {
+      const removeAction = action as RemoveRecentEntityAction;
+      if (!state[removeAction.guid]) {
+        return state;
+      }
+      const newState = { ...state };
+      delete newState[removeAction.guid];
+      return newState;
     }
   }
   return state;


### PR DESCRIPTION
## What

Introduces a **common entity-delete mechanism** for Cloud Foundry and routes
every CF entity delete through it, replacing the hand-curated per-mutation
cascade table with invalidation derived from the relation graph.

A single `EntityDeleteController` chokepoint now wraps `writeWithJob`, emits a
lifecycle event stream (`start → success | failure`), and on success:

- walks the relation graph to mark every affected `EndpointDataService` slice
  stale — **descendants** (`affectedSlices`, containment) **∪ referencing
  parents/siblings** (`referencingSlices`, reverse edges, so parent count
  columns and sibling relationship lists refresh),
- removes the deleted row from the local cache,
- fires cleanup hooks that drop the entity's **favorite + recents** entries.

## Why — fixes silently-dropped deletes

The ngrx→signal migration replaced the old schema-complete delete invalidation
with a hand-maintained `cascade-registry` that under-marked: it had **no
`routes` slice at all** and never cleaned favorites/recents. Result: after a
delete the server-side entity was gone but the UI kept stale lists and a
**stranded favorite** on Home. This reproduced live (create+favorite an org →
delete → org 404 server-side but still in the cache, favorite stranded).

The relation-graph derivation closes that gap (routes now covered) and the
cleanup hooks restore the favorite/recents removal the migration dropped.

## Scope

- Routed through the controller: **org, space, application, service-instance,
  route** (routes list + app-attached + app-detail action bar), **service
  binding** (apps config + detach-instance stepper + app-detail action bar).
- Removed the now-orphaned `delete()` from each `Cnsi*Source`; create / update /
  route-unmap stay.
- Pruned the dead `org/space/app/serviceInstance/serviceBinding.delete` cascade
  keys. `route.delete` stays (fired by route **unmap**, a relationship op, not
  an entity delete); create/update + dormant `serviceBroker.*` remain.

**Out of scope (deliberate, follow-up PR):** removing the legacy ngrx
`RecursiveDeleteEffect` / `EntityDeleteCompleteAction` engine — that needs the
last ngrx-pipeline delete consumer (kube) migrated first. This PR is purely
additive + behavior-preserving + bug-fixing.

## Verification

- Full gate green: **2367 unit tests** (3 skipped), lint, production build.
- Live-verified end-to-end on a lab CF for both backing patterns: an
  EDS-backed delete (org) and an orchestrator-backed delete (app) — delete-event
  success fired, entity left the cache + list, stranded favorite removed,
  server-side absent.

## Note

A separate pre-existing gap surfaced during testing — the per-CF "cf app wall"
is missing Org/Space columns (column-config, not data). Recorded in #5400; not
addressed here.
