### PR TITLE
fix(cf): recover managed service instance update from empty 202 body

### DIFF
--- a/src/jetstream/plugins/cloudfoundry/native_phase1c_writes_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_phase1c_writes_test.go
@@ -461,6 +461,79 @@ func TestUpdateManagedServiceInstance_AsyncBareFallback(t *testing.T) {
 	assert.Equal(t, http.MethodPatch, ts.lastMethod)
 }
 
+// CF returns 202 with an EMPTY body (job link in the Location header) for
+// managed-SI updates; fw-capi blindly unmarshals the body and errors with
+// "parsing job response: unexpected end of JSON input" (#5431). The handler
+// must recover by reading the SI's last_operation instead of surfacing the
+// parse error.
+func TestUpdateManagedServiceInstance_Empty202_RecoversSucceeded(t *testing.T) {
+	ts := newCaptureServer(map[string]capiHandler{
+		"PATCH /v3/service_instances/si-1": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Location", "/v3/jobs/job-1")
+			w.WriteHeader(http.StatusAccepted)
+			// Empty body — what real CF sends.
+		},
+		"GET /v3/service_instances/si-1": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"guid": "si-1",
+				"name": "my-si",
+				"type": "managed",
+				"last_operation": map[string]interface{}{
+					"type":        "update",
+					"state":       "succeeded",
+					"description": "update succeeded",
+				},
+				"created_at": "2024-01-01T00:00:00Z",
+				"updated_at": "2024-01-02T00:00:00Z",
+			})
+		},
+	})
+	defer ts.Close()
+
+	e := echo.New()
+	ctx, rec := newPhase1CContext(e, http.MethodPatch, "/pp/v1/cf/service_instances/cnsi-1/si-1", `{"parameters":{"foo":"bar"}}`)
+	ctx.SetParamNames("cnsiGuid", "siGuid")
+	ctx.SetParamValues("cnsi-1", "si-1")
+
+	require.NoError(t, newPhase1CPlugin(ts.URL).updateManagedServiceInstance(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"COMPLETE"`)
+}
+
+func TestUpdateManagedServiceInstance_Empty202_BrokerFailed(t *testing.T) {
+	ts := newCaptureServer(map[string]capiHandler{
+		"PATCH /v3/service_instances/si-1": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Location", "/v3/jobs/job-1")
+			w.WriteHeader(http.StatusAccepted)
+		},
+		"GET /v3/service_instances/si-1": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"guid": "si-1",
+				"name": "my-si",
+				"type": "managed",
+				"last_operation": map[string]interface{}{
+					"type":        "update",
+					"state":       "failed",
+					"description": "broker rejected the parameters",
+				},
+				"created_at": "2024-01-01T00:00:00Z",
+				"updated_at": "2024-01-02T00:00:00Z",
+			})
+		},
+	})
+	defer ts.Close()
+
+	e := echo.New()
+	ctx, rec := newPhase1CContext(e, http.MethodPatch, "/pp/v1/cf/service_instances/cnsi-1/si-1", `{"parameters":{"foo":"bar"}}`)
+	ctx.SetParamNames("cnsiGuid", "siGuid")
+	ctx.SetParamValues("cnsi-1", "si-1")
+
+	require.NoError(t, newPhase1CPlugin(ts.URL).updateManagedServiceInstance(ctx))
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"FAILED"`)
+	assert.Contains(t, rec.Body.String(), "broker rejected the parameters")
+}
+
 // ---------------------------------------------------------------------------
 // Roles (Slice 2)
 

--- a/src/jetstream/plugins/cloudfoundry/native_service_instances_writes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instances_writes.go
@@ -409,6 +409,70 @@ func recoverFromCreateParseError(
 	}
 }
 
+// recoverFromUpdateParseError determines the real outcome of a managed-SI
+// update after fw-capi errored on CF's empty 202 body. CF accepted the PATCH
+// (it returned 202), so the broker operation is under way — GET the SI and
+// read last_operation:
+//   - state "in progress"/"initial" → short-poll for the broker to settle,
+//     same window as the create recovery, so a quick broker rejection
+//     surfaces as a real failure instead of a false "updated" confirmation
+//   - type=update state=failed → 502 + broker description
+//   - settled otherwise (succeeded, or still in flight after the window) →
+//     200 fast-path COMPLETE envelope; the services list reflects terminal
+//     state once CF settles
+//   - GET fails / SI missing → (0, nil) so the caller falls through to the
+//     original fw-capi parse error
+func recoverFromUpdateParseError(
+	ctx context.Context,
+	cfClient capi.Client,
+	siGUID string,
+) (int, map[string]interface{}) {
+	si, err := cfClient.ServiceInstances().Get(ctx, siGUID)
+	if err != nil || si == nil {
+		return 0, nil
+	}
+	state, desc := readLastOpState(si.LastOperation)
+	for i := 0; i < 30 && (state == "in progress" || state == "initial"); i++ {
+		select {
+		case <-ctx.Done():
+			return 0, nil
+		case <-time.After(2 * time.Second):
+		}
+		refreshed, refreshErr := cfClient.ServiceInstances().Get(ctx, siGUID)
+		if refreshErr != nil || refreshed == nil {
+			break
+		}
+		si = refreshed
+		state, desc = readLastOpState(si.LastOperation)
+	}
+	opType := ""
+	if si.LastOperation != nil {
+		opType = si.LastOperation.Type
+	}
+	if opType == "update" && state == "failed" {
+		if desc == "" {
+			desc = "service broker rejected the update"
+		}
+		return http.StatusBadGateway, map[string]interface{}{
+			"state": stratosjobs.JobStateFailed,
+			"errors": []stratosjobs.StratosError{{
+				Code:    "cf.service_instance.last_operation.failed",
+				Message: "Service instance update failed",
+				Detail:  desc,
+			}},
+		}
+	}
+	return http.StatusOK, map[string]interface{}{
+		"state": stratosjobs.JobStateComplete,
+		"result": map[string]interface{}{
+			"last_operation": map[string]interface{}{
+				"state":       state,
+				"description": desc,
+			},
+		},
+	}
+}
+
 // updateManagedServiceInstance handles PATCH /pp/v1/cf/service_instances/{cnsiGuid}/{siGuid}
 // for managed (broker-backed) instances. V3 PATCH on a managed instance
 // returns 202 + job; we hand it off via RunFastPath.
@@ -440,6 +504,18 @@ func (cf *CloudFoundrySpecification) updateManagedServiceInstance(c echo.Context
 
 	out, updErr := cfClient.ServiceInstances().Update(reqCtx, siGUID, &req)
 	if updErr != nil {
+		// Same fw-capi empty-202-body bug as create/delete (#5431): CF
+		// returns 202 with an empty body and the job link in the Location
+		// header; fw-capi blindly unmarshals the body and errors with
+		// "parsing job response: unexpected end of JSON input". The update
+		// was accepted — recover via the SI's last_operation. Remove when
+		// upstream fw-capi reads the Location header on empty 202 bodies.
+		if strings.Contains(updErr.Error(), "parsing job response") {
+			if status, body := recoverFromUpdateParseError(reqCtx, cfClient, siGUID); body != nil {
+				c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+				return c.JSON(status, body)
+			}
+		}
 		return handleCapiError(c, updErr)
 	}
 	job, isJob := out.(*capi.Job)


### PR DESCRIPTION
## Problem

Editing a managed service instance's parameters failed with:

> Failed to update service instance: parsing job response: unexpected end of JSON input

CF V3 answers `PATCH /v3/service_instances/{guid}` on a managed instance with **202 + an empty body**, putting the job link in the `Location` header. The capi client library unconditionally unmarshals the response body as a Job, so the empty body produced the JSON parse error — even though CF had accepted the update and the broker operation was already under way. Non-empty parameters force a broker round-trip (async 202), which is why the bug only showed when parameters were supplied.

## Fix

The create and delete paths already recover from this capi-client behavior; this adds the same recovery to the update path. When the parse error occurs, the handler now:

1. GETs the service instance and reads `last_operation`
2. Short-polls while the broker update is still in flight
3. Returns **502 with the broker's failure description** if the update failed, or a **fast-path COMPLETE envelope** on success

so the user sees the real outcome instead of a client-side parse artifact.

## Testing

- Two new handler tests reproduce CF's empty-202 response; both failed with the exact reported error before the fix and pass after (broker-succeeded and broker-failed outcomes)
- Full gate (backend + frontend suites) green

## Follow up
The capi library will be modified to read the associated object from the header instead of assuming it is being returned in the body like many of the capi api calls.

Closes #5431