### PR TITLE
fix(cf): env var editor dialog — edit, rename, delete (Closes #5388)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.html
@@ -1,43 +1,7 @@
 <div>
   <div>
     <app-list-sub-nav title="Total Variables" [count]="totalVariables"
-                      [addAction]="addVariableAction" [isAdding]="isAdding">
-      <!-- Inline add form rendered on the L5 row when isAdding is true.
-           Replaces the +Add Variable button. Save/cancel route through
-           the component, which talks to AppVariableActionsService. -->
-      <div subNavForm class="flex items-center gap-2">
-        <!-- Validation runs on ✓ click, not reactively. Errors land in
-             an absolute-positioned label above the Name input (sitting
-             in the L5 row's top padding) so the row stays pixel-stable
-             whether the form is closed, open and valid, or open and
-             invalid. -->
-        <div class="relative">
-          @if (nameError()) {
-            <div class="absolute -top-3 left-1 text-red-500 text-[11px] leading-none whitespace-nowrap">
-              {{ nameError() }}
-            </div>
-          }
-          <input class="bg-white rounded-md border border-gray-300 px-3 py-2 text-base text-slate-800 placeholder:text-gray-400 placeholder:opacity-70 focus:outline-none focus:ring-1 focus:ring-primary disabled:bg-gray-100 disabled:text-gray-500"
-            id="envVarName" name="envVarName" placeholder="Name"
-            [ngModel]="addItem().name"
-            [disabled]="!!editingName()"
-            (ngModelChange)="addItem.set({ name: $event, value: addItem().value }); clearNameError()">
-        </div>
-        <input class="bg-white rounded-md border border-gray-300 px-3 py-2 text-base text-slate-800 placeholder:text-gray-400 placeholder:opacity-70 focus:outline-none focus:ring-1 focus:ring-primary"
-          id="envVarValue" name="envVarValue" placeholder="Value"
-          [ngModel]="addItem().value"
-          (ngModelChange)="addItem.set({ name: addItem().name, value: $event })">
-        <button id="addFormButtonAdd" class="btn btn-icon btn-success h-9"
-                type="button"
-                (click)="validateAndSave()">
-          <span class="material-icons">done</span>
-        </button>
-        <button id="addFormButtonCancel" class="btn btn-icon h-9"
-                type="button"
-                (click)="cancelAdd()">
-          <span class="material-icons">clear</span>
-        </button>
-      </div>
+                      [addAction]="addVariableAction">
     </app-list-sub-nav>
     <app-signal-list [config]="listConfig"></app-signal-list>
   </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.spec.ts
@@ -253,8 +253,6 @@ describe('VariablesTabComponent', () => {
     expect(cmp).toBe(VariableEditDialogComponent);
     expect(cfg.data.mode).toBe('add');
     expect(cfg.data.existingNames).toEqual(['FOO', 'BAR']);
-    // Top-anchored so content height changes don't re-center / jump the dialog.
-    expect(cfg.position).toBe('top');
   });
 
   it('Edit row action opens the dialog pre-filled, existingNames excluding self', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.spec.ts
@@ -253,6 +253,8 @@ describe('VariablesTabComponent', () => {
     expect(cmp).toBe(VariableEditDialogComponent);
     expect(cfg.data.mode).toBe('add');
     expect(cfg.data.existingNames).toEqual(['FOO', 'BAR']);
+    // Top-anchored so content height changes don't re-center / jump the dialog.
+    expect(cfg.position).toBe('top');
   });
 
   it('Edit row action opens the dialog pre-filled, existingNames excluding self', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.spec.ts
@@ -18,6 +18,7 @@ import { ApplicationServiceMock } from '@test-framework/cf';
 import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
+  TailwindDialogService,
   TailwindSnackBarService,
 } from '@stratosui/core';
 
@@ -26,6 +27,7 @@ import { AppVariableActionsService } from '../../../../../../shared/services/app
 import {
   CfAppVariablesSignalConfigService,
 } from '../../../../../../shared/signal-list-configs/app-variables/cf-app-variables-signal-config.service';
+import { VariableEditDialogComponent } from '../../../../../../shared/components/variable-edit-dialog/variable-edit-dialog.component';
 import { VariablesTabComponent } from './variables-tab.component';
 
 describe('VariablesTabComponent', () => {
@@ -38,28 +40,24 @@ describe('VariablesTabComponent', () => {
     pipe: vi.fn(() => of({})),
   };
 
-  const mockPmf = {
-    create: vi.fn(() => ({
-      currentPage$: of([]),
-      pagination$: of({}),
-      fetchingCurrentPage$: of(false),
-      isLoadingPage$: of(false),
-    })),
-  };
-
   // Spy holders, refreshed per test.
   let refreshScope: ReturnType<typeof vi.fn>;
+  let envVarsSig: WritableSignal<any>;
   let addVariable: ReturnType<typeof vi.fn>;
   let updateVariable: ReturnType<typeof vi.fn>;
+  let renameVariable: ReturnType<typeof vi.fn>;
   let deleteVariable: ReturnType<typeof vi.fn>;
   let confirmOpen: ReturnType<typeof vi.fn>;
   let configRefresh: ReturnType<typeof vi.fn>;
+  let dialogOpen: ReturnType<typeof vi.fn>;
+  let dialogResult: any; // value the stub dialog "closes" with
 
-  /** Minimal AppDetailDataService stub. */
+  /** Minimal AppDetailDataService stub with a settable envVars signal. */
   const makeDataStub = () => {
     refreshScope = vi.fn(async () => undefined);
+    envVarsSig = signal<any>(undefined);
     return {
-      envVars: signal<any>(undefined).asReadonly(),
+      envVars: envVarsSig.asReadonly(),
       loading: signal({ envVars: false } as any).asReadonly(),
       refresh: refreshScope,
     };
@@ -68,6 +66,7 @@ describe('VariablesTabComponent', () => {
   const makeVariableActionsStub = () => {
     addVariable = vi.fn(async () => undefined);
     updateVariable = vi.fn(async () => undefined);
+    renameVariable = vi.fn(async () => undefined);
     deleteVariable = vi.fn(async () => undefined);
     return {
       transitioningName: signal<string | null>(null).asReadonly(),
@@ -75,13 +74,10 @@ describe('VariablesTabComponent', () => {
       addVariable,
       deleteVariable,
       updateVariable,
+      renameVariable,
     };
   };
 
-  // Stub for the tab's signal-list config service. Mirrors the public
-  // surface the tab consumes (view pipeline, page/sort signals, columns,
-  // refresh/clear). The `actions` column carries an unwrapped invoke
-  // that the tab replaces with a confirm-wrapped factory.
   const makeVariablesConfigStub = () => {
     const variables: WritableSignal<any[]> = signal([]);
     const filtered = computed(() => variables());
@@ -127,10 +123,23 @@ describe('VariablesTabComponent', () => {
     return { open: confirmOpen };
   };
 
+  const makeDialogStub = () => {
+    dialogResult = undefined;
+    // of(dialogResult) captures the value set just before invoke().
+    dialogOpen = vi.fn(() => ({ afterClosed: () => of(dialogResult) }));
+    return { open: dialogOpen };
+  };
+
   const makeSnackStub = () => ({
     open: vi.fn(),
     error: vi.fn(),
   });
+
+  /** Pull the Edit/Delete row actions for a given row off the list config. */
+  const rowActionsFor = (row: any) => {
+    const actionsCol = component.listConfig.columns.find(c => c.key === 'actions');
+    return actionsCol!.actions!(row);
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -145,14 +154,12 @@ describe('VariablesTabComponent', () => {
         { provide: CloudFoundryService, useValue: { cFEndpoints$: of([]), connectedCFEndpoints$: of([]) } },
         { provide: AppDetailDataService, useFactory: makeDataStub },
         { provide: ConfirmationDialogService, useFactory: makeConfirmStub },
+        { provide: TailwindDialogService, useFactory: makeDialogStub },
         { provide: TailwindSnackBarService, useFactory: makeSnackStub },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     })
       .overrideComponent(VariablesTabComponent, {
-        // Replace the heavy tab-scoped providers with stubs so we can
-        // observe lifecycle calls without booting the real services
-        // (which would pull in HttpClient, ListStateStore, etc.).
         remove: {
           providers: [AppVariableActionsService, CfAppVariablesSignalConfigService],
         },
@@ -197,19 +204,18 @@ describe('VariablesTabComponent', () => {
   it('builds a signal-list config from the wave-2 service', () => {
     fixture.detectChanges();
     expect(component.listConfig).toBeTruthy();
-    expect(component.listConfig.pagedItems).toBeTruthy();
-    // Actions column carries the tab's confirm-wrapped factory, not the
-    // service's no-confirm one.
     const actionsCol = component.listConfig.columns.find(c => c.key === 'actions');
     expect(actionsCol).toBeTruthy();
     expect(actionsCol!.actions).toBeTruthy();
   });
 
+  // -------------------------------------------------------------------------
+  // Delete — unchanged: confirm dialog then explicit delete + refresh
+  // -------------------------------------------------------------------------
+
   it('opens a confirm dialog before deleting, refreshes on confirm', async () => {
     fixture.detectChanges();
-    const actionsCol = component.listConfig.columns.find(c => c.key === 'actions');
-    const rowActions = actionsCol!.actions!({ name: 'FOO', value: 'bar' } as any);
-    const del = rowActions.find(a => a.label === 'Delete');
+    const del = rowActionsFor({ name: 'FOO', value: 'bar' }).find(a => a.label === 'Delete');
     expect(del).toBeTruthy();
 
     del!.invoke({ name: 'FOO', value: 'bar' } as any);
@@ -218,7 +224,6 @@ describe('VariablesTabComponent', () => {
     const [config, onConfirm] = confirmOpen.mock.calls[0];
     expect(config).toBeInstanceOf(ConfirmationDialogConfig);
     expect((config as ConfirmationDialogConfig).message).toContain('FOO');
-
     expect(deleteVariable).not.toHaveBeenCalled();
 
     await onConfirm();
@@ -226,101 +231,108 @@ describe('VariablesTabComponent', () => {
     expect(configRefresh).toHaveBeenCalled();
   });
 
-  describe('edit affordance (restored lost functionality)', () => {
-    it('exposes an Edit row action alongside Delete', () => {
-      fixture.detectChanges();
-      const actionsCol = component.listConfig.columns.find(c => c.key === 'actions');
-      const rowActions = actionsCol!.actions!({ name: 'FOO', value: 'bar' } as any);
-      expect(rowActions.find(a => a.label === 'Edit')).toBeTruthy();
-      expect(rowActions.find(a => a.label === 'Delete')).toBeTruthy();
-    });
+  // -------------------------------------------------------------------------
+  // Editor dialog — Add / Edit / Rename routing
+  // -------------------------------------------------------------------------
 
-    it('Edit opens the inline form pre-filled and enters edit mode', () => {
-      fixture.detectChanges();
-      const actionsCol = component.listConfig.columns.find(c => c.key === 'actions');
-      const edit = actionsCol!.actions!({ name: 'FOO', value: 'bar' } as any).find(a => a.label === 'Edit');
-
-      edit!.invoke({ name: 'FOO', value: 'bar' } as any);
-
-      expect(component.isAdding()).toBe(true);
-      expect(component.editingName()).toBe('FOO');
-      expect(component.addItem()).toEqual({ name: 'FOO', value: 'bar' });
-    });
-
-    it('validateAndSave in edit mode calls updateVariable (not addVariable), then closes + refreshes', async () => {
-      fixture.detectChanges();
-      component.editingName.set('FOO');
-      component.addItem.set({ name: 'FOO', value: 'new-value' });
-
-      component.validateAndSave();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(updateVariable).toHaveBeenCalledWith('FOO', 'new-value');
-      expect(addVariable).not.toHaveBeenCalled();
-      expect(configRefresh).toHaveBeenCalled();
-      expect(component.isAdding()).toBe(false);
-      expect(component.editingName()).toBeNull();
-    });
-
-    it('edit mode skips the duplicate-name validation (the key already exists)', () => {
-      fixture.detectChanges();
-      component.editingName.set('FOO');
-      component.addItem.set({ name: 'FOO', value: 'v' });
-
-      component.validateAndSave();
-
-      expect(component.nameError()).toBe('');
-      expect(updateVariable).toHaveBeenCalled();
-    });
-
-    it('cancel clears edit mode', () => {
-      component.editingName.set('FOO');
-      component.isAdding.set(true);
-      component.cancelAdd();
-      expect(component.editingName()).toBeNull();
-      expect(component.isAdding()).toBe(false);
-    });
+  it('exposes an Edit row action alongside Delete', () => {
+    fixture.detectChanges();
+    const actions = rowActionsFor({ name: 'FOO', value: 'bar' });
+    expect(actions.find(a => a.label === 'Edit')).toBeTruthy();
+    expect(actions.find(a => a.label === 'Delete')).toBeTruthy();
   });
 
-  describe('validateAndSave()', () => {
-    it('flags Name is required when the name is empty', () => {
-      component.addItem.set({ name: '', value: '' });
-      component.validateAndSave();
-      expect(component.nameError()).toBe('Name is required');
-    });
+  it('Add button opens the editor dialog in add mode with all existing names', () => {
+    envVarsSig.set({ environment: { FOO: 'a', BAR: 'b' } });
+    fixture.detectChanges();
 
-    it('flags Name is required when the name is whitespace-only', () => {
-      component.addItem.set({ name: '   ', value: '' });
-      component.validateAndSave();
-      expect(component.nameError()).toBe('Name is required');
-    });
+    component.addVariableAction.invoke();
 
-    it('flags an invalid pattern when the name contains spaces', () => {
-      component.addItem.set({ name: 'bad name', value: '' });
-      component.validateAndSave();
-      expect(component.nameError()).toMatch(/letters, digits, and underscores/i);
-    });
-
-    it('flags an invalid pattern when the name starts with a digit', () => {
-      component.addItem.set({ name: '1FOO', value: '' });
-      component.validateAndSave();
-      expect(component.nameError()).toMatch(/letters, digits, and underscores/i);
-    });
-
-    it('accepts a valid name and clears any prior error', () => {
-      component.nameError.set('Name is required');
-      component.addItem.set({ name: 'MY_VAR', value: 'val' });
-      component.validateAndSave();
-      expect(component.nameError()).toBe('');
-    });
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    const [cmp, cfg] = dialogOpen.mock.calls[0];
+    expect(cmp).toBe(VariableEditDialogComponent);
+    expect(cfg.data.mode).toBe('add');
+    expect(cfg.data.existingNames).toEqual(['FOO', 'BAR']);
   });
 
-  describe('clearNameError()', () => {
-    it('resets the error signal when called', () => {
-      component.nameError.set('Name is required');
-      component.clearNameError();
-      expect(component.nameError()).toBe('');
-    });
+  it('Edit row action opens the dialog pre-filled, existingNames excluding self', () => {
+    envVarsSig.set({ environment: { FOO: 'a', BAR: 'b' } });
+    fixture.detectChanges();
+
+    const edit = rowActionsFor({ name: 'FOO', value: 'a' }).find(a => a.label === 'Edit');
+    edit!.invoke({ name: 'FOO', value: 'a' } as any);
+
+    const [, cfg] = dialogOpen.mock.calls[0];
+    expect(cfg.data.mode).toBe('edit');
+    expect(cfg.data.name).toBe('FOO');
+    expect(cfg.data.value).toBe('a');
+    expect(cfg.data.existingNames).toEqual(['BAR']); // self excluded
+  });
+
+  it('add result routes to addVariable then refreshes', async () => {
+    fixture.detectChanges();
+    dialogResult = { name: 'NEW', value: 'v' };
+
+    component.addVariableAction.invoke();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(addVariable).toHaveBeenCalledWith('NEW', 'v');
+    expect(configRefresh).toHaveBeenCalled();
+  });
+
+  it('edit result with unchanged name routes to updateVariable', async () => {
+    envVarsSig.set({ environment: { FOO: 'a' } });
+    fixture.detectChanges();
+    dialogResult = { name: 'FOO', value: 'changed' };
+
+    rowActionsFor({ name: 'FOO', value: 'a' }).find(a => a.label === 'Edit')!.invoke({ name: 'FOO', value: 'a' } as any);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(updateVariable).toHaveBeenCalledWith('FOO', 'changed');
+    expect(renameVariable).not.toHaveBeenCalled();
+    expect(configRefresh).toHaveBeenCalled();
+  });
+
+  it('edit result with a changed name routes to renameVariable (old -> new)', async () => {
+    envVarsSig.set({ environment: { FOO: 'a' } });
+    fixture.detectChanges();
+    dialogResult = { name: 'RENAMED', value: 'a' };
+
+    rowActionsFor({ name: 'FOO', value: 'a' }).find(a => a.label === 'Edit')!.invoke({ name: 'FOO', value: 'a' } as any);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(renameVariable).toHaveBeenCalledWith('FOO', 'RENAMED', 'a');
+    expect(updateVariable).not.toHaveBeenCalled();
+    expect(configRefresh).toHaveBeenCalled();
+  });
+
+  it('cancelling the dialog (no result) performs no action service call', async () => {
+    fixture.detectChanges();
+    dialogResult = undefined; // cancelled
+
+    component.addVariableAction.invoke();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(addVariable).not.toHaveBeenCalled();
+    expect(updateVariable).not.toHaveBeenCalled();
+    expect(renameVariable).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a snackbar error when the action service rejects', async () => {
+    fixture.detectChanges();
+    dialogResult = { name: 'NEW', value: 'v' };
+    addVariable.mockRejectedValueOnce(new Error('CF-Boom'));
+    const snack = TestBed.inject(TailwindSnackBarService) as any;
+
+    component.addVariableAction.invoke();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(snack.error).toHaveBeenCalled();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
@@ -9,7 +9,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { take } from 'rxjs/operators';
 
 import {
   ConfirmationDialogConfig,
@@ -20,6 +20,7 @@ import {
   SignalListComponent,
   SignalListConfig,
   SignalListRowAction,
+  TailwindDialogService,
   TailwindSnackBarService,
 } from '@stratosui/core';
 
@@ -30,6 +31,10 @@ import {
 import {
   CfAppVariablesSignalConfigService,
 } from '../../../../../../shared/signal-list-configs/app-variables/cf-app-variables-signal-config.service';
+import {
+  VariableEditDialogComponent,
+  VariableEditDialogResult,
+} from '../../../../../../shared/components/variable-edit-dialog/variable-edit-dialog.component';
 import { AppVariableActionsService } from '../../../../../../shared/services/app-variable-actions.service';
 import { AppDetailDataService } from '../../../../app-detail-data.service';
 
@@ -40,26 +45,21 @@ export interface VariableTabAllEnvVarType {
 }
 
 /**
- * VariablesTabComponent — signal-native rewrite of the app-detail
- * Variables tab. Mirrors the slice-3 RoutesTabComponent shape:
+ * VariablesTabComponent — signal-native app-detail Variables tab.
  *
  * - Tab-scoped CfAppVariablesSignalConfigService and
  *   AppVariableActionsService so per-variable transition state and
  *   filter/sort/page reset cleanly between apps.
- * - Reads the env envelope from `AppDetailDataService.envVars()` (already
- *   prefetched as part of slice 1). Triggers a refresh on tab init in
- *   case the user navigated here without going through the app-detail
- *   shell first; subsequent action-service success callbacks also call
- *   refresh so the next read sees the canonical CF view.
- * - L5 sub-nav row above the list shows the count + an inline Add
- *   Variable form (Name/Value + ✓/✕ buttons) wired to the action
- *   service. Validation runs on submit (legacy behavior) so the row
- *   stays pixel-stable while the user types.
- * - Wraps the config service's no-confirm Delete with a confirmation
- *   dialog (legacy text style).
- * - "All Variables" code block at the bottom renders the full env
- *   envelope (system + user + app/running/staging) by walking the
- *   StEnvVars sections directly.
+ * - Reads the env envelope from `AppDetailDataService.envVars()`; refreshes
+ *   on tab init and after each successful mutation so the next read reflects
+ *   the canonical CF view.
+ * - Add / Edit / Rename all go through a single popup `VariableEditDialogComponent`
+ *   (stacked editable Name + multiline Monaco value editor). The L5 sub-nav's
+ *   Add button and the per-row Edit action both open it; the dialog returns
+ *   `{name, value}` and this component routes to add / update / rename.
+ * - Delete is wrapped in a confirmation dialog and uses the action service's
+ *   explicit-`null` merge-patch delete.
+ * - "All Variables" code block at the bottom renders the full env envelope.
  */
 @Component({
   selector: 'app-variables-tab',
@@ -72,7 +72,6 @@ export interface VariableTabAllEnvVarType {
   ],
   imports: [
     CommonModule,
-    FormsModule,
     SignalListComponent,
     ListSubNavComponent,
     CodeBlockComponent,
@@ -83,6 +82,7 @@ export class VariablesTabComponent implements OnInit {
   private variablesConfig = inject(CfAppVariablesSignalConfigService);
   private actionsService = inject(AppVariableActionsService);
   private confirmDialog = inject(ConfirmationDialogService);
+  private dialog = inject(TailwindDialogService);
   private snackBar = inject(TailwindSnackBarService);
 
   /** Loading projection for the signal-list framework. */
@@ -94,67 +94,19 @@ export class VariablesTabComponent implements OnInit {
   /** Reactive total surfaced to the L5 sub-nav row above the list. */
   readonly totalVariables: Signal<number>;
 
-  // ---------------------------------------------------------------------------
-  // Inline add form state
-  // ---------------------------------------------------------------------------
-
-  /** True when the inline add form is open. The L5 sub-nav swaps the
-   *  +Add Variable button for the form when this is true. */
-  readonly isAdding: WritableSignal<boolean> = signal(false);
-
-  /** Bound to the Name/Value inputs in the inline add form. */
-  readonly addItem: WritableSignal<{ name: string; value: string }> = signal({ name: '', value: '' });
-
-  /**
-   * Name of the variable currently being edited, or null in add mode. The
-   * inline form is reused for edit: when set, the Name input is locked (the
-   * key is the variable's identity — only the value changes) and a save
-   * routes to updateVariable instead of addVariable. Restores the per-row
-   * Edit affordance dropped in the signal-native migration.
-   */
-  readonly editingName: WritableSignal<string | null> = signal(null);
-
-  /**
-   * Validation error for the Name input — populated by validateAndSave()
-   * when the user clicks the ✓ button with an invalid Name. Empty string
-   * = no error to display. Cleared on every keystroke so the user sees
-   * the error disappear as they correct the input.
-   *
-   * Validation runs on submit, not reactively per-keystroke, to keep the
-   * L5 row pixel-stable: error sits in the row's top padding via absolute
-   * positioning and only renders after the user attempts to save.
-   */
-  readonly nameError: WritableSignal<string> = signal('');
-
-  /** CF env var names follow shell-variable convention: must start with a
-   *  letter or underscore, and contain only letters, digits, and
-   *  underscores. */
-  private static readonly NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
-
-  /** Signal: names of user-defined environment variables surfaced via the
-   *  data service. Used by the duplicate-name validation in
-   *  validateAndSave() — it reads from the same canonical source the
-   *  list rows render from, so the check stays in sync with what the
-   *  user sees. */
+  /** Signal: names of user-defined environment variables. Used to seed the
+   *  editor dialog's duplicate-name check from the same canonical source the
+   *  list rows render from. */
   readonly envVarNames: Signal<string[]> = computed(() => {
     const env = this.dataService.envVars()?.environment;
     return env ? Object.keys(env) : [];
   });
 
-  /**
-   * L5 add action — opens the inline add-row form. Resets state so the
-   * user always starts with empty inputs and no leftover validation
-   * error from a previous attempt.
-   */
+  /** L5 add action — opens the editor dialog in add mode. */
   readonly addVariableAction: ListSubNavAddAction = {
     label: 'Add Variable',
     icon: 'add',
-    invoke: () => {
-      this.addItem.set({ name: '', value: '' });
-      this.nameError.set('');
-      this.editingName.set(null);
-      this.isAdding.set(true);
-    },
+    invoke: () => this.openEditor('add'),
   };
 
   // ---------------------------------------------------------------------------
@@ -164,10 +116,7 @@ export class VariablesTabComponent implements OnInit {
   /**
    * Flattened sections list for the "All Variables" code block: one
    * section per env source (USER PROVIDED / SYSTEM PROVIDED / APPLICATION /
-   * RUNNING / STAGING) followed by its keys. Mirrors the legacy
-   * `mapEnvVars` projection so the code block reads identically to the
-   * pre-migration UI; section keys read straight off the StEnvVars
-   * envelope rather than the legacy `*_env_json` field names.
+   * RUNNING / STAGING) followed by its keys.
    */
   readonly allEnvVars: Signal<VariableTabAllEnvVarType[]> = computed(() => {
     const env = this.dataService.envVars();
@@ -200,9 +149,8 @@ export class VariablesTabComponent implements OnInit {
 
   constructor() {
     // Build columns from the wave-2 config service, then replace the
-    // actions column's factory with our confirm-wrapped version. The
-    // service's default factory invokes the verbs directly (used by
-    // tests / future surfaces); the tab adds the legacy confirm dialogs.
+    // actions column's factory with our Edit-opens-dialog / confirm-delete
+    // version.
     const baseColumns = this.variablesConfig.buildColumns();
     const columns: SignalListColumn<ListAppEnvVar>[] = baseColumns.map(col => {
       if (col.key === 'actions' && col.kind === 'actions') {
@@ -239,115 +187,70 @@ export class VariablesTabComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // envVars are typically prefetched by the app-detail shell, but
-    // refresh on mount handles the case where the user navigates here
-    // directly (deep link / refresh) without the prefetch chain firing.
+    // envVars are typically prefetched by the app-detail shell; refresh on
+    // mount handles a direct deep link / refresh without the prefetch chain.
     void this.dataService.refresh('envVars');
   }
 
   // ---------------------------------------------------------------------------
-  // Inline add form handlers
+  // Editor dialog (Add / Edit / Rename)
   // ---------------------------------------------------------------------------
-
-  /** Validate the Add Variable form and either save or surface an error
-   *  in the absolute-positioned slot above the Name input. */
-  validateAndSave(): void {
-    const item = this.addItem();
-    const editing = this.editingName();
-    if (editing) {
-      // Edit mode: the key is fixed (Name input is locked), only the value
-      // changes, so the add-path name validation (required / pattern /
-      // duplicate) does not apply. Route straight to the update verb.
-      this.nameError.set('');
-      void this.saveEdit(editing, item.value ?? '');
-      return;
-    }
-    const name = (item.name ?? '').trim();
-    if (!name) {
-      this.nameError.set('Name is required');
-      return;
-    }
-    if (!VariablesTabComponent.NAME_PATTERN.test(name)) {
-      this.nameError.set('Use letters, digits, and underscores only; must start with a letter or underscore');
-      return;
-    }
-    if (this.envVarNames().includes(name)) {
-      this.nameError.set(`'${name}' is already in use`);
-      return;
-    }
-    this.nameError.set('');
-    void this.saveAdd(name, item.value ?? '');
-  }
-
-  /** Cancel the inline add/edit form. */
-  cancelAdd(): void {
-    this.nameError.set('');
-    this.editingName.set(null);
-    this.isAdding.set(false);
-  }
-
-  /** Clear any pending validation error so it doesn't linger as the user
-   *  edits. Bound to the Name input's (input) event. */
-  clearNameError(): void {
-    if (this.nameError()) {
-      this.nameError.set('');
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Internals
-  // ---------------------------------------------------------------------------
-
-  /** Submit the new variable to the action service; on success refresh
-   *  the env envelope so the next read picks up the new key and surface
-   *  any error via the snack bar (mirrors slice-3 routes pattern). */
-  private async saveAdd(name: string, value: string): Promise<void> {
-    try {
-      await this.actionsService.addVariable(name, value);
-      this.isAdding.set(false);
-      this.addItem.set({ name: '', value: '' });
-      await this.variablesConfig.refresh();
-    } catch (err: any) {
-      this.snackBar.error(`Add variable failed: ${err?.message ?? err}`);
-    }
-  }
-
-  /** Submit an edited variable's value via the update verb, then close the
-   *  form and refresh the env envelope so the next read reflects CF. */
-  private async saveEdit(name: string, value: string): Promise<void> {
-    try {
-      await this.actionsService.updateVariable(name, value);
-      this.isAdding.set(false);
-      this.editingName.set(null);
-      this.addItem.set({ name: '', value: '' });
-      await this.variablesConfig.refresh();
-    } catch (err: any) {
-      this.snackBar.error(`Update variable failed: ${err?.message ?? err}`);
-    }
-  }
 
   /**
-   * Per-row action factory. Wraps the wave-2 service's Delete verb with
-   * a confirmation dialog (legacy text style). On confirm we await the
-   * verb, then refresh the env envelope so the row vanishes synchronously
-   * (cf. routes / service-bindings tabs which evict via dataService —
-   * envVars has no eviction hook because it's a single envelope, not a
-   * list, so refresh is the eviction mechanism).
+   * Open the popup editor. Add mode forbids every existing name; edit mode
+   * forbids every name except the row's own (so an unchanged name passes,
+   * and a change to another existing key is blocked). On close the result
+   * `{name, value}` is routed to the matching verb.
    */
+  private openEditor(mode: 'add' | 'edit', row?: ListAppEnvVar): void {
+    const existingNames = mode === 'edit'
+      ? this.envVarNames().filter(n => n !== row!.name)
+      : this.envVarNames();
+
+    const ref = this.dialog.open(VariableEditDialogComponent, {
+      width: '640px',
+      data: { mode, name: row?.name, value: row?.value, existingNames },
+    });
+
+    ref.afterClosed().pipe(take(1)).subscribe((result?: VariableEditDialogResult) => {
+      if (!result) {
+        return; // cancelled
+      }
+      void this.applyEditorResult(mode, row, result);
+    });
+  }
+
+  /** Route a dialog result to add / update / rename, then refresh. */
+  private async applyEditorResult(
+    mode: 'add' | 'edit',
+    row: ListAppEnvVar | undefined,
+    result: VariableEditDialogResult,
+  ): Promise<void> {
+    try {
+      if (mode === 'add') {
+        await this.actionsService.addVariable(result.name, result.value);
+      } else if (row && result.name !== row.name) {
+        await this.actionsService.renameVariable(row.name, result.name, result.value);
+      } else {
+        await this.actionsService.updateVariable(result.name, result.value);
+      }
+      await this.variablesConfig.refresh();
+    } catch (err: any) {
+      this.snackBar.error(`Save variable failed: ${err?.message ?? err}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-row actions (Edit opens the dialog; Delete confirms + null-deletes)
+  // ---------------------------------------------------------------------------
+
   private readonly buildRowActions = (row: ListAppEnvVar): readonly SignalListRowAction<ListAppEnvVar>[] => {
     const disabled = this.actionsService.inFlight();
     return [
       {
         label: 'Edit', icon: 'edit',
         disabled,
-        invoke: () => {
-          // Reuse the inline form in edit mode: pre-fill name+value, lock
-          // the Name (the key is the variable's identity), save via update.
-          this.addItem.set({ name: row.name, value: row.value == null ? '' : String(row.value) });
-          this.nameError.set('');
-          this.editingName.set(row.name);
-          this.isAdding.set(true);
-        },
+        invoke: () => this.openEditor('edit', row),
       },
       {
         label: 'Delete', icon: 'delete', danger: true,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
@@ -211,6 +211,10 @@ export class VariablesTabComponent implements OnInit {
       // No fixed width: the dialog sizes to its (resizable) content so the
       // user can drag the editor wider/taller, capped at the viewport.
       maxWidth: '92vw',
+      // Anchor to the top so content height changes (validation message,
+      // resizing) grow downward instead of re-centering and jumping the
+      // fields under the cursor.
+      position: 'top',
       data: { mode, name: row?.name, value: row?.value, existingNames },
     });
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
@@ -211,10 +211,6 @@ export class VariablesTabComponent implements OnInit {
       // No fixed width: the dialog sizes to its (resizable) content so the
       // user can drag the editor wider/taller, capped at the viewport.
       maxWidth: '92vw',
-      // Anchor to the top so content height changes (validation message,
-      // resizing) grow downward instead of re-centering and jumping the
-      // fields under the cursor.
-      position: 'top',
       data: { mode, name: row?.name, value: row?.value, existingNames },
     });
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
@@ -208,7 +208,9 @@ export class VariablesTabComponent implements OnInit {
       : this.envVarNames();
 
     const ref = this.dialog.open(VariableEditDialogComponent, {
-      width: '640px',
+      // No fixed width: the dialog sizes to its (resizable) content so the
+      // user can drag the editor wider/taller, capped at the viewport.
+      maxWidth: '92vw',
       data: { mode, name: row?.name, value: row?.value, existingNames },
     });
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
@@ -1,0 +1,44 @@
+<div class="p-6 w-full">
+  <h1 class="text-lg font-semibold mb-4 text-content-text">{{ title }}</h1>
+
+  <!-- Name (full width, on top — never truncated) -->
+  <div class="mb-4">
+    <label for="variableName" class="block mb-1 text-sm text-content-muted">Name</label>
+    <input id="variableName" name="variableName" class="input w-full"
+      placeholder="Name"
+      [ngModel]="name()"
+      (ngModelChange)="name.set($event)">
+    @if (nameError()) {
+      <div class="mt-1 text-sm text-danger-shade-500">{{ nameError() }}</div>
+    } @else if (nameWarning()) {
+      <div class="mt-1 text-sm text-warning-shade-500">{{ nameWarning() }}</div>
+    }
+  </div>
+
+  <!-- Value (multiline Monaco editor below, full width) -->
+  <div class="mb-2">
+    <div class="flex items-center justify-between mb-1">
+      <span class="text-sm text-content-muted">Value</span>
+      <button type="button" class="btn btn-secondary btn-sm" (click)="toggleJsonMode()">
+        {{ jsonMode() ? 'Edit as plain text' : 'Edit as JSON' }}
+      </button>
+    </div>
+    <div class="h-64 border border-content-border rounded-md overflow-hidden">
+      <app-monaco-editor
+        [model]="model()"
+        [options]="editorOptions"
+        [ngModel]="value()"
+        (ngModelChange)="value.set($event)"
+        (onInit)="onEditorInit($event)">
+      </app-monaco-editor>
+    </div>
+    @if (jsonWarning()) {
+      <div class="mt-1 text-sm text-warning-shade-500">{{ jsonWarning() }}</div>
+    }
+  </div>
+
+  <div class="flex gap-2 justify-end mt-6">
+    <button type="button" class="btn btn-secondary" (click)="cancel()">Cancel</button>
+    <button type="button" class="btn btn-primary" (click)="save()" [disabled]="!canSave()">Save</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
@@ -7,14 +7,17 @@
     <input id="variableName" name="variableName" class="input w-full"
       placeholder="Name"
       [ngModel]="name()"
-      (ngModelChange)="name.set($event)">
+      (ngModelChange)="name.set($event); nameTouched.set(true)"
+      (blur)="nameTouched.set(true)">
     <!-- Always-present, fixed-height slot so showing/clearing the message
-         never changes the dialog height (no jump on the first keystroke). -->
+         never changes the dialog height (no jump on the first keystroke).
+         Messages only appear once the field is touched, so a fresh create
+         dialog doesn't show "Name is required" before the user types. -->
     <div class="mt-1 text-sm leading-5 min-h-[1.25rem]">
-      @if (nameError()) {
-        <span class="text-danger-shade-500">{{ nameError() }}</span>
-      } @else if (nameWarning()) {
-        <span class="text-warning-shade-500">{{ nameWarning() }}</span>
+      @if (visibleNameError()) {
+        <span class="text-danger-shade-500">{{ visibleNameError() }}</span>
+      } @else if (visibleNameWarning()) {
+        <span class="text-warning-shade-500">{{ visibleNameWarning() }}</span>
       }
     </div>
   </div>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
@@ -28,8 +28,8 @@
       <span class="text-sm text-content-muted">Value</span>
       <div class="flex items-center gap-2">
         @if (jsonMode()) {
-          <button type="button" class="btn btn-secondary btn-sm" (click)="formatJson()" [disabled]="!canFormat()">
-            Format
+          <button type="button" class="btn btn-secondary btn-sm" (click)="toggleFormat()" [disabled]="!canFormat()">
+            {{ isMinified() ? 'Format' : 'Minify' }}
           </button>
         }
         <button type="button" class="btn btn-secondary btn-sm" (click)="toggleJsonMode()">

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
@@ -19,11 +19,21 @@
   <div class="mb-2">
     <div class="flex items-center justify-between mb-1">
       <span class="text-sm text-content-muted">Value</span>
-      <button type="button" class="btn btn-secondary btn-sm" (click)="toggleJsonMode()">
-        {{ jsonMode() ? 'Edit as plain text' : 'Edit as JSON' }}
-      </button>
+      <div class="flex items-center gap-2">
+        @if (jsonMode()) {
+          <button type="button" class="btn btn-secondary btn-sm" (click)="formatJson()" [disabled]="!canFormat()">
+            Format
+          </button>
+        }
+        <button type="button" class="btn btn-secondary btn-sm" (click)="toggleJsonMode()">
+          {{ jsonMode() ? 'Edit as plain text' : 'Edit as JSON' }}
+        </button>
+      </div>
     </div>
-    <div class="h-64 border border-content-border rounded-md overflow-hidden">
+    <!-- Resizable: drag the bottom-right handle to grow the editor (and the
+         dialog with it) in both directions. Monaco automaticLayout re-fits. -->
+    <div class="resize overflow-auto border border-content-border rounded-md
+                h-64 w-[36rem] min-h-[8rem] min-w-[20rem] max-w-[88vw]">
       <app-monaco-editor
         [model]="model()"
         [options]="editorOptions"

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
@@ -8,11 +8,15 @@
       placeholder="Name"
       [ngModel]="name()"
       (ngModelChange)="name.set($event)">
-    @if (nameError()) {
-      <div class="mt-1 text-sm text-danger-shade-500">{{ nameError() }}</div>
-    } @else if (nameWarning()) {
-      <div class="mt-1 text-sm text-warning-shade-500">{{ nameWarning() }}</div>
-    }
+    <!-- Always-present, fixed-height slot so showing/clearing the message
+         never changes the dialog height (no jump on the first keystroke). -->
+    <div class="mt-1 text-sm leading-5 min-h-[1.25rem]">
+      @if (nameError()) {
+        <span class="text-danger-shade-500">{{ nameError() }}</span>
+      } @else if (nameWarning()) {
+        <span class="text-warning-shade-500">{{ nameWarning() }}</span>
+      }
+    </div>
   </div>
 
   <!-- Value (multiline Monaco editor below, full width) -->

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
@@ -40,6 +40,11 @@ describe('VariableEditDialogComponent', () => {
     expect(cmp.value()).toBe('');
   });
 
+  it('uses an enlarged Monaco font size for readability', () => {
+    const { cmp } = make({ mode: 'add' });
+    expect(cmp.editorOptions.fontSize).toBeGreaterThanOrEqual(16);
+  });
+
   it('auto-detects JSON mode for an object value', () => {
     const { cmp } = make({ mode: 'edit', name: 'STRATOS_PROJECT', value: '{"deploy":true}' });
     expect(cmp.jsonMode()).toBe(true);

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
@@ -1,0 +1,133 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, TailwindDialogRef } from '@stratosui/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VariableEditDialogComponent, VariableEditDialogData } from './variable-edit-dialog.component';
+
+function make(data: VariableEditDialogData) {
+  const close = vi.fn();
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      { provide: MAT_DIALOG_DATA, useValue: data },
+      { provide: TailwindDialogRef, useValue: { close } },
+    ],
+  });
+  // createComponent (no detectChanges) runs the constructor — initializing
+  // the signals from MAT_DIALOG_DATA — without rendering the Monaco editor.
+  const fixture = TestBed.createComponent(VariableEditDialogComponent);
+  return { cmp: fixture.componentInstance, close };
+}
+
+describe('VariableEditDialogComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  // -------------------------------------------------------------------------
+  // Initialization from dialog data
+  // -------------------------------------------------------------------------
+
+  it('initializes name and value from the dialog data', () => {
+    const { cmp } = make({ mode: 'edit', name: 'FOO', value: 'bar' });
+    expect(cmp.name()).toBe('FOO');
+    expect(cmp.value()).toBe('bar');
+  });
+
+  it('defaults to empty name/value in add mode', () => {
+    const { cmp } = make({ mode: 'add' });
+    expect(cmp.name()).toBe('');
+    expect(cmp.value()).toBe('');
+  });
+
+  it('auto-detects JSON mode for an object value', () => {
+    const { cmp } = make({ mode: 'edit', name: 'STRATOS_PROJECT', value: '{"deploy":true}' });
+    expect(cmp.jsonMode()).toBe(true);
+  });
+
+  it('stays in plain mode for a non-JSON value', () => {
+    const { cmp } = make({ mode: 'edit', name: 'ENV', value: 'production' });
+    expect(cmp.jsonMode()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // canSave gating
+  // -------------------------------------------------------------------------
+
+  it('blocks Save when the name is empty', () => {
+    const { cmp } = make({ mode: 'add' });
+    expect(cmp.canSave()).toBe(false);
+  });
+
+  it('blocks Save on a duplicate name (existingNames excludes self)', () => {
+    const { cmp } = make({ mode: 'add', existingNames: ['TAKEN'] });
+    cmp.name.set('TAKEN');
+    expect(cmp.canSave()).toBe(false);
+    expect(cmp.nameError()).toMatch(/in use/i);
+  });
+
+  it('allows Save (with a warning) on a shell-unsafe but CF-valid name', () => {
+    const { cmp } = make({ mode: 'add' });
+    cmp.name.set('my-var');
+    expect(cmp.canSave()).toBe(true);
+    expect(cmp.nameWarning()).toMatch(/shell/i);
+  });
+
+  it('allows Save on a clean name with no warning', () => {
+    const { cmp } = make({ mode: 'add' });
+    cmp.name.set('CLEAN_NAME');
+    expect(cmp.canSave()).toBe(true);
+    expect(cmp.nameWarning()).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // JSON-mode warning (warn but allow)
+  // -------------------------------------------------------------------------
+
+  it('surfaces a JSON warning only while in JSON mode', () => {
+    const { cmp } = make({ mode: 'edit', name: 'X', value: 'not json' });
+    expect(cmp.jsonMode()).toBe(false);
+    expect(cmp.jsonWarning()).toBeNull();
+
+    cmp.toggleJsonMode();
+    expect(cmp.jsonMode()).toBe(true);
+    expect(cmp.jsonWarning()).toMatch(/json/i);
+    expect(cmp.canSave()).toBe(true); // warn, never block
+  });
+
+  // -------------------------------------------------------------------------
+  // save / cancel
+  // -------------------------------------------------------------------------
+
+  it('save() closes with the trimmed name and verbatim value when allowed', () => {
+    const { cmp, close } = make({ mode: 'add' });
+    cmp.name.set('  NEW  ');
+    cmp.value.set('  spaced value  ');
+    cmp.save();
+    expect(close).toHaveBeenCalledWith({ name: 'NEW', value: '  spaced value  ' });
+  });
+
+  it('save() is a no-op when Save is blocked', () => {
+    const { cmp, close } = make({ mode: 'add' });
+    cmp.name.set(''); // blocked
+    cmp.save();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('cancel() closes with no result', () => {
+    const { cmp, close } = make({ mode: 'edit', name: 'FOO', value: 'bar' });
+    cmp.cancel();
+    expect(close).toHaveBeenCalledWith();
+  });
+
+  // -------------------------------------------------------------------------
+  // rename detection is the consumer's job — dialog just returns {name,value}
+  // -------------------------------------------------------------------------
+
+  it('returns the edited name even when changed (rename routing left to caller)', () => {
+    const { cmp, close } = make({ mode: 'edit', name: 'OLD', value: 'v', existingNames: [] });
+    cmp.name.set('RENAMED');
+    cmp.save();
+    expect(close).toHaveBeenCalledWith({ name: 'RENAMED', value: 'v' });
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
@@ -71,6 +71,20 @@ describe('VariableEditDialogComponent', () => {
     expect(cmp.nameError()).toMatch(/in use/i);
   });
 
+  it('does not surface the name error on a fresh create dialog (untouched), but still blocks Save', () => {
+    const { cmp } = make({ mode: 'add' });
+    expect(cmp.nameTouched()).toBe(false);
+    expect(cmp.nameError()).toMatch(/required/i); // validation still fails internally
+    expect(cmp.visibleNameError()).toBeNull();    // ...but nothing is shown yet
+    expect(cmp.canSave()).toBe(false);            // ...and Save stays disabled
+  });
+
+  it('surfaces the name error once the field is touched', () => {
+    const { cmp } = make({ mode: 'add' });
+    cmp.nameTouched.set(true);
+    expect(cmp.visibleNameError()).toMatch(/required/i);
+  });
+
   it('allows Save (with a warning) on a shell-unsafe but CF-valid name', () => {
     const { cmp } = make({ mode: 'add' });
     cmp.name.set('my-var');

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
@@ -112,6 +112,71 @@ describe('VariableEditDialogComponent', () => {
     expect(close).toHaveBeenCalledWith({ name: 'NEW', value: '  spaced value  ' });
   });
 
+  it('minifies a valid-JSON value on save (always stored compact)', () => {
+    const { cmp, close } = make({ mode: 'add' });
+    cmp.name.set('CFG');
+    cmp.value.set('{\n  "a": 1,\n  "b": [2, 3]\n}');
+    cmp.save();
+    expect(close).toHaveBeenCalledWith({ name: 'CFG', value: '{"a":1,"b":[2,3]}' });
+  });
+
+  it('stores a non-JSON value verbatim (no minify attempt)', () => {
+    const { cmp, close } = make({ mode: 'add' });
+    cmp.name.set('MSG');
+    cmp.value.set('hello world');
+    cmp.save();
+    expect(close).toHaveBeenCalledWith({ name: 'MSG', value: 'hello world' });
+  });
+
+  it('stores an empty value as "" (never null, never minified away)', () => {
+    const { cmp, close } = make({ mode: 'add' });
+    cmp.name.set('EMPTY');
+    cmp.value.set('');
+    cmp.save();
+    expect(close).toHaveBeenCalledWith({ name: 'EMPTY', value: '' });
+  });
+
+  // -------------------------------------------------------------------------
+  // Format button — pretty-print JSON in place (editing aid only)
+  // -------------------------------------------------------------------------
+
+  it('formatJson() pretty-prints valid JSON to 2-space indentation', () => {
+    const { cmp } = make({ mode: 'edit', name: 'CFG', value: '{"a":1}' });
+    expect(cmp.jsonMode()).toBe(true);
+    cmp.formatJson();
+    expect(cmp.value()).toBe('{\n  "a": 1\n}');
+  });
+
+  it('pretty-printing then saving stores the SAME minified value as saving directly', () => {
+    const direct = make({ mode: 'add' });
+    direct.cmp.name.set('CFG');
+    direct.cmp.value.set('{"a":1,"b":[2,3]}');
+    direct.cmp.save();
+
+    const formatted = make({ mode: 'add' });
+    formatted.cmp.name.set('CFG');
+    formatted.cmp.value.set('{"a":1,"b":[2,3]}');
+    formatted.cmp.formatJson(); // expand for readability
+    formatted.cmp.save();
+
+    // Format changed the editor text, but the persisted value is identical.
+    expect(formatted.close.mock.calls[0][0]).toEqual(direct.close.mock.calls[0][0]);
+  });
+
+  it('formatJson() is a no-op on invalid JSON', () => {
+    const { cmp } = make({ mode: 'edit', name: 'X', value: 'not json' });
+    cmp.toggleJsonMode(); // into JSON mode
+    cmp.formatJson();
+    expect(cmp.value()).toBe('not json');
+  });
+
+  it('canFormat is true only in JSON mode with valid JSON', () => {
+    const { cmp } = make({ mode: 'edit', name: 'CFG', value: '{"a":1}' });
+    expect(cmp.canFormat()).toBe(true);
+    cmp.toggleJsonMode(); // -> plain mode
+    expect(cmp.canFormat()).toBe(false);
+  });
+
   it('save() is a no-op when Save is blocked', () => {
     const { cmp, close } = make({ mode: 'add' });
     cmp.name.set(''); // blocked

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.spec.ts
@@ -154,14 +154,25 @@ describe('VariableEditDialogComponent', () => {
   // Format button — pretty-print JSON in place (editing aid only)
   // -------------------------------------------------------------------------
 
-  it('formatJson() pretty-prints valid JSON to 2-space indentation', () => {
+  it('toggleFormat() pretty-prints minified JSON to 2-space indentation', () => {
     const { cmp } = make({ mode: 'edit', name: 'CFG', value: '{"a":1}' });
     expect(cmp.jsonMode()).toBe(true);
-    cmp.formatJson();
+    expect(cmp.isMinified()).toBe(true); // button reads "Format"
+    cmp.toggleFormat();
     expect(cmp.value()).toBe('{\n  "a": 1\n}');
   });
 
-  it('pretty-printing then saving stores the SAME minified value as saving directly', () => {
+  it('toggleFormat() minifies pretty-printed JSON (round-trips back)', () => {
+    const { cmp } = make({ mode: 'edit', name: 'CFG', value: '{\n  "a": 1\n}' });
+    expect(cmp.isMinified()).toBe(false); // button reads "Minify"
+    cmp.toggleFormat();
+    expect(cmp.value()).toBe('{"a":1}');
+    expect(cmp.isMinified()).toBe(true);
+    cmp.toggleFormat(); // and back to pretty
+    expect(cmp.value()).toBe('{\n  "a": 1\n}');
+  });
+
+  it('formatting then saving stores the SAME minified value as saving directly', () => {
     const direct = make({ mode: 'add' });
     direct.cmp.name.set('CFG');
     direct.cmp.value.set('{"a":1,"b":[2,3]}');
@@ -170,17 +181,17 @@ describe('VariableEditDialogComponent', () => {
     const formatted = make({ mode: 'add' });
     formatted.cmp.name.set('CFG');
     formatted.cmp.value.set('{"a":1,"b":[2,3]}');
-    formatted.cmp.formatJson(); // expand for readability
+    formatted.cmp.toggleFormat(); // expand for readability
     formatted.cmp.save();
 
-    // Format changed the editor text, but the persisted value is identical.
+    // Toggling changed the editor text, but the persisted value is identical.
     expect(formatted.close.mock.calls[0][0]).toEqual(direct.close.mock.calls[0][0]);
   });
 
-  it('formatJson() is a no-op on invalid JSON', () => {
+  it('toggleFormat() is a no-op on invalid JSON', () => {
     const { cmp } = make({ mode: 'edit', name: 'X', value: 'not json' });
     cmp.toggleJsonMode(); // into JSON mode
-    cmp.formatJson();
+    cmp.toggleFormat();
     expect(cmp.value()).toBe('not json');
   });
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
@@ -84,6 +84,8 @@ export class VariableEditDialogComponent {
     scrollBeyondLastLine: false,
     wordWrap: 'on',
     tabSize: 2,
+    // Larger than Monaco's compact default so values stay easy to read.
+    fontSize: 16,
   };
 
   /** Captured Monaco editor instance (undefined until onInit fires; never

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
@@ -114,8 +114,8 @@ export class VariableEditDialogComponent {
   /** Save is gated solely by hard name errors — warnings never block. */
   readonly canSave: Signal<boolean> = computed(() => !this.nameValidation().hardError);
 
-  /** Format is offered only in JSON mode and only when the text parses —
-   *  pretty-printing non-JSON makes no sense. */
+  /** Format/Minify is offered only in JSON mode and only when the text
+   *  parses — reformatting non-JSON makes no sense. */
   readonly canFormat: Signal<boolean> = computed(() => {
     if (!this.jsonMode()) {
       return false;
@@ -123,6 +123,16 @@ export class VariableEditDialogComponent {
     try {
       JSON.parse(this.value());
       return true;
+    } catch {
+      return false;
+    }
+  });
+
+  /** Whether the value is already canonical-minified JSON — drives the
+   *  Format ↔ Minify toggle's label and direction. */
+  readonly isMinified: Signal<boolean> = computed(() => {
+    try {
+      return this.value() === JSON.stringify(JSON.parse(this.value()));
     } catch {
       return false;
     }
@@ -161,13 +171,16 @@ export class VariableEditDialogComponent {
   }
 
   /**
-   * Pretty-print the editor text (jq-style, 2-space) for readability. This
-   * is a pure editing aid: because save() always re-minifies valid JSON, it
-   * never changes the value that gets stored. No-op on invalid JSON.
+   * Toggle the editor text between pretty-printed (jq-style, 2-space) and
+   * canonical minified JSON. Pure editing aid: because save() always
+   * re-minifies valid JSON, this never changes the stored value. No-op on
+   * invalid JSON.
    */
-  formatJson(): void {
+  toggleFormat(): void {
     try {
-      this.value.set(JSON.stringify(JSON.parse(this.value()), null, 2));
+      const parsed = JSON.parse(this.value());
+      const minified = JSON.stringify(parsed);
+      this.value.set(this.value() === minified ? JSON.stringify(parsed, null, 2) : minified);
     } catch {
       // Invalid JSON — leave the text as-is (the warning already shows).
     }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
@@ -1,0 +1,147 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Signal,
+  WritableSignal,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import {
+  MAT_DIALOG_DATA,
+  MonacoEditorComponent,
+  MonacoEditorModel,
+  MonacoEditorOptions,
+  TailwindDialogRef,
+} from '@stratosui/core';
+
+import {
+  jsonModeWarning,
+  looksLikeJson,
+  validateVariableName,
+} from './variable-edit-dialog.validation';
+
+/** Input to the dialog. `existingNames` is the set the new name must NOT
+ *  collide with — the caller pre-excludes the row's own name when editing. */
+export interface VariableEditDialogData {
+  mode: 'add' | 'edit';
+  name?: string;
+  value?: string;
+  existingNames?: string[];
+}
+
+/** Result returned via dialogRef.close(). undefined = cancelled. Rename vs
+ *  update routing is the caller's job (compare against the original name). */
+export interface VariableEditDialogResult {
+  name: string;
+  value: string;
+}
+
+/**
+ * VariableEditDialogComponent — popup editor for a single app environment
+ * variable. Serves Add, Edit, and Rename (editing the Name = rename).
+ *
+ * Layout: full-width Name on top, multiline Monaco value editor below
+ * (vertical stack — Name never truncated, Value gets full width). The value
+ * is ALWAYS a string: opened verbatim, saved verbatim. "JSON mode" only sets
+ * Monaco's language (highlight/validate/format) — it never reformats the
+ * stored text. Auto-detected on open; a JSON/Plain toggle overrides.
+ *
+ * Validation (see variable-edit-dialog.validation): CF's real name rules are
+ * hard errors that block Save; the stricter shell-safe pattern and invalid
+ * JSON are advisory warnings that still allow Save.
+ */
+@Component({
+  selector: 'app-variable-edit-dialog',
+  templateUrl: './variable-edit-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, MonacoEditorComponent],
+})
+export class VariableEditDialogComponent {
+  private dialogRef = inject<TailwindDialogRef<VariableEditDialogComponent, VariableEditDialogResult>>(TailwindDialogRef);
+  private data = inject<VariableEditDialogData>(MAT_DIALOG_DATA);
+
+  /** Names the new key must not collide with (caller excludes self). */
+  private readonly existingNames: string[];
+
+  readonly name: WritableSignal<string>;
+  readonly value: WritableSignal<string>;
+  readonly jsonMode: WritableSignal<boolean>;
+
+  readonly title: string;
+
+  /** Monaco editor options — auto-layout so it fills its sized container;
+   *  no minimap/line numbers for a compact value editor. */
+  readonly editorOptions: MonacoEditorOptions = {
+    automaticLayout: true,
+    contextmenu: false,
+    minimap: { enabled: false },
+    lineNumbers: 'off',
+    scrollBeyondLastLine: false,
+    wordWrap: 'on',
+    tabSize: 2,
+  };
+
+  /** Captured Monaco editor instance (undefined until onInit fires; never
+   *  fires in unit tests, where Monaco isn't loaded). */
+  private editor: any;
+
+  private readonly nameValidation = computed(() => validateVariableName(this.name(), this.existingNames));
+  readonly nameError: Signal<string | null> = computed(() => this.nameValidation().hardError);
+  readonly nameWarning: Signal<string | null> = computed(() => this.nameValidation().warning);
+
+  /** JSON warning only applies while editing in JSON mode. */
+  readonly jsonWarning: Signal<string | null> = computed(() =>
+    this.jsonMode() ? jsonModeWarning(this.value()) : null,
+  );
+
+  /** Save is gated solely by hard name errors — warnings never block. */
+  readonly canSave: Signal<boolean> = computed(() => !this.nameValidation().hardError);
+
+  /** Monaco model — initial language reflects the auto-detected mode. Live
+   *  toggles are applied via setModelLanguage in the effect below. */
+  readonly model: Signal<MonacoEditorModel> = computed(() => ({
+    language: this.jsonMode() ? 'json' : 'plaintext',
+  }));
+
+  constructor() {
+    this.existingNames = this.data.existingNames ?? [];
+    this.name = signal(this.data.name ?? '');
+    this.value = signal(this.data.value ?? '');
+    this.jsonMode = signal(looksLikeJson(this.data.value ?? ''));
+    this.title = this.data.mode === 'add' ? 'Add Variable' : 'Edit Variable';
+
+    // Apply live language switches to the running editor when the user
+    // toggles JSON/Plain. Guarded so it's a no-op before the editor exists.
+    effect(() => {
+      const language = this.jsonMode() ? 'json' : 'plaintext';
+      const monaco = (window as any).monaco;
+      if (this.editor && monaco) {
+        monaco.editor.setModelLanguage(this.editor.getModel(), language);
+      }
+    });
+  }
+
+  onEditorInit(editor: any): void {
+    this.editor = editor;
+  }
+
+  toggleJsonMode(): void {
+    this.jsonMode.update((v) => !v);
+  }
+
+  save(): void {
+    if (!this.canSave()) {
+      return;
+    }
+    this.dialogRef.close({ name: this.name().trim(), value: this.value() });
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
@@ -104,6 +104,20 @@ export class VariableEditDialogComponent {
   /** Save is gated solely by hard name errors — warnings never block. */
   readonly canSave: Signal<boolean> = computed(() => !this.nameValidation().hardError);
 
+  /** Format is offered only in JSON mode and only when the text parses —
+   *  pretty-printing non-JSON makes no sense. */
+  readonly canFormat: Signal<boolean> = computed(() => {
+    if (!this.jsonMode()) {
+      return false;
+    }
+    try {
+      JSON.parse(this.value());
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
   /** Monaco model — initial language reflects the auto-detected mode. Live
    *  toggles are applied via setModelLanguage in the effect below. */
   readonly model: Signal<MonacoEditorModel> = computed(() => ({
@@ -136,14 +150,41 @@ export class VariableEditDialogComponent {
     this.jsonMode.update((v) => !v);
   }
 
+  /**
+   * Pretty-print the editor text (jq-style, 2-space) for readability. This
+   * is a pure editing aid: because save() always re-minifies valid JSON, it
+   * never changes the value that gets stored. No-op on invalid JSON.
+   */
+  formatJson(): void {
+    try {
+      this.value.set(JSON.stringify(JSON.parse(this.value()), null, 2));
+    } catch {
+      // Invalid JSON — leave the text as-is (the warning already shows).
+    }
+  }
+
   save(): void {
     if (!this.canSave()) {
       return;
     }
-    this.dialogRef.close({ name: this.name().trim(), value: this.value() });
+    this.dialogRef.close({ name: this.name().trim(), value: this.canonicalValue() });
   }
 
   cancel(): void {
     this.dialogRef.close();
+  }
+
+  /**
+   * Value as stored: valid JSON is always minified to its canonical compact
+   * form (independent of how it was displayed/edited); anything else — plain
+   * strings, empty string — is stored verbatim. Empty stays "" (never null).
+   */
+  private canonicalValue(): string {
+    const v = this.value();
+    try {
+      return JSON.stringify(JSON.parse(v));
+    } catch {
+      return v;
+    }
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
@@ -96,6 +96,16 @@ export class VariableEditDialogComponent {
   readonly nameError: Signal<string | null> = computed(() => this.nameValidation().hardError);
   readonly nameWarning: Signal<string | null> = computed(() => this.nameValidation().warning);
 
+  /** The name field starts untouched so a freshly-opened create dialog does
+   *  not show "Name is required" before the user has typed. Set on first
+   *  input / blur. */
+  readonly nameTouched: WritableSignal<boolean> = signal(false);
+
+  /** Validation messages are surfaced only once the field is touched; the
+   *  underlying nameError still gates canSave regardless of display. */
+  readonly visibleNameError: Signal<string | null> = computed(() => this.nameTouched() ? this.nameError() : null);
+  readonly visibleNameWarning: Signal<string | null> = computed(() => this.nameTouched() ? this.nameWarning() : null);
+
   /** JSON warning only applies while editing in JSON mode. */
   readonly jsonWarning: Signal<string | null> = computed(() =>
     this.jsonMode() ? jsonModeWarning(this.value()) : null,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.validation.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.validation.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { jsonModeWarning, looksLikeJson, validateVariableName } from './variable-edit-dialog.validation';
+
+describe('validateVariableName', () => {
+  // -------------------------------------------------------------------------
+  // Hard errors (Save must be blocked) — CF rejects these or they collide.
+  // -------------------------------------------------------------------------
+
+  it('blocks an empty name', () => {
+    expect(validateVariableName('', []).hardError).toMatch(/required/i);
+    expect(validateVariableName('   ', []).hardError).toMatch(/required/i);
+  });
+
+  it('blocks a VCAP_ / VMC_ prefix (case-insensitive)', () => {
+    expect(validateVariableName('VCAP_SERVICES', []).hardError).toMatch(/VCAP_|VMC_/);
+    expect(validateVariableName('vcap_foo', []).hardError).toMatch(/VCAP_|VMC_/);
+    expect(validateVariableName('VMC_THING', []).hardError).toMatch(/VCAP_|VMC_/);
+    expect(validateVariableName('vmc_thing', []).hardError).toMatch(/VCAP_|VMC_/);
+  });
+
+  it('blocks the reserved name PORT', () => {
+    expect(validateVariableName('PORT', []).hardError).toMatch(/PORT/);
+  });
+
+  it('blocks a duplicate of an existing key', () => {
+    expect(validateVariableName('FOO', ['FOO', 'BAR']).hardError).toMatch(/in use/i);
+  });
+
+  it('duplicate check is case-sensitive (env var names are case-sensitive)', () => {
+    expect(validateVariableName('foo', ['FOO']).hardError).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Warnings (Save allowed) — shell-pattern violations CF accepts.
+  // -------------------------------------------------------------------------
+
+  it('warns (but does not block) when the name violates the shell-safe pattern', () => {
+    const r = validateVariableName('my-var', []);
+    expect(r.hardError).toBeNull();
+    expect(r.warning).toMatch(/shell/i);
+  });
+
+  it('warns on a leading digit but does not block', () => {
+    const r = validateVariableName('2nd', []);
+    expect(r.hardError).toBeNull();
+    expect(r.warning).toMatch(/shell/i);
+  });
+
+  it('accepts a clean shell-safe name with no error or warning', () => {
+    expect(validateVariableName('MY_VAR_1', [])).toEqual({ hardError: null, warning: null });
+    expect(validateVariableName('_private', [])).toEqual({ hardError: null, warning: null });
+  });
+
+  it('hard error takes precedence over the shell-pattern warning', () => {
+    // 'VCAP-X' both starts with VCAP and breaks the shell pattern — hard wins.
+    const r = validateVariableName('VCAP_X', []);
+    expect(r.hardError).toMatch(/VCAP_|VMC_/);
+  });
+});
+
+describe('looksLikeJson', () => {
+  it('is true for an object/array that parses', () => {
+    expect(looksLikeJson('{"a":1}')).toBe(true);
+    expect(looksLikeJson('  [1,2,3] ')).toBe(true);
+  });
+
+  it('is false for a bare string/number even though JSON.parse would accept it', () => {
+    expect(looksLikeJson('hello')).toBe(false);
+    expect(looksLikeJson('42')).toBe(false);
+    expect(looksLikeJson('"quoted"')).toBe(false);
+  });
+
+  it('is false for empty or malformed object text', () => {
+    expect(looksLikeJson('')).toBe(false);
+    expect(looksLikeJson('   ')).toBe(false);
+    expect(looksLikeJson('{not json}')).toBe(false);
+  });
+});
+
+describe('jsonModeWarning', () => {
+  it('returns null for valid JSON', () => {
+    expect(jsonModeWarning('{"a":1}')).toBeNull();
+  });
+
+  it('returns null for empty value (no nagging)', () => {
+    expect(jsonModeWarning('')).toBeNull();
+    expect(jsonModeWarning('   ')).toBeNull();
+  });
+
+  it('warns for invalid JSON (but the caller still allows save)', () => {
+    expect(jsonModeWarning('{not json}')).toMatch(/json/i);
+    expect(jsonModeWarning('hello')).toMatch(/json/i);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.validation.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.validation.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure validation helpers for the Variables-tab edit dialog.
+ *
+ * Two-tier name validation (Norm 2026-06-04):
+ *  - HARD errors block Save — things CF actually rejects, or a key collision.
+ *    CF's real rules (cloud_controller_ng EnvironmentVariablesStringValuesValidator):
+ *    non-empty, must not start with VCAP_/VMC_ (case-insensitive), must not be PORT.
+ *  - WARNINGS allow Save — the stricter shell-safe pattern CF does NOT enforce,
+ *    kept as a deliberate UX nudge.
+ *
+ * Values are always stored/sent as strings; "JSON mode" is only an editing
+ * affordance, so invalid JSON warns but never blocks (CF accepts any string).
+ */
+
+export interface NameValidation {
+  /** Non-null = Save is blocked. */
+  hardError: string | null;
+  /** Non-null = advisory only; Save still allowed. */
+  warning: string | null;
+}
+
+/** Shell-variable convention: start with a letter/underscore, then
+ *  letters/digits/underscores. Stricter than CF — used only for the warning. */
+const SHELL_SAFE_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Validate an environment-variable name. `existingNames` is the set the new
+ * name must NOT collide with — the caller pre-excludes the row's own name
+ * when editing, so an unchanged name in edit mode passes.
+ */
+export function validateVariableName(name: string, existingNames: readonly string[]): NameValidation {
+  const n = name.trim();
+
+  if (!n) {
+    return { hardError: 'Name is required', warning: null };
+  }
+  if (/^(VCAP_|VMC_)/i.test(n)) {
+    return { hardError: "Name cannot start with 'VCAP_' or 'VMC_'", warning: null };
+  }
+  if (n === 'PORT') {
+    return { hardError: "'PORT' is a reserved name", warning: null };
+  }
+  if (existingNames.includes(n)) {
+    return { hardError: `'${n}' is already in use`, warning: null };
+  }
+  if (!SHELL_SAFE_PATTERN.test(n)) {
+    return {
+      hardError: null,
+      warning: 'Not a valid shell variable name (letters, digits, underscores; cannot start with a digit). CF will accept it.',
+    };
+  }
+  return { hardError: null, warning: null };
+}
+
+/**
+ * Whether a value should default to JSON editing mode: only object/array
+ * text that actually parses. A bare string/number is technically valid JSON
+ * but the user almost never means "JSON" by it, so it stays plain.
+ */
+export function looksLikeJson(value: string): boolean {
+  const t = value.trim();
+  if (!t || !/^[{[]/.test(t)) {
+    return false;
+  }
+  try {
+    JSON.parse(t);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Advisory warning for JSON mode: returns a message when the text is not
+ * valid JSON, or null when it is valid (or empty — no nagging on empty).
+ * Never blocks Save.
+ */
+export function jsonModeWarning(value: string): string | null {
+  if (!value.trim()) {
+    return null;
+  }
+  try {
+    JSON.parse(value);
+    return null;
+  } catch {
+    return 'Value is not valid JSON. It will be saved as-is.';
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/shared/services/app-variable-actions.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/app-variable-actions.service.spec.ts
@@ -1,0 +1,177 @@
+import { HttpClient } from '@angular/common/http';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Subject, of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppVariableActionsService } from './app-variable-actions.service';
+import { ApplicationService } from '../../features/applications/application.service';
+import { AppDetailDataService } from '../../features/applications/app-detail-data.service';
+
+// ---------------------------------------------------------------------------
+// Stubs — minimal: only the surface this service touches.
+// ---------------------------------------------------------------------------
+
+function makeAppServiceStub(cfGuid = 'cf-1', appGuid = 'app-1') {
+  return { cfGuid, appGuid };
+}
+
+// AppDetailDataService stub — the action service used to read the current
+// env map off this to recompose a full PATCH. After the delta wire-fix it
+// no longer needs it, but the provider must still resolve.
+function makeDataServiceStub(environment: Record<string, string> = { EXISTING: 'keep' }) {
+  return { envVars: signal({ environment }) } as unknown as AppDetailDataService;
+}
+
+// HttpClient stub — only patch() is exercised. Each test wires its own impl.
+function makeHttpStub(patchImpl?: () => any) {
+  return {
+    patch: vi.fn(patchImpl ?? (() => of({ guid: 'app-1' }))),
+  } as unknown as HttpClient & { patch: ReturnType<typeof vi.fn> };
+}
+
+async function tick(n = 4): Promise<void> {
+  for (let i = 0; i < n; i++) await Promise.resolve();
+}
+
+const URL = '/pp/v1/cf/apps/cf-1/app-1';
+
+describe('AppVariableActionsService', () => {
+  let svc: AppVariableActionsService;
+  let http: ReturnType<typeof makeHttpStub>;
+
+  function configure(httpStub = makeHttpStub(), dataStub = makeDataServiceStub()) {
+    TestBed.resetTestingModule();
+    http = httpStub;
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        AppVariableActionsService,
+        { provide: HttpClient, useValue: http },
+        { provide: ApplicationService, useValue: makeAppServiceStub() },
+        { provide: AppDetailDataService, useValue: dataStub },
+      ],
+    });
+    svc = TestBed.inject(AppVariableActionsService);
+  }
+
+  beforeEach(() => {
+    configure();
+  });
+
+  it('starts idle: transitioningName is null and inFlight is false', () => {
+    expect(svc.transitioningName()).toBeNull();
+    expect(svc.inFlight()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // add — delta PATCH with only the new key (NOT the full recomposed map)
+  // -------------------------------------------------------------------------
+
+  it('addVariable PATCHes the app URL with only the new key as a delta', async () => {
+    await svc.addVariable('NEW', 'val');
+
+    expect(http.patch).toHaveBeenCalledTimes(1);
+    expect(http.patch).toHaveBeenCalledWith(URL, { environment_json: { NEW: 'val' } });
+  });
+
+  it('addVariable preserves an empty-string value (never collapses "" to null)', async () => {
+    await svc.addVariable('EMPTY', '');
+
+    expect(http.patch).toHaveBeenCalledWith(URL, { environment_json: { EMPTY: '' } });
+  });
+
+  it('addVariable sets transitioningName mid-flight, clears on success', async () => {
+    const gate = new Subject<unknown>();
+    configure(makeHttpStub(() => gate.asObservable()));
+
+    const promise = svc.addVariable('NEW', 'val');
+    await tick();
+    expect(svc.transitioningName()).toBe('NEW');
+    expect(svc.inFlight()).toBe(true);
+
+    gate.next({ guid: 'app-1' });
+    gate.complete();
+    await promise;
+    expect(svc.transitioningName()).toBeNull();
+    expect(svc.inFlight()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // update — delta PATCH with the single key
+  // -------------------------------------------------------------------------
+
+  it('updateVariable PATCHes only the changed key as a delta (not the full map)', async () => {
+    // Multi-key env so a full-map recompose would leak OTHER into the body.
+    configure(makeHttpStub(), makeDataServiceStub({ EXISTING: 'keep', OTHER: 'untouched' }));
+
+    await svc.updateVariable('EXISTING', 'changed');
+
+    expect(http.patch).toHaveBeenCalledWith(URL, { environment_json: { EXISTING: 'changed' } });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete — explicit null (merge-patch delete), NOT key omission
+  // -------------------------------------------------------------------------
+
+  it('deleteVariable PATCHes the target key set to null (merge-patch delete)', async () => {
+    await svc.deleteVariable('EXISTING');
+
+    expect(http.patch).toHaveBeenCalledTimes(1);
+    expect(http.patch).toHaveBeenCalledWith(URL, { environment_json: { EXISTING: null } });
+  });
+
+  // -------------------------------------------------------------------------
+  // rename — one PATCH: old key -> null, new key -> value
+  // -------------------------------------------------------------------------
+
+  it('renameVariable PATCHes old->null and new->value in a single delta', async () => {
+    await svc.renameVariable('OLD', 'NEW', 'val');
+
+    expect(http.patch).toHaveBeenCalledTimes(1);
+    expect(http.patch).toHaveBeenCalledWith(URL, { environment_json: { OLD: null, NEW: 'val' } });
+  });
+
+  it('renameVariable sets transitioningName to the new name mid-flight, clears on success', async () => {
+    const gate = new Subject<unknown>();
+    configure(makeHttpStub(() => gate.asObservable()));
+
+    const promise = svc.renameVariable('OLD', 'NEW', 'val');
+    await tick();
+    expect(svc.transitioningName()).toBe('NEW');
+
+    gate.next({ guid: 'app-1' });
+    gate.complete();
+    await promise;
+    expect(svc.transitioningName()).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // error + reentrancy — shared shape across all verbs
+  // -------------------------------------------------------------------------
+
+  it('clears the signal and surfaces the error on HTTP failure', async () => {
+    const err = new Error('CF-UnprocessableEntity');
+    configure(makeHttpStub(() => throwError(() => err)));
+
+    await expect(svc.deleteVariable('EXISTING')).rejects.toBe(err);
+    expect(svc.transitioningName()).toBeNull();
+    expect(svc.inFlight()).toBe(false);
+  });
+
+  it('rejects a second verb while a first is still in flight', async () => {
+    const gate = new Subject<unknown>();
+    configure(makeHttpStub(() => gate.asObservable()));
+
+    const first = svc.addVariable('A', '1');
+    await tick();
+
+    await expect(svc.deleteVariable('B')).rejects.toThrow(/already in flight/i);
+    expect(svc.transitioningName()).toBe('A');
+
+    gate.next({ guid: 'app-1' });
+    gate.complete();
+    await first;
+    expect(svc.transitioningName()).toBeNull();
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/services/app-variable-actions.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/app-variable-actions.service.ts
@@ -3,28 +3,33 @@ import { Injectable, computed, inject, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 
 import { ApplicationService } from '../../features/applications/application.service';
-import { AppDetailDataService } from '../../features/applications/app-detail-data.service';
 
 /**
  * AppVariableActionsService
  *
- * Per-variable verbs (add, update, delete) for the app-detail Variables
- * tab. Sibling to AppRouteActionsService — same lifetime contract:
- * tab-scoped, single in-flight verb at a time, transitioning-name signal
- * for per-row UI gating.
+ * Per-variable verbs (add, update, delete, rename) for the app-detail
+ * Variables tab. Sibling to AppRouteActionsService — same lifetime
+ * contract: tab-scoped, single in-flight verb at a time, transitioning-name
+ * signal for per-row UI gating.
  *
- * Wire: `PATCH /pp/v1/cf/apps/{cnsi}/{app}` (handler `patchApp`).
+ * Wire: `PATCH /pp/v1/cf/apps/{cnsi}/{app}` (handler `patchApp`), sending
+ * only the `environment_json` field.
  *
- * The Stratos PATCH is multi-field; for environment writes we send only
- * the `environment_json` field with the FULL desired user-defined env
- * map. CF v3's environment_variables semantics (PATCH
- * /v3/apps/{guid}/environment_variables) treat keys absent from the
- * payload as unchanged and explicit `null` values as deletes — but the
- * Stratos handler currently passes the map straight through, so to
- * delete a key we must omit it entirely AND ensure no other key is
- * silently dropped. Therefore the action service composes the new map
- * by reading the current `dataService.envVars().environment` snapshot
- * and applying the requested mutation locally before sending.
+ * CF v3's environment_variables semantics (PATCH
+ * /v3/apps/{guid}/environment_variables, which the Stratos handler forwards
+ * verbatim) are merge-patch: a key present with a value is set/updated, a
+ * key present with explicit `null` is DELETED, and a key absent from the
+ * payload is left unchanged. We therefore send a minimal DELTA per verb —
+ * never the full recomposed map — so:
+ *   - add/update   -> { name: value }
+ *   - delete       -> { name: null }              (omission would no-op)
+ *   - rename        -> { oldName: null, newName: value }   (one PATCH)
+ * Sending only the delta also avoids clobbering concurrent mutations and
+ * removes the need to read a (possibly stale) full snapshot.
+ *
+ * Note: an empty-string value is a real, distinct value — `''` is sent as
+ * `''` (present, empty); only delete/rename send `null`. Values are always
+ * strings on the wire (CF rejects non-string values); `null` means delete.
  *
  * On success the consumer is expected to call `dataService.refresh('envVars')`
  * so the next read sees the canonical CF view (handles concurrent mutators).
@@ -36,7 +41,6 @@ import { AppDetailDataService } from '../../features/applications/app-detail-dat
 export class AppVariableActionsService {
   private http = inject(HttpClient);
   private applicationService = inject(ApplicationService);
-  private dataService = inject(AppDetailDataService);
 
   /** Name of the env var currently being mutated; null when idle.
    *  For "add", the value is the new variable name; for "update"/"delete",
@@ -48,73 +52,62 @@ export class AppVariableActionsService {
   readonly inFlight = computed(() => this._transitioningName() !== null);
 
   /**
-   * Add a new user-defined environment variable. The full env map is
-   * recomposed (current snapshot + new key) and sent as the
-   * `environment_json` field of the Stratos PATCH.
+   * Add a new user-defined environment variable. Sends a single-key delta
+   * `{ name: value }`; CF merge-patch sets the key and leaves the rest
+   * untouched.
    */
   async addVariable(name: string, value: string): Promise<void> {
-    if (this.inFlight()) {
-      throw new Error('Another variable action is already in flight');
-    }
-    const next = { ...this.currentEnv(), [name]: value };
-    this._transitioningName.set(name);
-    try {
-      await this.patch(next);
-    } finally {
-      this._transitioningName.set(null);
-    }
+    await this.run(name, { [name]: value });
   }
 
   /**
-   * Update an existing variable's value. Same wire shape as add — the
-   * full map is sent. If the variable doesn't currently exist this
-   * effectively becomes an add (no error).
+   * Update an existing variable's value. Same single-key delta as add —
+   * if the variable doesn't currently exist this effectively becomes an
+   * add (CF merge-patch, no error).
    */
   async updateVariable(name: string, value: string): Promise<void> {
-    if (this.inFlight()) {
-      throw new Error('Another variable action is already in flight');
-    }
-    const next = { ...this.currentEnv(), [name]: value };
-    this._transitioningName.set(name);
-    try {
-      await this.patch(next);
-    } finally {
-      this._transitioningName.set(null);
-    }
+    await this.run(name, { [name]: value });
   }
 
   /**
-   * Delete a variable. The current map is shallow-cloned, the key
-   * removed, and the resulting map sent as `environment_json`.
+   * Delete a variable via explicit `null` (CF merge-patch delete). Omitting
+   * the key would be a no-op — it MUST be sent as `null` to remove it.
    */
   async deleteVariable(name: string): Promise<void> {
-    if (this.inFlight()) {
-      throw new Error('Another variable action is already in flight');
-    }
-    const next = { ...this.currentEnv() };
-    delete next[name];
-    this._transitioningName.set(name);
-    try {
-      await this.patch(next);
-    } finally {
-      this._transitioningName.set(null);
-    }
+    await this.run(name, { [name]: null });
+  }
+
+  /**
+   * Rename a variable (and optionally change its value) in one PATCH:
+   * remove the old key (`null`) and set the new key to `value`. The
+   * transitioning name reflects the new (target) key.
+   */
+  async renameVariable(oldName: string, newName: string, value: string): Promise<void> {
+    await this.run(newName, { [oldName]: null, [newName]: value });
   }
 
   // ---------------------------------------------------------------------------
   // Internals
   // ---------------------------------------------------------------------------
 
-  /** Snapshot of the current user-defined env map; defensively defaults
-   *  to {} when envVars hasn't loaded yet. */
-  private currentEnv(): Record<string, string> {
-    return { ...(this.dataService.envVars()?.environment ?? {}) };
+  /** Shared verb runner: reentrancy guard + transition signalling around a
+   *  single delta PATCH. */
+  private async run(transitioningName: string, delta: Record<string, string | null>): Promise<void> {
+    if (this.inFlight()) {
+      throw new Error('Another variable action is already in flight');
+    }
+    this._transitioningName.set(transitioningName);
+    try {
+      await this.patch(delta);
+    } finally {
+      this._transitioningName.set(null);
+    }
   }
 
-  /** Send the PATCH with the merged environment map. The handler returns
-   *  200 with `{guid, _meta?}`; partial success is surfaced via _meta but
-   *  we leave inspection to the consumer (the snackbar wrapper). */
-  private async patch(env: Record<string, string>): Promise<void> {
+  /** Send the PATCH with the environment delta. The handler returns 200
+   *  with `{guid, _meta?}`; partial success is surfaced via _meta but we
+   *  leave inspection to the consumer (the snackbar wrapper). */
+  private async patch(env: Record<string, string | null>): Promise<void> {
     const { cfGuid, appGuid } = this.applicationService;
     const url = `/pp/v1/cf/apps/${cfGuid}/${appGuid}`;
     await firstValueFrom(this.http.patch(url, { environment_json: env }));

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app-variables/cf-app-variables-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app-variables/cf-app-variables-signal-config.service.ts
@@ -111,12 +111,9 @@ export class CfAppVariablesSignalConfigService {
   }
 
   // Build the column set for the Variables tab. Mirrors the legacy
-  // shape minimally: Name + Value + actions kebab. The legacy list also
-  // had an inline "edit" affordance via TableCellEditVariableComponent;
-  // we keep the door open for that as a follow-up — for now, edit is
-  // exposed as an Edit row action that re-opens the inline add form
-  // pre-filled with the existing name+value (handled by the consuming
-  // component).
+  // shape minimally: Name + Value + actions kebab. Edit is exposed as an
+  // Edit row action that opens the popup VariableEditDialogComponent
+  // (stacked Name + Monaco value editor) — wired by the consuming component.
   buildColumns(): SignalListColumn<ListAppEnvVar>[] {
     const columns: SignalListColumn<ListAppEnvVar>[] = [
       {


### PR DESCRIPTION
## Summary
Restores and improves editing of application environment variables on the app-detail **Variables** tab. Replaces the cramped inline form with a popup editor dialog (Add / Edit / Rename in one place) and fixes a silent data-loss bug on delete.

Closes #5388

## Wire correctness
- **Delete was broken** — it omitted the key from a full-map PATCH, which CF v3's `environment_variables` merge-patch treats as *unchanged*, so the variable persisted server-side (the user believed a var/secret was removed when it wasn't). Deletes — and the remove-old-key half of rename — now send an explicit `null` delta.
- add / update / rename send minimal deltas (no full-map recompose → no clobbering concurrent edits). Empty string stays `""` (never collapsed to `null`).

## Editor dialog (`VariableEditDialogComponent`)
- Stacked full-width **Name** + multiline **Monaco** value editor, opened over the tab via the ngrx-free `TailwindDialogService`.
- Value is always stored as a string and **minified** on save. A **Format / Minify** toggle pretty-prints (jq-style) for editing without changing what gets stored.
- Auto-detects JSON vs plain on open, with a manual toggle; resizable editor.
- Two-tier name validation: CF's real rules (non-empty, no `VCAP_`/`VMC_` prefix, not `PORT`, no duplicate) hard-block Save; the stricter shell-safe pattern and invalid JSON warn but allow.
- Centered dialog that no longer jumps on the first keystroke; the "required" message is deferred until the field is touched.

## Tests / verification
- New specs for the action-service (delta + explicit-null wire), the validation helpers, and the dialog logic — all green. Full cloud-foundry suite passes; production AOT build clean.
- Live-verified on a real CF endpoint: add → edit → rename → delete, with a JSON value preserved throughout.
