### PR TITLE
Retry app-stats reads once on a token-boundary 401

### DIFF
--- a/src/jetstream/plugins/cloudfoundry/native_apps_stats.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_stats.go
@@ -69,23 +69,27 @@ func (c *CloudFoundrySpecification) getAppStats(ctx echo.Context) error {
 	}
 
 	reqCtx := ctx.Request().Context()
-	cfClient, err := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID)
-	if err != nil {
-		return err
-	}
-
-	procGUID, lookupErr := lookupWebProcessGUID(reqCtx, cfClient, appGUID)
-	if lookupErr != nil {
-		return handleCapiError(ctx, lookupErr)
-	}
-
-	stats, statsErr := cfClient.Processes().GetStats(reqCtx, procGUID)
-	if statsErr != nil {
-		return handleCapiError(ctx, statsErr)
+	// Wrap the lookup + stats pair so a 401 at the token-expiry boundary
+	// rebuilds the client (refreshing the token) and replays both calls once,
+	// instead of surfacing a 401 to the polling app-detail page every ~20min.
+	resp, opErr := callWithCapiRetry(reqCtx, c.nativeProxy(), cnsiGUID, userGUID,
+		func(cfClient capi.Client) (StAppStatsResponse, error) {
+			procGUID, lookupErr := lookupWebProcessGUID(reqCtx, cfClient, appGUID)
+			if lookupErr != nil {
+				return StAppStatsResponse{}, lookupErr
+			}
+			stats, statsErr := cfClient.Processes().GetStats(reqCtx, procGUID)
+			if statsErr != nil {
+				return StAppStatsResponse{}, statsErr
+			}
+			return buildStatsResponse(stats), nil
+		})
+	if opErr != nil {
+		return handleCapiError(ctx, opErr)
 	}
 
 	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
-	return ctx.JSON(http.StatusOK, buildStatsResponse(stats))
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 // StAppStatsBatchResponse is the Stratos-shape JSON returned from the
@@ -136,40 +140,47 @@ func (c *CloudFoundrySpecification) getAppStatsBatch(ctx echo.Context) error {
 	}
 
 	reqCtx := ctx.Request().Context()
-	cfClient, err := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID)
-	if err != nil {
-		return err
-	}
-
-	processes, lookupErr := fetchWebProcessesForApps(ctx, cfClient, appGUIDs)
-	if lookupErr != nil {
-		return handleCapiError(ctx, lookupErr)
-	}
-
-	out := StAppStatsBatchResponse{Apps: make(map[string]StAppStatsResponse, len(appGUIDs))}
-	var mu sync.Mutex
-	eg, egCtx := errgroup.WithContext(reqCtx)
-	eg.SetLimit(maxParallelStatsCalls)
-	for _, appGUID := range appGUIDs {
-		proc, ok := processes[appGUID]
-		if !ok || proc.GUID == "" {
-			continue
-		}
-		ag, pg := appGUID, proc.GUID
-		eg.Go(func() error {
-			stats, statsErr := cfClient.Processes().GetStats(egCtx, pg)
-			if statsErr != nil {
-				// Per-app failure: skip rather than fail the batch.
-				return nil
+	// Wrap the web-process lookup + stats fan-out so a 401 at the token-expiry
+	// boundary rebuilds the client (refreshing the token) and replays once.
+	// The retry triggers on the gating fetchWebProcessesForApps call — the
+	// first CAPI request, which catches an expired token before the fan-out
+	// runs — so the rebuilt client carries the fresh token into the fan-out.
+	out, opErr := callWithCapiRetry(reqCtx, c.nativeProxy(), cnsiGUID, userGUID,
+		func(cfClient capi.Client) (StAppStatsBatchResponse, error) {
+			processes, lookupErr := fetchWebProcessesForApps(ctx, cfClient, appGUIDs)
+			if lookupErr != nil {
+				return StAppStatsBatchResponse{}, lookupErr
 			}
-			resp := buildStatsResponse(stats)
-			mu.Lock()
-			out.Apps[ag] = resp
-			mu.Unlock()
-			return nil
+
+			res := StAppStatsBatchResponse{Apps: make(map[string]StAppStatsResponse, len(appGUIDs))}
+			var mu sync.Mutex
+			eg, egCtx := errgroup.WithContext(reqCtx)
+			eg.SetLimit(maxParallelStatsCalls)
+			for _, appGUID := range appGUIDs {
+				proc, ok := processes[appGUID]
+				if !ok || proc.GUID == "" {
+					continue
+				}
+				ag, pg := appGUID, proc.GUID
+				eg.Go(func() error {
+					stats, statsErr := cfClient.Processes().GetStats(egCtx, pg)
+					if statsErr != nil {
+						// Per-app failure: skip rather than fail the batch.
+						return nil
+					}
+					resp := buildStatsResponse(stats)
+					mu.Lock()
+					res.Apps[ag] = resp
+					mu.Unlock()
+					return nil
+				})
+			}
+			_ = eg.Wait()
+			return res, nil
 		})
+	if opErr != nil {
+		return handleCapiError(ctx, opErr)
 	}
-	_ = eg.Wait()
 
 	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
 	return ctx.JSON(http.StatusOK, out)

--- a/src/jetstream/plugins/cloudfoundry/native_apps_stats_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_stats_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
@@ -12,6 +13,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Process list carrying the app relationship the batch handler needs to key
+// each web process back to its app GUID (the single-app lookup doesn't).
+const stubProcessListWithAppRelJSON = `{
+	"pagination":{"total_results":1,"total_pages":1},
+	"resources":[{"guid":"proc-1","type":"web","instances":2,"relationships":{"app":{"data":{"guid":"app-1"}}}}]
+}`
+
+// 401 body shaped like a CF auth-token rejection.
+const stubUnauthorizedJSON = `{"errors":[{"code":1000,"title":"CF-InvalidAuthToken","detail":"Invalid Auth Token"}]}`
 
 const stubProcessListJSON = `{
 	"pagination":{"total_results":1,"total_pages":1},
@@ -97,4 +108,109 @@ func TestGetAppStats_FullShapePreservesUsageQuotasUptime(t *testing.T) {
 	r1 := resp.Instances[1]
 	assert.Equal(t, "CRASHED", r1.State)
 	assert.Nil(t, r1.Usage)
+}
+
+// A poll that fires just before the ~20-minute CF token expires reaches CF
+// after the token has lapsed and is 401'd. getAppStats must rebuild the client
+// (refreshing the token) and replay the stats call once, returning 200 instead
+// of bubbling the 401 to the app-detail page every token cycle.
+func TestGetAppStats_RetriesOnceOn401(t *testing.T) {
+	var statsCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case "/v3/processes":
+			_, _ = w.Write([]byte(stubProcessListJSON))
+		case "/v3/processes/proc-1/stats":
+			if atomic.AddInt32(&statsCalls, 1) == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(stubUnauthorizedJSON))
+				return
+			}
+			_, _ = w.Write([]byte(stubProcessStatsJSON))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/app-stats/cnsi-1/app-1", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid", "appGuid")
+	ctx.SetParamValues("cnsi-1", "app-1")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getAppStats(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// Exactly one replay — the 401 path retries once, no more.
+	assert.Equal(t, int32(2), atomic.LoadInt32(&statsCalls))
+
+	var resp StAppStatsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Instances, 2)
+}
+
+// The batched endpoint retries on a 401 from its gating web-process lookup —
+// the first CAPI call, which catches the expired token before the stats
+// fan-out runs — then replays the whole operation with a refreshed client.
+func TestGetAppStatsBatch_RetriesOnceOn401(t *testing.T) {
+	var listCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case "/v3/processes":
+			if atomic.AddInt32(&listCalls, 1) == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(stubUnauthorizedJSON))
+				return
+			}
+			_, _ = w.Write([]byte(stubProcessListWithAppRelJSON))
+		case "/v3/processes/proc-1/stats":
+			_, _ = w.Write([]byte(stubProcessStatsJSON))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/app-stats/cnsi-1?app_guids=app-1", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("cnsi-1")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getAppStatsBatch(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls))
+
+	var resp StAppStatsBatchResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Contains(t, resp.Apps, "app-1")
+	require.Len(t, resp.Apps["app-1"].Instances, 2)
 }

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -110,6 +110,37 @@ func newCapiClient(ctx context.Context, proxy nativeCFProxy, cnsiGUID, userGUID 
 	return client, nil
 }
 
+// callWithCapiRetry builds an authenticated capi client and runs op against it.
+// If op fails with a 401, it rebuilds the client once and replays op a single
+// time. This is the reactive companion to newCapiClient's proactive expiry
+// refresh: a token that is still valid when the client is built can be rejected
+// by CF anyway — the per-CF token has a ~20-minute life and a poll that fires in
+// the last moments before expiry travels to CF (≈700ms RTT) and is 401'd by the
+// time CF validates it. By retry time the stored token has genuinely expired, so
+// the rebuild's newCapiClient proactively refreshes it and the replay succeeds.
+// Without this, a long-lived read poll (app-stats, summary, env) 401s every
+// token cycle. Mirrors the inline pattern in native_audit_events_reads.go;
+// generic so any native read/write handler can wrap its CAPI call(s).
+func callWithCapiRetry[T any](
+	reqCtx context.Context,
+	proxy nativeCFProxy,
+	cnsiGUID, userGUID string,
+	op func(capi.Client) (T, error),
+) (T, error) {
+	var zero T
+	client, err := newCapiClient(reqCtx, proxy, cnsiGUID, userGUID)
+	if err != nil {
+		return zero, err
+	}
+	res, opErr := op(client)
+	if opErr != nil && statusFromCapiError(opErr) == http.StatusUnauthorized {
+		if rc, rerr := newCapiClient(reqCtx, proxy, cnsiGUID, userGUID); rerr == nil {
+			res, opErr = op(rc)
+		}
+	}
+	return res, opErr
+}
+
 // normaliseStringMap ensures nil maps are returned as empty maps (not null in JSON).
 func normaliseStringMap(m map[string]string) map[string]string {
 	if m == nil {


### PR DESCRIPTION
## What

The app-detail stats poll fires on a ~30s cadence against a per-CF token with a ~20-minute life. A poll that fires in the final moments before expiry travels to CF (~700ms RTT) and is rejected with a **401** by the time CF validates it — `newCapiClient`'s *proactive* expiry refresh can't catch a token that was still valid when the client was built. The result is a recurring 401 once per token cycle on a long-lived read (observed firing every ~21 min in the field).

Add `callWithCapiRetry`: a small generic helper that runs an operation against a fresh capi client and, on a 401, **rebuilds the client once and replays** the operation. By retry time the stored token has genuinely expired, so the rebuild's `newCapiClient` proactively refreshes it and the replay succeeds. This is the reactive companion to the proactive check, mirroring the inline pattern already in `native_audit_events_reads.go` but reusable by any native read/write handler.

Both app-stats handlers route through it: the single-app endpoint replays its lookup + stats pair; the batched endpoint retries on its gating web-process lookup (the first CAPI call, which catches the expired token before the stats fan-out) so the rebuilt client carries the fresh token into the fan-out.

## Testing
- Two new Go tests (`native_apps_stats_test.go`): a 401 on the gating call triggers exactly one replay that returns 200 (single-app and batch).
- Full `make check gate` green (backend + frontend + prod build).