### PR TITLE
feat(cf): Org/Space column on per-CF apps tab + drop locked CF filter

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { CloudFoundryApplicationsSignalComponent as Cmp } from './cloud-foundry-applications-signal.component';
+import type { StApp } from '../../../../services/endpoint-data/stratos-types';
+
+// The per-CF Applications tab shows an Org/Space compound column — the
+// application wall's CF/Org/Space column minus the CF (endpoint) segment,
+// since the CF is already implied by the route. These cover the pure
+// resolution/rendering helpers that back that column.
+
+const EMPTY = new Map<string, string>();
+
+function app(overrides: Partial<StApp> = {}): StApp {
+  return {
+    cnsiGuid: 'cnsi-1',
+    guid: 'app-1',
+    name: 'my-app',
+    state: 'STARTED',
+    spaceGuid: 'space-1',
+    instances: 1,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  } as StApp;
+}
+
+describe('CloudFoundryApplicationsSignalComponent.resolveOrgSpace', () => {
+  it('prefers the names carried on the row (server-side join)', () => {
+    const r = Cmp.resolveOrgSpace(app({ orgName: 'my-org', spaceName: 'my-space' }), EMPTY, EMPTY);
+    expect(r).toEqual({ orgName: 'my-org', spaceName: 'my-space' });
+  });
+
+  it('falls back to the catalog name maps by guid when the row lacks names', () => {
+    const orgNames = new Map([['org-1', 'Cat Org']]);
+    const spaceNames = new Map([['space-1', 'Cat Space']]);
+    const r = Cmp.resolveOrgSpace(app({ orgGuid: 'org-1', spaceGuid: 'space-1' }), orgNames, spaceNames);
+    expect(r).toEqual({ orgName: 'Cat Org', spaceName: 'Cat Space' });
+  });
+
+  it('uses an em-dash when neither the row nor the catalog has a name', () => {
+    const r = Cmp.resolveOrgSpace(app({ orgGuid: 'org-x', spaceGuid: 'space-x' }), EMPTY, EMPTY);
+    expect(r).toEqual({ orgName: '—', spaceName: '—' });
+  });
+
+  it('uses an em-dash for a missing org guid', () => {
+    const r = Cmp.resolveOrgSpace(app({ orgGuid: undefined, spaceName: 'my-space' }), EMPTY, EMPTY);
+    expect(r.orgName).toBe('—');
+  });
+});
+
+describe('CloudFoundryApplicationsSignalComponent.renderOrgSpace', () => {
+  it('renders "org / space" for sort/filter flattening', () => {
+    expect(Cmp.renderOrgSpace(app({ orgName: 'o', spaceName: 's' }), EMPTY, EMPTY)).toBe('o / s');
+  });
+});
+
+describe('CloudFoundryApplicationsSignalComponent.compoundOrgSpace', () => {
+  it('returns exactly two segments — org then space — with NO CF segment', () => {
+    const segs = Cmp.compoundOrgSpace(
+      app({ orgGuid: 'org-1', orgName: 'my-org', spaceName: 'my-space' }), EMPTY, EMPTY);
+    expect(segs.map(s => s.text)).toEqual(['my-org', 'my-space']);
+    expect(segs.length).toBe(2);
+  });
+
+  it('links org and space to their CF detail pages once names resolve', () => {
+    const segs = Cmp.compoundOrgSpace(
+      app({ cnsiGuid: 'cnsi-1', orgGuid: 'org-1', spaceGuid: 'space-1', orgName: 'o', spaceName: 's' }),
+      EMPTY, EMPTY);
+    expect(segs[0].link).toEqual(['/cloud-foundry', 'cnsi-1', 'organizations', 'org-1']);
+    expect(segs[1].link).toEqual(['/cloud-foundry', 'cnsi-1', 'organizations', 'org-1', 'spaces', 'space-1']);
+  });
+
+  it('renders unresolved segments as plain text (no dead links)', () => {
+    const segs = Cmp.compoundOrgSpace(app({ orgGuid: 'org-x', spaceGuid: 'space-x' }), EMPTY, EMPTY);
+    expect(segs[0]).toEqual({ text: '—', link: undefined });
+    expect(segs[1]).toEqual({ text: '—', link: undefined });
+  });
+
+  it('does not link the space when the org guid is unknown', () => {
+    // Space link needs the org guid in its path, so without it the space is plain text.
+    const segs = Cmp.compoundOrgSpace(
+      app({ orgGuid: undefined, spaceGuid: 'space-1', spaceName: 's' }), EMPTY, EMPTY);
+    expect(segs[1].link).toBeUndefined();
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -10,6 +10,7 @@ import {
   CurrentUserPermissionsService,
   ListSubNavAddAction,
   ListSubNavComponent,
+  SignalListCompoundSegment,
   SignalListComponent,
   SignalListConfig,
   SignalListDropdown,
@@ -192,6 +193,19 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
           widthHint: '7rem',
         },
         {
+          // Org/Space — the application wall's CF/Org/Space column minus the
+          // CF segment (CF is already implied by this scoped route).
+          header: 'Org/Space', key: 'orgSpace',
+          sortField: (app: StApp) => CloudFoundryApplicationsSignalComponent.renderOrgSpace(
+            app, this.appsConfig.orgNames(), this.appsConfig.spaceNames()),
+          kind: 'compound',
+          compound: (app: StApp) => CloudFoundryApplicationsSignalComponent.compoundOrgSpace(
+            app, this.appsConfig.orgNames(), this.appsConfig.spaceNames()),
+          render: (app: StApp) => CloudFoundryApplicationsSignalComponent.renderOrgSpace(
+            app, this.appsConfig.orgNames(), this.appsConfig.spaceNames()),
+          widthHint: '14rem',
+        },
+        {
           header: 'Created', key: 'createdAt', sortField: 'createdAt',
           render: (app: StApp) => CloudFoundryApplicationsSignalComponent.formatDate(app.createdAt),
           widthHint: '12rem',
@@ -223,6 +237,10 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
         card: [6, 12, 24, 48, 96],
       },
       nameFilter: this.appsConfig.nameFilter,
+      // Filter-by-field parity with the wall: the text filter can target
+      // Name, Status, or the Org/Space column.
+      filterColumns: ['name', 'state', 'orgSpace'],
+      filterField: this.appsConfig.filterField,
       filterDropdowns: dropdowns,
       onRefresh: () => this.appsConfig.refresh(),
       onClear: () => this.appsConfig.clearFilters(),
@@ -230,6 +248,16 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
       viewMode: this.appsConfig.viewMode,
       sort: this.appsConfig.sort,
     });
+
+    // Sort + filter extractors for the Org/Space column (composed from name
+    // maps rather than a direct StApp field), plus name/state so the
+    // filter-by-field dropdown can target each.
+    const orgSpaceText = (app: StApp) => CloudFoundryApplicationsSignalComponent.renderOrgSpace(
+      app, this.appsConfig.orgNames(), this.appsConfig.spaceNames());
+    this.appsConfig.registerSortExtractor('orgSpace', orgSpaceText);
+    this.appsConfig.registerFilterExtractor('name', (app: StApp) => app.name ?? '');
+    this.appsConfig.registerFilterExtractor('state', stateLabel);
+    this.appsConfig.registerFilterExtractor('orgSpace', orgSpaceText);
 
     // Default per-CF tab presentation matches per-space: card view at 6/page.
     this.appsConfig.viewMode.set('card');
@@ -270,6 +298,56 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
       },
     ];
   };
+
+  /**
+   * Resolve an app's org + space display names. Prefers the names carried on
+   * the row from the server-side space→org / app→space join; falls back to
+   * the catalog name maps by guid, then to an em-dash placeholder (never a
+   * raw guid — guids stay in the URL/tooltip). Mirrors the application wall's
+   * resolution, minus the CF/endpoint segment (CF is implied by the route).
+   */
+  static resolveOrgSpace(
+    app: StApp,
+    orgNames: ReadonlyMap<string, string>,
+    spaceNames: ReadonlyMap<string, string>,
+  ): { orgName: string; spaceName: string } {
+    const orgName = app.orgName || (app.orgGuid ? (orgNames.get(app.orgGuid) ?? '—') : '—');
+    const spaceName = app.spaceName || (app.spaceGuid ? (spaceNames.get(app.spaceGuid) ?? '—') : '—');
+    return { orgName, spaceName };
+  }
+
+  /** Flatten org + space to a single string for sort/filter extractors. */
+  static renderOrgSpace(
+    app: StApp,
+    orgNames: ReadonlyMap<string, string>,
+    spaceNames: ReadonlyMap<string, string>,
+  ): string {
+    const { orgName, spaceName } = CloudFoundryApplicationsSignalComponent.resolveOrgSpace(app, orgNames, spaceNames);
+    return `${orgName} / ${spaceName}`;
+  }
+
+  /**
+   * Stacked Org/Space segments for the compound column. Each segment links
+   * to its CF detail page once the guid + name are both known; while a name
+   * is still '—' the segment renders as plain text (no dead anchors).
+   */
+  static compoundOrgSpace(
+    app: StApp,
+    orgNames: ReadonlyMap<string, string>,
+    spaceNames: ReadonlyMap<string, string>,
+  ): SignalListCompoundSegment[] {
+    const { orgName, spaceName } = CloudFoundryApplicationsSignalComponent.resolveOrgSpace(app, orgNames, spaceNames);
+    const orgLink = app.orgGuid && orgName !== '—'
+      ? ['/cloud-foundry', app.cnsiGuid, 'organizations', app.orgGuid]
+      : undefined;
+    const spaceLink = app.orgGuid && app.spaceGuid && spaceName !== '—'
+      ? ['/cloud-foundry', app.cnsiGuid, 'organizations', app.orgGuid, 'spaces', app.spaceGuid]
+      : undefined;
+    return [
+      { text: orgName, link: orgLink },
+      { text: spaceName, link: spaceLink },
+    ];
+  }
 
   static formatMb(mb: number | null | undefined): string {
     if (mb == null || typeof mb !== 'number' || Number.isNaN(mb)) return '—';

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -103,18 +103,12 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
     this.appsConfig.clearLockedSpace();
     this.appsConfig.initialize([cfGuid]);
     this.totalApplications = this.appsConfig.view.totalItems;
-    // CNSI is pre-chosen by the URL — pin the dropdown's selection to this
-    // CF and disable it so the scope is visible (matching Org/Space framing
-    // on per-org / per-space pages) but the user can't drift off this CF.
+    // CNSI is pre-chosen by the URL. Pin the selection so the Org/Space
+    // options stay scoped to this CF, but don't show a (locked) Cloud Foundry
+    // dropdown — the CF is already named in the breadcrumb, and a disabled
+    // control only adds clutter. Show just the interactive Org/Space filters.
     this.appsConfig.selectedCnsi.set(cfGuid);
-    const cnsiLocked: Signal<boolean> = signal(true).asReadonly();
     const dropdowns: SignalListDropdown[] = [
-      {
-        label: 'Cloud Foundry',
-        options: this.appsConfig.cnsiOptions,
-        selected: this.appsConfig.selectedCnsi,
-        disabled: cnsiLocked,
-      },
       {
         label: 'Organization',
         options: this.appsConfig.orgOptions,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-marketplace/cloud-foundry-marketplace-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-marketplace/cloud-foundry-marketplace-signal.component.ts
@@ -101,18 +101,11 @@ export class CloudFoundryMarketplaceSignalComponent implements OnInit {
     const cfGuid = this.cfEndpointService.cfGuid;
     this.offeringsConfig.initialize([cfGuid]);
     this.totalServiceOfferings = this.offeringsConfig.view.totalItems;
-    // CNSI is pre-chosen by the URL — show the dropdown but disable it so
-    // the scope is visible and can't drift.
+    // CNSI is pre-chosen by the URL and named in the breadcrumb. Pin the
+    // selection for scope, but show no (locked) Cloud Foundry dropdown — the
+    // Marketplace has no other filters, so the toolbar stays clean.
     this.offeringsConfig.selectedCnsi.set(cfGuid);
-    const cnsiLocked: Signal<boolean> = signal(true).asReadonly();
-    const dropdowns: SignalListDropdown[] = [
-      {
-        label: 'Cloud Foundry',
-        options: this.offeringsConfig.cnsiOptions,
-        selected: this.offeringsConfig.selectedCnsi,
-        disabled: cnsiLocked,
-      },
-    ];
+    const dropdowns: SignalListDropdown[] = [];
 
     const renderTags = (o: StServiceOffering): string =>
       (o.tags ?? []).join(', ');

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-routes/cloud-foundry-routes-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-routes/cloud-foundry-routes-signal.component.ts
@@ -154,23 +154,9 @@ export class CloudFoundryRoutesSignalComponent {
     const typeColor = (r: StRoute): SignalListPillColor =>
       r.port != null ? 'warning' : 'neutral';
 
-    // CNSI is pre-chosen by the URL — show the dropdown but disable it so
-    // the scope is visible and can't drift. Parity with services + market-
-    // place tabs which also lead with a locked Cloud Foundry indicator.
-    const endpointName = computed(() =>
-      this.cfEndpointService.endpoint()?.entity?.name ?? cfGuid,
-    );
-    const cnsiOptions = computed(() => [{ label: endpointName(), value: cfGuid }]);
-    const selectedCnsi = signal<string | null>(cfGuid);
-    const cnsiLocked: Signal<boolean> = signal(true).asReadonly();
-
+    // CF is fixed by the URL (and named in the breadcrumb), so we don't show
+    // a locked Cloud Foundry dropdown — just the interactive Org/Space filters.
     const dropdowns: SignalListDropdown[] = [
-      {
-        label: 'Cloud Foundry',
-        options: cnsiOptions,
-        selected: selectedCnsi,
-        disabled: cnsiLocked,
-      },
       {
         label: 'Organization',
         options: this.routesConfig.orgOptions,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
@@ -111,17 +111,12 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
     const cfGuid = this.cfEndpointService.cfGuid;
     this.instancesConfig.initialize([cfGuid]);
     this.totalServiceInstances = this.instancesConfig.view.totalItems;
-    // CNSI is pre-chosen by the URL — show the dropdown but disable it so
-    // the scope is visible and can't drift.
+    // CNSI is pre-chosen by the URL. Pin the selection so the Org/Space
+    // options stay scoped to this CF, but don't show a (locked) Cloud Foundry
+    // dropdown — the CF is already named in the breadcrumb. Show just the
+    // interactive Org/Space filters.
     this.instancesConfig.selectedCnsi.set(cfGuid);
-    const cnsiLocked: Signal<boolean> = signal(true).asReadonly();
     const dropdowns: SignalListDropdown[] = [
-      {
-        label: 'Cloud Foundry',
-        options: this.instancesConfig.cnsiOptions,
-        selected: this.instancesConfig.selectedCnsi,
-        disabled: cnsiLocked,
-      },
       {
         label: 'Organization',
         options: this.instancesConfig.orgOptions,


### PR DESCRIPTION
## Summary
Two UX improvements to the CF-scoped list tabs.

### Org/Space column on the per-CF Applications tab
Adds the application wall's `CF/Org/Space` column **minus the CF segment** (the CF is already implied by the `/cloud-foundry/:cnsi/...` route): a compound **Org/Space** column after Disk, each segment linking to its CF detail page once the name resolves (em-dash while pending). It sorts and joins the filter-by-field dropdown (Name / Status / Org/Space). Names come from the server-side join on the row, with the catalog maps as a fallback. Logic is in TDD'd static helpers.

### Drop the locked Cloud Foundry filter dropdown
On the **Applications, Routes, Services and Marketplace** tabs the Cloud Foundry dropdown was rendered but **disabled** — redundant with the breadcrumb and wasting toolbar space. Removed it, keeping only the interactive Org/Space filters (Marketplace now shows none). CF scoping is unchanged (data is still scoped via `initialize(cfGuid)` and the pinned `selectedCnsi`).

## Tests / verification
- New static-helper spec (org/space resolution + links) green; full cloud-foundry suite passes; production AOT build clean.
- All four tabs live-verified: Applications/Routes/Services show Org + Space only; Marketplace shows no scope dropdowns.
