### PR TITLE
fix(home): resolve favourite names and guard null metadata

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
@@ -218,6 +218,16 @@ function isValidByExistenceProbe(url: string): Observable<boolean> {
   );
 }
 
+// Favourite builders receive the entity in either the V2 APIResource shape
+// ({ entity, metadata }) or the signal-native Stratos shape ({ guid, name }).
+// Read tolerantly (typed `any` — the input is genuinely heterogeneous) so a
+// favourite created from a V3 page still captures name + guid, rather than
+// persisting null metadata and rendering as a bare guid.
+const favName = (e: any): string | undefined => e?.entity?.name ?? e?.name;
+const favGuid = (e: any): string | undefined => e?.metadata?.guid ?? e?.guid;
+const favSpaceOrgGuid = (e: any): string | undefined =>
+  e?.entity?.organization_guid ?? e?.entity?.organization?.metadata?.guid ?? e?.orgGuid ?? e?.organization_guid;
+
 export function generateCFEntities(): StratosBaseCatalogEntity[] {
   const endpointDefinition: StratosEndpointExtensionDefinition = {
     urlValidationRegexString: urlValidationExpression,
@@ -1145,10 +1155,10 @@ function generateCfApplicationEntity(endpointDefinition: StratosEndpointExtensio
     {
       entityBuilder: {
         getMetadata: app => ({
-          name: app.entity.name,
+          name: favName(app),
         }),
         getLink: favorite => `/applications/${favorite.endpointId}/${favorite.entityId}/summary`,
-        getGuid: entity => entity.metadata.guid,
+        getGuid: entity => favGuid(entity),
         getIsValid: (fav) => isValidByExistenceProbe(`/pp/v1/cf/apps/${fav.endpointId}/${fav.entityId}`)
       },
       actionBuilders: applicationActionBuilder
@@ -1192,11 +1202,11 @@ function generateCfSpaceEntity(endpointDefinition: StratosEndpointExtensionDefin
       ],
       entityBuilder: {
         getMetadata: space => ({
-          orgGuid: space.entity.organization_guid ? space.entity.organization_guid : space.entity.organization.metadata.guid,
-          name: space.entity.name,
+          orgGuid: favSpaceOrgGuid(space),
+          name: favName(space),
         }),
         getLink: favorite => `/cloud-foundry/${favorite.endpointId}/organizations/${favorite.metadata.orgGuid}/spaces/${favorite.entityId}/summary`,
-        getGuid: entity => entity.metadata.guid,
+        getGuid: entity => favGuid(entity),
         getIsValid: (fav) => isValidByExistenceProbe(`/pp/v1/cf/spaces/${fav.endpointId}/${fav.entityId}`)
       }
     }
@@ -1240,10 +1250,10 @@ function generateCfOrgEntity(endpointDefinition: StratosEndpointExtensionDefinit
       ],
       entityBuilder: {
         getMetadata: org => ({
-          name: org.entity.name,
+          name: favName(org),
         }),
         getLink: favorite => `/cloud-foundry/${favorite.endpointId}/organizations/${favorite.entityId}`,
-        getGuid: entity => entity.metadata.guid,
+        getGuid: entity => favGuid(entity),
         getIsValid: (favorite) => isValidByExistenceProbe(`/pp/v1/cf/org/${favorite.endpointId}/${favorite.entityId}`)
       }
     }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -82,15 +82,16 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
     const applicationService = this.applicationService;
     const scmService = inject(GitSCMService);
 
-    // Initialize favorite$ after applicationService is available
-    // Filter for fully-hydrated entity with cfGuid stamped — getFavorite
-    // resolves the endpoint id via cf-entity-generator's getEndpointIdFromEntity
-    // (entity.entity.cfGuid). Loose !!app emissions slip through with empty
-    // inner entity and trigger "endpointId is undefined" warnings on every
-    // ngrx state churn (4 on initial load, 14+ during a lifecycle action).
+    // Initialize favorite$ after applicationService is available.
+    // Filter for a fully-hydrated entity (inner entity present). The endpoint
+    // id comes from the PAGE context (applicationService.cfGuid), NOT the row's
+    // stamped cfGuid: rows can be mis-stamped when Stratos endpoints share one
+    // CAPI, which would render the star on the wrong endpoint (the cross-
+    // endpoint favourite leak). getFavoriteFromEntity takes the id explicitly.
     this.favorite$ = this.applicationService.app$.pipe(
       filter(info => !!info?.entity?.entity?.cfGuid),
-      map(info => this.userFavoriteManager.getFavorite<IFavoriteMetadata>(info.entity, applicationEntityType, CF_ENDPOINT_TYPE))
+      map(info => this.userFavoriteManager.getFavoriteFromEntity<IFavoriteMetadata>(
+        applicationEntityType, CF_ENDPOINT_TYPE, this.applicationService.cfGuid, info.entity))
     );
     const endpoints$ = toObservable(this.cfEndpoints.all);
     this.breadcrumbs$ = applicationService.waitForAppEntity$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-base/cloud-foundry-organization-base.component.ts
@@ -112,18 +112,22 @@ export class CloudFoundryOrganizationBaseComponent implements OnInit {
 
   // Favorite recomputes when the org signal lands. Built from the V3-native
   // org-detail snapshot — getMetadata reads `entity.name`, getGuid reads
-  // `metadata.guid`, getEndpointIdFromEntity reads `entity.cfGuid`, so we
-  // synthesise the minimal APIResource-shape favorites expect.
+  // `metadata.guid`. The endpoint id comes from the PAGE route (route.cfGuid)
+  // via getFavoriteFromEntity, NOT the row's stamped cfGuid: rows can be
+  // mis-stamped when Stratos endpoints share one CAPI, which would render the
+  // star on the wrong endpoint (the cross-endpoint favourite leak).
   public favorite: Signal<UserFavorite<IFavoriteMetadata> | null>;
 
   constructor() {
     const userFavoriteManager = inject(UserFavoriteManager);
+    const route = inject(ActiveRouteCfOrgSpace);
 
     this.favorite = computed(() => {
       const org = this.orgDataService.org();
       if (!org) return null;
-      const favEntity = { entity: { name: org.name, cfGuid: org.cnsiGuid }, metadata: { guid: org.guid } };
-      return userFavoriteManager.getFavorite<IFavoriteMetadata>(favEntity, organizationEntityType, CF_ENDPOINT_TYPE);
+      const favEntity = { entity: { name: org.name }, metadata: { guid: org.guid } };
+      return userFavoriteManager.getFavoriteFromEntity<IFavoriteMetadata>(
+        organizationEntityType, CF_ENDPOINT_TYPE, route.cfGuid, favEntity);
     });
     this.breadcrumbs$ = this.getBreadcrumbs();
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
@@ -122,21 +122,26 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
 
   // Favorite recomputes when the SpaceDataService signal lands. Synthesises
   // the minimal entity shape favorites expect: getMetadata reads name +
-  // organization_guid, getGuid reads metadata.guid, getEndpointIdFromEntity
-  // reads entity.cfGuid.
+  // organization_guid, getGuid reads metadata.guid. The endpoint id comes from
+  // the PAGE route (route.cfGuid) via getFavoriteFromEntity, NOT the row's
+  // stamped cfGuid: rows can be mis-stamped when Stratos endpoints share one
+  // CAPI, which would render the star on the wrong endpoint (the cross-endpoint
+  // favourite leak).
   public favorite: Signal<UserFavorite<ISpaceFavMetadata> | null>;
 
   constructor() {
     const userFavoriteManager = inject(UserFavoriteManager);
+    const route = inject(ActiveRouteCfOrgSpace);
 
     this.favorite = computed(() => {
       const space = this.spaceDataService.space();
       if (!space) return null;
       const favEntity = {
-        entity: { name: space.name, organization_guid: space.orgGuid, cfGuid: space.cnsiGuid },
+        entity: { name: space.name, organization_guid: space.orgGuid },
         metadata: { guid: space.guid },
       };
-      return userFavoriteManager.getFavorite<ISpaceFavMetadata>(favEntity, spaceEntityType, CF_ENDPOINT_TYPE);
+      return userFavoriteManager.getFavoriteFromEntity<ISpaceFavMetadata>(
+        spaceEntityType, CF_ENDPOINT_TYPE, route.cfGuid, favEntity);
     });
 
     this.setUpBreadcrumbs(this.cfEndpointService, this.cfOrgService);

--- a/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/compact-app-card/compact-app-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/compact-app-card/compact-app-card.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, ChangeDetectionStrategy, Signal, computed, inject, signal } from '@angular/core';
-import { AsyncPipe, CommonModule, DatePipe } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
 import { BREADCRUMB_URL_PARAM, ApplicationStateIconComponent } from '@stratosui/core';
@@ -17,7 +17,6 @@ import { ActiveRouteCfOrgSpace } from '../../../cf/cf-page.types';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     CommonModule,
-    AsyncPipe,
     DatePipe,
     RouterModule,
     ApplicationStateIconComponent

--- a/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.ts
+++ b/src/frontend/packages/core/src/core/signals/fresh-entity-name.service.ts
@@ -1,5 +1,8 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { EndpointModel, endpointEntityType } from '@stratosui/store';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 import { EndpointDataRegistry } from '../../../../cloud-foundry/src/services/endpoint-data/endpoint-data.registry';
 import { EndpointsSignalService } from './endpoints-signal.service';
@@ -34,6 +37,16 @@ export interface EntityNameRef {
 export class FreshEntityNameService {
   private registry = inject(EndpointDataRegistry);
   private endpointsSignals = inject(EndpointsSignalService);
+  private http = inject(HttpClient);
+
+  // Single-resource native endpoint path segment per CF favorite type. These
+  // return the Stratos shape ({ guid, name }); used only by the on-demand
+  // `fetchNameFor` fallback below.
+  private static readonly CF_FETCH_SEGMENT: Record<string, string> = {
+    [CF_APPLICATION]: 'apps',
+    [CF_ORGANIZATION]: 'org',
+    [CF_SPACE]: 'spaces',
+  };
 
   freshNameFor(ref: EntityNameRef): string | null {
     if (!ref) {
@@ -70,5 +83,33 @@ export class FreshEntityNameService {
     }
     const match = list.find(entity => entity.guid === ref.entityId);
     return match?.name ?? null;
+  }
+
+  /**
+   * On-demand fallback for `freshNameFor`: when the entity is in no loaded
+   * signal (e.g. the home card fetched only counts) AND the favorite carries no
+   * stored name, fetch the single resource and return its name. Async, so the
+   * caller backfills the favorite's metadata with the result — both showing the
+   * real name now and healing a null-metadata favorite for good. Returns null
+   * on any failure (deleted entity, disconnected endpoint, network error).
+   */
+  fetchNameFor(ref: EntityNameRef): Observable<string | null> {
+    if (!ref) {
+      return of(null);
+    }
+    if (ref.entityType === endpointEntityType) {
+      return of(this.endpointsSignals.endpoints()[ref.endpointId]?.name ?? null);
+    }
+    if (ref.entityId == null) {
+      return of(null);
+    }
+    const segment = FreshEntityNameService.CF_FETCH_SEGMENT[ref.entityType];
+    if (!segment) {
+      return of(null);
+    }
+    return this.http.get<{ name?: string }>(`/pp/v1/cf/${segment}/${ref.endpointId}/${ref.entityId}`).pipe(
+      map(entity => entity?.name ?? null),
+      catchError(() => of(null)),
+    );
   }
 }

--- a/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.spec.ts
+++ b/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { of } from 'rxjs';
 import { IFavoriteMetadata, UserFavorite, UserFavoritesDataService } from '@stratosui/store';
 import { BaseTestModulesNoShared, STORE_TEST_PROVIDERS } from "@test-framework/core-test.helper";
 import { ConfirmationDialogService } from '../../../../shared/components/confirmation-dialog.service';
@@ -23,15 +24,17 @@ describe('FavoritesMetaCardComponent', () => {
   let component: FavoritesMetaCardComponent;
   let fixture: ComponentFixture<FavoritesMetaCardComponent>;
   let freshName: string | null;
+  let fetchedName: string | null;
 
   beforeEach(() => {
     freshName = null;
+    fetchedName = null;
     TestBed.configureTestingModule({
       providers: [
         ...(STORE_TEST_PROVIDERS || []),
         ConfirmationDialogService,
         SessionService,
-        { provide: FreshEntityNameService, useValue: { freshNameFor: () => freshName } },
+        { provide: FreshEntityNameService, useValue: { freshNameFor: () => freshName, fetchNameFor: () => of(fetchedName) } },
         provideZonelessChangeDetection(),
       ],
       imports: [
@@ -80,6 +83,48 @@ describe('FavoritesMetaCardComponent', () => {
     component.favoriteEntity = makeFavoriteStub('same name');
     fixture.detectChanges();
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  // Regression: a favorite whose entity hasn't resolved can arrive with null
+  // metadata. Reading displayName() during template render must not throw — a
+  // single nameless favorite was breaking change detection for the whole
+  // endpoint home card (the "kevin 3 didn't load" report).
+  function makeFavoriteStubNoMetadata(): UserFavorite<IFavoriteMetadata> {
+    return {
+      guid: 'app1', endpointId: 'ep1', endpointType: 'cf', entityType: 'application', entityId: 'app1',
+      metadata: null,
+      getPrettyTypeName: () => 'Application', getIcon: () => ({} as any), getLink: () => '/cf/ep1/applications/app1',
+    } as unknown as UserFavorite<IFavoriteMetadata>;
+  }
+
+  it('does not throw and falls back to entity id when metadata is null', () => {
+    freshName = null;
+    expect(() => {
+      component.favoriteEntity = makeFavoriteStubNoMetadata();
+      fixture.detectChanges();
+    }).not.toThrow();
+    expect(component.displayName()).toBe('app1');
+  });
+
+  it('still shows the fresh name when metadata is null', () => {
+    freshName = 'fresh name';
+    component.favoriteEntity = makeFavoriteStubNoMetadata();
+    fixture.detectChanges();
+    expect(component.displayName()).toBe('fresh name');
+  });
+
+  it('fetches the name on demand and backfills metadata when nothing else resolves', () => {
+    const favData = TestBed.inject(UserFavoritesDataService);
+    const spy = vi.spyOn(favData, 'updateMetadata').mockImplementation(() => undefined);
+    freshName = null;            // not in any loaded signal (home counts-only)
+    fetchedName = 'opensource';  // single-resource fetch resolves the real name
+    component.favoriteEntity = makeFavoriteStubNoMetadata();
+    fixture.detectChanges();
+    // Renders the fetched name (not the entity-id fallback)...
+    expect(component.displayName()).toBe('opensource');
+    // ...and heals the null-metadata favorite for good.
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].metadata.name).toBe('opensource');
   });
 
   it('does not persist (and does not throw) when the favorite is malformed', () => {

--- a/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.ts
@@ -48,15 +48,26 @@ export class FavoritesMetaCardComponent {
   // Reactive favorite, so the rendered name tracks freshly-fetched entity data.
   private readonly favoriteSig = signal<UserFavorite<IFavoriteMetadata> | null>(null);
 
-  // The name to render: the freshly-fetched entity name when available, else
-  // the stored favorite metadata name (signal-native replacement for the old
-  // static `this.name = favorite.metadata.name`).
+  // Name fetched on demand (see recoverNameIfMissing) when the entity is in no
+  // loaded signal and the favorite carries no stored name.
+  private readonly fetchedName = signal<string | null>(null);
+  private nameFetchAttempted = false;
+
+  // Name precedence: live entity data → stored metadata → on-demand fetched
+  // name → entity id as a last resort. The metadata deref is guarded because a
+  // favourite whose entity hasn't resolved can carry null metadata, and an
+  // unguarded `.name` throw breaks the whole card's change detection (it took
+  // down the entire endpoint home card).
   readonly displayName = computed(() => {
     const fav = this.favoriteSig();
     if (!fav) {
       return '';
     }
-    return this.freshNames.freshNameFor(fav) ?? fav.metadata.name;
+    return this.freshNames.freshNameFor(fav)
+      ?? fav.metadata?.name
+      ?? this.fetchedName()
+      ?? fav.entityId
+      ?? '';
   });
 
   // Last name persisted, so a refresh round-trip doesn't fire duplicate POSTs.
@@ -74,16 +85,38 @@ export class FavoritesMetaCardComponent {
         return;
       }
       const fresh = this.freshNames.freshNameFor(fav);
-      if (fresh && fresh !== fav.metadata.name && fresh !== this.lastPersisted) {
-        const updated = this.userFavoriteManager.getUserFavoriteFromObject(fav);
-        if (!updated) {
-          return;
-        }
-        this.lastPersisted = fresh;
-        updated.metadata = { ...updated.metadata, name: fresh };
-        this.favoritesData.updateMetadata(updated);
+      if (fresh && fresh !== fav.metadata?.name && fresh !== this.lastPersisted) {
+        this.persistName(fav, fresh);
       }
     });
+  }
+
+  // Backup for the signal-only `freshNameFor`: when a favourite has no stored
+  // name and its entity is in no loaded signal (home cards fetch only counts),
+  // fetch the single resource once, render its name, and persist it so the
+  // null-metadata favourite is healed for good.
+  private recoverNameIfMissing(fav: UserFavorite<IFavoriteMetadata>) {
+    if (this.nameFetchAttempted || fav.metadata?.name || this.freshNames.freshNameFor(fav)) {
+      return;
+    }
+    this.nameFetchAttempted = true;
+    this.freshNames.fetchNameFor(fav).pipe(take(1)).subscribe(name => {
+      if (!name) {
+        return;
+      }
+      this.fetchedName.set(name);
+      this.persistName(fav, name);
+    });
+  }
+
+  private persistName(fav: UserFavorite<IFavoriteMetadata>, name: string) {
+    const updated = this.userFavoriteManager.getUserFavoriteFromObject(fav);
+    if (!updated) {
+      return;
+    }
+    this.lastPersisted = name;
+    updated.metadata = { ...updated.metadata, name };
+    this.favoritesData.updateMetadata(updated);
   }
 
   @Input()
@@ -94,7 +127,10 @@ export class FavoritesMetaCardComponent {
       this.icon = this.favorite.getIcon();
       this.routerLink = this.favorite.getLink();
       this.lastPersisted = null;
+      this.fetchedName.set(null);
+      this.nameFetchAttempted = false;
       this.favoriteSig.set(favoriteEntity);
+      this.recoverNameIfMissing(favoriteEntity);
     }
   }
 

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -211,9 +211,9 @@
   <div #scrollBody data-test="scroll-body" class="relative flex-1 overflow-auto">
     @if ((config.isAnyLoading() || isRefreshing()) && config.totalFilteredResults() === 0) {
       <div data-test="loading" class="flex items-center justify-center p-8 h-full">
-        <div class="flex items-center space-x-3 text-content-muted">
-          <div class="spinner spinner-primary"></div>
-          <span>{{ config.loadingMessage ?? 'Loading…' }}</span>
+        <div class="flex items-center space-x-4 text-content-muted">
+          <div class="spinner spinner-primary !h-7 !w-7 !border-[3px]"></div>
+          <span class="text-lg">{{ config.loadingMessage ?? 'Loading…' }}</span>
         </div>
       </div>
     } @else if (config.totalFilteredResults() === 0) {


### PR DESCRIPTION
## Problem

A favourite created from a signal-native (V3) page was persisted with **`metadata: null`**. The CF favourite entity builders (`app`/`space`/`org`) read the name only from the V2 APIResource shape (`x.entity.name` / `e.metadata.guid`), so a Stratos-shaped entity (`{ guid, name }`) produced no name. On the home page — which loads only entity **counts** — the name could not be recovered, so the favourite card rendered the bare **entity guid**, and the unguarded `metadata.name` deref **threw**, breaking the entire endpoint card's change detection (the card showed no counts/recent-apps).

## Fix (root cause + recovery + guard)

- **Root cause:** make the app/space/org `getMetadata`/`getGuid` shape-tolerant (`favName`/`favGuid`/`favSpaceOrgGuid` read from either the V2 or the Stratos shape), so favouriting from any page captures the name.
- **Recovery:** `FreshEntityNameService.fetchNameFor()` fetches the single resource on demand when the entity is in no loaded signal; the favourites card renders the fetched name and **backfills metadata**, healing already-saved null-metadata favourites permanently.
- **Guard:** null-safe `displayName` so one nameless favourite can never again take down an endpoint home card.
- **Cleanup:** drop an unused `AsyncPipe` import (NG8113) left over from the signal migration (verified the binding still renders via the signal).

## Verification

- Reproduced live: an org favourite with `metadata: null` rendered its guid; after the fix it renders its real name and the server-side metadata is healed.
- Full gate green: **2576 tests pass**, production build **0 errors**, NG8113 cleared.
- Adds regression specs: null-metadata render and the fetch+backfill path.