### PR TITLE
feat(cf): blocked delete state with reason classification + latch

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/services/deletes/block-classification.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/block-classification.spec.ts
@@ -1,0 +1,77 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { describe, expect, it } from 'vitest';
+import { StratosJobError } from '../async-jobs/async-job.types';
+import { classifyBlock } from './block-classification';
+
+// Builds a CF-style HttpErrorResponse the way Angular surfaces a rejected
+// observable: status + an `error` body carrying the CF error envelope.
+const httpError = (status: number, body: unknown): HttpErrorResponse =>
+  new HttpErrorResponse({ status, error: body, statusText: 'error' });
+
+// CF v3 error envelope shape: { errors: [{ code, title, detail }] }.
+const cfBody = (title: string, detail = '') => ({ errors: [{ code: 10000, title, detail }] });
+
+const jobError = (code: string, message: string): StratosJobError =>
+  new StratosJobError({
+    id: 'j1', kind: 'cf.delete', state: 'FAILED', startedAt: '', updatedAt: '',
+    errors: [{ code, message }],
+  });
+
+describe('classifyBlock', () => {
+  describe('HttpErrorResponse', () => {
+    it('422 CF-AssociationNotEmpty → has-dependents', () => {
+      expect(classifyBlock(httpError(422, cfBody('CF-AssociationNotEmpty',
+        'Please delete the spaces associations for your organizations.')))).toBe('has-dependents');
+    });
+
+    it('403 → forbidden', () => {
+      expect(classifyBlock(httpError(403, cfBody('CF-NotAuthorized')))).toBe('forbidden');
+    });
+
+    it('409 async operation in progress → operation-in-progress', () => {
+      expect(classifyBlock(httpError(409, cfBody('CF-AsyncServiceInstanceOperationInProgress',
+        'An operation for service instance x is in progress.')))).toBe('operation-in-progress');
+    });
+
+    it('422 with an in-progress message → operation-in-progress', () => {
+      expect(classifyBlock(httpError(422, cfBody('CF-AsyncServiceInstanceOperationInProgress')))).toBe('operation-in-progress');
+    });
+
+    it('generic 422 validation error → undefined (stays a failure)', () => {
+      expect(classifyBlock(httpError(422, cfBody('CF-UnprocessableEntity', 'name is too long')))).toBeUndefined();
+    });
+
+    it('500 → undefined (transient, retryable)', () => {
+      expect(classifyBlock(httpError(500, cfBody('CF-ServerError')))).toBeUndefined();
+    });
+  });
+
+  describe('StratosJobError (polled FAILED job)', () => {
+    it('association_not_empty message → has-dependents', () => {
+      expect(classifyBlock(jobError('http.422', 'association_not_empty: spaces remain'))).toBe('has-dependents');
+    });
+
+    it('http.403 code → forbidden', () => {
+      expect(classifyBlock(jobError('http.403', 'forbidden'))).toBe('forbidden');
+    });
+
+    it('operation-in-progress message → operation-in-progress', () => {
+      expect(classifyBlock(jobError('http.409', 'last_operation still in progress'))).toBe('operation-in-progress');
+    });
+
+    it('internal error → undefined', () => {
+      expect(classifyBlock(jobError('cf.500', 'internal error'))).toBeUndefined();
+    });
+  });
+
+  describe('non-classifiable inputs', () => {
+    it('plain Error → undefined', () => {
+      expect(classifyBlock(new Error('boom'))).toBeUndefined();
+    });
+
+    it('null / undefined → undefined', () => {
+      expect(classifyBlock(null)).toBeUndefined();
+      expect(classifyBlock(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/block-classification.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/block-classification.ts
@@ -1,0 +1,77 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { StratosJobError } from '../async-jobs/async-job.types';
+import type { BlockReason } from './delete-event.types';
+
+// Mechanism-owned default classification of a delete failure into a `blocked`
+// reason (the design's "stop — don't auto-retry until resolved" cases). A
+// caller may still promote any other failure to blocked itself; this only
+// covers the universal CF cases so every caller gets them for free.
+//
+// Returns undefined for transient/retryable errors (network, 5xx, generic
+// validation) — those stay `failure`.
+
+interface ErrorSignal {
+  /** HTTP status if recoverable, else 0. */
+  status: number;
+  /** Lower-cased blob of every human/code field, for keyword matching. */
+  text: string;
+}
+
+// writeWithJob throws one of two shapes: an HttpErrorResponse (synchronous
+// 4xx/5xx from the DELETE observable) or a StratosJobError (polled FAILED
+// job). Normalise both to a status + searchable text blob so the classifier
+// reasons over one shape.
+function extractSignal(error: unknown): ErrorSignal {
+  if (error instanceof HttpErrorResponse) {
+    const parts: string[] = [String(error.statusText ?? '')];
+    const body = error.error;
+    if (body && typeof body === 'object') {
+      const errors = (body as { errors?: Array<Record<string, unknown>> }).errors;
+      errors?.forEach(e => parts.push(String(e.code ?? ''), String(e.title ?? ''),
+        String(e.detail ?? ''), String(e.message ?? '')));
+      const top = body as { message?: unknown; error?: unknown };
+      parts.push(String(top.message ?? ''), String(top.error ?? ''));
+    } else if (typeof body === 'string') {
+      parts.push(body);
+    }
+    return { status: error.status, text: parts.join(' ').toLowerCase() };
+  }
+
+  if (error instanceof StratosJobError) {
+    const parts: string[] = [];
+    let status = 0;
+    error.job.errors?.forEach(e => {
+      parts.push(String(e.code ?? ''), String(e.message ?? ''), String(e.detail ?? ''));
+      // write-with-job stamps synthesised codes as `http.<status>`.
+      const m = /^http\.(\d{3})$/.exec(String(e.code ?? ''));
+      if (m) status = Number(m[1]);
+    });
+    return { status, text: parts.join(' ').toLowerCase() };
+  }
+
+  if (error instanceof Error) {
+    return { status: 0, text: error.message.toLowerCase() };
+  }
+  return { status: 0, text: '' };
+}
+
+export function classifyBlock(error: unknown): BlockReason | undefined {
+  const { status, text } = extractSignal(error);
+
+  if (status === 403) return 'forbidden';
+
+  // CF surfaces a long-running last_operation as 409 or via a *OperationInProgress
+  // error title; recognise either so a delete racing an in-flight op latches
+  // rather than hammering the API.
+  if (status === 409
+    || text.includes('operationinprogress')
+    || text.includes('in progress')) {
+    return 'operation-in-progress';
+  }
+
+  // CF-AssociationNotEmpty (422): the entity still has dependents the operator
+  // must remove first — the canonical "has-dependents" block.
+  if (text.includes('association')) return 'has-dependents';
+
+  return undefined;
+}

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
 import { config as rxjsConfig } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -287,6 +287,137 @@ describe('EntityDeleteController', () => {
       expect(eds.markStale).not.toHaveBeenCalled();
       expect(eds.removeOrg).not.toHaveBeenCalled();
       expect(hook).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // blocked state + persistent latch (Increment 3). A classified failure
+  // (422 association_not_empty / 403 / in-progress) terminates as `blocked`
+  // with a reason and latches the entity: subsequent delete()s short-circuit
+  // to blocked (no server call) until an explicit clear().
+  // -------------------------------------------------------------------------
+
+  describe('blocked state + latch', () => {
+    // CF-AssociationNotEmpty 422 — the canonical has-dependents block.
+    const assocError = new HttpErrorResponse({
+      status: 422,
+      statusText: 'error',
+      error: { errors: [{ code: 10006, title: 'CF-AssociationNotEmpty', detail: 'spaces remain' }] },
+    });
+
+    // Builds a controller whose write throws `error` on every call, with a
+    // call-count so tests can assert the server was (not) hit.
+    const configureThrowing = (error: unknown) => {
+      const writeFn = vi.fn(async () => { throw error; });
+      const eds = {
+        markStale: vi.fn(), removeOrg: vi.fn(), removeSpace: vi.fn(), removeApp: vi.fn(),
+        removeServiceInstance: vi.fn(), removeServiceCredentialBinding: vi.fn(),
+      };
+      const diag = { emitCounter: vi.fn() };
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          EntityDeleteController,
+          { provide: WRITE_WITH_JOB, useValue: writeFn },
+          { provide: EndpointDataRegistry, useValue: { peek: () => eds } },
+          { provide: SignalRelationFetcherService, useValue: { snapshotRegistry: () => indexDescriptors([]) } },
+          { provide: StratosDiagnostics, useValue: diag },
+        ],
+      });
+      return { ctrl: TestBed.inject(EntityDeleteController), writeFn, eds, diag };
+    };
+
+    it('terminates a classified failure as blocked with a reason', async () => {
+      const { ctrl } = configureThrowing(assocError);
+      const states = await collectStates(ctrl, makeRequest());
+      expect(states).toEqual(['start', 'blocked']);
+    });
+
+    it('blocked terminal carries reason and error', async () => {
+      const { ctrl } = configureThrowing(assocError);
+      const terminal = await ctrl.delete(makeRequest()).done;
+      expect(terminal.state).toBe('blocked');
+      expect(terminal.reason).toBe('has-dependents');
+      expect(terminal.error).toBe(assocError);
+    });
+
+    it('emits a blocked diagnostics counter', async () => {
+      const { ctrl, diag } = configureThrowing(assocError);
+      await ctrl.delete(makeRequest()).done;
+      expect(diag.emitCounter).toHaveBeenCalledWith('delete-event', { state: 'blocked', entityKind: 'app' });
+    });
+
+    it('does not invalidate or run cleanup on the blocked path', async () => {
+      const { ctrl, eds } = configureThrowing(assocError);
+      const hook = vi.fn();
+      ctrl.registerCleanup(hook);
+      await ctrl.delete(makeRequest()).done;
+      expect(eds.markStale).not.toHaveBeenCalled();
+      expect(eds.removeApp).not.toHaveBeenCalled();
+      expect(hook).not.toHaveBeenCalled();
+    });
+
+    it('latches the entity so a second delete short-circuits without calling write', async () => {
+      const { ctrl, writeFn } = configureThrowing(assocError);
+      const req = makeRequest();
+      await ctrl.delete(req).done;             // first attempt hits the server -> blocked
+      expect(writeFn).toHaveBeenCalledTimes(1);
+      expect(ctrl.isBlocked(req)).toBe(true);
+
+      const states = await collectStates(ctrl, req); // second attempt is latched
+      expect(states).toEqual(['blocked']);     // no `start` — never attempted
+      expect(writeFn).toHaveBeenCalledTimes(1); // still 1: server not hit again
+    });
+
+    it('the short-circuited blocked event preserves the original reason + error', async () => {
+      const { ctrl } = configureThrowing(assocError);
+      const req = makeRequest();
+      await ctrl.delete(req).done;
+      const terminal = await ctrl.delete(req).done;
+      expect(terminal.state).toBe('blocked');
+      expect(terminal.reason).toBe('has-dependents');
+      expect(terminal.error).toBe(assocError);
+    });
+
+    it('clear() releases the latch so the next delete attempts the server again', async () => {
+      const { ctrl, writeFn } = configureThrowing(assocError);
+      const req = makeRequest();
+      await ctrl.delete(req).done;
+      ctrl.clear(req);
+      expect(ctrl.isBlocked(req)).toBe(false);
+      await ctrl.delete(req).done;
+      expect(writeFn).toHaveBeenCalledTimes(2); // attempted again after clear
+    });
+
+    it('an unclassified failure stays failure and does NOT latch', async () => {
+      const { ctrl } = configureThrowing(new Error('boom'));
+      const req = makeRequest();
+      const terminal = await ctrl.delete(req).done;
+      expect(terminal.state).toBe('failure');
+      expect(ctrl.isBlocked(req)).toBe(false);
+    });
+
+    it('a successful delete clears any stale latch for that entity', async () => {
+      // First block, then a write that succeeds clears the latch defensively.
+      const writeFn = vi.fn()
+        .mockImplementationOnce(async () => { throw assocError; })
+        .mockImplementationOnce(async () => ({ status: 'COMPLETE', state: undefined }));
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          EntityDeleteController,
+          { provide: WRITE_WITH_JOB, useValue: writeFn },
+          ...stubInvalidationProviders(),
+        ],
+      });
+      const ctrl = TestBed.inject(EntityDeleteController);
+      const req = makeRequest();
+      await ctrl.delete(req).done;
+      expect(ctrl.isBlocked(req)).toBe(true);
+      ctrl.clear(req);
+      const terminal = await ctrl.delete(req).done;
+      expect(terminal.state).toBe('success');
+      expect(ctrl.isBlocked(req)).toBe(false);
     });
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/entity-delete.controller.ts
@@ -9,7 +9,13 @@ import { EndpointDataRegistry } from '../endpoint-data/endpoint-data.registry';
 import type { EndpointDataService } from '../endpoint-data/endpoint-data.service';
 import { SignalRelationFetcherService } from '../../entity-relations/signal/signal-relation-fetcher.service';
 import { affectedSlices, ENTITY_TYPE_TO_SLICE, referencingSlices } from './affected-slices';
-import type { DeleteCleanupHook, DeleteEvent, DeleteHandle, DeleteRequest } from './delete-event.types';
+import { classifyBlock } from './block-classification';
+import type { BlockReason, DeleteCleanupHook, DeleteEvent, DeleteHandle, DeleteRequest } from './delete-event.types';
+
+/** Identity of a delete target, for latch keying. */
+type DeleteKey = Pick<DeleteRequest, 'cnsiGuid' | 'entityKind' | 'deleteGuid'>;
+
+const latchKey = (req: DeleteKey): string => `${req.cnsiGuid}:${req.entityKind}:${req.deleteGuid}`;
 
 // ---------------------------------------------------------------------------
 // Injection token — lets tests supply a fake without touching HttpClient.
@@ -62,9 +68,26 @@ export class EntityDeleteController {
   // invoked after every successful delete.
   private readonly cleanups: DeleteCleanupHook[] = [];
 
+  // Persistent blocked latch (Increment 3). Keyed by entity identity, holds
+  // the classified reason + original error. While an entry is set the
+  // mechanism refuses to re-attempt — delete() short-circuits to `blocked`
+  // until an explicit clear(). Stops auto-retry/refresh loops from hammering a
+  // delete that needs human resolution (remove dependents, fix permissions).
+  private readonly blocked = new Map<string, { reason: BlockReason; error: unknown }>();
+
   /** Register a cleanup hook fired after each successful delete. */
   registerCleanup(hook: DeleteCleanupHook): void {
     this.cleanups.push(hook);
+  }
+
+  /** True while a delete for this entity is latched blocked. */
+  isBlocked(req: DeleteKey): boolean {
+    return this.blocked.has(latchKey(req));
+  }
+
+  /** Release the blocked latch so a subsequent delete re-attempts the server. */
+  clear(req: DeleteKey): void {
+    this.blocked.delete(latchKey(req));
   }
 
   delete(req: DeleteRequest): DeleteHandle {
@@ -88,17 +111,38 @@ export class EntityDeleteController {
       } catch { /* diagnostics must never break the lifecycle */ }
     };
 
+    const key = latchKey(req);
+
     const done = (async (): Promise<DeleteEvent> => {
+      // Latched: refuse to re-attempt. Re-emit blocked from the stored
+      // classification (no `start`, no server call) until the caller clear()s.
+      const held = this.blocked.get(key);
+      if (held) {
+        const terminal: DeleteEvent = { ...base, state: 'blocked', reason: held.reason, error: held.error };
+        safeNext(terminal);
+        try { subject.complete(); } catch { /* observer threw */ }
+        return terminal;
+      }
+
       let terminal: DeleteEvent;
       try {
         safeNext({ ...base, state: 'start' });
         await this.writeFn(this.http, req.call());
+        // A prior block for this key is now moot — the entity is gone.
+        this.blocked.delete(key);
         // Invalidate caches + run cleanup BEFORE emitting success so a
         // success observer sees a consistent post-delete world.
         this.invalidateAndCleanup(req);
         terminal = { ...base, state: 'success' };
       } catch (error: unknown) {
-        terminal = { ...base, state: 'failure', error };
+        const reason = classifyBlock(error);
+        if (reason) {
+          // Classified non-retryable: latch the entity and surface `blocked`.
+          this.blocked.set(key, { reason, error });
+          terminal = { ...base, state: 'blocked', reason, error };
+        } else {
+          terminal = { ...base, state: 'failure', error };
+        }
       }
       safeNext(terminal);
       try { subject.complete(); } catch { /* observer threw */ }

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.spec.ts
@@ -57,6 +57,16 @@ describe('runCfDelete', () => {
     ).rejects.toBe(boom);
   });
 
+  it('throws the terminal error when the delete is blocked', async () => {
+    const boom = new Error('CF-AssociationNotEmpty');
+    const controller = makeController({ state: 'blocked', reason: 'has-dependents', error: boom });
+    await expect(
+      runCfDelete(controller, makeHttp(), {
+        cnsiGuid: 'c1', entityKind: 'organization', deleteGuid: 'o1', path: '/pp/v1/cf/orgs/c1/o1',
+      }),
+    ).rejects.toBe(boom);
+  });
+
   it('resolves void on success', async () => {
     const controller = makeController({});
     await expect(

--- a/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/deletes/run-cf-delete.ts
@@ -5,8 +5,10 @@ import type { EntityDeleteController } from './entity-delete.controller';
  * Shared helper that routes a CF entity delete through the
  * EntityDeleteController chokepoint. Builds the DeleteRequest (a CF v3
  * DELETE with `observe: 'response'` so writeWithJob can read the 202 + job
- * URL), awaits the terminal lifecycle event, and throws on failure so the
- * calling component's catch can surface a snackbar.
+ * URL), awaits the terminal lifecycle event, and throws on a non-success
+ * terminal (failure or blocked) so the calling component's catch can surface
+ * a snackbar — for blocked, the stored CF error (e.g. association_not_empty)
+ * carries through.
  *
  * Every per-entity signal-config `deleteX` is a thin call to this so the
  * delete-and-invalidate path has exactly one implementation.
@@ -34,7 +36,7 @@ export async function runCfDelete(
     deleteName,
     call: () => http.delete(req.path, { observe: 'response' }),
   }).done;
-  if (result.state === 'failure') {
+  if (result.state === 'failure' || result.state === 'blocked') {
     throw result.error ?? new Error(`Failed to delete ${req.entityKind} "${deleteName}"`);
   }
 }


### PR DESCRIPTION
## What

Adds the `blocked` lifecycle state to the signal-native `EntityDeleteController` (Increment 3 of the common delete-mechanism work), so a delete that fails for a known precondition is surfaced distinctly from a transient failure and stops auto-retry loops.

- **`classifyBlock(error)`** — pure classifier mapping a delete failure (either an `HttpErrorResponse` or a polled `StratosJobError`) to a `BlockReason`: `403` → `forbidden`, async/`last_operation` in-progress → `operation-in-progress`, `CF-AssociationNotEmpty` → `has-dependents`. Transient/5xx/generic-validation stay `failure`.
- **Controller** emits a `blocked` terminal (with `reason` + error) instead of `failure` for classified cases, and **latches** the entity by `cnsi:kind:guid`. While latched, `delete()` short-circuits to `blocked` (re-emitting the stored reason/error, no server call) until an explicit `clear()`. `isBlocked()`/`clear()` expose the latch; a successful delete clears it defensively. Blocked runs no invalidation/cleanup and fires a `delete-event` `state:'blocked'` diagnostics counter.
- **`runCfDelete`** throws on `blocked` too, so the stored CF error (e.g. association_not_empty) reaches the component snackbar instead of resolving silently.

Presentation of the `blocked` state (rendering the latch, wiring a UI `clear()`) is intentionally out of scope — it lands when a view adopts the lifecycle stream.

## Testing

Full `make check gate` green (2389 frontend tests, 0 TS/build errors). TDD throughout — 22 controller tests, classifier and runCfDelete specs.