### PR TITLE
Disambiguate same-named spaces in the apps filter dropdown

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -267,6 +267,54 @@ describe('CfAppsSignalConfigService', () => {
     expect(svc.spaceOptions().map(o => o.label)).toContain('e2e');
   });
 
+  it('disambiguates same-named spaces across orgs as "<space> - <org>" when no org is selected', async () => {
+    // space_1 exists in both org_a and org_b. With Org = All a bare-name
+    // list would render two identical "space_1" rows, so the dropdown must
+    // append the org name to tell them apart (parity with the Routes /
+    // Services / Users tabs). Selecting an org fixes the scope, so the
+    // label collapses back to the bare space name.
+    const httpMock = {
+      get: vi.fn((url: string) => {
+        if (url.startsWith('/pp/v1/cf/orgs/cnsi-1')) {
+          return of({
+            resources: [
+              { guid: 'org-a', name: 'org_a', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+              { guid: 'org-b', name: 'org_b', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+            ],
+          });
+        }
+        if (url.startsWith('/pp/v1/cf/spaces/cnsi-1')) {
+          return of({
+            resources: [
+              { guid: 'space-1a', name: 'space_1', orgGuid: 'org-a', createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+              { guid: 'space-1b', name: 'space_1', orgGuid: 'org-b', createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+            ],
+          });
+        }
+        return of({
+          resources: [],
+          pagination: { totalResults: 0, totalPages: 1, next: null, previous: null, first: { href: '' }, last: { href: '' } },
+        });
+      }),
+    } as unknown as HttpClient;
+    const cf = makeStubCfService([{ guid: 'cnsi-1', name: 'Primary CF' }]);
+    const svc = makeSvc(httpMock, cf);
+    svc.selectedCnsi.set('cnsi-1');
+    svc.initialize(['cnsi-1']);
+    // Await the catalog drain directly (orgs + priority spaces chunk) rather
+    // than counting microtasks.
+    await svc.ensureNamesLoaded(['cnsi-1']);
+    TestBed.tick();
+
+    // Org = All → disambiguated, sorted by space name then org name.
+    expect(svc.spaceOptions().map(o => o.label)).toEqual(['All', 'space_1 - org_a', 'space_1 - org_b']);
+
+    // Org selected → bare space name (the org is already fixed).
+    svc.selectedOrg.set('org-a');
+    TestBed.tick();
+    expect(svc.spaceOptions().map(o => o.label)).toEqual(['All', 'space_1']);
+  });
+
   it('preserves a valid selection across navigation (re-initialize)', async () => {
     // Regression: the singleton service's _hasLoadedOnce was latching true
     // forever after the first load. On re-navigation, a fresh initialize()

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -249,21 +249,49 @@ export class CfAppsSignalConfigService {
     // Space options are scoped to the selected CF and, when set, the
     // selected org. StSpace carries orgGuid so we can filter from the
     // catalog without needing an app to exist in the space.
+    //
+    // - Org selected: the org is fixed, so the bare space name is
+    //   unambiguous. Label = space name, natural sort.
+    // - Org = All: spaces from different orgs commonly share a name
+    //   (space_1 in org_1, space_1 in org_2, …). A bare-name list would
+    //   render a wall of identical "space_1" entries, so disambiguate each
+    //   as "<space> - <org>" (mirrors the Routes/Services/Users tabs),
+    //   sorted by space name then org name. Falls back to the bare name
+    //   when the org name isn't resolved yet (catalog still draining).
     this.spaceOptions = computed(() => {
       const cnsi = this.selectedCnsi();
       const org = this.selectedOrg();
       const byCnsi = this._spacesByCnsi();
-      const seen = new Map<string, string>();
       const sources = cnsi ? [byCnsi.get(cnsi) ?? []] : Array.from(byCnsi.values());
+      // Dedup by guid, retaining the org guid so the All-orgs branch can
+      // append the org name.
+      const seen = new Map<string, { name: string; orgGuid: string }>();
       for (const spaces of sources) {
         for (const s of spaces) {
           if (org && s.orgGuid !== org) continue;
-          if (!seen.has(s.guid)) seen.set(s.guid, s.name);
+          if (!seen.has(s.guid)) seen.set(s.guid, { name: s.name, orgGuid: s.orgGuid });
         }
       }
       const opts: SignalListDropdownOption[] = [{ label: 'All', value: null }];
-      const sorted = Array.from(seen.entries()).sort(([, a], [, b]) => naturalCompare(a, b));
-      for (const [guid, label] of sorted) opts.push({ label, value: guid });
+      if (org) {
+        const sorted = Array.from(seen.entries()).sort(([, a], [, b]) => naturalCompare(a.name, b.name));
+        for (const [guid, s] of sorted) opts.push({ label: s.name, value: guid });
+        return opts;
+      }
+      const orgNames = this.orgNames();
+      const augmented = Array.from(seen.entries()).map(([guid, s]) => ({
+        guid,
+        spaceName: s.name,
+        orgName: orgNames.get(s.orgGuid) ?? '',
+      }));
+      augmented.sort((a, b) => {
+        const bySpace = naturalCompare(a.spaceName, b.spaceName);
+        if (bySpace !== 0) return bySpace;
+        return naturalCompare(a.orgName, b.orgName);
+      });
+      for (const s of augmented) {
+        opts.push({ label: s.orgName ? `${s.spaceName} - ${s.orgName}` : s.spaceName, value: s.guid });
+      }
       return opts;
     });
 


### PR DESCRIPTION
## What

When no organization is selected, the applications **Space** filter dropdown listed every space by its bare name. CF space names are only unique within an org, so a CF with `space_1` in fifty orgs rendered fifty identical `space_1` rows — impossible to tell apart or pick from.

Label each space `"<space> - <org>"` when **Org = All** (sorted by space name then org name), collapsing back to the bare name once an org is selected and the scope is unambiguous. This matches what the Routes, Services, and Users tabs already do, and applies to both the per-CF Applications tab and the global application wall (shared `CfAppsSignalConfigService`).

Org names come from the same per-CF catalog that backs the Organization dropdown; an as-yet-unresolved org name falls back to the bare space name rather than a trailing `" - "`.

## Testing
- Unit test added (`cf-apps-signal-config.service.spec.ts`): All-orgs → `"space_1 - org_a"` / `"space_1 - org_b"`; org-selected → bare `"space_1"`.
- Full `make check gate` green.
- Live-verified on the app wall: `space_1 - org_1`, `gui - system`, etc.