### PR TITLE
Applications: filter-dropdown fixes, app-stats 401 retry, and deploy-from-Git source/commit UX

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.html
@@ -1,15 +1,30 @@
 @if (listConfig(); as cfg) {
-  <!-- Bounded height + internal scroll so the stepper's footer buttons stay on
-       screen; the signal-list host is h-full, so it must size to a parent with
-       a definite height rather than carry the height itself. -->
-  <div class="h-[24rem] min-h-0">
-    <app-signal-list [config]="cfg">
-      <ng-template appSignalListCell="sha" let-row>
-        <a [href]="row.html_url" target="_blank">{{ row.sha.substring(0, 8) }}</a>
-      </ng-template>
-      <ng-template appSignalListCell="author" let-row>
-        <app-github-commit-author [commit]="row"></app-github-commit-author>
-      </ng-template>
-    </app-signal-list>
-  </div>
+  <!-- Deploy the latest commit on the branch without pinning a specific SHA.
+       When on, the commit list is hidden and the deploy sends an empty commit
+       so CF builds whatever HEAD currently points at. -->
+  <label class="flex items-center gap-2 mb-3 text-sm text-content-text cursor-pointer">
+    <input type="checkbox" [checked]="useLatestHead()"
+      (change)="setUseLatestHead($any($event.target).checked)">
+    <span>Deploy the latest commit on <b>{{ branchName() || 'the branch' }}</b> (don't pin a commit)</span>
+  </label>
+
+  @if (useLatestHead()) {
+    <div class="text-sm text-content-muted">
+      The most recent commit on <b>{{ branchName() || 'the branch' }}</b> will be deployed. Every redeploy picks up new commits automatically.
+    </div>
+  } @else {
+    <!-- Bounded height + internal scroll so the stepper's footer buttons stay on
+         screen; the signal-list host is h-full, so it must size to a parent with
+         a definite height rather than carry the height itself. -->
+    <div class="h-[24rem] min-h-0">
+      <app-signal-list [config]="cfg">
+        <ng-template appSignalListCell="sha" let-row>
+          <a [href]="row.html_url" target="_blank">{{ row.sha.substring(0, 8) }}</a>
+        </ng-template>
+        <ng-template appSignalListCell="author" let-row>
+          <app-github-commit-author [commit]="row"></app-github-commit-author>
+        </ng-template>
+      </app-signal-list>
+    </div>
+  }
 }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.ts
@@ -44,12 +44,33 @@ export class CommitListWrapperComponent {
 
   public readonly listConfig: WritableSignal<SignalListConfig<GitCommit> | undefined> = signal(undefined);
 
+  // Branch the commits are listed from — shown in the deploy-latest-HEAD note.
+  public readonly branchName: WritableSignal<string> = signal('');
+
+  // "Deploy the latest commit on the branch" — when on, no specific commit is
+  // pinned; the deploy sends an empty SHA and CF deploys whatever HEAD points
+  // at. Off (default) preserves the pick-a-commit behaviour.
+  public readonly useLatestHead: WritableSignal<boolean> = signal(false);
+  readonly useLatestHead$: Observable<boolean> = toObservable(this.useLatestHead);
+
   // The chosen commit (or null) — derived from the radio selection signal.
   // deploy-application-step2-1 subscribes to this to drive step validity and
   // seed the deploy payload.
   readonly selectedCommit$: Observable<GitCommit | null> = toObservable(
     computed(() => this.signalConfig.selectedCommit() ?? null)
   );
+
+  // Toggle handler for the deploy-latest-HEAD checkbox. Clears the radio
+  // selection while on (so a stale pin isn't carried) and restores the
+  // newest-commit default when toggled back off.
+  setUseLatestHead(value: boolean): void {
+    this.useLatestHead.set(value);
+    if (value) {
+      this.signalConfig.selectedKey.set(null);
+    } else {
+      this.signalConfig.selectFirst();
+    }
+  }
 
   constructor() {
     // Resolve the git source (project + branch) from the deploy wizard's
@@ -66,6 +87,7 @@ export class CommitListWrapperComponent {
       take(1),
     ).subscribe(fetchDetails => {
       const scm = this.scmService.getSCM(fetchDetails.scm, fetchDetails.endpointGuid, fetchDetails.accessToken);
+      this.branchName.set(fetchDetails.sha);
       this.signalConfig.initialize(scm, fetchDetails.projectName, fetchDetails.sha);
       this.listConfig.set(this.buildListConfig());
       // Auto-select the first (newest) commit once the list loads so the step

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/deploy-application-step2-1.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/deploy-application-step2-1.component.spec.ts
@@ -4,11 +4,14 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
 
+import { GitCommit } from '@stratosui/git';
+import { CfDeployAppDataService } from '../../../../services/domain-data/cf-deploy-app-data.service';
 import { DeployApplicationStep21Component } from './deploy-application-step2-1.component';
 
 describe('DeployApplicationStep21Component', () => {
   let component: DeployApplicationStep21Component;
   let fixture: ComponentFixture<DeployApplicationStep21Component>;
+  let deployData: { setDeployCommit: ReturnType<typeof vi.fn> };
 
   // Mock Store
   const mockStore = {
@@ -18,6 +21,7 @@ describe('DeployApplicationStep21Component', () => {
   };
 
   beforeEach(async () => {
+    deployData = { setDeployCommit: vi.fn() };
     await TestBed.configureTestingModule({
       imports: [
         DeployApplicationStep21Component,
@@ -25,6 +29,7 @@ describe('DeployApplicationStep21Component', () => {
       providers: [
         provideZonelessChangeDetection(),
         { provide: Store, useValue: mockStore },
+        { provide: CfDeployAppDataService, useValue: deployData },
       ]
     }).compileComponents();
 
@@ -35,5 +40,35 @@ describe('DeployApplicationStep21Component', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('deploy target: pin a commit vs deploy latest HEAD', () => {
+    const commit = { sha: 'abc123def456' } as GitCommit;
+
+    it('is valid when a specific commit is selected', () => {
+      expect(DeployApplicationStep21Component.isStepValid(false, commit)).toBe(true);
+    });
+
+    it('is valid when deploying latest HEAD with no commit pinned', () => {
+      expect(DeployApplicationStep21Component.isStepValid(true, null)).toBe(true);
+    });
+
+    it('is invalid when neither a commit is selected nor latest HEAD is chosen', () => {
+      expect(DeployApplicationStep21Component.isStepValid(false, null)).toBe(false);
+    });
+
+    it('onNext pins the selected commit SHA when not deploying latest HEAD', () => {
+      (component as unknown as { selectedCommitSubject: { next(c: GitCommit): void } }).selectedCommitSubject.next(commit);
+      component.onNext();
+      expect(deployData.setDeployCommit).toHaveBeenCalledWith('abc123def456');
+    });
+
+    it('onNext sends an empty commit (deploy latest HEAD) when that option is chosen', () => {
+      // Even with a commit still selected underneath, latest-HEAD wins and unpins.
+      (component as unknown as { selectedCommitSubject: { next(c: GitCommit): void } }).selectedCommitSubject.next(commit);
+      (component as unknown as { useLatestHeadSubject: { next(v: boolean): void } }).useLatestHeadSubject.next(true);
+      component.onNext();
+      expect(deployData.setDeployCommit).toHaveBeenCalledWith('');
+    });
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/deploy-application-step2-1.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/deploy-application-step2-1.component.ts
@@ -1,6 +1,6 @@
 
 import { Component, ComponentRef, ViewChild, ViewContainerRef, ChangeDetectionStrategy, inject } from '@angular/core';
-import { BehaviorSubject, Observable, of as observableOf, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
 
 import { StepOnNextFunction } from '@stratosui/core';
 import { GitCommit } from '@stratosui/git';
@@ -26,10 +26,17 @@ export class DeployApplicationStep21Component {
   // `validate`, which under OnPush + zoneless CD is not guaranteed to be
   // re-read after the parent has first bound it.
   private selectedCommitSubject = new BehaviorSubject<GitCommit | null>(null);
+  private useLatestHeadSubject = new BehaviorSubject<boolean>(false);
   private validateSubject = new BehaviorSubject<boolean>(false);
 
   readonly selectedCommit$: Observable<GitCommit | null> = this.selectedCommitSubject.asObservable();
   readonly validate: Observable<boolean> = this.validateSubject.asObservable();
+
+  // The step is valid when the user has picked a specific commit OR opted to
+  // deploy the latest commit on the branch (HEAD) without pinning one.
+  static isStepValid(useLatestHead: boolean, commit: GitCommit | null): boolean {
+    return useLatestHead || !!commit;
+  }
 
   @ViewChild('target', { read: ViewContainerRef, static: true })
   target!: ViewContainerRef;
@@ -41,6 +48,7 @@ export class DeployApplicationStep21Component {
     this.wrapperSub?.unsubscribe();
     this.wrapperSub = undefined;
     this.selectedCommitSubject.next(null);
+    this.useLatestHeadSubject.next(false);
     this.validateSubject.next(false);
     this.wrapperRef.destroy();
     this.target.clear();
@@ -51,16 +59,28 @@ export class DeployApplicationStep21Component {
     this.wrapperRef = this.target.createComponent(CommitListWrapperComponent);
     const wrapper = this.wrapperRef.instance as CommitListWrapperComponent;
     this.wrapperSub?.unsubscribe();
-    this.wrapperSub = wrapper.selectedCommit$.subscribe(commit => {
-      this.selectedCommitSubject.next(commit ?? null);
-      this.validateSubject.next(!!commit);
-    });
+    // Validity is driven by either a pinned commit OR the deploy-latest-HEAD
+    // toggle — combine both wrapper streams so the step settles correctly when
+    // the user flips the toggle on/off.
+    this.wrapperSub = combineLatest([wrapper.selectedCommit$, wrapper.useLatestHead$])
+      .subscribe(([commit, useLatestHead]) => {
+        this.selectedCommitSubject.next(commit ?? null);
+        this.useLatestHeadSubject.next(useLatestHead);
+        this.validateSubject.next(DeployApplicationStep21Component.isStepValid(useLatestHead, commit ?? null));
+      });
   };
 
   onNext: StepOnNextFunction = () => {
-    const commit = this.selectedCommitSubject.getValue();
-    if (commit) {
-      this.deployData.setDeployCommit(commit.sha);
+    // Latest-HEAD wins: send an empty commit so the backend deploys whatever
+    // the branch currently points at (it skips the `git reset` when Commit is
+    // empty). Otherwise pin the selected commit's SHA.
+    if (this.useLatestHeadSubject.getValue()) {
+      this.deployData.setDeployCommit('');
+    } else {
+      const commit = this.selectedCommitSubject.getValue();
+      if (commit) {
+        this.deployData.setDeployCommit(commit.sha);
+      }
     }
     return observableOf({ success: true });
   };

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -16,26 +16,70 @@
               <div>
                 @if (sourceType.group === 'gitscm') {
                   <div>
+                    @if (!isRedeploy) {
+                      <!-- Access mode: Public / Private / Enterprise. Each tab
+                           reveals only the fields that path needs, in the order
+                           they're required (auth gates the repo lookup). -->
+                      <div class="flex border-b border-content-border mb-4" role="tablist" aria-label="Repository access">
+                        <button type="button" role="tab" [attr.aria-selected]="gitMode === 'public'"
+                          class="px-4 py-2 text-sm border-b-2 -mb-px"
+                          [class.border-content-text]="gitMode === 'public'"
+                          [class.text-content-text]="gitMode === 'public'"
+                          [class.font-medium]="gitMode === 'public'"
+                          [class.border-transparent]="gitMode !== 'public'"
+                          [class.text-content-muted]="gitMode !== 'public'"
+                          (click)="setGitMode('public')">Public</button>
+                        <button type="button" role="tab" [attr.aria-selected]="gitMode === 'private'"
+                          class="px-4 py-2 text-sm border-b-2 -mb-px"
+                          [class.border-content-text]="gitMode === 'private'"
+                          [class.text-content-text]="gitMode === 'private'"
+                          [class.font-medium]="gitMode === 'private'"
+                          [class.border-transparent]="gitMode !== 'private'"
+                          [class.text-content-muted]="gitMode !== 'private'"
+                          (click)="setGitMode('private')">Private</button>
+                        <button type="button" role="tab" [attr.aria-selected]="gitMode === 'enterprise'"
+                          class="px-4 py-2 text-sm border-b-2 -mb-px"
+                          [class.border-content-text]="gitMode === 'enterprise'"
+                          [class.text-content-text]="gitMode === 'enterprise'"
+                          [class.font-medium]="gitMode === 'enterprise'"
+                          [class.border-transparent]="gitMode !== 'enterprise'"
+                          [class.text-content-muted]="gitMode !== 'enterprise'"
+                          (click)="setGitMode('enterprise')">{{ sourceType.id === DEPLOY_TYPES_IDS.GITLAB ? 'Self-hosted GitLab' : 'GitHub Enterprise' }}</button>
+                      </div>
+                    }
                     <div class="github-project-details">
                       <div>
+                        @if (gitMode === 'enterprise') {
+                          <div class="form-field">
+                            <label class="block text-sm text-content-muted mb-1" for="githubEnterpriseUrl">
+                              {{ sourceType.id === DEPLOY_TYPES_IDS.GITLAB ? 'GitLab base URL' : 'GitHub Enterprise URL' }} <span class="text-red-500">*</span>
+                            </label>
+                            <input id="githubEnterpriseUrl" type="text" class="input" [(ngModel)]="githubEnterpriseUrl"
+                              placeholder="https://github.mycorp.com" name="githubEnterpriseUrl"
+                              [disabled]="isRedeploy" required>
+                            @if (isInvalidGithubEnterpriseUrl) {
+                              <div class="text-red-500 text-sm mt-1">
+                                The base URL is not valid
+                              </div>
+                            }
+                          </div>
+                        }
+                        @if (gitMode !== 'public') {
+                          <div class="form-field">
+                            <label class="block text-sm text-content-muted mb-1" for="githubAccessToken">
+                              Access token <span class="text-red-500">*</span>
+                            </label>
+                            <input id="githubAccessToken" type="password" class="input" [(ngModel)]="accessToken"
+                              placeholder="Personal access token" name="githubAccessToken"
+                              autocomplete="off" spellcheck="false" [disabled]="isRedeploy" required>
+                          </div>
+                        }
                         <div class="form-field">
-                          <input type="text" class="input" [(ngModel)]="githubEnterpriseUrl"
-                            placeholder="GitHub Enterprise URL (optional)" name="githubEnterpriseUrl"
-                            [disabled]="isRedeploy">
-                          @if (isInvalidGithubEnterpriseUrl) {
-                            <div class="text-red-500 text-sm mt-1">
-                              GitHub Enterprise deployment URL is not valid
-                            </div>
-                          }
-                        </div>
-                        <div class="form-field">
-                          <input type="password" class="input" [(ngModel)]="accessToken"
-                            placeholder="GitHub Access Token (optional)" name="githubAccessToken"
-                            autocomplete="off" spellcheck="false" [disabled]="isRedeploy">
-                        </div>
-                        <div class="form-field">
-                          <input type="text" class="input" [disabled]="isRedeploy" [(ngModel)]="repository"
-                            placeholder="Project" name="projectName"
+                          <label class="block text-sm text-content-muted mb-1" for="projectName">
+                            Project <span class="text-red-500">*</span>
+                          </label>
+                          <input id="projectName" type="text" class="input" [disabled]="isRedeploy" [(ngModel)]="repository"
+                            placeholder="owner/repo" name="projectName"
                             [appGithubProjectExists]="sourceType.id + ',' + sourceType.endpointGuid + ',' + (accessToken || '')" required
                             list="repo-suggestions">
                           <!-- Repository suggestions datalist -->
@@ -76,53 +120,58 @@
                         </div>
                       </div>
                     }
-                  </div>
-                  <div class="form-field">
-                    <select class="input"
-                      [disabled]="isRedeploy || !repository || !sourceSelectionForm.controls.projectName.valid"
-                      [(ngModel)]="repositoryBranch" name="repositoryBranch"
-                      (change)="updateBranchName($event.target.value)" required>
-                      <option value="" disabled>Branch</option>
-                      @for (branch of repositoryBranches$ | async; track branch) {
-                        <option [value]="branch">
-                          {{ branch.name }}
-                        </option>
-                      }
-                    </select>
-                  </div>
-                  @if (isRedeploy && commitInfo) {
-                    <div
-                      class="deploy-step2-form__project-info-group deploy-step2-form__commit">
-                      <div>
-                        <img src="{{commitInfo.author.avatar_url}}" alt="">
-                      </div>
-                      <div src="description">
-                        <div>
-                          <a href="{{commitInfo.html_url}}" target="_blank">{{commitInfo.sha | limitTo:8}}</a>
-                        </div>
-                        <div>
-                          {{commitInfo.commit.message}}
-                        </div>
-                        <div class="author-info">
-                          <div>
-                            {{commitInfo.commit.author.name}}
-                          </div>
-                          <div>
-                            {{commitInfo.commit.author.date | date: 'medium'}}
-                          </div>
-                        </div>
-                      </div>
                     </div>
-                  }
-                </div>
-              }
+                    <div class="form-field">
+                      <label class="block text-sm text-content-muted mb-1" for="repositoryBranch">
+                        Branch <span class="text-red-500">*</span>
+                      </label>
+                      <select id="repositoryBranch" class="input"
+                        [disabled]="isRedeploy || !repository || !sourceSelectionForm.controls.projectName.valid"
+                        [(ngModel)]="repositoryBranch" name="repositoryBranch"
+                        (change)="updateBranchName($event.target.value)" required>
+                        <option value="" disabled>Select a branch</option>
+                        @for (branch of repositoryBranches$ | async; track branch) {
+                          <option [value]="branch">
+                            {{ branch.name }}
+                          </option>
+                        }
+                      </select>
+                    </div>
+                    @if (isRedeploy && commitInfo) {
+                      <div
+                        class="deploy-step2-form__project-info-group deploy-step2-form__commit">
+                        <div>
+                          <img src="{{commitInfo.author.avatar_url}}" alt="">
+                        </div>
+                        <div src="description">
+                          <div>
+                            <a href="{{commitInfo.html_url}}" target="_blank">{{commitInfo.sha | limitTo:8}}</a>
+                          </div>
+                          <div>
+                            {{commitInfo.commit.message}}
+                          </div>
+                          <div class="author-info">
+                            <div>
+                              {{commitInfo.commit.author.name}}
+                            </div>
+                            <div>
+                              {{commitInfo.commit.author.date | date: 'medium'}}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    }
+                  </div>
+                }
               @if (sourceType.id === DEPLOY_TYPES_IDS.GIT_URL) {
                 <div>
                   <div class="form-field">
-                    <input class="input" [disabled]="isRedeploy" [(ngModel)]="gitUrl" placeholder="Git URL" name="gitUrl" required>
+                    <label class="block text-sm text-content-muted mb-1" for="gitUrl">Git URL <span class="text-red-500">*</span></label>
+                    <input id="gitUrl" class="input" [disabled]="isRedeploy" [(ngModel)]="gitUrl" placeholder="https://github.com/owner/repo.git" name="gitUrl" required>
                   </div>
                   <div class="form-field">
-                    <input class="input" [(ngModel)]="gitUrlBranchName" placeholder="Branch or Tag" name="urlBranchName" required>
+                    <label class="block text-sm text-content-muted mb-1" for="urlBranchName">Branch or tag <span class="text-red-500">*</span></label>
+                    <input id="urlBranchName" class="input" [(ngModel)]="gitUrlBranchName" placeholder="main" name="urlBranchName" required>
                   </div>
                 </div>
               }
@@ -131,7 +180,8 @@
           @if (sourceType.id === DEPLOY_TYPES_IDS.DOCKER_IMG) {
             <div>
               <div class="form-field">
-                <input class="input" [disabled]="isRedeploy" [(ngModel)]="dockerAppName" placeholder="Application Name"
+                <label class="block text-sm text-content-muted mb-1" for="dockerAppName">Application name <span class="text-red-500">*</span></label>
+                <input id="dockerAppName" class="input" [disabled]="isRedeploy" [(ngModel)]="dockerAppName" placeholder="my-app"
                   name="dockerAppName" required>
                 @if (sourceSelectionForm.controls.dockerAppName?.errors?.required) {
                   <div class="text-red-500 text-sm mt-1">
@@ -140,7 +190,8 @@
                 }
               </div>
               <div class="form-field">
-                <input class="input" [disabled]="isRedeploy" [(ngModel)]="dockerImg" placeholder="Docker Image" name="dockerImg"
+                <label class="block text-sm text-content-muted mb-1" for="dockerImg">Docker image <span class="text-red-500">*</span></label>
+                <input id="dockerImg" class="input" [disabled]="isRedeploy" [(ngModel)]="dockerImg" placeholder="repo/image:tag" name="dockerImg"
                   required>
                 @if (sourceSelectionForm.controls.dockerImg?.errors?.required) {
                   <div class="text-red-500 text-sm mt-1">
@@ -154,7 +205,8 @@
                 }
               </div>
               <div class="form-field">
-                <input class="input" [(ngModel)]="dockerUsername" placeholder="Docker Username" name="dockerUsername">
+                <label class="block text-sm text-content-muted mb-1" for="dockerUsername">Docker username <span class="text-content-muted">(optional)</span></label>
+                <input id="dockerUsername" class="input" [(ngModel)]="dockerUsername" placeholder="Docker username" name="dockerUsername">
                 <p class="mt-1 text-sm text-content-muted">Docker Username works with the Application's `CF_DOCKER_PASSWORD` environment variable</p>
               </div>
             </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
@@ -137,6 +137,78 @@ describe('DeployApplicationStep2Component', () => {
       expect(scmSpy.clearAccessToken).not.toHaveBeenCalled();
     });
 
+  });
+
+  describe('git access mode (Public / Private / Enterprise tabs)', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(DeployApplicationStep2Component);
+      component = fixture.componentInstance;
+    });
+
+    it('derives Enterprise when a base URL is present', () => {
+      expect(DeployApplicationStep2Component.deriveGitMode('https://github.corp.com', 'tok')).toBe('enterprise');
+      // URL alone (token still to be entered) is still Enterprise.
+      expect(DeployApplicationStep2Component.deriveGitMode('https://github.corp.com', '')).toBe('enterprise');
+    });
+
+    it('derives Private when a token is present but no base URL', () => {
+      expect(DeployApplicationStep2Component.deriveGitMode('', 'tok')).toBe('private');
+      expect(DeployApplicationStep2Component.deriveGitMode(undefined, 'tok')).toBe('private');
+    });
+
+    it('derives Public when neither a base URL nor a token is present', () => {
+      expect(DeployApplicationStep2Component.deriveGitMode('', '')).toBe('public');
+      expect(DeployApplicationStep2Component.deriveGitMode(undefined, undefined)).toBe('public');
+    });
+
+    it('switching to Public clears both the base URL and the token', () => {
+      component.githubEnterpriseUrl = 'https://github.corp.com';
+      component.accessToken = 'tok';
+      component.setGitMode('public');
+      expect(component.gitMode).toBe('public');
+      expect(component.githubEnterpriseUrl).toBe('');
+      expect(component.accessToken).toBe('');
+    });
+
+    it('switching to Private clears the base URL but keeps the token', () => {
+      component.githubEnterpriseUrl = 'https://github.corp.com';
+      component.accessToken = 'tok';
+      component.setGitMode('private');
+      expect(component.gitMode).toBe('private');
+      expect(component.githubEnterpriseUrl).toBe('');
+      expect(component.accessToken).toBe('tok');
+    });
+
+    it('switching to Enterprise keeps both the base URL and the token', () => {
+      component.githubEnterpriseUrl = 'https://github.corp.com';
+      component.accessToken = 'tok';
+      component.setGitMode('enterprise');
+      expect(component.gitMode).toBe('enterprise');
+      expect(component.githubEnterpriseUrl).toBe('https://github.corp.com');
+      expect(component.accessToken).toBe('tok');
+    });
+  });
+
+  describe('applyGithubEnterpriseAndToken — form wiring', () => {
+    let scmSpy: {
+      setPublicApi: ReturnType<typeof vi.fn>;
+      setAccessToken: ReturnType<typeof vi.fn>;
+      clearAccessToken: ReturnType<typeof vi.fn>;
+      getType: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(DeployApplicationStep2Component);
+      component = fixture.componentInstance;
+      scmSpy = {
+        setPublicApi: vi.fn(),
+        setAccessToken: vi.fn(),
+        clearAccessToken: vi.fn(),
+        getType: vi.fn().mockReturnValue('github'),
+      };
+      component.scm = scmSpy as unknown as GitHubSCM;
+    });
+
     it('wires applyGithubEnterpriseAndToken to the sourceSelectionForm valueChanges stream', () => {
       // Mock the NgForm ViewChild with a Subject so we can emit form values
       // without standing up the full template-driven reactive form. Also mock

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -51,6 +51,12 @@ import { DeployApplicationFsComponent } from './deploy-application-fs/deploy-app
 
 
 
+// Access mode for the gitscm (GitHub / GitLab) source sub-form.
+//  public     — public host repo, no auth
+//  private    — host private repo, access token only (no base URL)
+//  enterprise — custom base URL (GitHub Enterprise / self-hosted GitLab) + token
+export type GitAccessMode = 'public' | 'private' | 'enterprise';
+
 @Component({
 selector: 'app-deploy-application-step2',
   templateUrl: './deploy-application-step2.component.html',
@@ -122,6 +128,13 @@ export class DeployApplicationStep2Component
   isInvalidGithubEnterpriseUrl = false;
   githubEnterpriseUrl: string;
   accessToken: string;
+
+  // Active git access mode for the gitscm sub-form, driven by the
+  // Public / Private / Enterprise tab strip. Held as local component state —
+  // the store still sees only githubEnterpriseUrl + accessToken. Switching
+  // tabs clears the fields that don't belong to the new mode so a stale base
+  // URL / token is never carried into the deploy.
+  gitMode: GitAccessMode = 'public';
   // --------------
 
   // Git URL
@@ -254,6 +267,8 @@ export class DeployApplicationStep2Component
 
   /* Git ------------------*/
   private setupForGit() {
+    // Land the tab strip on the mode that matches any restored auth values.
+    this.gitMode = DeployApplicationStep2Component.deriveGitMode(this.githubEnterpriseUrl, this.accessToken);
     this.projectInfo$ = this.projectExists$.pipe(
       filter(p => !!p),
       map(p => (!!p.exists && !!p.data) ? p.data : null),
@@ -415,5 +430,33 @@ export class DeployApplicationStep2Component
     this.deployData.setDeployBranch(branch.name);
   }
 
+  // Infer the opening access mode from restored values (redeploy / nav back),
+  // so the tab strip lands on the mode that matches what's already set. A base
+  // URL implies Enterprise even before its token is entered; a token alone
+  // (no URL) implies a Private host repo; neither implies Public.
+  static deriveGitMode(enterpriseUrl: string | undefined, accessToken: string | undefined): GitAccessMode {
+    if (enterpriseUrl) {
+      return 'enterprise';
+    }
+    if (accessToken) {
+      return 'private';
+    }
+    return 'public';
+  }
+
+  // Tab handler: switch the active access mode and clear the now-irrelevant
+  // auth fields (Public → drop URL + token; Private → drop URL, keep token;
+  // Enterprise → keep both), then re-sync the SCM so a cleared token/URL stops
+  // being applied to subsequent repo/branch lookups.
+  setGitMode(mode: GitAccessMode): void {
+    this.gitMode = mode;
+    if (mode === 'public') {
+      this.githubEnterpriseUrl = '';
+      this.accessToken = '';
+    } else if (mode === 'private') {
+      this.githubEnterpriseUrl = '';
+    }
+    this.applyGithubEnterpriseAndToken(this.githubEnterpriseUrl, this.accessToken);
+  }
 
 }

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CloudFoundryApplicationsSignalComponent as Cmp } from './cloud-foundry-applications-signal.component';
+import { CurrentUserPermissionsService, TabNavService } from '@stratosui/core';
+import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
+import { generateCfBaseTestModulesNoShared } from '@test-framework/cloud-foundry-endpoint-service.helper';
+
+import {
+  CloudFoundryApplicationsSignalComponent,
+  CloudFoundryApplicationsSignalComponent as Cmp,
+} from './cloud-foundry-applications-signal.component';
+import { CfAppsSignalConfigService } from '../../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
+import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import type { StApp } from '../../../../services/endpoint-data/stratos-types';
 
 // The per-CF Applications tab shows an Org/Space compound column — the
@@ -81,5 +95,106 @@ describe('CloudFoundryApplicationsSignalComponent.compoundOrgSpace', () => {
     const segs = Cmp.compoundOrgSpace(
       app({ orgGuid: undefined, spaceGuid: 'space-1', spaceName: 's' }), EMPTY, EMPTY);
     expect(segs[1].link).toBeUndefined();
+  });
+});
+
+// The per-CF Applications tab keeps its OWN lazy org/space catalog (rather
+// than the shared EndpointDataService the other per-CF tabs read), so its
+// toolbar dropdowns only populate once ensureNamesLoaded() runs. These cover
+// the component wiring that triggers that fetch on first dropdown open.
+function makeStubAppsConfig() {
+  const allOption = { label: 'All', value: null };
+  const view = {
+    pagedItems: signal([]).asReadonly(),
+    totalFilteredResults: signal(0).asReadonly(),
+    totalPages: signal(1).asReadonly(),
+    totalItems: signal(0).asReadonly(),
+  };
+  const orchestrator = {
+    isAnyLoading: signal(false).asReadonly(),
+    errorsByCnsi: signal(new Map<string, unknown>()).asReadonly(),
+  };
+  return {
+    initialize: vi.fn(),
+    clearLockedSpace: vi.fn(),
+    ensureNamesLoaded: vi.fn().mockResolvedValue(undefined),
+    loadAll: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    deleteApp: vi.fn().mockResolvedValue(undefined),
+    startStatsPolling: vi.fn(),
+    clearFilters: vi.fn(),
+    registerSortExtractor: vi.fn(),
+    registerFilterExtractor: vi.fn(),
+    appStats: signal(new Map<string, { running: number; total: number }>()),
+    filter: signal(() => true),
+    sort: signal({ field: 'name' as const, direction: 'asc' as const }),
+    pageSize: signal(6),
+    pageIndex: signal(0),
+    view,
+    orchestrator,
+    selectedCnsi: signal<string | null>(null),
+    selectedOrg: signal<string | null>(null),
+    selectedSpace: signal<string | null>(null),
+    nameFilter: signal(''),
+    filterField: signal('name'),
+    viewMode: signal<'card' | 'table'>('card'),
+    orgOptions: signal([allOption]).asReadonly(),
+    spaceOptions: signal([allOption]).asReadonly(),
+    isLoadingOrgs: signal(false).asReadonly(),
+    isLoadingSpaces: signal(false).asReadonly(),
+    orgNames: signal(new Map<string, string>()).asReadonly(),
+    spaceNames: signal(new Map<string, string>()).asReadonly(),
+  };
+}
+
+describe('CloudFoundryApplicationsSignalComponent (component)', () => {
+  let component: CloudFoundryApplicationsSignalComponent;
+  let fixture: ComponentFixture<CloudFoundryApplicationsSignalComponent>;
+  let stubAppsConfig: ReturnType<typeof makeStubAppsConfig>;
+
+  beforeEach(async () => {
+    stubAppsConfig = makeStubAppsConfig();
+    const stubEndpointService = { cfGuid: 'cnsi-1' } as any;
+    await TestBed.configureTestingModule({
+      imports: [CloudFoundryApplicationsSignalComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideHttpClient(),
+        ...STORE_TEST_PROVIDERS,
+        importProvidersFrom(generateCfBaseTestModulesNoShared()),
+        TabNavService,
+        { provide: CfAppsSignalConfigService, useValue: stubAppsConfig },
+        { provide: CloudFoundryEndpointService, useValue: stubEndpointService },
+        { provide: CurrentUserPermissionsService, useValue: { can: () => of(true) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CloudFoundryApplicationsSignalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('builds Org/Space filter dropdowns with no locked Cloud Foundry dropdown', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+    expect(cfg!.filterDropdowns!.map(d => d.label)).toEqual(['Organization', 'Space']);
+    expect(cfg!.filterDropdowns![0].selected).toBe(stubAppsConfig.selectedOrg);
+    expect(cfg!.filterDropdowns![1].selected).toBe(stubAppsConfig.selectedSpace);
+  });
+
+  it('lazily loads this CF’s org/space catalog when a dropdown is first opened', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    // Catalog is NOT fetched on mount — only on first dropdown interaction.
+    expect(stubAppsConfig.ensureNamesLoaded).not.toHaveBeenCalled();
+    for (const d of cfg!.filterDropdowns!) {
+      expect(d.onOpen).toBeTypeOf('function');
+      d.onOpen!();
+    }
+    // Both dropdowns share one handler scoped to the route's single CNSI;
+    // the service-side promise dedupes repeated opens to one fanout.
+    expect(stubAppsConfig.ensureNamesLoaded).toHaveBeenCalledWith(['cnsi-1']);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -108,18 +108,29 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
     // dropdown — the CF is already named in the breadcrumb, and a disabled
     // control only adds clutter. Show just the interactive Org/Space filters.
     this.appsConfig.selectedCnsi.set(cfGuid);
+    // First open of either Org/Space dropdown lazily fetches this CF's
+    // org+space catalog. Unlike the other per-CF tabs (which read the shared
+    // EndpointDataService the parent CF page already hydrates), the apps
+    // config keeps its OWN lazy catalog so the multi-CF app wall doesn't
+    // saturate the network on mount — see CfAppsSignalConfigService.loadNames.
+    // That catalog is gated behind ensureNamesLoaded(); without this onOpen
+    // hook the dropdowns never populate beyond "All". Scope the fetch to the
+    // single CNSI in view (tighter than the wall's all-endpoints default).
+    const onDropdownOpen = () => { void this.appsConfig.ensureNamesLoaded([cfGuid]); };
     const dropdowns: SignalListDropdown[] = [
       {
         label: 'Organization',
         options: this.appsConfig.orgOptions,
         selected: this.appsConfig.selectedOrg,
         loading: this.appsConfig.isLoadingOrgs,
+        onOpen: onDropdownOpen,
       },
       {
         label: 'Space',
         options: this.appsConfig.spaceOptions,
         selected: this.appsConfig.selectedSpace,
         loading: this.appsConfig.isLoadingSpaces,
+        onOpen: onDropdownOpen,
       },
     ];
 

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -267,6 +267,54 @@ describe('CfAppsSignalConfigService', () => {
     expect(svc.spaceOptions().map(o => o.label)).toContain('e2e');
   });
 
+  it('disambiguates same-named spaces across orgs as "<space> - <org>" when no org is selected', async () => {
+    // space_1 exists in both org_a and org_b. With Org = All a bare-name
+    // list would render two identical "space_1" rows, so the dropdown must
+    // append the org name to tell them apart (parity with the Routes /
+    // Services / Users tabs). Selecting an org fixes the scope, so the
+    // label collapses back to the bare space name.
+    const httpMock = {
+      get: vi.fn((url: string) => {
+        if (url.startsWith('/pp/v1/cf/orgs/cnsi-1')) {
+          return of({
+            resources: [
+              { guid: 'org-a', name: 'org_a', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+              { guid: 'org-b', name: 'org_b', status: 'active', labels: {}, annotations: {}, createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+            ],
+          });
+        }
+        if (url.startsWith('/pp/v1/cf/spaces/cnsi-1')) {
+          return of({
+            resources: [
+              { guid: 'space-1a', name: 'space_1', orgGuid: 'org-a', createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+              { guid: 'space-1b', name: 'space_1', orgGuid: 'org-b', createdAt: '', updatedAt: '', cnsiGuid: 'cnsi-1' },
+            ],
+          });
+        }
+        return of({
+          resources: [],
+          pagination: { totalResults: 0, totalPages: 1, next: null, previous: null, first: { href: '' }, last: { href: '' } },
+        });
+      }),
+    } as unknown as HttpClient;
+    const cf = makeStubCfService([{ guid: 'cnsi-1', name: 'Primary CF' }]);
+    const svc = makeSvc(httpMock, cf);
+    svc.selectedCnsi.set('cnsi-1');
+    svc.initialize(['cnsi-1']);
+    // Await the catalog drain directly (orgs + priority spaces chunk) rather
+    // than counting microtasks.
+    await svc.ensureNamesLoaded(['cnsi-1']);
+    TestBed.tick();
+
+    // Org = All → disambiguated, sorted by space name then org name.
+    expect(svc.spaceOptions().map(o => o.label)).toEqual(['All', 'space_1 - org_a', 'space_1 - org_b']);
+
+    // Org selected → bare space name (the org is already fixed).
+    svc.selectedOrg.set('org-a');
+    TestBed.tick();
+    expect(svc.spaceOptions().map(o => o.label)).toEqual(['All', 'space_1']);
+  });
+
   it('preserves a valid selection across navigation (re-initialize)', async () => {
     // Regression: the singleton service's _hasLoadedOnce was latching true
     // forever after the first load. On re-navigation, a fresh initialize()

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -249,21 +249,49 @@ export class CfAppsSignalConfigService {
     // Space options are scoped to the selected CF and, when set, the
     // selected org. StSpace carries orgGuid so we can filter from the
     // catalog without needing an app to exist in the space.
+    //
+    // - Org selected: the org is fixed, so the bare space name is
+    //   unambiguous. Label = space name, natural sort.
+    // - Org = All: spaces from different orgs commonly share a name
+    //   (space_1 in org_1, space_1 in org_2, …). A bare-name list would
+    //   render a wall of identical "space_1" entries, so disambiguate each
+    //   as "<space> - <org>" (mirrors the Routes/Services/Users tabs),
+    //   sorted by space name then org name. Falls back to the bare name
+    //   when the org name isn't resolved yet (catalog still draining).
     this.spaceOptions = computed(() => {
       const cnsi = this.selectedCnsi();
       const org = this.selectedOrg();
       const byCnsi = this._spacesByCnsi();
-      const seen = new Map<string, string>();
       const sources = cnsi ? [byCnsi.get(cnsi) ?? []] : Array.from(byCnsi.values());
+      // Dedup by guid, retaining the org guid so the All-orgs branch can
+      // append the org name.
+      const seen = new Map<string, { name: string; orgGuid: string }>();
       for (const spaces of sources) {
         for (const s of spaces) {
           if (org && s.orgGuid !== org) continue;
-          if (!seen.has(s.guid)) seen.set(s.guid, s.name);
+          if (!seen.has(s.guid)) seen.set(s.guid, { name: s.name, orgGuid: s.orgGuid });
         }
       }
       const opts: SignalListDropdownOption[] = [{ label: 'All', value: null }];
-      const sorted = Array.from(seen.entries()).sort(([, a], [, b]) => naturalCompare(a, b));
-      for (const [guid, label] of sorted) opts.push({ label, value: guid });
+      if (org) {
+        const sorted = Array.from(seen.entries()).sort(([, a], [, b]) => naturalCompare(a.name, b.name));
+        for (const [guid, s] of sorted) opts.push({ label: s.name, value: guid });
+        return opts;
+      }
+      const orgNames = this.orgNames();
+      const augmented = Array.from(seen.entries()).map(([guid, s]) => ({
+        guid,
+        spaceName: s.name,
+        orgName: orgNames.get(s.orgGuid) ?? '',
+      }));
+      augmented.sort((a, b) => {
+        const bySpace = naturalCompare(a.spaceName, b.spaceName);
+        if (bySpace !== 0) return bySpace;
+        return naturalCompare(a.orgName, b.orgName);
+      });
+      for (const s of augmented) {
+        opts.push({ label: s.orgName ? `${s.spaceName} - ${s.orgName}` : s.spaceName, value: s.guid });
+      }
       return opts;
     });
 

--- a/src/jetstream/plugins/cloudfoundry/native_apps_stats.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_stats.go
@@ -69,23 +69,27 @@ func (c *CloudFoundrySpecification) getAppStats(ctx echo.Context) error {
 	}
 
 	reqCtx := ctx.Request().Context()
-	cfClient, err := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID)
-	if err != nil {
-		return err
-	}
-
-	procGUID, lookupErr := lookupWebProcessGUID(reqCtx, cfClient, appGUID)
-	if lookupErr != nil {
-		return handleCapiError(ctx, lookupErr)
-	}
-
-	stats, statsErr := cfClient.Processes().GetStats(reqCtx, procGUID)
-	if statsErr != nil {
-		return handleCapiError(ctx, statsErr)
+	// Wrap the lookup + stats pair so a 401 at the token-expiry boundary
+	// rebuilds the client (refreshing the token) and replays both calls once,
+	// instead of surfacing a 401 to the polling app-detail page every ~20min.
+	resp, opErr := callWithCapiRetry(reqCtx, c.nativeProxy(), cnsiGUID, userGUID,
+		func(cfClient capi.Client) (StAppStatsResponse, error) {
+			procGUID, lookupErr := lookupWebProcessGUID(reqCtx, cfClient, appGUID)
+			if lookupErr != nil {
+				return StAppStatsResponse{}, lookupErr
+			}
+			stats, statsErr := cfClient.Processes().GetStats(reqCtx, procGUID)
+			if statsErr != nil {
+				return StAppStatsResponse{}, statsErr
+			}
+			return buildStatsResponse(stats), nil
+		})
+	if opErr != nil {
+		return handleCapiError(ctx, opErr)
 	}
 
 	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
-	return ctx.JSON(http.StatusOK, buildStatsResponse(stats))
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 // StAppStatsBatchResponse is the Stratos-shape JSON returned from the
@@ -136,40 +140,47 @@ func (c *CloudFoundrySpecification) getAppStatsBatch(ctx echo.Context) error {
 	}
 
 	reqCtx := ctx.Request().Context()
-	cfClient, err := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID)
-	if err != nil {
-		return err
-	}
-
-	processes, lookupErr := fetchWebProcessesForApps(ctx, cfClient, appGUIDs)
-	if lookupErr != nil {
-		return handleCapiError(ctx, lookupErr)
-	}
-
-	out := StAppStatsBatchResponse{Apps: make(map[string]StAppStatsResponse, len(appGUIDs))}
-	var mu sync.Mutex
-	eg, egCtx := errgroup.WithContext(reqCtx)
-	eg.SetLimit(maxParallelStatsCalls)
-	for _, appGUID := range appGUIDs {
-		proc, ok := processes[appGUID]
-		if !ok || proc.GUID == "" {
-			continue
-		}
-		ag, pg := appGUID, proc.GUID
-		eg.Go(func() error {
-			stats, statsErr := cfClient.Processes().GetStats(egCtx, pg)
-			if statsErr != nil {
-				// Per-app failure: skip rather than fail the batch.
-				return nil
+	// Wrap the web-process lookup + stats fan-out so a 401 at the token-expiry
+	// boundary rebuilds the client (refreshing the token) and replays once.
+	// The retry triggers on the gating fetchWebProcessesForApps call — the
+	// first CAPI request, which catches an expired token before the fan-out
+	// runs — so the rebuilt client carries the fresh token into the fan-out.
+	out, opErr := callWithCapiRetry(reqCtx, c.nativeProxy(), cnsiGUID, userGUID,
+		func(cfClient capi.Client) (StAppStatsBatchResponse, error) {
+			processes, lookupErr := fetchWebProcessesForApps(ctx, cfClient, appGUIDs)
+			if lookupErr != nil {
+				return StAppStatsBatchResponse{}, lookupErr
 			}
-			resp := buildStatsResponse(stats)
-			mu.Lock()
-			out.Apps[ag] = resp
-			mu.Unlock()
-			return nil
+
+			res := StAppStatsBatchResponse{Apps: make(map[string]StAppStatsResponse, len(appGUIDs))}
+			var mu sync.Mutex
+			eg, egCtx := errgroup.WithContext(reqCtx)
+			eg.SetLimit(maxParallelStatsCalls)
+			for _, appGUID := range appGUIDs {
+				proc, ok := processes[appGUID]
+				if !ok || proc.GUID == "" {
+					continue
+				}
+				ag, pg := appGUID, proc.GUID
+				eg.Go(func() error {
+					stats, statsErr := cfClient.Processes().GetStats(egCtx, pg)
+					if statsErr != nil {
+						// Per-app failure: skip rather than fail the batch.
+						return nil
+					}
+					resp := buildStatsResponse(stats)
+					mu.Lock()
+					res.Apps[ag] = resp
+					mu.Unlock()
+					return nil
+				})
+			}
+			_ = eg.Wait()
+			return res, nil
 		})
+	if opErr != nil {
+		return handleCapiError(ctx, opErr)
 	}
-	_ = eg.Wait()
 
 	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
 	return ctx.JSON(http.StatusOK, out)

--- a/src/jetstream/plugins/cloudfoundry/native_apps_stats_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_stats_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
@@ -12,6 +13,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Process list carrying the app relationship the batch handler needs to key
+// each web process back to its app GUID (the single-app lookup doesn't).
+const stubProcessListWithAppRelJSON = `{
+	"pagination":{"total_results":1,"total_pages":1},
+	"resources":[{"guid":"proc-1","type":"web","instances":2,"relationships":{"app":{"data":{"guid":"app-1"}}}}]
+}`
+
+// 401 body shaped like a CF auth-token rejection.
+const stubUnauthorizedJSON = `{"errors":[{"code":1000,"title":"CF-InvalidAuthToken","detail":"Invalid Auth Token"}]}`
 
 const stubProcessListJSON = `{
 	"pagination":{"total_results":1,"total_pages":1},
@@ -97,4 +108,109 @@ func TestGetAppStats_FullShapePreservesUsageQuotasUptime(t *testing.T) {
 	r1 := resp.Instances[1]
 	assert.Equal(t, "CRASHED", r1.State)
 	assert.Nil(t, r1.Usage)
+}
+
+// A poll that fires just before the ~20-minute CF token expires reaches CF
+// after the token has lapsed and is 401'd. getAppStats must rebuild the client
+// (refreshing the token) and replay the stats call once, returning 200 instead
+// of bubbling the 401 to the app-detail page every token cycle.
+func TestGetAppStats_RetriesOnceOn401(t *testing.T) {
+	var statsCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case "/v3/processes":
+			_, _ = w.Write([]byte(stubProcessListJSON))
+		case "/v3/processes/proc-1/stats":
+			if atomic.AddInt32(&statsCalls, 1) == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(stubUnauthorizedJSON))
+				return
+			}
+			_, _ = w.Write([]byte(stubProcessStatsJSON))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/app-stats/cnsi-1/app-1", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid", "appGuid")
+	ctx.SetParamValues("cnsi-1", "app-1")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getAppStats(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// Exactly one replay — the 401 path retries once, no more.
+	assert.Equal(t, int32(2), atomic.LoadInt32(&statsCalls))
+
+	var resp StAppStatsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Instances, 2)
+}
+
+// The batched endpoint retries on a 401 from its gating web-process lookup —
+// the first CAPI call, which catches the expired token before the stats
+// fan-out runs — then replays the whole operation with a refreshed client.
+func TestGetAppStatsBatch_RetriesOnceOn401(t *testing.T) {
+	var listCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case "/v3/processes":
+			if atomic.AddInt32(&listCalls, 1) == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(stubUnauthorizedJSON))
+				return
+			}
+			_, _ = w.Write([]byte(stubProcessListWithAppRelJSON))
+		case "/v3/processes/proc-1/stats":
+			_, _ = w.Write([]byte(stubProcessStatsJSON))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/app-stats/cnsi-1?app_guids=app-1", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("cnsi-1")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getAppStatsBatch(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&listCalls))
+
+	var resp StAppStatsBatchResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Contains(t, resp.Apps, "app-1")
+	require.Len(t, resp.Apps["app-1"].Instances, 2)
 }

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -110,6 +110,37 @@ func newCapiClient(ctx context.Context, proxy nativeCFProxy, cnsiGUID, userGUID 
 	return client, nil
 }
 
+// callWithCapiRetry builds an authenticated capi client and runs op against it.
+// If op fails with a 401, it rebuilds the client once and replays op a single
+// time. This is the reactive companion to newCapiClient's proactive expiry
+// refresh: a token that is still valid when the client is built can be rejected
+// by CF anyway — the per-CF token has a ~20-minute life and a poll that fires in
+// the last moments before expiry travels to CF (≈700ms RTT) and is 401'd by the
+// time CF validates it. By retry time the stored token has genuinely expired, so
+// the rebuild's newCapiClient proactively refreshes it and the replay succeeds.
+// Without this, a long-lived read poll (app-stats, summary, env) 401s every
+// token cycle. Mirrors the inline pattern in native_audit_events_reads.go;
+// generic so any native read/write handler can wrap its CAPI call(s).
+func callWithCapiRetry[T any](
+	reqCtx context.Context,
+	proxy nativeCFProxy,
+	cnsiGUID, userGUID string,
+	op func(capi.Client) (T, error),
+) (T, error) {
+	var zero T
+	client, err := newCapiClient(reqCtx, proxy, cnsiGUID, userGUID)
+	if err != nil {
+		return zero, err
+	}
+	res, opErr := op(client)
+	if opErr != nil && statusFromCapiError(opErr) == http.StatusUnauthorized {
+		if rc, rerr := newCapiClient(reqCtx, proxy, cnsiGUID, userGUID); rerr == nil {
+			res, opErr = op(rc)
+		}
+	}
+	return res, opErr
+}
+
 // normaliseStringMap ensures nil maps are returned as empty maps (not null in JSON).
 func normaliseStringMap(m map[string]string) map[string]string {
 	if m == nil {


### PR DESCRIPTION
A batch of Applications-area improvements found while working the deploy-from-Git flow and the per-CF tabs. Five focused commits:

### 1. `feat(cf-apps): populate the per-CF Org/Space filter dropdowns`
The per-CF Applications tab's Org/Space dropdowns only ever showed "All" — unlike the other per-CF tabs (Routes/Services/Users) which read the shared `EndpointDataService`, the apps config keeps its own lazy catalog that's gated behind an `onOpen` hook the tab never wired. Add the hook (scoped to the route's CNSI). Audited the sibling tabs — Apps was the only gap.

### 2. `feat(cf-apps): disambiguate same-named spaces in the filter dropdown`
With Org = All, the Space dropdown listed every space by bare name, so a CF with `space_1` in N orgs showed N identical rows. Label each `"<space> - <org>"` when no org is selected (matching Routes/Services/Users); bare name once an org is picked. Applies to the per-CF tab and the global app wall.

### 3. `fix(cf): retry app-stats reads once on a token-boundary 401`
The app-detail stats poll 401s once per ~20-min token cycle: a poll firing just before expiry is rejected by CF by the time it validates, and the proactive refresh can't catch a token that was valid at build time. Add `callWithCapiRetry` — a reusable helper that rebuilds the client and replays once on a 401 (by retry time the token has genuinely expired, so the rebuild refreshes it). Both app-stats handlers route through it.

### 4. `feat(deploy): tabbed access modes on the GitHub/GitLab source step`
The source step crammed an optional Enterprise URL + token ahead of the required Project/Branch, with no labels and no sign that the "optional" auth gates the repo lookup. Replace it with **Public / Private / Enterprise** tabs that reveal only each path's fields in dependency order, with labels + required markers; provider-aware third-tab label (GitHub Enterprise / Self-hosted GitLab). Presentation only — no backend/store change. Also labels the Git URL + Docker source types.

### 5. `feat(deploy): allow deploying the latest commit without pinning a SHA`
The commit step always pinned a specific SHA. Add a "Deploy the latest commit on {branch} (don't pin a commit)" checkbox that sends an empty commit so CF deploys whatever HEAD points at (the backend already skips the reset when the commit is empty).

Addresses two items of #5400 (source-step UX, deploy-latest-HEAD) plus follow-ups to the per-CF tab work.

## Testing
- Unit tests added for each behavioural change (cf-apps space labels & dropdown wiring; Go retry tests; gitMode derivation/clearing; commit step validity & pin-vs-HEAD).
- Full `make check gate` green across all five commits (backend + frontend + prod AOT build).
- Live-verified: per-CF dropdowns populate with disambiguated space labels; the source step's three tabs render correctly and still resolve a real repo + branches. (The deploy-latest-HEAD toggle is unit + AOT verified; full wizard drive to the commit step pending.)