### PR TITLE
Populate the per-CF Applications Org/Space filter dropdowns

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CloudFoundryApplicationsSignalComponent as Cmp } from './cloud-foundry-applications-signal.component';
+import { CurrentUserPermissionsService, TabNavService } from '@stratosui/core';
+import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
+import { generateCfBaseTestModulesNoShared } from '@test-framework/cloud-foundry-endpoint-service.helper';
+
+import {
+  CloudFoundryApplicationsSignalComponent,
+  CloudFoundryApplicationsSignalComponent as Cmp,
+} from './cloud-foundry-applications-signal.component';
+import { CfAppsSignalConfigService } from '../../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
+import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import type { StApp } from '../../../../services/endpoint-data/stratos-types';
 
 // The per-CF Applications tab shows an Org/Space compound column — the
@@ -81,5 +95,106 @@ describe('CloudFoundryApplicationsSignalComponent.compoundOrgSpace', () => {
     const segs = Cmp.compoundOrgSpace(
       app({ orgGuid: undefined, spaceGuid: 'space-1', spaceName: 's' }), EMPTY, EMPTY);
     expect(segs[1].link).toBeUndefined();
+  });
+});
+
+// The per-CF Applications tab keeps its OWN lazy org/space catalog (rather
+// than the shared EndpointDataService the other per-CF tabs read), so its
+// toolbar dropdowns only populate once ensureNamesLoaded() runs. These cover
+// the component wiring that triggers that fetch on first dropdown open.
+function makeStubAppsConfig() {
+  const allOption = { label: 'All', value: null };
+  const view = {
+    pagedItems: signal([]).asReadonly(),
+    totalFilteredResults: signal(0).asReadonly(),
+    totalPages: signal(1).asReadonly(),
+    totalItems: signal(0).asReadonly(),
+  };
+  const orchestrator = {
+    isAnyLoading: signal(false).asReadonly(),
+    errorsByCnsi: signal(new Map<string, unknown>()).asReadonly(),
+  };
+  return {
+    initialize: vi.fn(),
+    clearLockedSpace: vi.fn(),
+    ensureNamesLoaded: vi.fn().mockResolvedValue(undefined),
+    loadAll: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    deleteApp: vi.fn().mockResolvedValue(undefined),
+    startStatsPolling: vi.fn(),
+    clearFilters: vi.fn(),
+    registerSortExtractor: vi.fn(),
+    registerFilterExtractor: vi.fn(),
+    appStats: signal(new Map<string, { running: number; total: number }>()),
+    filter: signal(() => true),
+    sort: signal({ field: 'name' as const, direction: 'asc' as const }),
+    pageSize: signal(6),
+    pageIndex: signal(0),
+    view,
+    orchestrator,
+    selectedCnsi: signal<string | null>(null),
+    selectedOrg: signal<string | null>(null),
+    selectedSpace: signal<string | null>(null),
+    nameFilter: signal(''),
+    filterField: signal('name'),
+    viewMode: signal<'card' | 'table'>('card'),
+    orgOptions: signal([allOption]).asReadonly(),
+    spaceOptions: signal([allOption]).asReadonly(),
+    isLoadingOrgs: signal(false).asReadonly(),
+    isLoadingSpaces: signal(false).asReadonly(),
+    orgNames: signal(new Map<string, string>()).asReadonly(),
+    spaceNames: signal(new Map<string, string>()).asReadonly(),
+  };
+}
+
+describe('CloudFoundryApplicationsSignalComponent (component)', () => {
+  let component: CloudFoundryApplicationsSignalComponent;
+  let fixture: ComponentFixture<CloudFoundryApplicationsSignalComponent>;
+  let stubAppsConfig: ReturnType<typeof makeStubAppsConfig>;
+
+  beforeEach(async () => {
+    stubAppsConfig = makeStubAppsConfig();
+    const stubEndpointService = { cfGuid: 'cnsi-1' } as any;
+    await TestBed.configureTestingModule({
+      imports: [CloudFoundryApplicationsSignalComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideHttpClient(),
+        ...STORE_TEST_PROVIDERS,
+        importProvidersFrom(generateCfBaseTestModulesNoShared()),
+        TabNavService,
+        { provide: CfAppsSignalConfigService, useValue: stubAppsConfig },
+        { provide: CloudFoundryEndpointService, useValue: stubEndpointService },
+        { provide: CurrentUserPermissionsService, useValue: { can: () => of(true) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CloudFoundryApplicationsSignalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('builds Org/Space filter dropdowns with no locked Cloud Foundry dropdown', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+    expect(cfg!.filterDropdowns!.map(d => d.label)).toEqual(['Organization', 'Space']);
+    expect(cfg!.filterDropdowns![0].selected).toBe(stubAppsConfig.selectedOrg);
+    expect(cfg!.filterDropdowns![1].selected).toBe(stubAppsConfig.selectedSpace);
+  });
+
+  it('lazily loads this CF’s org/space catalog when a dropdown is first opened', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    // Catalog is NOT fetched on mount — only on first dropdown interaction.
+    expect(stubAppsConfig.ensureNamesLoaded).not.toHaveBeenCalled();
+    for (const d of cfg!.filterDropdowns!) {
+      expect(d.onOpen).toBeTypeOf('function');
+      d.onOpen!();
+    }
+    // Both dropdowns share one handler scoped to the route's single CNSI;
+    // the service-side promise dedupes repeated opens to one fanout.
+    expect(stubAppsConfig.ensureNamesLoaded).toHaveBeenCalledWith(['cnsi-1']);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -108,18 +108,29 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
     // dropdown — the CF is already named in the breadcrumb, and a disabled
     // control only adds clutter. Show just the interactive Org/Space filters.
     this.appsConfig.selectedCnsi.set(cfGuid);
+    // First open of either Org/Space dropdown lazily fetches this CF's
+    // org+space catalog. Unlike the other per-CF tabs (which read the shared
+    // EndpointDataService the parent CF page already hydrates), the apps
+    // config keeps its OWN lazy catalog so the multi-CF app wall doesn't
+    // saturate the network on mount — see CfAppsSignalConfigService.loadNames.
+    // That catalog is gated behind ensureNamesLoaded(); without this onOpen
+    // hook the dropdowns never populate beyond "All". Scope the fetch to the
+    // single CNSI in view (tighter than the wall's all-endpoints default).
+    const onDropdownOpen = () => { void this.appsConfig.ensureNamesLoaded([cfGuid]); };
     const dropdowns: SignalListDropdown[] = [
       {
         label: 'Organization',
         options: this.appsConfig.orgOptions,
         selected: this.appsConfig.selectedOrg,
         loading: this.appsConfig.isLoadingOrgs,
+        onOpen: onDropdownOpen,
       },
       {
         label: 'Space',
         options: this.appsConfig.spaceOptions,
         selected: this.appsConfig.selectedSpace,
         loading: this.appsConfig.isLoadingSpaces,
+        onOpen: onDropdownOpen,
       },
     ];
 


### PR DESCRIPTION
## What

The per-CF **Applications** tab's Organization and Space filter dropdowns only ever showed **"All"**.

Unlike the other per-CF tabs (Routes, Services, Users), which read the shared `EndpointDataService` that the parent CF page hydrates, the apps config keeps its **own** lazy org/space catalog so the global multi-CF application wall doesn't saturate the network on mount. That catalog is gated behind `ensureNamesLoaded()`, triggered by the toolbar dropdowns' `onOpen` hook — which only the global app wall wired, never the per-CF tab.

This adds the `onOpen` hook to both dropdowns, scoped to the route's single CNSI (tighter than the wall's all-endpoints default). First open of either dropdown now fetches this CF's org+space catalog; the service-side promise dedupes repeated opens to one fanout.

## Audit

Checked every per-CF tab toolbar:

| Tab | Dropdowns | Status |
|-----|-----------|--------|
| **Applications** | Org / Space | **Fixed** — was empty, now populates on open |
| Routes | Org / Space | Already populates via shared `EndpointDataService` |
| Services | Org / Space | Already populates via shared `EndpointDataService` |
| Users | Org / Space | Already populates via shared `EndpointDataService` |
| Marketplace | — | No scope dropdowns by design |

The Applications tab was the only gap.

## Testing

- Added TestBed coverage asserting the dropdowns carry no locked Cloud Foundry entry and that first-open triggers `ensureNamesLoaded` for the scoped CNSI.
- Full `make check gate` green (frontend 2491 tests, backend Go suite, prod build).
- Live-verified against a CF with 50+ orgs: the Applications dropdowns populate (57 orgs / hundreds of spaces) on first open; Routes/Services/Users confirmed already populated.

## Follow-up (out of scope)

The Applications tab labels spaces by bare name (duplicate `space_1` entries) while the other tabs use disambiguated "space - org" labels. Pre-existing, and shared with the global app wall.