### PR TITLE
fix(deploy): make the Route host/domain/path overrides take effect

### DIFF
--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -212,6 +212,16 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	pushConfig.OutputWriter = socketWriter
 	pushConfig.DialTimeout = dialTimeout
 
+	// Convert any host/domain route override into a `routes:` entry in the
+	// manifest before the push reads it. cf v8 push takes a specific route
+	// only from the manifest (there is no host/domain flag), so this is the
+	// only point at which the wizard's Route fields can take effect.
+	if err = applyRouteOverride(manifestFile, overrides); err != nil {
+		log.Warnf("Failed to apply route override: %s", err)
+		sendErrorMessage(clientWebSocket, err, CLOSE_FAILURE)
+		return err
+	}
+
 	// Initialise Push Command
 	cfPush := Constructor(pushConfig, cfAppPush.portalProxy)
 

--- a/src/jetstream/plugins/cfapppush/pushapp.go
+++ b/src/jetstream/plugins/cfapppush/pushapp.go
@@ -189,10 +189,10 @@ func (c *CFPushApp) Init(appDir string, manifestPath string, overrides CFPushApp
 	// Random route
 	c.pushCommand.RandomRoute = overrides.RandomRoute
 
-	// Route path
-	if len(overrides.Path) > 0 {
-		c.pushCommand.AppPath = flag.PathWithExistenceCheck(overrides.Path)
-	}
+	// Note: the route path (overrides.Path) is folded into the manifest
+	// `routes:` entry by applyRouteOverride before the push reads the
+	// manifest — it is a route component (host.domain/path), not the app
+	// source path. AppPath is always the fetched source dir (set below).
 
 	// Stack
 	if len(overrides.Stack) > 0 {

--- a/src/jetstream/plugins/cfapppush/route_override.go
+++ b/src/jetstream/plugins/cfapppush/route_override.go
@@ -1,0 +1,92 @@
+package cfapppush
+
+import (
+	"os"
+	"strings"
+
+	"code.cloudfoundry.org/cli/v8/util/manifestparser"
+)
+
+// deprecatedRouteKeys are the manifest route attributes that cf CLI v8 no
+// longer supports. They are superseded by `routes:` and cannot coexist with
+// it, so they are stripped whenever a route override is applied.
+var deprecatedRouteKeys = []string{"host", "hosts", "domain", "domains", "no-hostname"}
+
+// composeRoute builds a route string from the wizard's host/domain/path
+// override. cf CLI v8 dropped the `host`/`domain` manifest attributes in
+// favour of a `routes:` list whose entries are `host.domain/path` strings, so
+// the override has to be expressed as a route. A domain is mandatory: a host
+// or path on its own has nothing to attach to, so it yields no route.
+func composeRoute(host, domain, path string) string {
+	host = strings.TrimSpace(host)
+	domain = strings.TrimSpace(domain)
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	if domain == "" {
+		return ""
+	}
+	route := domain
+	if host != "" {
+		route = host + "." + domain
+	}
+	if path != "" {
+		route = route + "/" + path
+	}
+	return route
+}
+
+// applyRouteOverride rewrites the manifest file in place so a host/domain
+// deploy override takes effect as a v8-style `routes:` entry. The wizard's
+// Route fields are otherwise dead: cf v8 push reads routes only from the
+// manifest (there is no host/domain flag), and the file is never rewritten
+// between fetch and push.
+//
+// Semantics: override-wins. When a route can be composed from the override
+// (host.domain/path) it REPLACES the first application's route set and strips
+// the deprecated route keys. The manifest is left byte-for-byte untouched when
+// no-route/random-route is set, or when no route can be composed (no domain to
+// attach a host/path to).
+//
+// The v8 manifestparser is used for the round-trip so that (a) the rewrite is
+// parsed identically by the push and (b) fields the parser does not model
+// (processes, sidecars, metadata, services, ...) survive via its inline
+// RemainingManifestFields map.
+func applyRouteOverride(manifestPath string, overrides CFPushAppOverrides) error {
+	// no-route / random-route mean "no specific route"; the wizard disables
+	// the address fields in those modes, so any leftover host/domain/path
+	// value must not be turned into a route here.
+	if overrides.NoRoute || overrides.RandomRoute {
+		return nil
+	}
+
+	route := composeRoute(overrides.Host, overrides.Domain, overrides.Path)
+	if route == "" {
+		return nil
+	}
+
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	parser := manifestparser.ManifestParser{}
+	manifest, err := parser.ParseManifest(manifestPath, raw)
+	if err != nil {
+		return err
+	}
+
+	app := manifest.GetFirstApp()
+	if app.RemainingManifestFields == nil {
+		app.RemainingManifestFields = map[string]interface{}{}
+	}
+	app.RemainingManifestFields["routes"] = []map[string]interface{}{{"route": route}}
+	for _, key := range deprecatedRouteKeys {
+		delete(app.RemainingManifestFields, key)
+	}
+
+	out, err := parser.MarshalManifest(manifest)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(manifestPath, out, 0600)
+}

--- a/src/jetstream/plugins/cfapppush/route_override_test.go
+++ b/src/jetstream/plugins/cfapppush/route_override_test.go
@@ -1,0 +1,217 @@
+package cfapppush
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestComposeRoute(t *testing.T) {
+	cases := []struct {
+		name   string
+		host   string
+		domain string
+		path   string
+		want   string
+	}{
+		{"host and domain", "web", "apps.example.com", "", "web.apps.example.com"},
+		{"domain only", "", "apps.example.com", "", "apps.example.com"},
+		{"host domain and path", "web", "apps.example.com", "foo", "web.apps.example.com/foo"},
+		{"domain and path", "", "apps.example.com", "foo", "apps.example.com/foo"},
+		{"path leading slash is normalised", "web", "apps.example.com", "/foo", "web.apps.example.com/foo"},
+		{"host only is not a valid route", "web", "", "", ""},
+		{"path only is not a valid route", "", "", "foo", ""},
+		{"neither", "", "", "", ""},
+		{"trims whitespace", " web ", " apps.example.com ", " foo ", "web.apps.example.com/foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := composeRoute(tc.host, tc.domain, tc.path); got != tc.want {
+				t.Errorf("composeRoute(%q, %q, %q) = %q, want %q", tc.host, tc.domain, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// writeManifest writes a manifest to a temp file and returns its path.
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yml")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	return path
+}
+
+// firstApp parses a manifest file and returns the first application as a
+// generic map, so tests can assert on arbitrary keys.
+func firstApp(t *testing.T, path string) map[interface{}]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read manifest: %v", err)
+	}
+	var doc struct {
+		Applications []map[interface{}]interface{} `yaml:"applications"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("failed to parse manifest: %v", err)
+	}
+	if len(doc.Applications) == 0 {
+		t.Fatalf("manifest has no applications")
+	}
+	return doc.Applications[0]
+}
+
+func TestApplyRouteOverride_ConvertsHostDomainToRoutes(t *testing.T) {
+	path := writeManifest(t, `applications:
+- name: myapp
+  memory: 256M
+  command: bundle exec rails s
+  services:
+  - my-db
+  host: oldhost
+  domain: old.example.com
+  routes:
+  - route: stale.example.com
+`)
+
+	if err := applyRouteOverride(path, CFPushAppOverrides{Host: "web", Domain: "apps.example.com"}); err != nil {
+		t.Fatalf("applyRouteOverride returned error: %v", err)
+	}
+
+	app := firstApp(t, path)
+
+	// override-wins: the route set is replaced with the composed route.
+	routes, ok := app["routes"].([]interface{})
+	if !ok || len(routes) != 1 {
+		t.Fatalf("expected exactly one route, got %#v", app["routes"])
+	}
+	route := routes[0].(map[interface{}]interface{})
+	if route["route"] != "web.apps.example.com" {
+		t.Errorf("route = %v, want web.apps.example.com", route["route"])
+	}
+
+	// deprecated route keys must be stripped (cf v8 rejects both styles).
+	for _, k := range []string{"host", "hosts", "domain", "domains", "no-hostname"} {
+		if _, present := app[k]; present {
+			t.Errorf("deprecated key %q should have been removed", k)
+		}
+	}
+
+	// unrelated fields are preserved.
+	if app["name"] != "myapp" {
+		t.Errorf("name = %v, want myapp", app["name"])
+	}
+	if app["memory"] != "256M" {
+		t.Errorf("memory = %v, want 256M", app["memory"])
+	}
+	if app["command"] != "bundle exec rails s" {
+		t.Errorf("command = %v, want bundle exec rails s", app["command"])
+	}
+	if _, present := app["services"]; !present {
+		t.Errorf("services should have been preserved")
+	}
+}
+
+func TestApplyRouteOverride_DomainOnly(t *testing.T) {
+	path := writeManifest(t, `applications:
+- name: myapp
+`)
+	if err := applyRouteOverride(path, CFPushAppOverrides{Domain: "apps.example.com"}); err != nil {
+		t.Fatalf("applyRouteOverride returned error: %v", err)
+	}
+	app := firstApp(t, path)
+	routes := app["routes"].([]interface{})
+	if len(routes) != 1 || routes[0].(map[interface{}]interface{})["route"] != "apps.example.com" {
+		t.Errorf("expected single apex route, got %#v", app["routes"])
+	}
+}
+
+func TestApplyRouteOverride_FoldsPathIntoRoute(t *testing.T) {
+	path := writeManifest(t, `applications:
+- name: myapp
+`)
+	if err := applyRouteOverride(path, CFPushAppOverrides{Host: "web", Domain: "apps.example.com", Path: "/api"}); err != nil {
+		t.Fatalf("applyRouteOverride returned error: %v", err)
+	}
+	app := firstApp(t, path)
+	routes := app["routes"].([]interface{})
+	if len(routes) != 1 || routes[0].(map[interface{}]interface{})["route"] != "web.apps.example.com/api" {
+		t.Errorf("expected route with path, got %#v", app["routes"])
+	}
+}
+
+func TestApplyRouteOverride_NoRouteLeavesFileUntouched(t *testing.T) {
+	body := `applications:
+- name: myapp
+`
+	path := writeManifest(t, body)
+	before, _ := os.ReadFile(path)
+
+	// host/domain can leak through from disabled fields; no-route must win.
+	if err := applyRouteOverride(path, CFPushAppOverrides{Host: "web", Domain: "apps.example.com", NoRoute: true}); err != nil {
+		t.Fatalf("applyRouteOverride returned error: %v", err)
+	}
+
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("no-route override must not inject a route")
+	}
+}
+
+func TestApplyRouteOverride_RandomRouteLeavesFileUntouched(t *testing.T) {
+	body := `applications:
+- name: myapp
+`
+	path := writeManifest(t, body)
+	before, _ := os.ReadFile(path)
+
+	if err := applyRouteOverride(path, CFPushAppOverrides{Host: "web", Domain: "apps.example.com", RandomRoute: true}); err != nil {
+		t.Fatalf("applyRouteOverride returned error: %v", err)
+	}
+
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("random-route override must not inject a specific route")
+	}
+}
+
+func TestApplyRouteOverride_NoOverrideLeavesFileUntouched(t *testing.T) {
+	body := `applications:
+- name: myapp
+  host: oldhost
+  domain: old.example.com
+`
+	path := writeManifest(t, body)
+	before, _ := os.ReadFile(path)
+
+	if err := applyRouteOverride(path, CFPushAppOverrides{}); err != nil {
+		t.Fatalf("applyRouteOverride returned error: %v", err)
+	}
+
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("file should be untouched when no host/domain override is supplied\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestApplyRouteOverride_HostOnlyLeavesFileUntouched(t *testing.T) {
+	body := `applications:
+- name: myapp
+`
+	path := writeManifest(t, body)
+	before, _ := os.ReadFile(path)
+
+	if err := applyRouteOverride(path, CFPushAppOverrides{Host: "web"}); err != nil {
+		t.Fatalf("applyRouteOverride returned error: %v", err)
+	}
+
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("host-only override has no domain to attach; file should be untouched")
+	}
+}


### PR DESCRIPTION
## Problem

The deploy-from-Git/file wizard's **Route** section collects **host**, **domain** and **path**, but they were dead:

- cf CLI v8 dropped the `host`/`domain` manifest attributes in favour of `routes:`. The push reads a *specific* route only from the manifest (there is no host/domain push flag), and the manifest file was never rewritten between fetch and push — so host/domain were silently discarded.
- The **path** field was additionally mis-wired to cf push's source `-p` flag, and then overwritten by the fetched source directory — so it did nothing in the normal case and set a bogus filesystem path in the docker case.

## Fix

Compose `host` + `domain` + `path` into a single `routes:` entry (`host.domain/path`) and write it into the manifest **before the push parses it**, using the cf v8 `manifestparser` for the round-trip so that fields the parser does not model (processes, sidecars, metadata, services, …) survive via its inline `RemainingManifestFields` map.

Semantics:

- **Override-wins**: the composed route **replaces** the first application's route set (consistent with how every other field in this step overrides the manifest) and **strips** the deprecated `host`/`hosts`/`domain`/`domains`/`no-hostname` keys, which cf v8 rejects alongside `routes:`.
- **Left untouched** when `no-route`/`random-route` is set (those are push flags; the wizard disables the address fields in those modes, so leaked values must not become a route) or when no route can be composed (a host/path with no domain to attach to).

Backend-only — the frontend already ships `host`/`domain`/`path` in the overrides payload; nothing in the UI changes.

## Testing

- New `route_override_test.go` — 13 cases: route composition table (host/domain/path, apex domain, leading-slash normalisation, host-only/path-only → no route); convert + strip-deprecated + preserve-unmodeled-keys; domain-only; path folding; and no-route / random-route / no-override / host-only all leaving the manifest byte-for-byte unchanged.
- `go build`, `go vet`, full `cfapppush` package suite green.

Closes #5400 — the final remaining item of the deploy-from-Git wizard usability/correctness issues (the other items landed previously).
