### PR TITLE
fix(home): restore favorite/recent display-name auto-refresh (signal-native)

### DIFF
--- a/src/frontend/packages/core/src/app.module.ts
+++ b/src/frontend/packages/core/src/app.module.ts
@@ -220,10 +220,11 @@ export class AppModule {
     // Init Auth Types and Endpoint Types provided by extensions
     // Once the CF modules become an extension point, these should be moved to a CF specific module
 
-    // NOTE: The favorites/recents name-refresh that used to subscribe to the
-    // ngrx `requestData` store (via getAPIRequestDataState) has been removed
-    // with the request/pagination store engine. That refresh is already-broken
-    // lost functionality being restored signal-natively in a follow-up PR.
+    // The favorites/recents display-name refresh (formerly a debounced
+    // subscription to the ngrx `requestData` store) is now signal-native and
+    // lives in the cards themselves: FreshEntityNameService resolves the fresh
+    // name and FavoritesMetaCardComponent / RecentEntitiesComponent persist
+    // corrections via UserFavoritesDataService.updateMetadata / recents.set.
 
     // Configure navigation behavior - hide CF-specific menu items when no CF endpoints are connected
     customizationService.set({

--- a/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.spec.ts
+++ b/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal, WritableSignal } from '@angular/core';
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { EndpointModel } from '@stratosui/store';
+
+import { EndpointsSignalService } from './endpoints-signal.service';
+import { EndpointDataRegistry } from '../../../../cloud-foundry/src/services/endpoint-data/endpoint-data.registry';
+import { FreshEntityNameService } from './fresh-entity-name.service';
+
+// Minimal per-endpoint data stub: only the three list signals the resolver reads.
+function makeEndpointDataStub() {
+  const apps: WritableSignal<{ guid: string; name: string }[]> = signal([]);
+  const orgs: WritableSignal<{ guid: string; name: string }[]> = signal([]);
+  const spaces: WritableSignal<{ guid: string; name: string }[]> = signal([]);
+  return { apps, orgs, spaces };
+}
+
+describe('FreshEntityNameService', () => {
+  let endpointData: ReturnType<typeof makeEndpointDataStub>;
+  let registryStub: { peek: (guid: string) => unknown };
+  let endpointsSig: WritableSignal<Record<string, EndpointModel>>;
+  let service: FreshEntityNameService;
+
+  beforeEach(() => {
+    endpointData = makeEndpointDataStub();
+    registryStub = { peek: (guid: string) => (guid === 'ep1' ? endpointData : undefined) };
+    endpointsSig = signal<Record<string, EndpointModel>>({});
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: EndpointDataRegistry, useValue: registryStub },
+        { provide: EndpointsSignalService, useValue: { endpoints: endpointsSig } },
+        FreshEntityNameService,
+      ],
+    });
+    service = TestBed.inject(FreshEntityNameService);
+  });
+
+  it('returns null when the endpoint has not been loaded (peek miss)', () => {
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'application', endpointId: 'nope', entityId: 'a1' })).toBeNull();
+  });
+
+  it('resolves a fresh application name by guid', () => {
+    endpointData.apps.set([{ guid: 'a1', name: 'fresh app' }]);
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'application', endpointId: 'ep1', entityId: 'a1' })).toBe('fresh app');
+  });
+
+  it('resolves org and space names by guid', () => {
+    endpointData.orgs.set([{ guid: 'o1', name: 'fresh org' }]);
+    endpointData.spaces.set([{ guid: 's1', name: 'fresh space' }]);
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'organization', endpointId: 'ep1', entityId: 'o1' })).toBe('fresh org');
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'space', endpointId: 'ep1', entityId: 's1' })).toBe('fresh space');
+  });
+
+  it('returns null when the entity is absent from the fresh list (deleted)', () => {
+    endpointData.apps.set([{ guid: 'other', name: 'x' }]);
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'application', endpointId: 'ep1', entityId: 'a1' })).toBeNull();
+  });
+
+  it('resolves a fresh endpoint name from the endpoints signal', () => {
+    endpointsSig.set({ ep1: { guid: 'ep1', name: 'fresh endpoint' } as unknown as EndpointModel });
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'endpoint', endpointId: 'ep1', entityId: null })).toBe('fresh endpoint');
+  });
+
+  it('returns null for an unknown endpoint favorite', () => {
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'endpoint', endpointId: 'ghost', entityId: null })).toBeNull();
+  });
+
+  it('returns null for an unsupported entity type', () => {
+    expect(service.freshNameFor({ endpointType: 'cf', entityType: 'route', endpointId: 'ep1', entityId: 'r1' })).toBeNull();
+  });
+});

--- a/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.ts
+++ b/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.ts
@@ -1,0 +1,68 @@
+import { Injectable, inject } from '@angular/core';
+import { EndpointModel, endpointEntityType } from '@stratosui/store';
+
+import { EndpointDataRegistry } from '../../../../cloud-foundry/src/services/endpoint-data/endpoint-data.registry';
+import { EndpointsSignalService } from './endpoints-signal.service';
+
+// CF entity-type keys. Inlined as string literals (NOT imported from the
+// cloud-foundry package) to keep this the only spot that reaches into CF, and
+// to avoid widening the static type-dependency surface. These are stable wire
+// keys (see cloud-foundry/src/cf-entity-types.ts).
+const CF_APPLICATION = 'application';
+const CF_ORGANIZATION = 'organization';
+const CF_SPACE = 'space';
+
+/** The (endpoint, type, id) coordinates a favorite or recent carries. */
+export interface EntityNameRef {
+  endpointType: string;
+  entityType: string;
+  endpointId: string;
+  entityId?: string | null;
+}
+
+/**
+ * Signal-native replacement for the deleted ngrx `requestData` name-sync: given
+ * a favorited/recent entity's coordinates, return its freshly-fetched display
+ * name, or null when no fresh data is available (source not loaded, entity
+ * deleted, or endpoint disconnected).
+ *
+ * Reads signals only — call it inside a `computed()`/`effect()` to get
+ * reactivity. This is the single (precedented) core->cloud-foundry reader; it
+ * uses `EndpointDataRegistry.peek()` so it never creates or triggers a load.
+ */
+@Injectable({ providedIn: 'root' })
+export class FreshEntityNameService {
+  private registry = inject(EndpointDataRegistry);
+  private endpointsSignals = inject(EndpointsSignalService);
+
+  freshNameFor(ref: EntityNameRef): string | null {
+    if (!ref) {
+      return null;
+    }
+    // Endpoint favorites (any endpointType) resolve from the endpoints signal;
+    // app/org/space (CF-only entity-type keys) resolve from the CF registry.
+    if (ref.entityType === endpointEntityType) {
+      const endpoint: EndpointModel | undefined = this.endpointsSignals.endpoints()[ref.endpointId];
+      return endpoint?.name ?? null;
+    }
+    const svc = this.registry.peek(ref.endpointId);
+    if (!svc) {
+      return null;
+    }
+    const list =
+      ref.entityType === CF_APPLICATION ? svc.apps() :
+      ref.entityType === CF_ORGANIZATION ? svc.orgs() :
+      ref.entityType === CF_SPACE ? svc.spaces() :
+      null;
+    if (!list) {
+      return null;
+    }
+    // Non-endpoint favorites always carry an entity guid; a null id can never
+    // match a real entity, so bail explicitly rather than scanning the list.
+    if (ref.entityId == null) {
+      return null;
+    }
+    const match = list.find(entity => entity.guid === ref.entityId);
+    return match?.name ?? null;
+  }
+}

--- a/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.ts
+++ b/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.ts
@@ -47,6 +47,12 @@ export class FreshEntityNameService {
     }
     const svc = this.registry.peek(ref.endpointId);
     if (!svc) {
+      // Intentionally non-reactive: a peek-miss reads no signal, so a caller's
+      // computed/effect won't re-run purely because this endpoint's data later
+      // arrives — it re-resolves on its own trigger (favorite identity / recents
+      // state change). Do NOT read a signal here to "fix" that; it would couple
+      // every card to the registry's internal map. This is the accepted
+      // "refresh where endpoint data is loaded" boundary.
       return null;
     }
     const list =

--- a/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.html
+++ b/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.html
@@ -16,7 +16,7 @@
         }
       </div>
       <div class="flex-1 min-w-0">
-        <div class="text-sm font-medium fav-card__name truncate">{{ name }}</div>
+        <div class="text-sm font-medium fav-card__name truncate">{{ displayName() }}</div>
         <div class="text-xs fav-card__type mt-1 truncate">{{ favoriteType }}</div>
       </div>
       @if (!valid) {

--- a/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.spec.ts
+++ b/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.spec.ts
@@ -1,21 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { IFavoriteMetadata, UserFavorite, UserFavoritesDataService } from '@stratosui/store';
 import { BaseTestModulesNoShared, STORE_TEST_PROVIDERS } from "@test-framework/core-test.helper";
 import { ConfirmationDialogService } from '../../../../shared/components/confirmation-dialog.service';
 import { SessionService } from '../../../../shared/services/session.service';
+import { FreshEntityNameService } from '../../../../core/signals/fresh-entity-name.service';
 import { FavoritesMetaCardComponent } from './favorites-meta-card.component';
+
+// A favorite-shaped stub: only the fields/methods the card setter + effect use.
+function makeFavoriteStub(name: string): UserFavorite<IFavoriteMetadata> {
+  return {
+    guid: 'app1', endpointId: 'ep1', endpointType: 'cf', entityType: 'application', entityId: 'app1',
+    metadata: { name },
+    getPrettyTypeName: () => 'Application',
+    getIcon: () => ({} as any),
+    getLink: () => '/cf/ep1/applications/app1',
+  } as unknown as UserFavorite<IFavoriteMetadata>;
+}
 
 describe('FavoritesMetaCardComponent', () => {
   let component: FavoritesMetaCardComponent;
   let fixture: ComponentFixture<FavoritesMetaCardComponent>;
+  let freshName: string | null;
 
   beforeEach(() => {
+    freshName = null;
     TestBed.configureTestingModule({
       providers: [
         ...(STORE_TEST_PROVIDERS || []),
         ConfirmationDialogService,
         SessionService,
+        { provide: FreshEntityNameService, useValue: { freshNameFor: () => freshName } },
         provideZonelessChangeDetection(),
       ],
       imports: [
@@ -23,16 +39,59 @@ describe('FavoritesMetaCardComponent', () => {
         FavoritesMetaCardComponent,
       ],
     });
-      TestBed.compileComponents();
-  });
-
-  beforeEach(() => {
+    TestBed.compileComponents();
     fixture = TestBed.createComponent(FavoritesMetaCardComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('shows the stored name when no fresh name is available', () => {
+    freshName = null;
+    component.favoriteEntity = makeFavoriteStub('stored name');
+    fixture.detectChanges();
+    expect(component.displayName()).toBe('stored name');
+  });
+
+  it('shows the fresh name when one is available', () => {
+    freshName = 'fresh name';
+    component.favoriteEntity = makeFavoriteStub('stored name');
+    fixture.detectChanges();
+    expect(component.displayName()).toBe('fresh name');
+  });
+
+  it('persists the corrected name once when fresh diverges from stored', () => {
+    const favData = TestBed.inject(UserFavoritesDataService);
+    const spy = vi.spyOn(favData, 'updateMetadata').mockImplementation(() => undefined);
+    freshName = 'renamed app';
+    component.favoriteEntity = makeFavoriteStub('old app');
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].metadata.name).toBe('renamed app');
+  });
+
+  it('does not persist when fresh equals stored', () => {
+    const favData = TestBed.inject(UserFavoritesDataService);
+    const spy = vi.spyOn(favData, 'updateMetadata').mockImplementation(() => undefined);
+    freshName = 'same name';
+    component.favoriteEntity = makeFavoriteStub('same name');
+    fixture.detectChanges();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not persist (and does not throw) when the favorite is malformed', () => {
+    const favData = TestBed.inject(UserFavoritesDataService);
+    const spy = vi.spyOn(favData, 'updateMetadata').mockImplementation(() => undefined);
+    freshName = 'renamed app';
+    // Missing entityType -> userFavoriteManager.getUserFavoriteFromObject returns null.
+    const malformed = {
+      guid: 'x', endpointId: 'ep1', endpointType: 'cf', entityId: 'x', metadata: { name: 'old' },
+      getPrettyTypeName: () => 'App', getIcon: () => ({} as any), getLink: () => '/x',
+    } as unknown as UserFavorite<IFavoriteMetadata>;
+    expect(() => { component.favoriteEntity = malformed; fixture.detectChanges(); }).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.ts
@@ -1,12 +1,13 @@
 
 import { NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Injector, Input, inject, runInInjectionContext } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, Input, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { take, defaultIfEmpty } from 'rxjs/operators';
-import { entityCatalog, FavoriteIconData, IFavoriteMetadata, UserFavorite, UserFavoriteManager } from '@stratosui/store';
+import { entityCatalog, FavoriteIconData, IFavoriteMetadata, UserFavorite, UserFavoriteManager, UserFavoritesDataService } from '@stratosui/store';
 
 import { EntityFavoriteStarComponent } from '../../../../core/entity-favorite-star/entity-favorite-star.component';
+import { FreshEntityNameService } from '../../../../core/signals/fresh-entity-name.service';
 import { ConfirmationDialogConfig } from '../../../../shared/components/confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../../shared/components/confirmation-dialog.service';
 
@@ -25,6 +26,8 @@ export class FavoritesMetaCardComponent {
   private router = inject(Router);
   private confirmDialog = inject(ConfirmationDialogService);
   private userFavoriteManager = inject(UserFavoriteManager);
+  private favoritesData = inject(UserFavoritesDataService);
+  private freshNames = inject(FreshEntityNameService);
   private injector = inject(Injector);
 
 
@@ -36,14 +39,52 @@ export class FavoritesMetaCardComponent {
   // Type of favorite - e.g. 'Application'
   public favoriteType: string;
 
-  // Favorite name
-  public name!: string;
-
   public routerLink!: string;
 
   public icon: FavoriteIconData;
 
   public valid = true;
+
+  // Reactive favorite, so the rendered name tracks freshly-fetched entity data.
+  private readonly favoriteSig = signal<UserFavorite<IFavoriteMetadata> | null>(null);
+
+  // The name to render: the freshly-fetched entity name when available, else
+  // the stored favorite metadata name (signal-native replacement for the old
+  // static `this.name = favorite.metadata.name`).
+  readonly displayName = computed(() => {
+    const fav = this.favoriteSig();
+    if (!fav) {
+      return '';
+    }
+    return this.freshNames.freshNameFor(fav) ?? fav.metadata.name;
+  });
+
+  // Last name persisted, so a refresh round-trip doesn't fire duplicate POSTs.
+  private lastPersisted: string | null = null;
+
+  constructor() {
+    // Persist a corrected name back to the favorites store when the fresh
+    // entity name diverges from the stored one (signal-native replacement for
+    // the deleted ngrx `syncFavorite`). The guard self-settles: updateMetadata
+    // updates the favorites signal, the parent re-passes the favorite, and the
+    // next run sees fresh === stored.
+    effect(() => {
+      const fav = this.favoriteSig();
+      if (!fav) {
+        return;
+      }
+      const fresh = this.freshNames.freshNameFor(fav);
+      if (fresh && fresh !== fav.metadata.name && fresh !== this.lastPersisted) {
+        const updated = this.userFavoriteManager.getUserFavoriteFromObject(fav);
+        if (!updated) {
+          return;
+        }
+        this.lastPersisted = fresh;
+        updated.metadata = { ...updated.metadata, name: fresh };
+        this.favoritesData.updateMetadata(updated);
+      }
+    });
+  }
 
   @Input()
   set favoriteEntity(favoriteEntity: UserFavorite<IFavoriteMetadata>) {
@@ -51,8 +92,9 @@ export class FavoritesMetaCardComponent {
       this.favorite = favoriteEntity;
       this.favoriteType = this.favorite.getPrettyTypeName();
       this.icon = this.favorite.getIcon();
-      this.name = this.favorite.metadata.name;
       this.routerLink = this.favorite.getLink();
+      this.lastPersisted = null;
+      this.favoriteSig.set(favoriteEntity);
     }
   }
 

--- a/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.spec.ts
@@ -1,21 +1,29 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { RouterTestingModule } from '@angular/router/testing';
+import { RecentlyVisitedDataService } from '@stratosui/store';
 import { createBasicStoreModule } from "@test-framework/core-test.helper";
 
 import { CoreTestingModule } from "@test-framework/core-test.modules";
 import { CoreModule } from '../../../core/core.module';
+import { FreshEntityNameService } from '../../../core/signals/fresh-entity-name.service';
 import { RecentEntitiesComponent } from './recent-entities.component';
 
 describe('RecentEntitiesComponent', () => {
   let component: RecentEntitiesComponent;
   let fixture: ComponentFixture<RecentEntitiesComponent>;
+  let freshName: string | null;
+  let recents: RecentlyVisitedDataService;
 
   beforeEach(() => {
+    freshName = null;
     TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: FreshEntityNameService, useValue: { freshNameFor: () => freshName } },
+      ],
       imports: [
         RouterTestingModule,
         CoreModule,
@@ -24,16 +32,34 @@ describe('RecentEntitiesComponent', () => {
         createBasicStoreModule(),
       ]
     });
-      TestBed.compileComponents();
-  });
-
-  beforeEach(() => {
+    TestBed.compileComponents();
+    recents = TestBed.inject(RecentlyVisitedDataService);
     fixture = TestBed.createComponent(RecentEntitiesComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('writes back the fresh name when a recent has been renamed', () => {
+    recents.add({
+      guid: 'app1', date: 1, entityType: 'application', endpointType: 'cf', entityId: 'app1',
+      name: 'old app', routerLink: '/x', prettyType: 'Application', endpointId: 'ep1', metadata: { name: 'old app' },
+    } as any);
+    freshName = 'renamed app';
+    fixture.detectChanges();
+    expect(recents.state()['app1'].name).toBe('renamed app');
+  });
+
+  it('leaves the stored name when no fresh name is available', () => {
+    recents.add({
+      guid: 'app1', date: 1, entityType: 'application', endpointType: 'cf', entityId: 'app1',
+      name: 'old app', routerLink: '/x', prettyType: 'Application', endpointId: 'ep1', metadata: { name: 'old app' },
+    } as any);
+    freshName = null;
+    fixture.detectChanges();
+    expect(recents.state()['app1'].name).toBe('old app');
   });
 });

--- a/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.ts
+++ b/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, effect, inject, ChangeDetectionStrategy } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
@@ -14,6 +14,7 @@ import { Observable, of as observableOf } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { EndpointsSignalService } from '../../../core/signals/endpoints-signal.service';
+import { FreshEntityNameService } from '../../../core/signals/fresh-entity-name.service';
 import { NoContentMessageComponent } from '../no-content-message/no-content-message.component';
 
 class RenderableRecent {
@@ -62,6 +63,11 @@ class RenderableRecent {
 export class RecentEntitiesComponent {
   private recents = inject(RecentlyVisitedDataService);
   private endpointsSignals = inject(EndpointsSignalService);
+  private freshNames = inject(FreshEntityNameService);
+
+  // Names already written back, keyed by recent guid — prevents the
+  // write-back effect from re-emitting the same correction.
+  private lastPersisted = new Map<string, string>();
 
   @Input()
   public history = false;
@@ -90,6 +96,25 @@ export class RecentEntitiesComponent {
     this.hasHits$ = this.recentEntities$.pipe(
       map(recentEntities => recentEntities && recentEntities.length > 0)
     );
+
+    // Signal-native name refresh (replaces the deleted ngrx requestData sync):
+    // when a recent's freshly-fetched entity name diverges from the stored one,
+    // write it back through the recents store. The update flows through state$
+    // to the rendered list, so no render-path change is needed. The guard +
+    // lastPersisted map make this converge after a single write per rename.
+    effect(() => {
+      const state = this.recents.state();
+      Object.values(state).forEach((recent: IRecentlyVisitedEntity) => {
+        if (!recent) {
+          return;
+        }
+        const fresh = this.freshNames.freshNameFor(recent);
+        if (fresh && fresh !== recent.name && this.lastPersisted.get(recent.guid) !== fresh) {
+          this.lastPersisted.set(recent.guid, fresh);
+          this.recents.set({ ...recent, name: fresh });
+        }
+      });
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
Restores the favorite/recent display-name auto-refresh that was lost when the ngrx `requestData` engine was removed — renaming an app/org/space/endpoint in CF now updates its favorite and recent cards again, signal-natively.

- **New `FreshEntityNameService`** (core) resolves a favorite/recent's freshly-fetched name from the per-endpoint signal stores: `EndpointDataService.apps()/orgs()/spaces()` via `EndpointDataRegistry.peek()` (CF entities) and `EndpointsSignalService.endpoints()` (endpoints). Returns null when no fresh data is loaded.
- **`favorites-meta-card`** renders `freshName ?? storedName` and persists a corrected name via `UserFavoritesDataService.updateMetadata` on a delta.
- **`recent-entities`** writes corrected names back through `RecentlyVisitedDataService.set`; the display updates via the existing state pipeline.
- Signal-native: no central driver (the old pattern that broke), no new store. Uses the side-effect-free `peek()`, so names refresh wherever the endpoint's data has been loaded (e.g. the home page); elsewhere the last-known name is shown.

Scope is the full favoritable/recent set — applications, organizations, spaces, and endpoints.

## Test Plan
- [x] Unit tests (vitest): `FreshEntityNameService` (7), `favorites-meta-card` (6), `recent-entities` (3); full `core` project 648 pass.
- [x] `make check gate` green (lint + production build + all frontend/backend suites).
- [ ] Manual: favorite an app/org/space, rename it in CF, reload Home → favorite + recents show the new name; hard-reload → name persists.