### PR TITLE
Tabbed access modes on the deploy-from-Git source step

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -16,26 +16,70 @@
               <div>
                 @if (sourceType.group === 'gitscm') {
                   <div>
+                    @if (!isRedeploy) {
+                      <!-- Access mode: Public / Private / Enterprise. Each tab
+                           reveals only the fields that path needs, in the order
+                           they're required (auth gates the repo lookup). -->
+                      <div class="flex border-b border-content-border mb-4" role="tablist" aria-label="Repository access">
+                        <button type="button" role="tab" [attr.aria-selected]="gitMode === 'public'"
+                          class="px-4 py-2 text-sm border-b-2 -mb-px"
+                          [class.border-content-text]="gitMode === 'public'"
+                          [class.text-content-text]="gitMode === 'public'"
+                          [class.font-medium]="gitMode === 'public'"
+                          [class.border-transparent]="gitMode !== 'public'"
+                          [class.text-content-muted]="gitMode !== 'public'"
+                          (click)="setGitMode('public')">Public</button>
+                        <button type="button" role="tab" [attr.aria-selected]="gitMode === 'private'"
+                          class="px-4 py-2 text-sm border-b-2 -mb-px"
+                          [class.border-content-text]="gitMode === 'private'"
+                          [class.text-content-text]="gitMode === 'private'"
+                          [class.font-medium]="gitMode === 'private'"
+                          [class.border-transparent]="gitMode !== 'private'"
+                          [class.text-content-muted]="gitMode !== 'private'"
+                          (click)="setGitMode('private')">Private</button>
+                        <button type="button" role="tab" [attr.aria-selected]="gitMode === 'enterprise'"
+                          class="px-4 py-2 text-sm border-b-2 -mb-px"
+                          [class.border-content-text]="gitMode === 'enterprise'"
+                          [class.text-content-text]="gitMode === 'enterprise'"
+                          [class.font-medium]="gitMode === 'enterprise'"
+                          [class.border-transparent]="gitMode !== 'enterprise'"
+                          [class.text-content-muted]="gitMode !== 'enterprise'"
+                          (click)="setGitMode('enterprise')">{{ sourceType.id === DEPLOY_TYPES_IDS.GITLAB ? 'Self-hosted GitLab' : 'GitHub Enterprise' }}</button>
+                      </div>
+                    }
                     <div class="github-project-details">
                       <div>
+                        @if (gitMode === 'enterprise') {
+                          <div class="form-field">
+                            <label class="block text-sm text-content-muted mb-1" for="githubEnterpriseUrl">
+                              {{ sourceType.id === DEPLOY_TYPES_IDS.GITLAB ? 'GitLab base URL' : 'GitHub Enterprise URL' }} <span class="text-red-500">*</span>
+                            </label>
+                            <input id="githubEnterpriseUrl" type="text" class="input" [(ngModel)]="githubEnterpriseUrl"
+                              placeholder="https://github.mycorp.com" name="githubEnterpriseUrl"
+                              [disabled]="isRedeploy" required>
+                            @if (isInvalidGithubEnterpriseUrl) {
+                              <div class="text-red-500 text-sm mt-1">
+                                The base URL is not valid
+                              </div>
+                            }
+                          </div>
+                        }
+                        @if (gitMode !== 'public') {
+                          <div class="form-field">
+                            <label class="block text-sm text-content-muted mb-1" for="githubAccessToken">
+                              Access token <span class="text-red-500">*</span>
+                            </label>
+                            <input id="githubAccessToken" type="password" class="input" [(ngModel)]="accessToken"
+                              placeholder="Personal access token" name="githubAccessToken"
+                              autocomplete="off" spellcheck="false" [disabled]="isRedeploy" required>
+                          </div>
+                        }
                         <div class="form-field">
-                          <input type="text" class="input" [(ngModel)]="githubEnterpriseUrl"
-                            placeholder="GitHub Enterprise URL (optional)" name="githubEnterpriseUrl"
-                            [disabled]="isRedeploy">
-                          @if (isInvalidGithubEnterpriseUrl) {
-                            <div class="text-red-500 text-sm mt-1">
-                              GitHub Enterprise deployment URL is not valid
-                            </div>
-                          }
-                        </div>
-                        <div class="form-field">
-                          <input type="password" class="input" [(ngModel)]="accessToken"
-                            placeholder="GitHub Access Token (optional)" name="githubAccessToken"
-                            autocomplete="off" spellcheck="false" [disabled]="isRedeploy">
-                        </div>
-                        <div class="form-field">
-                          <input type="text" class="input" [disabled]="isRedeploy" [(ngModel)]="repository"
-                            placeholder="Project" name="projectName"
+                          <label class="block text-sm text-content-muted mb-1" for="projectName">
+                            Project <span class="text-red-500">*</span>
+                          </label>
+                          <input id="projectName" type="text" class="input" [disabled]="isRedeploy" [(ngModel)]="repository"
+                            placeholder="owner/repo" name="projectName"
                             [appGithubProjectExists]="sourceType.id + ',' + sourceType.endpointGuid + ',' + (accessToken || '')" required
                             list="repo-suggestions">
                           <!-- Repository suggestions datalist -->
@@ -76,53 +120,58 @@
                         </div>
                       </div>
                     }
-                  </div>
-                  <div class="form-field">
-                    <select class="input"
-                      [disabled]="isRedeploy || !repository || !sourceSelectionForm.controls.projectName.valid"
-                      [(ngModel)]="repositoryBranch" name="repositoryBranch"
-                      (change)="updateBranchName($event.target.value)" required>
-                      <option value="" disabled>Branch</option>
-                      @for (branch of repositoryBranches$ | async; track branch) {
-                        <option [value]="branch">
-                          {{ branch.name }}
-                        </option>
-                      }
-                    </select>
-                  </div>
-                  @if (isRedeploy && commitInfo) {
-                    <div
-                      class="deploy-step2-form__project-info-group deploy-step2-form__commit">
-                      <div>
-                        <img src="{{commitInfo.author.avatar_url}}" alt="">
-                      </div>
-                      <div src="description">
-                        <div>
-                          <a href="{{commitInfo.html_url}}" target="_blank">{{commitInfo.sha | limitTo:8}}</a>
-                        </div>
-                        <div>
-                          {{commitInfo.commit.message}}
-                        </div>
-                        <div class="author-info">
-                          <div>
-                            {{commitInfo.commit.author.name}}
-                          </div>
-                          <div>
-                            {{commitInfo.commit.author.date | date: 'medium'}}
-                          </div>
-                        </div>
-                      </div>
                     </div>
-                  }
-                </div>
-              }
+                    <div class="form-field">
+                      <label class="block text-sm text-content-muted mb-1" for="repositoryBranch">
+                        Branch <span class="text-red-500">*</span>
+                      </label>
+                      <select id="repositoryBranch" class="input"
+                        [disabled]="isRedeploy || !repository || !sourceSelectionForm.controls.projectName.valid"
+                        [(ngModel)]="repositoryBranch" name="repositoryBranch"
+                        (change)="updateBranchName($event.target.value)" required>
+                        <option value="" disabled>Select a branch</option>
+                        @for (branch of repositoryBranches$ | async; track branch) {
+                          <option [value]="branch">
+                            {{ branch.name }}
+                          </option>
+                        }
+                      </select>
+                    </div>
+                    @if (isRedeploy && commitInfo) {
+                      <div
+                        class="deploy-step2-form__project-info-group deploy-step2-form__commit">
+                        <div>
+                          <img src="{{commitInfo.author.avatar_url}}" alt="">
+                        </div>
+                        <div src="description">
+                          <div>
+                            <a href="{{commitInfo.html_url}}" target="_blank">{{commitInfo.sha | limitTo:8}}</a>
+                          </div>
+                          <div>
+                            {{commitInfo.commit.message}}
+                          </div>
+                          <div class="author-info">
+                            <div>
+                              {{commitInfo.commit.author.name}}
+                            </div>
+                            <div>
+                              {{commitInfo.commit.author.date | date: 'medium'}}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    }
+                  </div>
+                }
               @if (sourceType.id === DEPLOY_TYPES_IDS.GIT_URL) {
                 <div>
                   <div class="form-field">
-                    <input class="input" [disabled]="isRedeploy" [(ngModel)]="gitUrl" placeholder="Git URL" name="gitUrl" required>
+                    <label class="block text-sm text-content-muted mb-1" for="gitUrl">Git URL <span class="text-red-500">*</span></label>
+                    <input id="gitUrl" class="input" [disabled]="isRedeploy" [(ngModel)]="gitUrl" placeholder="https://github.com/owner/repo.git" name="gitUrl" required>
                   </div>
                   <div class="form-field">
-                    <input class="input" [(ngModel)]="gitUrlBranchName" placeholder="Branch or Tag" name="urlBranchName" required>
+                    <label class="block text-sm text-content-muted mb-1" for="urlBranchName">Branch or tag <span class="text-red-500">*</span></label>
+                    <input id="urlBranchName" class="input" [(ngModel)]="gitUrlBranchName" placeholder="main" name="urlBranchName" required>
                   </div>
                 </div>
               }
@@ -131,7 +180,8 @@
           @if (sourceType.id === DEPLOY_TYPES_IDS.DOCKER_IMG) {
             <div>
               <div class="form-field">
-                <input class="input" [disabled]="isRedeploy" [(ngModel)]="dockerAppName" placeholder="Application Name"
+                <label class="block text-sm text-content-muted mb-1" for="dockerAppName">Application name <span class="text-red-500">*</span></label>
+                <input id="dockerAppName" class="input" [disabled]="isRedeploy" [(ngModel)]="dockerAppName" placeholder="my-app"
                   name="dockerAppName" required>
                 @if (sourceSelectionForm.controls.dockerAppName?.errors?.required) {
                   <div class="text-red-500 text-sm mt-1">
@@ -140,7 +190,8 @@
                 }
               </div>
               <div class="form-field">
-                <input class="input" [disabled]="isRedeploy" [(ngModel)]="dockerImg" placeholder="Docker Image" name="dockerImg"
+                <label class="block text-sm text-content-muted mb-1" for="dockerImg">Docker image <span class="text-red-500">*</span></label>
+                <input id="dockerImg" class="input" [disabled]="isRedeploy" [(ngModel)]="dockerImg" placeholder="repo/image:tag" name="dockerImg"
                   required>
                 @if (sourceSelectionForm.controls.dockerImg?.errors?.required) {
                   <div class="text-red-500 text-sm mt-1">
@@ -154,7 +205,8 @@
                 }
               </div>
               <div class="form-field">
-                <input class="input" [(ngModel)]="dockerUsername" placeholder="Docker Username" name="dockerUsername">
+                <label class="block text-sm text-content-muted mb-1" for="dockerUsername">Docker username <span class="text-content-muted">(optional)</span></label>
+                <input id="dockerUsername" class="input" [(ngModel)]="dockerUsername" placeholder="Docker username" name="dockerUsername">
                 <p class="mt-1 text-sm text-content-muted">Docker Username works with the Application's `CF_DOCKER_PASSWORD` environment variable</p>
               </div>
             </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
@@ -137,6 +137,78 @@ describe('DeployApplicationStep2Component', () => {
       expect(scmSpy.clearAccessToken).not.toHaveBeenCalled();
     });
 
+  });
+
+  describe('git access mode (Public / Private / Enterprise tabs)', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(DeployApplicationStep2Component);
+      component = fixture.componentInstance;
+    });
+
+    it('derives Enterprise when a base URL is present', () => {
+      expect(DeployApplicationStep2Component.deriveGitMode('https://github.corp.com', 'tok')).toBe('enterprise');
+      // URL alone (token still to be entered) is still Enterprise.
+      expect(DeployApplicationStep2Component.deriveGitMode('https://github.corp.com', '')).toBe('enterprise');
+    });
+
+    it('derives Private when a token is present but no base URL', () => {
+      expect(DeployApplicationStep2Component.deriveGitMode('', 'tok')).toBe('private');
+      expect(DeployApplicationStep2Component.deriveGitMode(undefined, 'tok')).toBe('private');
+    });
+
+    it('derives Public when neither a base URL nor a token is present', () => {
+      expect(DeployApplicationStep2Component.deriveGitMode('', '')).toBe('public');
+      expect(DeployApplicationStep2Component.deriveGitMode(undefined, undefined)).toBe('public');
+    });
+
+    it('switching to Public clears both the base URL and the token', () => {
+      component.githubEnterpriseUrl = 'https://github.corp.com';
+      component.accessToken = 'tok';
+      component.setGitMode('public');
+      expect(component.gitMode).toBe('public');
+      expect(component.githubEnterpriseUrl).toBe('');
+      expect(component.accessToken).toBe('');
+    });
+
+    it('switching to Private clears the base URL but keeps the token', () => {
+      component.githubEnterpriseUrl = 'https://github.corp.com';
+      component.accessToken = 'tok';
+      component.setGitMode('private');
+      expect(component.gitMode).toBe('private');
+      expect(component.githubEnterpriseUrl).toBe('');
+      expect(component.accessToken).toBe('tok');
+    });
+
+    it('switching to Enterprise keeps both the base URL and the token', () => {
+      component.githubEnterpriseUrl = 'https://github.corp.com';
+      component.accessToken = 'tok';
+      component.setGitMode('enterprise');
+      expect(component.gitMode).toBe('enterprise');
+      expect(component.githubEnterpriseUrl).toBe('https://github.corp.com');
+      expect(component.accessToken).toBe('tok');
+    });
+  });
+
+  describe('applyGithubEnterpriseAndToken — form wiring', () => {
+    let scmSpy: {
+      setPublicApi: ReturnType<typeof vi.fn>;
+      setAccessToken: ReturnType<typeof vi.fn>;
+      clearAccessToken: ReturnType<typeof vi.fn>;
+      getType: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(DeployApplicationStep2Component);
+      component = fixture.componentInstance;
+      scmSpy = {
+        setPublicApi: vi.fn(),
+        setAccessToken: vi.fn(),
+        clearAccessToken: vi.fn(),
+        getType: vi.fn().mockReturnValue('github'),
+      };
+      component.scm = scmSpy as unknown as GitHubSCM;
+    });
+
     it('wires applyGithubEnterpriseAndToken to the sourceSelectionForm valueChanges stream', () => {
       // Mock the NgForm ViewChild with a Subject so we can emit form values
       // without standing up the full template-driven reactive form. Also mock

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -51,6 +51,12 @@ import { DeployApplicationFsComponent } from './deploy-application-fs/deploy-app
 
 
 
+// Access mode for the gitscm (GitHub / GitLab) source sub-form.
+//  public     — public host repo, no auth
+//  private    — host private repo, access token only (no base URL)
+//  enterprise — custom base URL (GitHub Enterprise / self-hosted GitLab) + token
+export type GitAccessMode = 'public' | 'private' | 'enterprise';
+
 @Component({
 selector: 'app-deploy-application-step2',
   templateUrl: './deploy-application-step2.component.html',
@@ -122,6 +128,13 @@ export class DeployApplicationStep2Component
   isInvalidGithubEnterpriseUrl = false;
   githubEnterpriseUrl: string;
   accessToken: string;
+
+  // Active git access mode for the gitscm sub-form, driven by the
+  // Public / Private / Enterprise tab strip. Held as local component state —
+  // the store still sees only githubEnterpriseUrl + accessToken. Switching
+  // tabs clears the fields that don't belong to the new mode so a stale base
+  // URL / token is never carried into the deploy.
+  gitMode: GitAccessMode = 'public';
   // --------------
 
   // Git URL
@@ -254,6 +267,8 @@ export class DeployApplicationStep2Component
 
   /* Git ------------------*/
   private setupForGit() {
+    // Land the tab strip on the mode that matches any restored auth values.
+    this.gitMode = DeployApplicationStep2Component.deriveGitMode(this.githubEnterpriseUrl, this.accessToken);
     this.projectInfo$ = this.projectExists$.pipe(
       filter(p => !!p),
       map(p => (!!p.exists && !!p.data) ? p.data : null),
@@ -415,5 +430,33 @@ export class DeployApplicationStep2Component
     this.deployData.setDeployBranch(branch.name);
   }
 
+  // Infer the opening access mode from restored values (redeploy / nav back),
+  // so the tab strip lands on the mode that matches what's already set. A base
+  // URL implies Enterprise even before its token is entered; a token alone
+  // (no URL) implies a Private host repo; neither implies Public.
+  static deriveGitMode(enterpriseUrl: string | undefined, accessToken: string | undefined): GitAccessMode {
+    if (enterpriseUrl) {
+      return 'enterprise';
+    }
+    if (accessToken) {
+      return 'private';
+    }
+    return 'public';
+  }
+
+  // Tab handler: switch the active access mode and clear the now-irrelevant
+  // auth fields (Public → drop URL + token; Private → drop URL, keep token;
+  // Enterprise → keep both), then re-sync the SCM so a cleared token/URL stops
+  // being applied to subsequent repo/branch lookups.
+  setGitMode(mode: GitAccessMode): void {
+    this.gitMode = mode;
+    if (mode === 'public') {
+      this.githubEnterpriseUrl = '';
+      this.accessToken = '';
+    } else if (mode === 'private') {
+      this.githubEnterpriseUrl = '';
+    }
+    this.applyGithubEnterpriseAndToken(this.githubEnterpriseUrl, this.accessToken);
+  }
 
 }


### PR DESCRIPTION
## What

Addresses the **"Source step confusing"** item of #5400. The deploy-from-Git source step crammed the gitscm fields onto one flat, placeholder-only list: an optional GitHub Enterprise URL and access token led, the required Project and Branch followed unmarked, and nothing showed that the "optional" auth actually **gates the repo lookup** for private / Enterprise repos.

Replace the flat form with a **Public / Private / Enterprise** tab strip that reveals only the fields each path needs, in dependency order:

| Tab | Fields |
|-----|--------|
| **Public** | Project, Branch |
| **Private** | Access token, Project, Branch |
| **Enterprise** | Base URL, Access token, Project, Branch |

The third tab is provider-aware — **"GitHub Enterprise"** for GitHub, **"Self-hosted GitLab"** for GitLab (the gitscm sub-form serves both). Every field now has a real label and a required marker. Switching tabs clears the auth fields that don't belong to the new mode, so a stale URL / token is never carried into the deploy.

Presentation only — the active mode is local component state derived from the existing `githubEnterpriseUrl` + `accessToken` bindings; **no backend or store change**. GitLab's token forwarding stays GitHub-only as before (a pre-existing, separately-tested behaviour).

Also adds labels + required/optional markers to the Git URL and Docker source types for consistency.

## Testing
- `deriveGitMode` + `setGitMode` (tab-switch field clearing) unit-tested (TDD).
- Full `make check gate` green (incl. prod AOT build).
- Live-verified: all three tabs render the right fields with labels/required markers; the core flow still resolves `cloudfoundry/stratos` and loads its branches; Next gates per mode; ARIA tablist/tab roles.

Design doc lives in the team Knowledge Store (kept out of this repo).