### PR TITLE
refactor(helm): strip dead ngrx version/install effects + entities

### DIFF
--- a/src/frontend/packages/kubernetes/src/helm/helm-entity-catalog.ts
+++ b/src/frontend/packages/kubernetes/src/helm/helm-entity-catalog.ts
@@ -5,10 +5,8 @@ import {
 import { IFavoriteMetadata } from '../../../store/src/types/user-favorites.types';
 import {
   HelmChartActionBuilders,
-  HelmChartVersionsActionBuilders,
-  HelmVersionActionBuilders,
 } from './store/helm.action-builders';
-import { HelmVersion, MonocularChart, MonocularVersion } from './store/helm.types';
+import { MonocularChart } from './store/helm.types';
 
 /**
  * A strongly typed collection of Helm Catalog Entities.
@@ -17,8 +15,6 @@ import { HelmVersion, MonocularChart, MonocularVersion } from './store/helm.type
 export class HelmEntityCatalog {
   endpoint!: StratosCatalogEndpointEntity;
   chart!: StratosCatalogEntity<IFavoriteMetadata, MonocularChart, HelmChartActionBuilders>;
-  version!: StratosCatalogEntity<IFavoriteMetadata, HelmVersion, HelmVersionActionBuilders>;
-  chartVersions!: StratosCatalogEntity<IFavoriteMetadata, MonocularVersion[], HelmChartVersionsActionBuilders>;
 }
 
 /**

--- a/src/frontend/packages/kubernetes/src/helm/helm-entity-factory.ts
+++ b/src/frontend/packages/kubernetes/src/helm/helm-entity-factory.ts
@@ -2,11 +2,9 @@ import { Schema, schema } from 'normalizr';
 
 import { EntitySchema } from '../../../store/src/helpers/entity-schema';
 import { stratosMonocularEndpointGuid } from './monocular/stratos-monocular.helper';
-import { HelmVersion, MonocularChart } from './store/helm.types';
+import { MonocularChart } from './store/helm.types';
 
-export const helmVersionsEntityType = 'helmVersions';
 export const monocularChartsEntityType = 'monocularCharts';
-export const monocularChartVersionsEntityType = 'monocularChartVersions';
 
 export const HELM_ENDPOINT_TYPE = 'helm';
 export const HELM_REPO_ENDPOINT_TYPE = 'repo';
@@ -43,18 +41,6 @@ entityCache[monocularChartsEntityType] = new HelmEntitySchema(
       return monocularPrefix + '/' + entity.id;
     }
   }
-);
-
-entityCache[helmVersionsEntityType] = new HelmEntitySchema(
-  helmVersionsEntityType,
-  {},
-  { idAttribute: (entity: HelmVersion) => entity.endpointId }
-);
-
-entityCache[monocularChartVersionsEntityType] = new HelmEntitySchema(
-  monocularChartVersionsEntityType,
-  {},
-  { idAttribute: (entity: MonocularChart) => entity.id }
 );
 
 export function helmEntityFactory(key: string): EntitySchema {

--- a/src/frontend/packages/kubernetes/src/helm/helm-entity-generator.ts
+++ b/src/frontend/packages/kubernetes/src/helm/helm-entity-generator.ts
@@ -19,18 +19,12 @@ import {
   HELM_HUB_ENDPOINT_TYPE,
   HELM_REPO_ENDPOINT_TYPE,
   helmEntityFactory,
-  helmVersionsEntityType,
-  monocularChartsEntityType,
-  monocularChartVersionsEntityType } from './helm-entity-factory';
+  monocularChartsEntityType } from './helm-entity-factory';
 import { HelmHubRegistrationComponent } from './helm-hub-registration/helm-hub-registration.component';
 import {
   HelmChartActionBuilders,
-  helmChartActionBuilders,
-  HelmChartVersionsActionBuilders,
-  helmChartVersionsActionBuilders,
-  HelmVersionActionBuilders,
-  helmVersionActionBuilders } from './store/helm.action-builders';
-import { HelmVersion, MonocularChart, MonocularVersion } from './store/helm.types';
+  helmChartActionBuilders } from './store/helm.action-builders';
+import { MonocularChart } from './store/helm.types';
 
 
 export function generateHelmEntities(): StratosBaseCatalogEntity[] {
@@ -107,8 +101,6 @@ export function generateHelmEntities(): StratosBaseCatalogEntity[] {
   return [
     generateEndpointEntity(endpointDefinition),
     generateChartEntity(endpointDefinition),
-    generateVersionEntity(endpointDefinition),
-    generateChartVersionsEntity(endpointDefinition),
   ];
 }
 
@@ -133,36 +125,6 @@ function generateChartEntity(endpointDefinition: StratosEndpointExtensionDefinit
     }
   );
   return helmEntityCatalog.chart;
-}
-
-function generateVersionEntity(endpointDefinition: StratosEndpointExtensionDefinition) {
-  const definition = {
-    type: helmVersionsEntityType,
-    schema: helmEntityFactory(helmVersionsEntityType),
-    endpoint: endpointDefinition
-  };
-  helmEntityCatalog.version = new StratosCatalogEntity<IFavoriteMetadata, HelmVersion, HelmVersionActionBuilders>(
-    definition,
-    {
-      actionBuilders: helmVersionActionBuilders
-    }
-  );
-  return helmEntityCatalog.version;
-}
-
-function generateChartVersionsEntity(endpointDefinition: StratosEndpointExtensionDefinition) {
-  const definition = {
-    type: monocularChartVersionsEntityType,
-    schema: helmEntityFactory(monocularChartVersionsEntityType),
-    endpoint: endpointDefinition
-  };
-  helmEntityCatalog.chartVersions = new StratosCatalogEntity<IFavoriteMetadata, MonocularVersion[], HelmChartVersionsActionBuilders>(
-    definition,
-    {
-      actionBuilders: helmChartVersionsActionBuilders
-    }
-  );
-  return helmEntityCatalog.chartVersions;
 }
 
 

--- a/src/frontend/packages/kubernetes/src/helm/store/helm.action-builders.ts
+++ b/src/frontend/packages/kubernetes/src/helm/store/helm.action-builders.ts
@@ -1,49 +1,13 @@
 import { OrchestratedActionBuilders } from '../../../../store/src/entity-catalog/action-orchestrator/action-orchestrator';
 import { EndpointModel } from '../../../../store/src/public-api';
-import { GetHelmChartVersions, GetHelmVersions, GetMonocularCharts, HelmInstall, HelmSynchronise } from './helm.actions';
-import { HelmInstallValues } from './helm.types';
+import { GetMonocularCharts, HelmSynchronise } from './helm.actions';
 
 export interface HelmChartActionBuilders extends OrchestratedActionBuilders {
   getMultiple: () => GetMonocularCharts;
-  // Helm install added to chart action builder and not helm release/workload to ensure action & effect are available in this module
-  // (others may not have loaded)
-  install: (values: HelmInstallValues) => HelmInstall;
   synchronise: (endpoint: EndpointModel) => HelmSynchronise;
 }
 
 export const helmChartActionBuilders: HelmChartActionBuilders = {
   getMultiple: () => new GetMonocularCharts(),
-  install: (values: HelmInstallValues) => new HelmInstall(values),
   synchronise: (endpoint: EndpointModel) => new HelmSynchronise(endpoint)
-};
-
-export interface HelmVersionActionBuilders extends OrchestratedActionBuilders {
-  getMultiple: () => GetHelmVersions;
-}
-
-export const helmVersionActionBuilders: HelmVersionActionBuilders = {
-  getMultiple: () => new GetHelmVersions()
-};
-
-export interface HelmChartVersionsActionBuilders extends OrchestratedActionBuilders {
-  getMultiple: (
-    endpointGuid: string,
-    paginationKey: string,
-    extraArgs: {
-      monocularEndpoint: string,
-      repoName: string,
-      chartName: string;
-    }) => GetHelmChartVersions;
-}
-
-export const helmChartVersionsActionBuilders: HelmChartVersionsActionBuilders = {
-  getMultiple: (
-    endpointGuid: string,
-    paginationKey: string,
-    extraArgs: {
-      monocularEndpoint: string,
-      repoName: string,
-      chartName: string;
-    }) =>
-    new GetHelmChartVersions(extraArgs.monocularEndpoint, extraArgs.repoName, extraArgs.chartName)
 };

--- a/src/frontend/packages/kubernetes/src/helm/store/helm.actions.ts
+++ b/src/frontend/packages/kubernetes/src/helm/store/helm.actions.ts
@@ -5,27 +5,12 @@ import { EntityRequestAction } from '../../../../store/src/types/request.types';
 import {
   HELM_ENDPOINT_TYPE,
   helmEntityFactory,
-  helmVersionsEntityType,
   monocularChartsEntityType,
-  monocularChartVersionsEntityType,
 } from '../helm-entity-factory';
-import { HelmInstallValues } from './helm.types';
 
 export const GET_MONOCULAR_CHARTS = '[Monocular] Get Charts';
 export const GET_MONOCULAR_CHARTS_SUCCESS = '[Monocular] Get Charts Success';
 export const GET_MONOCULAR_CHARTS_FAILURE = '[Monocular] Get Charts Failure';
-
-export const GET_MONOCULAR_CHART_VERSIONS = '[Monocular] Get Chart Versions';
-export const GET_MONOCULAR_CHART_VERSIONS_SUCCESS = '[Monocular] Get Chart Versions Success';
-export const GET_MONOCULAR_CHART_VERSIONS_FAILURE = '[Monocular] Get Chart Versions Failure';
-
-export const GET_HELM_VERSIONS = '[Helm] Get Versions';
-export const GET_HELM_VERSIONS_SUCCESS = '[Helm] Get Versions Success';
-export const GET_HELM_VERSIONS_FAILURE = '[Helm] Get Versions Failure';
-
-export const HELM_INSTALL = '[Helm] Install';
-export const HELM_INSTALL_SUCCESS = '[Helm] Install Success';
-export const HELM_INSTALL_FAILURE = '[Helm] Install Failure';
 
 export const HELM_SYNCHRONISE = '[Helm] Synchronise';
 
@@ -59,56 +44,4 @@ export class HelmSynchronise implements Action {
   constructor(public endpoint: EndpointModel) {
     this.guid = endpoint.guid;
   }
-}
-
-export class HelmInstall implements EntityRequestAction {
-  type = HELM_INSTALL;
-  endpointType = HELM_ENDPOINT_TYPE;
-  entityType = monocularChartsEntityType;
-  guid: string;
-  constructor(public values: HelmInstallValues) {
-    this.guid = '<New Release>' + this.values.releaseName;
-  }
-}
-
-export class GetHelmVersions implements MonocularPaginationAction {
-  constructor() {
-    this.paginationKey = 'helm-versions';
-  }
-  type = GET_HELM_VERSIONS;
-  endpointType = HELM_ENDPOINT_TYPE;
-  entityType = helmVersionsEntityType;
-  entity = [helmEntityFactory(helmVersionsEntityType)];
-  actions = [
-    GET_HELM_VERSIONS,
-    GET_HELM_VERSIONS_SUCCESS,
-    GET_HELM_VERSIONS_FAILURE
-  ];
-  paginationKey: string;
-  initialParams = {
-    'order-direction': 'asc',
-    'order-direction-field': 'version',
-  };
-  flattenPagination = true;
-}
-
-export class GetHelmChartVersions implements MonocularPaginationAction {
-  constructor(public monocularEndpoint: string, public repoName: string, public chartName: string) {
-    this.paginationKey = `'monocular-chart-versions-${repoName}-${chartName}`;
-  }
-  type = GET_MONOCULAR_CHART_VERSIONS;
-  endpointType = HELM_ENDPOINT_TYPE;
-  entityType = monocularChartVersionsEntityType;
-  entity = [helmEntityFactory(monocularChartVersionsEntityType)];
-  actions = [
-    GET_MONOCULAR_CHART_VERSIONS,
-    GET_MONOCULAR_CHART_VERSIONS_SUCCESS,
-    GET_MONOCULAR_CHART_VERSIONS_FAILURE
-  ];
-  paginationKey: string;
-  initialParams = {
-    'order-direction': 'asc',
-    'order-direction-field': 'version',
-  };
-  flattenPagination = true;
 }

--- a/src/frontend/packages/kubernetes/src/helm/store/helm.effects.ts
+++ b/src/frontend/packages/kubernetes/src/helm/store/helm.effects.ts
@@ -5,7 +5,7 @@ import { combineLatest, Observable, of } from 'rxjs';
 import { catchError, flatMap, map, mergeMap } from 'rxjs/operators';
 
 import { environment } from '../../../../core/src/environments/environment';
-import { ClearPaginationOfType, ResetPaginationOfType } from '../../../../store/src/actions/pagination.actions';
+import { ResetPaginationOfType } from '../../../../store/src/actions/pagination.actions';
 import { EntitySchema } from '../../../../store/src/helpers/entity-schema';
 import { isJetstreamError } from '../../../../store/src/jetstream';
 import {
@@ -20,29 +20,18 @@ import {
   entityCatalog,
   NormalizedResponse,
   ofType } from '../../../../store/src/public-api';
-import { ApiRequestTypes } from '../../../../store/src/reducers/api-request-reducer/request-helpers';
 import { EndpointDisconnectCleanupService } from '../../../../store/src/services/endpoint-disconnect-cleanup.service';
 import {
-  EntityRequestAction,
   StartRequestAction,
   WrapperRequestActionFailed } from '../../../../store/src/types/request.types';
 import { helmEntityCatalog } from '../helm-entity-catalog';
 import { HELM_ENDPOINT_TYPE, HELM_HUB_ENDPOINT_TYPE, HELM_REPO_ENDPOINT_TYPE } from '../helm-entity-factory';
 import { Chart } from '../monocular/shared/models/chart';
-import { ChartVersion } from '../monocular/shared/models/chart-version';
-import { stratosMonocularEndpointGuid } from '../monocular/stratos-monocular.helper';
 import {
-  GET_HELM_VERSIONS,
-  GET_MONOCULAR_CHART_VERSIONS,
   GET_MONOCULAR_CHARTS,
-  GetHelmChartVersions,
-  GetHelmVersions,
   GetMonocularCharts,
-  HELM_INSTALL,
   HELM_SYNCHRONISE,
-  HelmInstall,
   HelmSynchronise } from './helm.actions';
-import { HelmVersion } from './helm.types';
 
 type MonocularChartsResponse = {
   data: Chart[];
@@ -167,100 +156,6 @@ export class HelmEffects {
   ));
 
   
-  fetchVersions$ = createEffect(() => this.actions$.pipe(
-    ofType<GetHelmVersions>(GET_HELM_VERSIONS),
-    flatMap(action => {
-      const entityKey = entityCatalog.getEntityKey(action);
-      return this.makeRequest(action, `/pp/${this.proxyAPIVersion}/helm/versions`, (response) => {
-        const processedData: NormalizedResponse = {
-          entities: { [entityKey]: {} },
-          result: []
-        };
-
-        // Go through each endpoint ID
-        Object.keys(response).forEach(endpoint => {
-          const responseObj = response as Record<string, unknown>;
-          const endpointData = responseObj[endpoint] || {};
-          if (isJetstreamError(endpointData)) {
-            throw endpointData;
-          }
-          // Maintain typing
-          const version: HelmVersion = {
-            endpointId: endpoint,
-            ...endpointData as Omit<HelmVersion, 'endpointId'>
-          };
-          processedData.entities[entityKey][action.entity[0].getId(version)] = version;
-          processedData.result.push(endpoint);
-        });
-        return processedData;
-      }, []);
-    })
-  ));
-
-  
-  fetchChartVersions$ = createEffect(() => this.actions$.pipe(
-    ofType<GetHelmChartVersions>(GET_MONOCULAR_CHART_VERSIONS),
-    flatMap(action => {
-      const entityKey = entityCatalog.getEntityKey(action);
-      return this.makeRequest(action, `/pp/${this.proxyAPIVersion}/chartsvc/v1/charts/${action.repoName}/${action.chartName}/versions`,
-        (response) => {
-          const base: NormalizedResponse = {
-            entities: { [entityKey]: {} },
-            result: []
-          };
-
-          const items = (response as { data: ChartVersion[] }).data;
-          const processedData = items.reduce((res, data) => {
-            const id = action.entity[0].getId(data);
-            res.entities[entityKey][id] = data;
-            // Promote the name to the top-level object for simplicity
-            (data as unknown as { name: string }).name = data.attributes.name;
-            res.result.push(id);
-            return res;
-          }, base);
-          return processedData;
-        }, [], {
-        'x-cap-cnsi-list': action.monocularEndpoint && action.monocularEndpoint !== stratosMonocularEndpointGuid ?
-          action.monocularEndpoint :
-          ''
-      });
-    })
-  ));
-
-  
-  helmInstall$ = createEffect(() => this.actions$.pipe(
-    ofType<HelmInstall>(HELM_INSTALL),
-    flatMap(action => {
-      const requestType: ApiRequestTypes = 'create';
-      const url = '/pp/v1/helm/install';
-      this.store.dispatch(new StartRequestAction(action, requestType));
-      return this.httpClient.post(url, action.values).pipe(
-        mergeMap(() => {
-          this.appRef.tick();
-          return [
-            new ClearPaginationOfType(action),
-            new WrapperRequestActionSuccess(null, action)
-          ];
-        }),
-        catchError(error => {
-          this.appRef.tick();
-          const { status, message } = HelmEffects.createHelmError(error);
-          const errorMessage = `Failed to install helm chart: ${message}`;
-          return [
-            new WrapperRequestActionFailed(errorMessage, action, requestType, {
-              endpointIds: [action.values.endpoint],
-              url: error.url || url,
-              eventCode: status,
-              message: errorMessage,
-              error
-            })
-          ];
-        })
-      );
-    })
-  ));
-
-
   helmSynchronise$ = createEffect(() => this.actions$.pipe(
     ofType<HelmSynchronise>(HELM_SYNCHRONISE),
     flatMap((action): Action[] => {
@@ -294,8 +189,6 @@ export class HelmEffects {
       }
       this.appRef.tick();
       this.store.dispatch(new ResetPaginationOfType(helmEntityCatalog.chart.getSchema()));
-      this.store.dispatch(new ResetPaginationOfType(helmEntityCatalog.chartVersions.getSchema()));
-      this.store.dispatch(new ResetPaginationOfType(helmEntityCatalog.version.getSchema()));
     });
 
     // Replaces legacy `registerEndpoint$` (REGISTER_ENDPOINTS_SUCCESS) —
@@ -388,39 +281,6 @@ export class HelmEffects {
     return helmRepoEndpoints ?
       this.httpClient.get<MonocularChartsResponse>(`/pp/${this.proxyAPIVersion}/chartsvc/v1/charts`) :
       of({ data: [] });
-  }
-
-  private makeRequest(
-    action: EntityRequestAction,
-    url: string,
-    mapResult: (response: unknown) => NormalizedResponse,
-    endpointIds: string[],
-    headers: Record<string, string> = {}
-  ): Observable<Action> {
-    this.store.dispatch(new StartRequestAction(action));
-    const requestArgs: { headers: Record<string, string>; params: null } = {
-      headers,
-      params: null
-    };
-    return this.httpClient.get(url, requestArgs).pipe(
-      mergeMap((response: unknown) => {
-        this.appRef.tick();
-        return [new WrapperRequestActionSuccess(mapResult(response), action)];
-      }),
-      catchError(error => {
-        this.appRef.tick();
-        const { status, message } = HelmEffects.createHelmError(error);
-        return [
-          new WrapperRequestActionFailed(message, action, 'fetch', {
-            endpointIds,
-            url: error.url || url,
-            eventCode: status,
-            message,
-            error
-          })
-        ];
-      })
-    );
   }
 
   private checkSyncStatus(): void {


### PR DESCRIPTION
## What

First slice of the wave-4 kubernetes/helm `@ngrx` removal: strip the helm ngrx surface that has **zero live consumers**, verified by a whole-frontend reference sweep before any deletion.

Removed:
- **Effects**: `fetchVersions$`, `fetchChartVersions$`, `helmInstall$` (+ the now-orphaned `makeRequest` helper). Install already uses `KubeHelmDataService.install()` (direct HTTP); chart versions read via `ChartsService` (direct HTTP) — none dispatch these actions.
- **Actions**: `HelmInstall`, `GetHelmVersions`, `GetHelmChartVersions` + their type constants.
- **Action builders**: `install`, `helmVersionActionBuilders`, `helmChartVersionsActionBuilders`.
- **Entities**: `helmEntityCatalog.version` + `.chartVersions` registrations + their `helmVersions`/`monocularChartVersions` schema-factory entries.
- Trimmed the now-dead `chartVersions`/`version` `ResetPaginationOfType` dispatches from the live endpoint-disconnect cleanup handler (kept the `chart` one).

Live paths kept intact: `fetchCharts$` (catalog tab), `helmSynchronise$` (endpoint "Synchronize"), chart cleanup. `MonocularVersion`/`helm.types.ts` preserved (still used by the upgrade-release signal config).

Net −299 lines.

## Testing

Full `make check gate` green (2367 tests, 0 TS/build errors). No specs referenced any removed symbol.