### PR TITLE
fix(deploy): Deploy-from-Git wizard fixes (scoped CF lock, route exclusivity, new-app GUID, token retry)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.ts
@@ -112,7 +112,10 @@ export class ApplicationDeleteComponent implements OnDestroy {
         this.selectedRoutes ?? [],
         this.selectedServiceBindings ?? [],
       );
-      this.router.navigate(['/applications', cfGuid, appGuid]);
+      // Preserve ?returnUrl so the detail page's orchestrated delete can send
+      // the user back to the CF-scoped wall they came from (see
+      // AppApplicationActionsService.deleteWithCleanup).
+      this.router.navigate(['/applications', cfGuid, appGuid], { queryParamsHandling: 'preserve' });
     },
   };
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit, inject, ChangeDetectionStrategy } from '@
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { AbstractControl, ReactiveFormsModule, FormControl, FormGroup, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { from, Observable, of as observableOf, throwError } from 'rxjs';
 import { catchError, filter, map, mergeMap, switchMap } from 'rxjs/operators';
 
@@ -39,6 +39,7 @@ interface DomainHostForm {
 export class CreateApplicationStep3Component implements OnInit, OnDestroy {
   private createAppState = inject(CreateAppStateService);
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
   private http = inject(HttpClient);
   private endpointDataRegistry = inject(EndpointDataRegistry);
 
@@ -75,7 +76,15 @@ export class CreateApplicationStep3Component implements OnInit, OnDestroy {
         : observableOf(appGuid),
       ),
       map(appGuid => {
-        this.router.navigate(['applications', cloudFoundry, appGuid, 'summary']);
+        // When created from a CF-scoped wall, tag the new app's detail page
+        // with ?breadcrumbs=cf so its "Applications" breadcrumb returns to the
+        // CF-scoped wall rather than the global one.
+        const returnUrl = this.route.snapshot.queryParams['returnUrl'];
+        const cfScoped = typeof returnUrl === 'string' && returnUrl.startsWith('/cloud-foundry/');
+        this.router.navigate(
+          ['applications', cloudFoundry, appGuid, 'summary'],
+          cfScoped ? { queryParams: { breadcrumbs: 'cf' } } : undefined,
+        );
         return { success: true };
       }),
       catchError((err: Error | HttpErrorResponse) => {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application.component.html
@@ -1,7 +1,7 @@
 <app-page-header>
   Create
 </app-page-header>
-<app-steppers cancel="/applications">
+<app-steppers [cancel]="returnUrl">
   <app-step [title]="'Cloud Foundry'" [signalHandle]="step1Handle">
     <app-create-application-step1 #step1></app-create-application-step1>
   </app-step>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application.component.ts
@@ -10,9 +10,11 @@ import {
   inject,
   signal,
 } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Subscription, firstValueFrom } from 'rxjs';
 
 import { PageHeaderComponent, SignalStepHandle, StepComponent, SteppersComponent } from '@stratosui/core';
+import { RETURN_URL_PARAM } from '../new-application-base-step/new-application-base-step.component';
 import { CreateApplicationStep1Component } from '../../../shared/components/create-application/create-application-step1/create-application-step1.component';
 import { CfOrgSpaceDataService } from '../../../shared/data-services/cf-org-space-service.service';
 import { CfAppsSignalConfigService } from '../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
@@ -40,6 +42,11 @@ export class CreateApplicationComponent implements OnInit, OnDestroy {
   private cdr = inject(ChangeDetectorRef);
   public cfOrgSpaceService = inject(CfOrgSpaceDataService);
   private appsConfig = inject(CfAppsSignalConfigService);
+  private route = inject(ActivatedRoute);
+
+  // Where Cancel returns to — the CF-scoped wall when this flow was launched
+  // from one (?returnUrl set by new-application-base-step), else the global wall.
+  readonly returnUrl: string = this.route.snapshot.queryParams[RETURN_URL_PARAM] || '/applications';
 
   // FWT-959 Part 2 (Partition B): SignalStepHandle wiring for the 3-step
   // create-application flow. Cross-step state (CF/org/space + new app

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.spec.ts
@@ -43,4 +43,32 @@ describe('DeployApplicationOptionsStepComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('clears a stale random_route value when no_route is checked', () => {
+    const c = component.deployOptionsForm.controls;
+    // Seed a random_route value without firing exclusivity (e.g. preseeded
+    // from overrides) so it would otherwise leak into the cf push command.
+    c.random_route.setValue(true, { emitEvent: false });
+
+    c.no_route.setValue(true);
+
+    expect(c.random_route.value).toBe(false); // cleared, not stale
+    expect(c.random_route.disabled).toBe(true);
+    const overrides = component.formToObj(c);
+    expect(overrides.noRoute).toBe(true);
+    expect(overrides.randomRoute).toBe(false); // CF rejects --no-route with --random-route
+  });
+
+  it('keeps no_route and random_route mutually exclusive (two-way)', () => {
+    const c = component.deployOptionsForm.controls;
+
+    c.random_route.setValue(true);
+    expect(c.no_route.disabled).toBe(true);
+
+    c.random_route.setValue(false);
+    expect(c.no_route.disabled).toBe(false);
+
+    c.no_route.setValue(true);
+    expect(c.random_route.disabled).toBe(true);
+  });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-options-step/deploy-application-options-step.component.ts
@@ -107,10 +107,50 @@ export class DeployApplicationOptionsStepComponent implements OnInit, OnDestroy 
     );
   }
 
+  // Guards the no_route / random_route mutual-exclusivity wiring against
+  // feedback loops: setValue/enable/disable on one control fires the
+  // other's valueChanges, which would otherwise recurse and undo the
+  // address-field state.
+  private syncingRoutes = false;
+
   private disableAddressFields() {
     this.deployOptionsForm.controls.host.disable();
     this.deployOptionsForm.controls.domain.disable();
     this.deployOptionsForm.controls.path.disable();
+  }
+
+  // no_route ("don't create a route") and random_route ("create a random
+  // route") are mutually exclusive — CF rejects `--no-route` together with
+  // `--random-route`. Checking either one CLEARS the other's value (so a
+  // stale flag isn't read out in formToObj and sent to cf push) and
+  // disables it; unchecking re-enables the other. random_route stays
+  // disabled on redeploy (appGuid present).
+  private syncRouteOptions(changed: 'no_route' | 'random_route', checked: boolean) {
+    if (this.syncingRoutes) {
+      return;
+    }
+    this.syncingRoutes = true;
+    try {
+      const controls = this.deployOptionsForm.controls;
+      const other = changed === 'no_route' ? controls.random_route : controls.no_route;
+      if (checked) {
+        // Clear the value FIRST so formToObj never reads a stale `true`,
+        // then lock the control.
+        if (other.value) {
+          other.setValue(false);
+        }
+        other.disable();
+        this.disableAddressFields();
+      } else {
+        const canEnable = other === controls.random_route ? !this.appGuid : true;
+        if (canEnable) {
+          other.enable();
+        }
+        this.enableAddressFields();
+      }
+    } finally {
+      this.syncingRoutes = false;
+    }
   }
 
   private enableAddressFields() {
@@ -163,31 +203,11 @@ export class DeployApplicationOptionsStepComponent implements OnInit, OnDestroy 
       share()
     );
 
-    // Ensure that when the no route + random route options are checked the host, domain and path fields are enabled/disabled
-    this.subs.push(noRouteChanged$.subscribe(value => {
-      if (value) {
-        this.disableAddressFields();
-        this.deployOptionsForm.controls.random_route.disable();
-      } else {
-        this.enableAddressFields();
-        if (!this.appGuid) {
-          // This can only be enabled if this is not a redeploy
-          this.deployOptionsForm.controls.random_route.enable();
-        }
-      }
-    }));
-    this.subs.push(combineLatest([
-      noRouteChanged$,
-      randomRouteChanged$
-    ]).subscribe(([noRoute, randomRoute]) => {
-      // control.valueChanges fires whenever the value ... or enabled/disabled state changes. This means whenever noRouteChanged$ changes
-      // randomRoute this also fires ... which undos the host+domain state
-      if (noRoute || randomRoute) {
-        this.disableAddressFields();
-      } else {
-        this.enableAddressFields();
-      }
-    }));
+    // Keep no_route / random_route mutually exclusive (two-way) and toggle
+    // the host/domain/path address fields. See syncRouteOptions for why the
+    // re-entrancy guard is needed.
+    this.subs.push(noRouteChanged$.subscribe(value => this.syncRouteOptions('no_route', !!value)));
+    this.subs.push(randomRouteChanged$.subscribe(value => this.syncRouteOptions('random_route', !!value)));
 
     // Extract any existing values from the app's env var and assign to form.
     // Redeploy path: the wizard was launched against an existing app and the

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs.component.html
@@ -11,7 +11,7 @@
     <div>
       <input #localPathSelectFile fileread="localPathFile" type="file" class="h-0 invisible w-0"
         name="localPathSelectFile" id="localPathSelectFile" (change)="onFileChange($event)" /> Choose an
-        <button (click)="localPathSelectFile.click()" class="btn btn-primary mx-px">Application Archive
+        <button type="button" (click)="localPathSelectFile.click()" class="btn btn-primary mx-px">Application Archive
         file</button>
       </div>
     }
@@ -19,7 +19,7 @@
       <div>
         <input #localPathSelectFolder webkitdirectory fileread="localPathFile" type="file" class="h-0 invisible w-0"
           name="localPathSelectFolder" id="localPathSelectFolder" (change)="onFileChange($event)" /> Choose an
-          <button (click)="localPathSelectFolder.click()" class="btn btn-primary mx-px">Application
+          <button type="button" (click)="localPathSelectFolder.click()" class="btn btn-primary mx-px">Application
           Folder</button>
         </div>
       }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { ChangeDetectorRef, Component, Injector, Input, OnDestroy, signal, ChangeDetectionStrategy, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import {
   BehaviorSubject,
   combineLatest as observableCombineLatest,
@@ -32,6 +32,7 @@ import { DeployApplicationDeployer } from '../deploy-application-deployer';
 })
 export class DeployApplicationStep3Component implements OnDestroy {
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
   private deployData = inject(CfDeployAppDataService);
   private snackBarService = inject(SnackBarService);
   cfOrgSpaceService = inject(CfOrgSpaceDataService);
@@ -257,7 +258,14 @@ export class DeployApplicationStep3Component implements OnDestroy {
     // nothing reads anymore.
     const { cfGuid } = this.deployer;
     if (this.appGuid) {
-      this.router.navigate(['applications', cfGuid, this.appGuid]);
+      // When deployed from a CF-scoped wall, tag the app detail with
+      // ?breadcrumbs=cf so its "Applications" breadcrumb returns to that wall.
+      const returnUrl = this.route.snapshot.queryParams['returnUrl'];
+      const cfScoped = typeof returnUrl === 'string' && returnUrl.startsWith('/cloud-foundry/');
+      this.router.navigate(
+        ['applications', cfGuid, this.appGuid],
+        cfScoped ? { queryParams: { breadcrumbs: 'cf' } } : undefined,
+      );
     }
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
@@ -2,7 +2,7 @@
   <h1>{{ getTitle() | async }}</h1>
 </app-page-header>
 
-<app-steppers cancel="/applications">
+<app-steppers [cancel]="returnUrl">
   <!-- Select the cf/org/space -->
   @if (!appGuid) {
     <app-step [title]="'Cloud Foundry'" [signalHandle]="step1Handle">

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.ts
@@ -20,7 +20,7 @@ import { SourceType } from '../../../store/types/deploy-application.types';
 import { CfDeployAppDataService } from '../../../services/domain-data/cf-deploy-app-data.service';
 import { CfAppsSignalConfigService } from '../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
 import { CfOrgSpaceDataService } from '../../../shared/data-services/cf-org-space-service.service';
-import { AUTO_SELECT_CF_URL_PARAM } from '../new-application-base-step/new-application-base-step.component';
+import { AUTO_SELECT_CF_URL_PARAM, RETURN_URL_PARAM } from '../new-application-base-step/new-application-base-step.component';
 import { ApplicationDeploySourceTypes } from './deploy-application-steps.types';
 import { PageHeaderComponent, SignalStepHandle, SteppersComponent, StepComponent } from '@stratosui/core';
 import { CreateApplicationStep1Component } from '../../../shared/components/create-application/create-application-step1/create-application-step1.component';
@@ -64,6 +64,9 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
 
 
   appGuid: string;
+  // Where Cancel returns to — the CF-scoped wall when launched from one
+  // (?returnUrl, set by new-application-base-step), else the global wall.
+  readonly returnUrl: string = this.activatedRoute.snapshot.queryParams[RETURN_URL_PARAM] || '/applications';
   initCfOrgSpaceService: Subscription[] = [];
   deployButtonText = 'Deploy';
   skipConfig$: Observable<boolean> = observableOf(false);

--- a/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.ts
@@ -12,6 +12,11 @@ import {
 } from '../deploy-application/deploy-application-steps.types';
 
 export const AUTO_SELECT_CF_URL_PARAM = 'auto-select-endpoint';
+// Query param carrying where a create/deploy flow should return on cancel /
+// success — set to the CF-scoped wall when launched from one, else absent
+// (callers fall back to the global wall). Shared by the create, deploy and
+// add-service-instance flows.
+export const RETURN_URL_PARAM = 'returnUrl';
 
 
 export interface IAppTileData extends ITileData {
@@ -64,6 +69,9 @@ export class NewApplicationBaseStepComponent {
       if (endpoint) {
         query[AUTO_SELECT_CF_URL_PARAM] = endpoint;
         query[BASE_REDIRECT_QUERY] += `/${endpoint}`;
+        // Launched from a CF-scoped Applications wall — return there (cancel /
+        // success) instead of the global wall.
+        query[RETURN_URL_PARAM] = `/cloud-foundry/${endpoint}/applications`;
       }
 
       this.router.navigate(`${baseUrl}/${type}`.split('/'), { queryParams: query });

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.ts
@@ -800,8 +800,11 @@ export class AddServiceInstanceComponent implements OnInit, OnDestroy {
     this.cSIHelperService = this.cSIHelperServiceFactory.create(endpointId, serviceGuid);
     void this.cSIHelperService.load();
     this.csiState.setServiceGuid(serviceGuid);
-    this.csiState.setServiceInstanceGuid(si.guid);
-    this.csiState.setAll(si.name, spaceGuid, si.tags ?? [], '');
+    // setAll's last arg IS the serviceInstanceGuid — it overwrites whatever was
+    // there (default null). Pass si.guid here so the edit-mode PATCH targets the
+    // real instance; a separate setServiceInstanceGuid() before setAll would be
+    // immediately clobbered back to null, sending PATCH .../null → CF 404 (#5412).
+    this.csiState.setAll(si.name, spaceGuid, si.tags ?? [], '', false, si.guid);
     if (si.servicePlan?.guid) {
       this.csiState.setServicePlan(si.servicePlan.guid);
     }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/csi-state.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/csi-state.service.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { CsiStateService } from './csi-state.service';
+
+describe('CsiStateService', () => {
+  it('setAll carries the serviceInstanceGuid when provided (edit mode)', () => {
+    const svc = new CsiStateService();
+    svc.setAll('my-si', 'space-1', ['tag'], '', false, 'si-guid-123');
+    expect(svc.serviceInstanceGuid()).toBe('si-guid-123');
+  });
+
+  it('setAll without a guid clears serviceInstanceGuid (the #5412 foot-gun)', () => {
+    // This is why the managed edit setup must pass si.guid THROUGH setAll:
+    // calling setServiceInstanceGuid() first and then setAll() with no guid
+    // arg clobbered it back to null, sending PATCH /service_instances/{cnsi}/null.
+    const svc = new CsiStateService();
+    svc.setServiceInstanceGuid('si-guid-123');
+    svc.setAll('my-si', 'space-1', [], '');
+    expect(svc.serviceInstanceGuid() ?? null).toBeNull();
+  });
+
+  it('the fixed managed-edit call sequence preserves the serviceInstanceGuid (#5412)', () => {
+    // Mirrors applyManagedEditModeState: setServiceGuid → setAll(..., si.guid)
+    // → setServicePlan. The instance guid must survive to the edit-mode PATCH.
+    const svc = new CsiStateService();
+    svc.setServiceGuid('svc-1');
+    svc.setAll('my-si', 'space-1', ['tag'], '', false, 'si-guid-123');
+    svc.setServicePlan('plan-1');
+    expect(svc.serviceInstanceGuid()).toBe('si-guid-123');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
@@ -3,7 +3,7 @@
   @if (!isMarketplaceMode) {
     <app-form-field>
       <app-select id="cf" #cfSelect="ngModel" placeholder="Cloud Foundry" [autoSelectSingleOption]="false"
-        [disabled]="cfOrgSpaceService.cf.loading() || isRedeploy"
+        [disabled]="cfOrgSpaceService.cf.loading() || isRedeploy || endpointScoped"
         [ngModel]="cfOrgSpaceService.cf.select()"
         (selectionChange)="onCfChange($event.value)" required name="cf"
         [appFocus]="!cfOrgSpaceService.cf.loading()">

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.spec.ts
@@ -13,7 +13,7 @@ describe('CreateApplicationStep1Component', () => {
   let component: CreateApplicationStep1Component;
   let fixture: ComponentFixture<CreateApplicationStep1Component>;
 
-  beforeEach(async () => {
+  async function setup(endpointGuid: string | null) {
     await TestBed.configureTestingModule({
       imports: [
         CreateApplicationStep1Component,
@@ -30,7 +30,7 @@ describe('CreateApplicationStep1Component', () => {
           useValue: {
             root: {
               snapshot: {
-                queryParams: { endpointGuid: null },
+                queryParams: { endpointGuid },
               }
             }
           }
@@ -41,9 +41,21 @@ describe('CreateApplicationStep1Component', () => {
     fixture = TestBed.createComponent(CreateApplicationStep1Component);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  it('should be created', async () => {
+    await setup(null);
+    expect(component).toBeTruthy();
   });
 
-  it('should be created', () => {
-    expect(component).toBeTruthy();
+  it('does not lock the CF dropdown when not scoped to an endpoint', async () => {
+    await setup(null);
+    expect(component.endpointScoped).toBe(false);
+  });
+
+  it('pre-selects and locks the CF dropdown when scoped to an endpoint', async () => {
+    await setup('cf-endpoint-guid');
+    expect(component.endpointScoped).toBe(true);
+    expect(component.cfOrgSpaceService.cf.select()).toBe('cf-endpoint-guid');
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.ts
@@ -50,6 +50,13 @@ export class CreateApplicationStep1Component implements OnInit, AfterContentInit
 
   @Input() isRedeploy = false;
 
+  // A deploy scoped to an endpoint arrives with an `endpointGuid` query
+  // param (e.g. from a CF's Applications tab). The CF is fixed for the
+  // whole flow, so we pre-select AND lock the Cloud Foundry dropdown —
+  // org / space stay selectable. Distinct from isRedeploy, which locks
+  // all three.
+  endpointScoped = false;
+
   validate!: Observable<boolean>;
 
   @Input()
@@ -127,6 +134,7 @@ export class CreateApplicationStep1Component implements OnInit, AfterContentInit
   ngOnInit() {
     if (this.route.root.snapshot.queryParams.endpointGuid) {
       this.cfOrgSpaceService.cf.select.set(this.route.root.snapshot.queryParams.endpointGuid);
+      this.endpointScoped = true;
     }
     this.spaces$ = this.getSpacesFromPermissions();
     this.hasSpaces$ = this.spaces$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, computed, inject, signal, Signal } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { ConfirmationDialogConfig, ConfirmationDialogService } from '@stratosui/core';
+import { ConfirmationDialogConfig, ConfirmationDialogService, TailwindSnackBarService } from '@stratosui/core';
 
 import { ApplicationService } from '../../features/applications/application.service';
 import { AppDeleteSelectionService } from '../../features/applications/app-delete-selection.service';
@@ -56,6 +56,7 @@ export class AppApplicationActionsService {
   private apps = inject(CfAppsSignalConfigService);
   private deleteSelection = inject(AppDeleteSelectionService);
   private statsRegistry = inject(AppStatsDataRegistry);
+  private snackBar = inject(TailwindSnackBarService);
 
   // In-flight flag delegates to AppLifecycleStateService — the leaf
   // shared-state service used to break the construction cycle with
@@ -451,7 +452,16 @@ export class AppApplicationActionsService {
       orgName: this.dataService.org()?.name ?? '',
       spaceName: this.dataService.space()?.name ?? '',
     });
-    this.router.navigate(['/applications', cfGuid, appGuid, 'delete']);
+    // Remember where to return after the delete. If the app was opened from
+    // the CF-scoped Applications wall (the row link tags ?breadcrumbs=cf), send
+    // the user back there instead of the global wall. Threaded through the
+    // delete nav chain as ?returnUrl and read in deleteWithCleanup.
+    const cfScoped = this.router.parseUrl(this.router.url).queryParams['breadcrumbs'] === 'cf';
+    const returnUrl = cfScoped ? `/cloud-foundry/${cfGuid}/applications` : undefined;
+    this.router.navigate(
+      ['/applications', cfGuid, appGuid, 'delete'],
+      returnUrl ? { queryParams: { returnUrl } } : undefined,
+    );
   }
 
   /**
@@ -473,6 +483,7 @@ export class AppApplicationActionsService {
     preResolvedTarget?: { appName: string; endpointName: string; orgName: string; spaceName: string },
   ): Promise<void> {
     const { cfg, target } = this.buildDialog('Delete', 'Are you sure you want to delete', 'Delete', preResolvedTarget);
+    const appName = preResolvedTarget?.appName ?? this.parseTarget(target).app;
     this.confirmDialog.open(cfg, () => {
       this.runLifecycleAction(
         'delete',
@@ -508,9 +519,17 @@ export class AppApplicationActionsService {
           await this.apps.deleteApp(cfGuid, appGuid);
         },
         () => {
-          // App is gone — navigate to the app wall instead of staying on
-          // the now-orphaned detail page.
-          this.router.navigate(['/applications']);
+          // App is gone. The in-page lifecycle-progress overlay is
+          // component-scoped to this (about-to-be-destroyed) detail page, so
+          // its 10s linger can't survive the navigation — pop a root-level
+          // snackbar (mounted on document.body, providedIn:'root') that rides
+          // the navigation and auto-dismisses after 10s.
+          this.snackBar.open(`Application "${appName}" deleted`, 'Dismiss', { duration: 10000 });
+          // Return to where the delete was launched from — the CF-scoped wall
+          // if the user came from one (threaded via ?returnUrl), else the
+          // global app wall.
+          const returnUrl = this.router.parseUrl(this.router.url).queryParams['returnUrl'] || '/applications';
+          this.router.navigateByUrl(returnUrl);
         },
       );
     });

--- a/src/jetstream/plugins/cfapppush/connection_wrapper.go
+++ b/src/jetstream/plugins/cfapppush/connection_wrapper.go
@@ -1,12 +1,15 @@
 package cfapppush
 
 import (
+	"errors"
 	"time"
 
 	"code.cloudfoundry.org/cli/v8/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/v8/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/v8/command"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	log "github.com/sirupsen/logrus"
 )
 
 // PushConnectionWrapper can wrap a given connection allowing the wrapper to modify
@@ -26,28 +29,63 @@ func (cw PushConnectionWrapper) Wrap(innerconnection cloudcontroller.Connection)
 
 // Make makes an HTTP request
 func (cw PushConnectionWrapper) Make(request *cloudcontroller.Request, passedResponse *cloudcontroller.Response) error {
-	// Check to see if the token is about to expire, if it is, refresh it first
-	token, found := cw.portalProxy.GetCNSITokenRecord(cw.config.EndpointID, cw.config.UserID)
-	if found {
-		// Aways update the access token, in case someone else refreshed it
-		cw.config.AuthToken = token.AuthToken
-
-		// Check if this is about to expire in the next 30 seconds
-		expiry := token.TokenExpiry - 30
-		expTime := time.Unix(expiry, 0)
-		if expTime.Before(time.Now()) {
-			cnsiRecord, err := cw.portalProxy.GetCNSIRecord(cw.config.EndpointID)
-			if err == nil {
-				// Refresh token first - makes sure it will be valid when we do the push
-				refreshedTokenRec, err := cw.portalProxy.RefreshOAuthToken(cnsiRecord.SkipSSLValidation, cnsiRecord.GUID, cw.config.UserID, cnsiRecord.ClientId, cnsiRecord.ClientSecret, cnsiRecord.TokenEndpoint)
-				if err == nil {
-					cw.config.AuthToken = refreshedTokenRec.AuthToken
-				}
-			}
-		}
-	}
-
+	// Proactively refresh the token if it is about to expire, so we don't start
+	// a request with a token that's about to lapse.
+	cw.ensureFreshToken()
 	cw.cmdConfig.SetAccessToken("bearer " + cw.config.AuthToken)
 
-	return cw.inner.Make(request, passedResponse)
+	err := cw.inner.Make(request, passedResponse)
+
+	// Reactive safety net: even after the proactive refresh, a token can still be
+	// rejected at its expiry boundary — clock skew, or it lapsed mid-push during a
+	// long-running request. On an invalid/expired-token error, force a refresh and
+	// replay the request once. A replay needs the body rewound (ResetBody); a
+	// streamed upload (non-seekable pipe) can't be rewound, so we surface the
+	// original error in that case. We only retry InvalidAuthTokenError (a refresh
+	// fixes it), not UnauthorizedError (a permissions problem a refresh won't fix).
+	var invalidToken ccerror.InvalidAuthTokenError
+	if errors.As(err, &invalidToken) && cw.forceRefreshToken() {
+		if resetErr := request.ResetBody(); resetErr != nil {
+			log.Warnf("cf push: cannot replay request after token refresh (body not seekable): %s", resetErr)
+			return err
+		}
+		cw.cmdConfig.SetAccessToken("bearer " + cw.config.AuthToken)
+		return cw.inner.Make(request, passedResponse)
+	}
+
+	return err
+}
+
+// ensureFreshToken refreshes the CF token when it is within 30 seconds of expiry.
+// It always picks up the latest stored access token first, in case another
+// request refreshed it concurrently.
+func (cw PushConnectionWrapper) ensureFreshToken() {
+	token, found := cw.portalProxy.GetCNSITokenRecord(cw.config.EndpointID, cw.config.UserID)
+	if !found {
+		return
+	}
+	cw.config.AuthToken = token.AuthToken
+
+	// Refresh if it expires within the next 30 seconds.
+	if time.Unix(token.TokenExpiry-30, 0).Before(time.Now()) {
+		cw.forceRefreshToken()
+	}
+}
+
+// forceRefreshToken unconditionally refreshes the CF OAuth token and updates the
+// cached access token on the shared config. Returns true on success; on failure it
+// logs and leaves the existing token in place.
+func (cw PushConnectionWrapper) forceRefreshToken() bool {
+	cnsiRecord, err := cw.portalProxy.GetCNSIRecord(cw.config.EndpointID)
+	if err != nil {
+		log.Warnf("cf push: could not load endpoint record to refresh token: %s", err)
+		return false
+	}
+	refreshedTokenRec, err := cw.portalProxy.RefreshOAuthToken(cnsiRecord.SkipSSLValidation, cnsiRecord.GUID, cw.config.UserID, cnsiRecord.ClientId, cnsiRecord.ClientSecret, cnsiRecord.TokenEndpoint)
+	if err != nil {
+		log.Warnf("cf push: failed to refresh CF token: %s", err)
+		return false
+	}
+	cw.config.AuthToken = refreshedTokenRec.AuthToken
+	return true
 }

--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -232,6 +233,17 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 
 	log.Debug("Sending message to front-end to indicate push completed")
 	sendEvent(clientWebSocket, EVENT_PUSH_COMPLETED)
+
+	// For a new app the GUID isn't known until the push has created it, so
+	// (unlike the redeploy path above, which notifies up-front) resolve it now
+	// by name in the target space and notify the client — otherwise the UI's
+	// applicationGuid$ stays null and "Go to App Summary" never enables.
+	// Best-effort: a lookup failure must not fail the deploy.
+	if len(appID) == 0 {
+		if guid := cfAppPush.resolvePushedAppGUID(cnsiGUID, userGUID, spaceGUID, overrides, manifest); guid != "" {
+			cfAppPush.SendEvent(clientWebSocket, APP_GUID_NOTIFY, guid)
+		}
+	}
 
 	sendEvent(clientWebSocket, CLOSE_SUCCESS)
 
@@ -776,4 +788,37 @@ func (cfAppPush *CFAppPush) SendEvent(clientWebSocket *websocket.Conn, event Mes
 	if err := clientWebSocket.WriteMessage(websocket.TextMessage, msg); err != nil {
 		log.Warnf("Failed to write message to web socket: %s", err)
 	}
+}
+
+// resolvePushedAppGUID looks up the GUID of a just-pushed (new) app by its name
+// within the target space. The push name is the override name if supplied,
+// otherwise the manifest's app name. Returns "" on any failure — the caller
+// treats this as best-effort and must not fail the deploy over it.
+func (cfAppPush *CFAppPush) resolvePushedAppGUID(cnsiGUID, userGUID, spaceGUID string, overrides CFPushAppOverrides, manifest Applications) string {
+	appName := overrides.Name
+	if appName == "" && len(manifest.Applications) > 0 {
+		appName = manifest.Applications[0].Name
+	}
+	if appName == "" || spaceGUID == "" {
+		log.Warnf("Cannot resolve pushed app GUID: missing app name or space GUID")
+		return ""
+	}
+
+	requestURL := fmt.Sprintf("/v3/apps?names=%s&space_guids=%s", url.QueryEscape(appName), url.QueryEscape(spaceGUID))
+	res, err := cfAppPush.portalProxy.DoProxySingleRequest(cnsiGUID, userGUID, "GET", requestURL, nil, nil)
+	if err != nil || res == nil || res.StatusCode != http.StatusOK {
+		log.Warnf("Failed to resolve GUID for pushed app %q: %v", appName, err)
+		return ""
+	}
+
+	var list struct {
+		Resources []struct {
+			GUID string `json:"guid"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(res.Response, &list); err != nil || len(list.Resources) == 0 {
+		log.Warnf("Could not find pushed app %q in space %q to notify its GUID", appName, spaceGUID)
+		return ""
+	}
+	return list.Resources[0].GUID
 }


### PR DESCRIPTION
## Deploy-from-Git wizard fixes (Refs #5400)

Addresses four of the open items in #5400. Each is an independent, atomic commit.

> Not closing #5400: item 2 (source-step UX) is deferred to a design pass, and item 3 (deploy latest HEAD without pinning) is being folded into the in-flight GithubCommits signal-list migration which owns the commit picker.

### Item 1 — lock the CF endpoint when scoped (`create-application-step1`)
A deploy launched from a CF's Applications tab carries an `endpointGuid` query param and pre-selects that Cloud Foundry, but the dropdown stayed editable, letting the user pick a different endpoint than the one they scoped to. The CF dropdown is now locked in that case (org/space remain selectable), mirroring how `isRedeploy` already locks the selection.

### Item 4 — no-route / random-route mutual exclusivity (`deploy-application-options-step`)
Checking "Do not create a route" disabled "Create a random route" but left its value set, so a stale `--random-route` shipped alongside `--no-route` and CF rejected the push ("cannot be used together"). The other control's value is now cleared before it's disabled, and the exclusivity is two-way, guarded against `valueChanges` feedback loops.

### Item 6 — notify the new app's GUID after a first-time push (`deploy.go`)
`APP_GUID_NOTIFY` was only sent up-front for redeploys (where the GUID is already known), so a brand-new app's GUID never reached the client and "Go to App Summary" stayed disabled. After a successful new-app push, the GUID is resolved by name in the target space and sent. Best-effort — a lookup failure does not fail the deploy.

### Item 5 — retry a push request once on an expired token (`connection_wrapper.go`)
A long push could start a request with a token at its expiry boundary and fail with an invalid-token error even though jetstream refreshes moments later. A reactive retry now force-refreshes the token and replays the request once on `InvalidAuthTokenError` (`ResetBody` rewinds any payload), mirroring the CLI library's own retry pattern. Only the refreshable error is retried — not permission 401s.

### Testing
- Full `make check gate` green: lint (no new warnings), 2431 frontend tests pass, prod AOT build completes, backend tests pass.
- New frontend specs cover the scoped-CF lock and the two-way route exclusivity (incl. the stale-`--random-route` regression).
- Backend changes verified with `go build` + `go vet` on the `cfapppush` module; the wrapper retry mirrors the cloudcontroller library's canonical body-reset retry. (The `cfapppush` module has no existing PortalProxy mock harness, so these are covered by build/vet rather than a new unit test.)
