### PR TITLE
fix(cf): restore migration-dropped app-detail affordances (labels, instance count, restage spinner)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.spec.ts
@@ -125,7 +125,7 @@ describe('ApplicationTabsBaseComponent', () => {
         // AppApplicationActionsService injects AppDetailDataService for
         // the post-op refresh fan-out. Provide a no-op stub so the test
         // doesn't need to thread the full HTTP-backed service.
-        { provide: AppDetailDataService, useValue: { refresh: () => Promise.resolve() } },
+        { provide: AppDetailDataService, useValue: { refresh: () => Promise.resolve(), app: signal(undefined), updating: signal(false) } },
         provideRouter([]),
         provideZonelessChangeDetection(),
       ]

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -300,7 +300,19 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
       });
     });
 
-    this.isFetching$ = this.applicationService.isFetchingApp$;
+    // The full-page "Retrieving application" overlay is for the INITIAL load
+    // only. Lifecycle actions (restage/start/stop/restart) refresh the app
+    // entity on success, which flips isFetchingApp$ true again — but the app
+    // is already on screen and the Status card (stage-row progress) + the
+    // snackbar convey the action's progress/result in place. Gating on "app
+    // not yet present" stops those refreshes from blanking the whole page with
+    // the spinner (the restage repaint regression).
+    this.isFetching$ = observableCombineLatest(
+      this.applicationService.isFetchingApp$,
+      toObservable(this.detail.app, { injector: this.injector }),
+    ).pipe(
+      map(([isFetchingApp, app]) => isFetchingApp && !app),
+    );
 
     this.isBusyUpdating$ = toObservable(this.detail.updating, { injector: this.injector }).pipe(
       map(updating => ({ updating })),

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step2/create-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step2/create-application-step2.component.html
@@ -2,7 +2,7 @@
 <form novalidate [formGroup]="form" class="flex flex-col gap-6">
   <div>
     <app-form-field class="relative">
-      <input required appInput placeholder="Application Name" formControlName="appName" autocomplete="off" [appApplicationNameUnique]="appNameChecking">
+      <input class="w-full placeholder:!text-transparent focus:outline-none" required appInput placeholder="Application Name" formControlName="appName" autocomplete="off" [appApplicationNameUnique]="appNameChecking">
       @if (form.controls.appName?.hasError('appNameTaken')) {
         <app-error>
           This name has been taken, please try another.

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step2/create-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step2/create-application-step2.component.ts
@@ -4,7 +4,7 @@ import { FormsModule, ReactiveFormsModule,FormBuilder, FormControl, FormGroup } 
 import { Observable, of as observableOf } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { CustomFormFieldComponent, ErrorStateMatcher, ShowOnDirtyErrorStateMatcher, StatefulIconComponent, StepOnNextFunction } from '@stratosui/core';
+import { AppInputDirective, CustomFormFieldComponent, ErrorStateMatcher, ShowOnDirtyErrorStateMatcher, StatefulIconComponent, StepOnNextFunction } from '@stratosui/core';
 import { CreateAppStateService } from '../../../../shared/data-services/create-app-state.service';
 import { AppNameUniqueChecking, AppNameUniqueDirective } from '../../../../shared/directives/app-name-unique.directive/app-name-unique.directive';
 
@@ -23,6 +23,7 @@ selector: 'app-create-application-step2',
   imports: [
     FormsModule,
     ReactiveFormsModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     AppNameUniqueDirective,
     StatefulIconComponent

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.html
@@ -10,7 +10,7 @@
     </app-select>
   </app-form-field>
   <app-form-field>
-    <input required formControlName="host" appInput placeholder="Host" name="hostName">
+    <input class="w-full placeholder:!text-transparent focus:outline-none" required formControlName="host" appInput placeholder="Host" name="hostName">
     @if (setDomainHost.controls['host']?.errors?.maxlength) {
       <app-error>Host cannot exceed 63 characters</app-error>
     }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { from, Observable, of as observableOf, throwError } from 'rxjs';
 import { catchError, filter, map, mergeMap, switchMap } from 'rxjs/operators';
 
-import { CustomFormFieldComponent, CustomSelectComponent, CustomOptionComponent, ErrorStateMatcher, ShowOnDirtyErrorStateMatcher, StepOnNextFunction } from '@stratosui/core';
+import { AppInputDirective, CustomFormFieldComponent, CustomSelectComponent, CustomOptionComponent, ErrorStateMatcher, ShowOnDirtyErrorStateMatcher, StepOnNextFunction } from '@stratosui/core';
 import { CnsiAppsSource } from '../../../../services/data-sources/cnsi-apps-source';
 import { CnsiRoutesSource } from '../../../../services/data-sources/cnsi-routes-source';
 import { EndpointDataRegistry } from '../../../../services/endpoint-data/endpoint-data.registry';
@@ -27,6 +27,7 @@ interface DomainHostForm {
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,
     CustomOptionComponent

--- a/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.html
@@ -10,7 +10,7 @@
   <app-step [title]="'Edit Application'" [signalHandle]="signalHandle">
     <form [formGroup]="editAppForm" validate class="flex flex-col gap-6 p-6">
       <app-form-field class="relative">
-        <input appInput placeholder="Application Name" formControlName="name" autocomplete="off" [appFocus]="true">
+        <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Application Name" formControlName="name" autocomplete="off" [appFocus]="true">
         @if (editAppForm.controls.name.errors?.required) {
           <app-error>Application name is required</app-error>
         }
@@ -22,13 +22,13 @@
         </div>
       </app-form-field>
       <app-form-field>
-        <input appInput placeholder="Number of Instances" formControlName="instances" type="number">
+        <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Number of Instances" formControlName="instances" type="number">
       </app-form-field>
       <app-form-field>
-        <input appInput placeholder="Disk Quota (MB)" formControlName="disk_quota" type="number" min="1">
+        <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Disk Quota (MB)" formControlName="disk_quota" type="number" min="1">
       </app-form-field>
       <app-form-field>
-        <input appInput placeholder="Memory Quota (MB)" formControlName="memory" type="number" min="1">
+        <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Memory Quota (MB)" formControlName="memory" type="number" min="1">
       </app-form-field>
       <app-slide-toggle class="mt-2" formControlName="enable_ssh">Enable SSH to Application Instances</app-slide-toggle>
     </form>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, inject, computed } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, Validators, FormBuilder, FormControl, FormGroup } from '@angular/forms';
-import { CustomFormFieldComponent } from '@stratosui/core';
+import { AppInputDirective, CustomFormFieldComponent } from '@stratosui/core';
 import { Router, RouterModule } from '@angular/router';
 import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@stratosui/core';
 import { defer, firstValueFrom, from, Observable, of as observableOf, Subscription } from 'rxjs';
@@ -45,6 +45,7 @@ interface EditApplicationForm {
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     CustomSlideToggleComponent,
     PageHeaderComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.html
@@ -19,7 +19,7 @@
         <div class="add-route__form-fields">
           <div>
             <app-form-field>
-              <input appInput formControlName="host" placeholder="Host" required class="w-full">
+              <input appInput formControlName="host" placeholder="Host" required class="w-full placeholder:!text-transparent focus:outline-none">
               @if (addHTTPRoute.controls['host'].errors?.pattern) {
                 <app-error>Invalid Hostname</app-error>
               }
@@ -30,7 +30,7 @@
           </div>
           <div>
             <app-form-field>
-              <input appInput formControlName="path" placeholder="Path" class="w-full">
+              <input appInput formControlName="path" placeholder="Path" class="w-full placeholder:!text-transparent focus:outline-none">
               @if (addHTTPRoute.controls['path'].errors?.pattern) {
                 <app-error>Invalid Path</app-error>
               }
@@ -51,7 +51,7 @@
           <div>
             <app-checkbox formControlName="useRandomPort">Use a random port</app-checkbox>
             <app-form-field>
-              <input type="number" appInput formControlName="port" placeholder="Port" required class="w-full">
+              <input type="number" appInput formControlName="port" placeholder="Port" required class="w-full placeholder:!text-transparent focus:outline-none">
               @if (addTCPRoute.controls['port'].errors?.pattern) {
                 <app-error>Invalid Port</app-error>
               }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.ts
@@ -16,6 +16,7 @@ import { filter, startWith } from 'rxjs/operators';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 import {
+  AppInputDirective,
   CustomFormFieldComponent,
   CustomSelectComponent,
   CustomOptionComponent,
@@ -92,6 +93,7 @@ const pathPattern = `^([\\w\\-\\/\\!\\#\\[\\]\\@\\&\\$\\'\\(\\)\\*\\+\\;\\=\\,]*
   imports: [
     FormsModule,
     ReactiveFormsModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,
     CustomOptionComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.html
@@ -22,7 +22,7 @@
       The UAA origin that the user/s are registered with (Optional)
       <form class="stepper-form">
         <app-form-field>
-          <input appInput [(ngModel)]="origin" name="origin" placeholder="Origin">
+          <input class="w-full placeholder:!text-transparent focus:outline-none" appInput [(ngModel)]="origin" name="origin" placeholder="Origin">
         </app-form-field>
       </form>
     </div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.ts
@@ -6,6 +6,7 @@ import { combineLatest, Observable, of } from 'rxjs';
 import { take, defaultIfEmpty, map, publishReplay, refCount, startWith, switchMap } from 'rxjs/operators';
 
 import {
+  AppInputDirective,
   CustomFormFieldComponent,
   PermissionConfig,
   CurrentUserPermissionsService,
@@ -43,6 +44,7 @@ export class ManageUsersSetUsernamesHelper {
   imports: [
     CommonModule,
     FormsModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     StackedInputActionsComponent
   ]

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.html
@@ -29,7 +29,7 @@
     </div>
   }
   @if (canEdit()) {
-    @if (showActions && isRunning() && !isEditing) {
+    @if (showActions && !isEditing) {
       <div class="absolute top-4 right-4 flex gap-1 text-right">
         <button (click)="edit()" class="btn btn-icon" [disabled]="isUpdating()">
           <span class="material-icons">edit</span>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.spec.ts
@@ -157,10 +157,15 @@ describe('CardAppInstancesComponent', () => {
       expect(html).toContain('add_circle_outline');
     });
 
-    it('hides scale buttons when app is stopped', () => {
+    it('renders scale buttons when app is stopped (scaling is valid in any state)', () => {
+      // CF accepts scaling a stopped app — it sets the expected instance count,
+      // applied on next start. v4.9.2 wrongly gated these on the app running;
+      // show them whenever the user can edit, running or stopped.
       const { fixture } = setup({ showActions: true, appState: 'STOPPED' });
       const html: string = fixture.nativeElement.innerHTML;
-      expect(html).not.toContain('add_circle_outline');
+      expect(html).toContain('edit');
+      expect(html).toContain('remove_circle_outline');
+      expect(html).toContain('add_circle_outline');
     });
 
     it('hides actions when canEdit is false', () => {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-instances/card-app-instances.component.ts
@@ -99,9 +99,6 @@ export class CardAppInstancesComponent implements OnDestroy {
   /** Disable scale buttons while an app-level update is in flight. */
   readonly isUpdating = computed(() => this.dataService.loading().app);
 
-  /** True when the app entity reports STARTED. */
-  readonly isRunning = computed(() => this.dataService.running());
-
   /**
    * Edit-permission gate. Wraps the perm-check Observable into a signal
    * so the template stays pipe-free. canEdit() is null while the perm

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-status/card-app-status.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-status/card-app-status.component.spec.ts
@@ -14,6 +14,7 @@ function makeDataStub(overrides: Partial<{
   diskMb: number;
   statsRunning: number;
   statsTotal: number;
+  desiredInstances: number;
   lastPolledAt: Date | null;
 }> = {}) {
   const state = overrides.state ?? 'STARTED';
@@ -21,6 +22,10 @@ function makeDataStub(overrides: Partial<{
   const diskMb = overrides.diskMb ?? 1024;
   const runningCount = overrides.statsRunning ?? 2;
   const totalCount = overrides.statsTotal ?? 2;
+  // Desired (expected) instance count drives the denominator. Defaults to the
+  // stats total so running-app tests stay aligned; stopped-app tests override
+  // it independently (stats empty, but the expected count is still meaningful).
+  const desiredInstances = overrides.desiredInstances ?? totalCount;
   const lastPoll = overrides.lastPolledAt ?? null;
 
   const stats = Array.from({ length: totalCount }, (_, i) => ({
@@ -31,7 +36,7 @@ function makeDataStub(overrides: Partial<{
   }));
 
   return {
-    app: signal<any>({ entity: { state } }).asReadonly(),
+    app: signal<any>({ entity: { state, instances: desiredInstances } }).asReadonly(),
     summary: signal<any>({ memory: memoryMb, disk_quota: diskMb }).asReadonly(),
     stats: signal<any[]>(stats).asReadonly(),
     state: computed(() => ({ label: state, indicator: null, actions: {} })),
@@ -161,8 +166,17 @@ describe('CardAppStatusComponent', () => {
       expect(component.instancesLabel()).toBe('2/3 running');
     });
 
-    it('shows 0/0 when stats are empty', () => {
-      const { fixture } = setup({ statsRunning: 0, statsTotal: 0 });
+    it('uses the expected instance count as denominator when stopped (no stats)', () => {
+      // Regression: a stopped app has no per-instance stats, but its expected
+      // count is still 1 — the row must read "0/1 running", not "0/0 running"
+      // (which used stats.length as the denominator). Matches the Instances card.
+      const { fixture } = setup({ state: 'STOPPED', statsRunning: 0, statsTotal: 0, desiredInstances: 1 });
+      const component = fixture.componentInstance;
+      expect(component.instancesLabel()).toBe('0/1 running');
+    });
+
+    it('shows 0/0 when the app has no expected instances and no stats', () => {
+      const { fixture } = setup({ state: 'STOPPED', statsRunning: 0, statsTotal: 0, desiredInstances: 0 });
       const component = fixture.componentInstance;
       expect(component.instancesLabel()).toBe('0/0 running');
     });

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-status/card-app-status.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-app-status/card-app-status.component.ts
@@ -56,10 +56,15 @@ export class CardAppStatusComponent {
   });
 
   readonly instancesLabel = computed(() => {
-    const stats = this.data.stats();
     if (this.actions.inFlight() && this.staleSeconds() > 7) return 'updating…';
-    if (!stats?.length) return '0/0 running';
-    const running = stats.filter(s => s.state === 'RUNNING').length;
-    return `${running}/${stats.length} running`;
+    // Denominator is the EXPECTED instance count off the app entity — a
+    // persistent process property — not stats.length. A stopped app has no
+    // per-instance stats (stats fetch is skipped to avoid CF's stopped-stats
+    // error), so stats.length was 0 and the row read "0/0 running" even when
+    // the app expects 1. Mirror the Instances card: running / expected.
+    const expected = this.data.app()?.entity?.instances ?? 0;
+    const stats = this.data.stats();
+    const running = stats?.filter(s => s.state === 'RUNNING').length ?? 0;
+    return `${running}/${expected} running`;
   });
 }

--- a/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.html
+++ b/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.html
@@ -14,7 +14,7 @@
   </div>
   <div [formGroup]="formGroup">
     <app-form-field>
-      <input appInput placeholder="Description" formControlName="comment" required>
+      <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Description" formControlName="comment" required>
     </app-form-field>
   </div>
 

--- a/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.ts
+++ b/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/forms';
 import { ApiKey } from '@stratosui/store';
 
-import { CustomFormFieldComponent } from '../../../shared/components/custom-form-field/custom-form-field.component';
+import { AppInputDirective, CustomFormFieldComponent } from '../../../shared/components/custom-form-field/custom-form-field.component';
 import { DialogErrorComponent } from '../../../shared/components/dialog-error/dialog-error.component';
 import { AppProgressBarComponent } from '../../../shared/components/progress-bar/app-progress-bar.component';
 import { TailwindDialogRef } from '../../../shared/services/tailwind-dialog.service';
@@ -31,6 +31,7 @@ interface AddApiKeyForm {
   standalone: true,
   imports: [
     ReactiveFormsModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     AppProgressBarComponent,
     DialogErrorComponent,

--- a/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.html
+++ b/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.html
@@ -11,13 +11,13 @@
     <div>
       <form [formGroup]="editProfileForm" validate class="mt-2.5 flex flex-col max-w-full">
         <app-form-field>
-          <input appInput placeholder="Given Name" formControlName="givenName">
+          <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Given Name" formControlName="givenName">
         </app-form-field>
         <app-form-field>
-          <input appInput placeholder="Family Name" formControlName="familyName">
+          <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Family Name" formControlName="familyName">
         </app-form-field>
         <app-form-field>
-          <input appInput placeholder="Primary Email Address" formControlName="emailAddress">
+          <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Primary Email Address" formControlName="emailAddress">
         </app-form-field>
         @if ((canChangePassword | async) === false && needsPasswordForEmailChange) {
           <p>Current password is required when
@@ -29,7 +29,7 @@
         }
         @if (needsPasswordForEmailChange) {
           <app-form-field>
-            <input appInput placeholder="Current Password" [type]="!showPassword[1] ? 'password' : 'text'"
+            <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Current Password" [type]="!showPassword[1] ? 'password' : 'text'"
               formControlName="currentPassword" [required]="passwordRequired">
             <span matSuffix>
               <app-show-hide-button (changed)="showPassword[1] = $event"></app-show-hide-button>
@@ -41,7 +41,7 @@
             <p>Change Password (Leave blank to keep current password)</p>
             @if (!needsPasswordForEmailChange) {
               <app-form-field>
-                <input appInput placeholder="Current Password" [type]="!showPassword[2] ? 'password' : 'text'"
+                <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Current Password" [type]="!showPassword[2] ? 'password' : 'text'"
                   formControlName="currentPassword" [required]="passwordRequired">
                 <span matSuffix>
                   <app-show-hide-button (changed)="showPassword[2] = $event"></app-show-hide-button>
@@ -49,14 +49,14 @@
               </app-form-field>
             }
             <app-form-field>
-              <input appInput placeholder="New Password" [type]="!showPassword[3] ? 'password' : 'text'"
+              <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="New Password" [type]="!showPassword[3] ? 'password' : 'text'"
                 formControlName="newPassword">
               <span matSuffix>
                 <app-show-hide-button (changed)="showPassword[3] = $event"></app-show-hide-button>
               </span>
             </app-form-field>
             <app-form-field>
-              <input appInput placeholder="Confirm New Password" [type]="!showPassword[4] ? 'password' : 'text'"
+              <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Confirm New Password" [type]="!showPassword[4] ? 'password' : 'text'"
                 formControlName="confirmPassword">
               <span matSuffix>
                 <app-show-hide-button (changed)="showPassword[4] = $event"></app-show-hide-button>

--- a/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.ts
+++ b/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AbstractControl, ReactiveFormsModule, FormBuilder, FormGroup, FormControl, ValidatorFn, Validators } from '@angular/forms';
-import { CustomFormFieldComponent } from '../../../shared/components/custom-form-field/custom-form-field.component';
+import { AppInputDirective, CustomFormFieldComponent } from '../../../shared/components/custom-form-field/custom-form-field.component';
 import { Router, RouterModule } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '../../../shared/services/tailwind-error-state-matcher';
@@ -40,6 +40,7 @@ interface EditProfileForm {
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     CustomIconComponent,
     PageHeaderComponent,

--- a/src/frontend/packages/example-extensions/src/acme-login/acme-login.component.html
+++ b/src/frontend/packages/example-extensions/src/acme-login/acme-login.component.html
@@ -6,12 +6,12 @@
         <form class="acme-login__form" name="loginForm" (ngSubmit)="login()" #loginForm="ngForm">
           @if (!ssoLogin) {
             <app-form-field>
-              <input appInput required [(ngModel)]="username" name="username" placeholder="Username" autocomplete="username">
+              <input class="w-full placeholder:!text-transparent focus:outline-none" appInput required [(ngModel)]="username" name="username" placeholder="Username" autocomplete="username">
             </app-form-field>
           }
           @if (!ssoLogin) {
             <app-form-field>
-              <input appInput required type="password" [(ngModel)]="password" name="password" placeholder="Password" autocomplete="current-password">
+              <input class="w-full placeholder:!text-transparent focus:outline-none" appInput required type="password" [(ngModel)]="password" name="password" placeholder="Password" autocomplete="current-password">
             </app-form-field>
           }
           @if (!loggedIn) {

--- a/src/frontend/packages/example-extensions/src/example.module.ts
+++ b/src/frontend/packages/example-extensions/src/example.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import {
+  AppInputDirective,
   CoreModule,
   CustomizationService,
   CustomizationsMetadata,
@@ -20,6 +21,7 @@ const AcmeCustomizations: CustomizationsMetadata = {
 
 @NgModule({
   imports: [
+    AppInputDirective,
     CoreModule,
     SharedModule,
     MDAppModule,

--- a/src/frontend/packages/kubernetes/src/helm/tabs/catalog-tab/catalog-tab.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/tabs/catalog-tab/catalog-tab.component.html
@@ -4,7 +4,7 @@
       [ngClass]="{'mr-0 min-w-0 w-0': collapsed, 'mr-2.5 min-w-[200px] w-auto': !collapsed}">
       <h3 class="text-base my-1.5">Filter By Repository</h3>
       <app-form-field>
-        <input appInput placeholder="Filter by Repository" name="searchReposValue" [(ngModel)]="searchReposValue"
+        <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Filter by Repository" name="searchReposValue" [(ngModel)]="searchReposValue"
           (ngModelChange)="searchReposChange($event)">
       </app-form-field>
       <div class="max-h-full overflow-auto pr-2.5">

--- a/src/frontend/packages/kubernetes/src/helm/tabs/catalog-tab/catalog-tab.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/tabs/catalog-tab/catalog-tab.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Observable, Subscription, firstValueFrom } from 'rxjs';
 import { filter, map, publishReplay, refCount, take } from 'rxjs/operators';
 
-import { CustomFormFieldComponent } from '../../../../../core/src/shared/components/custom-form-field/custom-form-field.component';
+import { AppInputDirective, CustomFormFieldComponent } from '../../../../../core/src/shared/components/custom-form-field/custom-form-field.component';
 import { SignalListComponent, SignalListConfig } from '../../../../../core/src/shared/components/signal-list/signal-list.component';
 import { EndpointModel, EndpointsDataService } from '../../../../../store/src/public-api';
 import { MonocularChart } from '../../../services/endpoint-data/kube-types';
@@ -27,6 +27,7 @@ import { ChartItemComponent } from '../../monocular/chart-item/chart-item.compon
   imports: [
     CommonModule,
     FormsModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     SignalListComponent,
     ChartItemComponent,

--- a/src/frontend/packages/kubernetes/src/kubernetes/auth-forms/kubernetes-aws-auth-form/kubernetes-aws-auth-form.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/auth-forms/kubernetes-aws-auth-form/kubernetes-aws-auth-form.component.html
@@ -1,13 +1,13 @@
 <div [formGroup]="formGroup">
   <div formGroupName="authValues" class="flex flex-col">
     <app-form-field>
-      <input appInput placeholder="Cluster" formControlName="cluster">
+      <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Cluster" formControlName="cluster">
     </app-form-field>
     <app-form-field>
-      <input appInput placeholder="Access Key ID" formControlName="access_key">
+      <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Access Key ID" formControlName="access_key">
     </app-form-field>
     <app-form-field>
-      <input appInput placeholder="Secret Access Key" [type]="!showPassword ? 'password' : 'text'"
+      <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Secret Access Key" [type]="!showPassword ? 'password' : 'text'"
         formControlName="secret_key">
       <span appSuffix>
         <app-show-hide-button (changed)="showPassword = $event"></app-show-hide-button>

--- a/src/frontend/packages/kubernetes/src/kubernetes/auth-forms/kubernetes-aws-auth-form/kubernetes-aws-auth-form.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/auth-forms/kubernetes-aws-auth-form/kubernetes-aws-auth-form.component.ts
@@ -3,7 +3,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { IAuthForm } from '../../../../../store/src/extension-types';
 import { ShowHideButtonComponent } from '../../../../../core/src/core/show-hide-button/show-hide-button.component';
-import { CustomFormFieldComponent } from '../../../../../core/src/shared/components/custom-form-field/custom-form-field.component';
+import { AppInputDirective, CustomFormFieldComponent } from '../../../../../core/src/shared/components/custom-form-field/custom-form-field.component';
 
 interface AWSAuthForm {
   cluster: FormControl<string>;
@@ -18,6 +18,7 @@ interface AWSAuthForm {
   standalone: true,
   imports: [
     ReactiveFormsModule,
+    AppInputDirective,
     CustomFormFieldComponent,
     ShowHideButtonComponent
   ]


### PR DESCRIPTION
Restores three UI behaviors dropped/regressed during the V3 signal-native migration. All verified live and via full `make check gate` (2419 frontend tests + prod AOT bundle + backend, green).

## 1. Form-field labels (Closes #5387)
Ten standalone forms used `<input appInput placeholder="…">` without importing `AppInputDirective`, so `custom-form-field`'s `@ContentChild(AppInputDirective)` never resolved and the floating `<label>` never rendered — prefilled fields (e.g. **Edit Application**) showed values with no field names. Added the directive import + the canonical `w-full placeholder:!text-transparent focus:outline-none` input class so labels render and the native placeholder is suppressed, matching every other form. (acme-login wired via its NgModule since it is not standalone.)

## 2. Stopped-app instance count + scaling
- The Status card used `stats.length` as the instances denominator, which is 0 for a stopped app (per-instance stats are skipped to avoid CF's stopped-stats error), so it read **"0/0 running"** while the app expects 1 — and disagreed with the Instances card. Now uses the expected count (`app.entity.instances`) → **"0/1 running"**.
- Dropped the `isRunning()` gate on the inline +/- scale controls so a **stopped** app can be scaled from the Instances card. CF accepts scaling a stopped app (the count applies on next start); v4.9.2 wrongly hid the controls when stopped.

## 3. Restage no longer blanks the page
Lifecycle actions (restage/start/stop/restart) refresh the app entity on success, flipping `isFetchingApp$` true again — which the full-page `app-loading-page` overlay reacted to, repainting the whole detail page with the "Retrieving application" spinner. The Status card stage-row + the snackbar already convey progress/result in place. The overlay now shows on **initial load only** (app entity not yet present), so action refreshes update in place.