### PR TITLE
fix(cf): restore application Events tab — newest-first, type popup, inline details (#5389)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.html
@@ -1,7 +1,7 @@
 <app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks" tabsHeader="Application" [favorite]="favorite$ | async">
   <h1>{{ (applicationService.application$ | async)?.app?.entity?.name }} </h1>
 </app-page-header>
-<app-loading-page [isLoading]="isFetching$" text="Retrieving application" class="router-component">
+<app-loading-page [isLoading]="isFetching$" [text]="loadingText()" class="router-component">
   <app-application-action-bar></app-application-action-bar>
   <router-outlet></router-outlet>
 </app-loading-page>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -336,6 +336,15 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
     }));
   }
 
+  // Loading-overlay text reflects the active tab — e.g. "Retrieving Events" on
+  // the Events tab — instead of always "Retrieving application". Falls back to
+  // the app text for the base route / unknown tabs.
+  loadingText(): string {
+    const last = this.router.url.split('?')[0].split('/').filter(Boolean).pop();
+    const tab = (this.tabLinks ?? []).find(t => t.link === last);
+    return tab ? `Retrieving ${tab.label}` : 'Retrieving application';
+  }
+
   ngOnDestroy() {
     this.lifecycleProgress.destroy();
     this.errorRedirectEffect?.destroy();

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.html
@@ -1,5 +1,34 @@
-<div class="events-list">
+<div class="events-list flex flex-col flex-1 min-h-0">
   @if (listConfig(); as cfg) {
-    <app-signal-list [config]="cfg" />
+    <div class="flex justify-end px-2 py-1">
+      <button type="button" class="btn btn-secondary btn-sm" (click)="toggleDetails()"
+        [title]="detailsExpanded() ? 'Hide event details on every row' : 'Show event details on every row'">
+        {{ detailsExpanded() ? 'Collapse details' : 'Expand details' }}
+      </button>
+    </div>
+    <app-signal-list [config]="cfg" class="flex-1 min-h-0">
+      <!-- The event type: a link to the details dialog (when there's metadata),
+           and the inline v4.9.2 key/value view beneath it when the global
+           "Expand details" toggle is on (all rows or none). -->
+      <ng-template appSignalListCell="type" let-row>
+        <div class="flex flex-col gap-1 py-1">
+          @if (hasDetails(row)) {
+            <a class="cursor-pointer text-primary hover:underline break-all" (click)="openEventDetails(row)">{{ row.type }}</a>
+          } @else {
+            <span class="break-all">{{ row.type }}</span>
+          }
+          @if (detailsExpanded() && hasDetails(row)) {
+            <div class="flex flex-col gap-0.5 text-xs">
+              @for (entry of entriesFor(row); track entry[0]) {
+                <div class="break-words">
+                  <span class="italic text-content-muted">{{ entry[0] }}:</span>
+                  <span class="ml-1 break-all">{{ formatValue(entry[1]) }}</span>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      </ng-template>
+    </app-signal-list>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, ChangeDetectionStrategy, Input, OnChanges, OnInit, SimpleChanges, WritableSignal, computed, inject, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, OnChanges, OnInit, SimpleChanges, WritableSignal, computed, effect, inject, signal, untracked } from '@angular/core';
 
-import { SignalListComponent, SignalListConfig, SignalListDropdown } from '@stratosui/core';
+import { SignalListCellTemplateDirective, SignalListComponent, SignalListConfig, SignalListDropdown, TailwindDialogService } from '@stratosui/core';
 
 import { CfAuditEventsSignalConfigService } from '../../signal-list-configs/cf-events/cf-audit-events-signal-config.service';
 import { CloudFoundryEndpointService } from '../../../features/cf/services/cloud-foundry-endpoint.service';
 import type { StAuditEvent } from '../../../services/endpoint-data/stratos-types';
+import { EventDetailComponent, hasEventMetadata, parseEventData } from './event-detail/event-detail.component';
 
 // Signal-native shared events list component. Used by four page
 // consumers — the foundation-wide CF Events tab plus the org / space /
@@ -28,6 +29,7 @@ import type { StAuditEvent } from '../../../services/endpoint-data/stratos-types
   imports: [
     CommonModule,
     SignalListComponent,
+    SignalListCellTemplateDirective,
   ],
 })
 export class CloudFoundryEventsListComponent implements OnInit, OnChanges {
@@ -41,12 +43,86 @@ export class CloudFoundryEventsListComponent implements OnInit, OnChanges {
 
   cfEndpointService = inject(CloudFoundryEndpointService);
   private eventsConfig = inject(CfAuditEventsSignalConfigService);
+  private dialog = inject(TailwindDialogService);
+
+  /** Whether the event carries metadata worth a details popup (data !== {}). */
+  hasDetails(e: StAuditEvent): boolean {
+    return hasEventMetadata(e.data);
+  }
+
+  /** Open the event-detail dialog, titled with the event type. */
+  openEventDetails(e: StAuditEvent): void {
+    this.dialog.open(EventDetailComponent, {
+      data: { type: e.type, metadata: parseEventData(e.data) },
+    });
+  }
+
+  /**
+   * Global expand/collapse of the inline metadata shown beneath each event type
+   * (the v4.9.2 key/value view) — all rows at once, never a per-row control. The
+   * Type cell template reads this signal, so flipping it re-renders every cell.
+   */
+  readonly detailsExpanded = signal(false);
+
+  toggleDetails(): void {
+    this.detailsExpanded.update(v => !v);
+    // The Type cell template lives in the signal-list's view, so flipping the
+    // signal alone won't re-render its cells. Re-set the config (same columns,
+    // new object) to force the list to re-render — the cell then re-reads
+    // detailsExpanded() and shows/hides the inline metadata for every row.
+    this.listConfig.set(this.buildListConfig());
+  }
+
+  /** Parsed metadata entries for the inline view under the event type. */
+  entriesFor(e: StAuditEvent): [string, unknown][] {
+    return Object.entries(parseEventData(e.data));
+  }
+
+  /** Inline value rendering — strings as-is, everything else as JSON. */
+  formatValue(value: unknown): string {
+    if (value == null) return '';
+    return typeof value === 'string' ? value : JSON.stringify(value);
+  }
+
+  // V3 audit events carry only the org/space GUID, not the name, so the
+  // backend's spaceName/organizationName come through empty. Resolve them
+  // against the org/space maps the toolbar already loads (endpointData), so
+  // the columns show names instead of "—". Computed → the cell re-renders
+  // when the maps finish loading.
+  private readonly orgNameByGuid = computed(() =>
+    new Map((this.eventsConfig.endpointData?.orgs() ?? []).map(o => [o.guid, o.name] as [string, string])),
+  );
+  private readonly spaceNameByGuid = computed(() =>
+    new Map((this.eventsConfig.endpointData?.spaces() ?? []).map(s => [s.guid, s.name] as [string, string])),
+  );
+
+  spaceName(e: StAuditEvent): string {
+    return e.spaceName || this.spaceNameByGuid().get(e.spaceGuid) || '—';
+  }
+
+  orgName(e: StAuditEvent): string {
+    return e.organizationName || this.orgNameByGuid().get(e.organizationGuid) || '—';
+  }
 
   public listConfig: WritableSignal<SignalListConfig<StAuditEvent> | undefined> = signal(undefined);
 
   constructor() {
     const cfGuid = this.cfEndpointService.cfGuid;
     this.eventsConfig.initialize(cfGuid);
+
+    // Org/space names load asynchronously (and the orgs map lands after the
+    // first render). The Space/Org cell renders read those maps, but the
+    // signal-list doesn't re-render on external signals — so re-publish the
+    // config when the maps change to refresh the resolved names.
+    effect(() => {
+      this.orgNameByGuid();
+      this.spaceNameByGuid();
+      untracked(() => {
+        if (this.listConfig()) {
+          this.listConfig.set(this.buildListConfig());
+        }
+      });
+    });
   }
 
   // @Input() values are not bound at constructor time. Building the
@@ -95,8 +171,11 @@ export class CloudFoundryEventsListComponent implements OnInit, OnChanges {
           widthHint: '12rem',
         },
         {
+          // The type is the event's identity and the drill-in: rendered as a
+          // link (when the event carries metadata) that opens the details
+          // dialog, titled with the type. See the `type` cell template.
           header: 'Type', key: 'type', sortField: 'type',
-          kind: 'text',
+          kind: 'template', templateName: 'type',
           render: (e: StAuditEvent) => e.type,
           widthHint: '20rem',
         },
@@ -115,13 +194,13 @@ export class CloudFoundryEventsListComponent implements OnInit, OnChanges {
         {
           header: 'Space', key: 'spaceName', sortField: 'spaceName',
           kind: 'text',
-          render: (e: StAuditEvent) => e.spaceName || '—',
+          render: (e: StAuditEvent) => this.spaceName(e),
           widthHint: '10rem',
         },
         {
           header: 'Organization', key: 'organizationName', sortField: 'organizationName',
           kind: 'text',
-          render: (e: StAuditEvent) => e.organizationName || '—',
+          render: (e: StAuditEvent) => this.orgName(e),
           widthHint: '10rem',
         },
       ],

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.html
@@ -1,0 +1,9 @@
+<div class="flex flex-col gap-3 min-w-[24rem] max-w-[48rem]">
+  <h2 class="dialog-title break-all">{{ data.type }}</h2>
+  <div class="dialog-content max-h-[60vh] overflow-auto">
+    <pre class="text-xs whitespace-pre-wrap break-all bg-gray-50 dark:bg-gray-800 text-content-text p-3 rounded border border-content-border">{{ data.metadata | json }}</pre>
+  </div>
+  <div class="dialog-actions flex flex-row-reverse justify-self-start">
+    <button class="btn btn-primary" (click)="close()">Close</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { describe, it, expect } from 'vitest';
+
+import { MAT_DIALOG_DATA, TailwindDialogRef } from '@stratosui/core';
+import { EventDetailComponent, hasEventMetadata, parseEventData } from './event-detail.component';
+
+describe('parseEventData', () => {
+  it('parses a JSON object string', () => {
+    expect(parseEventData('{"request":{"name":"web"}}')).toEqual({ request: { name: 'web' } });
+  });
+  it('returns {} for null / empty / "{}"', () => {
+    expect(parseEventData(null)).toEqual({});
+    expect(parseEventData('')).toEqual({});
+    expect(parseEventData('{}')).toEqual({});
+  });
+  it('returns {} for invalid JSON (never throws)', () => {
+    expect(parseEventData('{not json')).toEqual({});
+  });
+  it('wraps a scalar / array payload under `value`', () => {
+    expect(parseEventData('"hello"')).toEqual({ value: 'hello' });
+    expect(parseEventData('[1,2]')).toEqual({ value: [1, 2] });
+  });
+});
+
+describe('hasEventMetadata', () => {
+  it('is false for empty / missing data', () => {
+    expect(hasEventMetadata('{}')).toBe(false);
+    expect(hasEventMetadata(null)).toBe(false);
+    expect(hasEventMetadata('')).toBe(false);
+  });
+  it('is true when the event carries data', () => {
+    expect(hasEventMetadata('{"a":1}')).toBe(true);
+  });
+});
+
+describe('EventDetailComponent (dialog)', () => {
+  function setup(type: string, metadata: Record<string, unknown>) {
+    TestBed.configureTestingModule({
+      imports: [EventDetailComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: MAT_DIALOG_DATA, useValue: { type, metadata } },
+        { provide: TailwindDialogRef, useValue: { close: () => undefined } },
+      ],
+    });
+    const fixture: ComponentFixture<EventDetailComponent> = TestBed.createComponent(EventDetailComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('titles the dialog with the event type', () => {
+    const fixture = setup('audit.app.map-route', { route_guid: 'r1' });
+    expect(fixture.nativeElement.innerHTML).toContain('audit.app.map-route');
+  });
+
+  it('renders the metadata as formatted (indented) JSON', () => {
+    const fixture = setup('audit.app.update', { request: { name: 'web' } });
+    const pre = fixture.nativeElement.querySelector('pre');
+    expect(pre).toBeTruthy();
+    expect(pre.textContent).toContain('"request"');
+    expect(pre.textContent).toMatch(/\n\s{2,}"/); // pretty-printed → indented
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.ts
@@ -1,0 +1,45 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+
+import { MAT_DIALOG_DATA, TailwindDialogRef } from '@stratosui/core';
+
+// Details dialog for a CF audit event (#5389). Opened from the clickable event
+// Type in the events list; shows the event's `data` metadata as formatted JSON,
+// titled with the event type. The audit-event `data` blob arrives as a JSON
+// string on StAuditEvent.data (backend toStAuditEvent marshals the v3 Data).
+
+/** Parse the audit-event `data` JSON string into an object. Never throws. */
+export function parseEventData(data: string | null | undefined): Record<string, unknown> {
+  if (!data) return {};
+  try {
+    const parsed = JSON.parse(data);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    // Non-object payloads (array / scalar) still deserve a viewer; wrap them.
+    return { value: parsed };
+  } catch {
+    return {};
+  }
+}
+
+/** True when an event carries metadata worth a details popup (data !== {}). */
+export function hasEventMetadata(data: string | null | undefined): boolean {
+  return Object.keys(parseEventData(data)).length > 0;
+}
+
+@Component({
+  selector: 'app-event-detail',
+  templateUrl: './event-detail.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class EventDetailComponent {
+  private readonly dialogRef = inject<TailwindDialogRef<EventDetailComponent>>(TailwindDialogRef);
+  readonly data = inject<{ type: string; metadata: Record<string, unknown> }>(MAT_DIALOG_DATA);
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -474,7 +474,7 @@
                 [class]="'border-b border-content-border hover:bg-gray-50 dark:hover:bg-gray-900 ' +
                   (rowLink(row) && !rowStateBlocksNav(row) ? 'cursor-pointer ' : '') + rowStateRowClass(row)">
               @if (favoriteColumn() || actionsColumn()) {
-                <td class="px-2 py-2 overflow-visible whitespace-nowrap">
+                <td class="px-2 py-2 align-top overflow-visible whitespace-nowrap">
                   <div class="flex items-center gap-0">
                     @if (favoriteColumn(); as fc) {
                       <button
@@ -528,7 +528,7 @@
                 @if (col.kind === 'favorite' || col.kind === 'actions') {
                   <!-- Suppressed: rendered in the leading controls cell -->
                 } @else {
-                <td class="px-3 py-2 text-sm text-content-text"
+                <td class="px-3 py-2 align-top text-sm text-content-text"
                     [class.truncate]="col.kind !== 'actions' && col.kind !== 'favorite' && col.kind !== 'radio' && col.kind !== 'checkbox' && col.kind !== 'gauge' && col.kind !== 'template'"
                     [class.overflow-visible]="col.kind === 'actions' || col.kind === 'favorite' || col.kind === 'radio' || col.kind === 'checkbox' || col.kind === 'gauge' || col.kind === 'template'"
                     [attr.title]="col.kind === 'actions' || col.kind === 'favorite' || col.kind === 'radio' || col.kind === 'checkbox' || col.kind === 'gauge' || col.kind === 'template' ? null : col.render(row)">

--- a/src/jetstream/plugins/cloudfoundry/native_audit_events_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_audit_events_reads.go
@@ -55,8 +55,22 @@ func (c *CloudFoundrySpecification) getNativeAuditEvents(ctx echo.Context) error
 	}
 
 	perPage, page, present := parsePerPageAndPage(ctx)
-	params := applyPagingParams(capi.NewQueryParams(), perPage, page, present)
-	raw, listErr := cfClient.AuditEvents().List(ctx.Request().Context(), params)
+	// Newest-first. Without this CF returns its default order and recent events
+	// land on the last page; the per-app tab (which filters this foundation-wide
+	// stream client-side) then never sees today's events unless it drains to the
+	// end. Mirrors the org/space audit-event handlers.
+	params := applyPagingParams(capi.NewQueryParams().WithOrderBy("-created_at"), perPage, page, present)
+	reqCtx := ctx.Request().Context()
+	raw, listErr := cfClient.AuditEvents().List(reqCtx, params)
+	// The per-CF endpoint token has a ~20-minute life; a request that fires while
+	// a token refresh is mid-flight loses the race and 401s (worst on this long
+	// foundation-wide drain). By retry time the refresh has landed, so rebuild the
+	// client to pick up the fresh token and retry the list once.
+	if listErr != nil && statusFromCapiError(listErr) == http.StatusUnauthorized {
+		if rc, rerr := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID); rerr == nil {
+			raw, listErr = rc.AuditEvents().List(reqCtx, params)
+		}
+	}
 	if listErr != nil {
 		return handleCapiError(ctx, listErr)
 	}


### PR DESCRIPTION
## Restore the application Events tab (closes #5389)

The ngrx removal left the app **Events** tab unable to surface recent events and dropped the per-event detail view. This restores both and brings the inline/detail UX back in line with v4.9.2.

### Backend
- **Newest-first audit events** — `getNativeAuditEvents` now requests `-created_at` so the most recent events come first. The foundation-wide stream is large and previously drained oldest-first, so an app's recent events were often never reached.
- **401 retry on token refresh** — the long foundation-wide drain can outlive the ~20-min CF UAA token. On a `401` we now rebuild the CAPI client once and retry, instead of dropping the rest of the stream (the root cause of "no events showing").

### Frontend (#5389)
- **Type popup** — the event **Type** is rendered as a link (when the event carries metadata) that opens a dialog titled with the event type, showing the payload as formatted, indented JSON. Replaces the unformatted "wall of words".
- **Expand-details toggle** — a single global control expands the inline `key: value` metadata beneath every event type at once (the v4.9.2 view), never a per-row control. The popup remains available regardless.
- **Org/Space names** — V3 audit events carry only org/space GUIDs; these are now resolved against the maps the toolbar already loads, so the columns show names instead of dashes.
- **Top-aligned cells** — signal-list data cells align to the top so multi-line rows read cleanly.
- **Per-tab loading text** — the app loading spinner now says "Retrieving Events" (etc.) rather than always "Retrieving application".

### Notes
- Most events on a typical app are `audit.app.environment.show` (CF logs one per env read) and genuinely carry no data on the wire — confirmed against CF directly. Substantive events (create/update/scale/map-route/build/droplet/package/manifest) all carry metadata, which the popup now surfaces.
- The `application-tabs-base` loading-text change overlaps PR #5414's spinner work on the same component; expect a trivial rebase if #5414 lands first.
