### PR TITLE
Adopt fw-capi quota contract fixes

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition-form/quota-form-mapping.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition-form/quota-form-mapping.ts
@@ -32,9 +32,9 @@ export function formToOrgQuotaWriteBody(values: OrgQuotaFormValues): OrgQuotaWri
     name: values.name,
     apps: {
       total_memory_in_mb: limitToWire(values.memoryLimit),
-      total_instance_memory_in_mb: limitToWire(values.instanceMemoryLimit),
+      per_process_memory_in_mb: limitToWire(values.instanceMemoryLimit),
       total_instances: limitToWire(values.appInstanceLimit),
-      total_app_tasks: limitToWire(values.appTasksLimit),
+      per_app_tasks: limitToWire(values.appTasksLimit),
     },
     services: {
       paid_services_allowed: !!values.nonBasicServicesAllowed,
@@ -63,9 +63,9 @@ export function formToSpaceQuotaUpdateBody(values: SpaceQuotaFormValues): SpaceQ
     name: values.name,
     apps: {
       total_memory_in_mb: limitToWire(values.memoryLimit),
-      total_instance_memory_in_mb: limitToWire(values.instanceMemoryLimit),
+      per_process_memory_in_mb: limitToWire(values.instanceMemoryLimit),
       total_instances: limitToWire(values.appInstanceLimit),
-      total_app_tasks: limitToWire(values.appTasksLimit),
+      per_app_tasks: limitToWire(values.appTasksLimit),
     },
     services: {
       paid_services_allowed: !!values.nonBasicServicesAllowed,

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/quota-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/quota-data.service.ts
@@ -22,9 +22,9 @@ export interface OrgQuotaWriteBody {
   name?: string;
   apps?: {
     total_memory_in_mb?: number | null;
-    total_instance_memory_in_mb?: number | null;
+    per_process_memory_in_mb?: number | null;
     total_instances?: number | null;
-    total_app_tasks?: number | null;
+    per_app_tasks?: number | null;
   };
   services?: {
     paid_services_allowed?: boolean;

--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -242,3 +242,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/fivetwenty-io/capi/v3 => github.com/norman-abramovitz/fw-capi/v3 v3.216.7-quota-fixes.1

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -156,8 +156,6 @@ github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fivetwenty-io/capi/v3 v3.216.6 h1:Isx5zpP9A17wFAep+kjhCxt2g+XIsDbLBSfhxfzSDdo=
-github.com/fivetwenty-io/capi/v3 v3.216.6/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/foxcpp/go-mockdns v1.2.0 h1:omK3OrHRD1IWJz1FuFBCFquhXslXoF17OvBS6JPzZF0=
 github.com/foxcpp/go-mockdns v1.2.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -368,6 +366,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/norman-abramovitz/fw-capi/v3 v3.216.7-quota-fixes.1 h1:yoCVAql7QXRGwPaUB2qLcyU2Wi/vcpjSb+0I9zwlZEM=
+github.com/norman-abramovitz/fw-capi/v3 v3.216.7-quota-fixes.1/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=

--- a/src/jetstream/plugins/cloudfoundry/native_org_quotas_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_org_quotas_reads.go
@@ -135,9 +135,9 @@ func toStOrgQuota(q capi.OrganizationQuota, cnsiGUID string) StOrgQuota {
 	}
 	if q.Apps != nil {
 		out.TotalMemoryInMB = nilIntToUnlimited(q.Apps.TotalMemoryInMB)
-		out.TotalInstanceMemoryInMB = nilIntToUnlimited(q.Apps.TotalInstanceMemoryInMB)
+		out.TotalInstanceMemoryInMB = nilIntToUnlimited(q.Apps.PerProcessMemoryInMB)
 		out.TotalInstances = nilIntToUnlimited(q.Apps.TotalInstances)
-		out.TotalAppTasks = nilIntToUnlimited(q.Apps.TotalAppTasks)
+		out.TotalAppTasks = nilIntToUnlimited(q.Apps.PerAppTasks)
 	}
 	if q.Services != nil {
 		if q.Services.PaidServicesAllowed != nil {

--- a/src/jetstream/plugins/cloudfoundry/native_org_quotas_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_org_quotas_reads_test.go
@@ -42,7 +42,7 @@ func TestGetNativeOrgQuotas_ReturnsMappedQuotas(t *testing.T) {
 						"created_at":"2026-04-22T12:00:00Z",
 						"updated_at":"2026-04-22T12:00:00Z",
 						"name":"default",
-						"apps":{"total_memory_in_mb":102400,"total_instance_memory_in_mb":2048,"total_instances":1000,"total_app_tasks":500},
+						"apps":{"total_memory_in_mb":102400,"per_process_memory_in_mb":2048,"total_instances":1000,"per_app_tasks":500},
 						"services":{"paid_services_allowed":true,"total_service_instances":250,"total_service_keys":250},
 						"routes":{"total_routes":1000,"total_reserved_ports":100},
 						"domains":{"total_domains":10},

--- a/src/jetstream/plugins/cloudfoundry/native_org_quotas_writes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_org_quotas_writes.go
@@ -126,7 +126,9 @@ func (c *CloudFoundrySpecification) deleteNativeOrgQuota(ctx echo.Context) error
 		return err
 	}
 
-	if delErr := cfClient.OrganizationQuotas().Delete(ctx.Request().Context(), quotaGUID); delErr != nil {
+	// fw-capi >= v3.217 returns the async job ref; the UI contract here
+	// stays 204-on-accepted, so the job is not yet surfaced.
+	if _, delErr := cfClient.OrganizationQuotas().Delete(ctx.Request().Context(), quotaGUID); delErr != nil {
 		return handleCapiError(ctx, delErr)
 	}
 

--- a/src/jetstream/plugins/cloudfoundry/native_space_quotas_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_space_quotas_reads.go
@@ -122,9 +122,9 @@ func toStSpaceQuota(q capi.SpaceQuotaV3, cnsiGUID string) StSpaceQuota {
 	}
 	if q.Apps != nil {
 		out.TotalMemoryInMB = nilIntToUnlimited(q.Apps.TotalMemoryInMB)
-		out.TotalInstanceMemoryInMB = nilIntToUnlimited(q.Apps.TotalInstanceMemoryInMB)
+		out.TotalInstanceMemoryInMB = nilIntToUnlimited(q.Apps.PerProcessMemoryInMB)
 		out.TotalInstances = nilIntToUnlimited(q.Apps.TotalInstances)
-		out.TotalAppTasks = nilIntToUnlimited(q.Apps.TotalAppTasks)
+		out.TotalAppTasks = nilIntToUnlimited(q.Apps.PerAppTasks)
 	}
 	if q.Services != nil {
 		if q.Services.PaidServicesAllowed != nil {

--- a/src/jetstream/plugins/cloudfoundry/native_space_quotas_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_space_quotas_reads_test.go
@@ -41,7 +41,7 @@ func TestGetNativeSpaceQuotas_ReturnsMappedQuotas(t *testing.T) {
 						"created_at":"2026-04-22T12:00:00Z",
 						"updated_at":"2026-04-22T12:00:00Z",
 						"name":"small",
-						"apps":{"total_memory_in_mb":2048,"total_instance_memory_in_mb":1024,"total_instances":50,"total_app_tasks":25},
+						"apps":{"total_memory_in_mb":2048,"per_process_memory_in_mb":1024,"total_instances":50,"per_app_tasks":25},
 						"services":{"paid_services_allowed":true,"total_service_instances":10,"total_service_keys":10},
 						"routes":{"total_routes":50,"total_reserved_ports":5},
 						"relationships":{
@@ -287,7 +287,7 @@ func TestGetNativeSpaceQuotaDetail_ReturnsMappedQuota(t *testing.T) {
 				"created_at":"2026-04-22T12:00:00Z",
 				"updated_at":"2026-04-22T12:00:00Z",
 				"name":"small",
-				"apps":{"total_memory_in_mb":2048,"total_instance_memory_in_mb":1024,"total_instances":50,"total_app_tasks":25},
+				"apps":{"total_memory_in_mb":2048,"per_process_memory_in_mb":1024,"total_instances":50,"per_app_tasks":25},
 				"services":{"paid_services_allowed":true,"total_service_instances":10,"total_service_keys":10},
 				"routes":{"total_routes":50,"total_reserved_ports":5},
 				"relationships":{

--- a/src/jetstream/plugins/cloudfoundry/native_space_quotas_writes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_space_quotas_writes.go
@@ -111,7 +111,9 @@ func (c *CloudFoundrySpecification) deleteNativeSpaceQuota(ctx echo.Context) err
 		return err
 	}
 
-	if delErr := cfClient.SpaceQuotas().Delete(ctx.Request().Context(), quotaGUID); delErr != nil {
+	// fw-capi >= v3.217 returns the async job ref; the UI contract here
+	// stays 204-on-accepted, so the job is not yet surfaced.
+	if _, delErr := cfClient.SpaceQuotas().Delete(ctx.Request().Context(), quotaGUID); delErr != nil {
 		return handleCapiError(ctx, delErr)
 	}
 


### PR DESCRIPTION
## Summary

Adopts three CF v3 contract fixes from fw-capi (norman-abramovitz/fw-capi#1,
merged), found by a docs-contract audit and verified live against a real CF
through `make dev`:

1. **Quota deletes return the async job ref** — the org/space quota delete
   handlers updated for the new `(*Job, error)` signature; the UI contract
   stays 204-on-accepted for now (surfacing job progress is a follow-up).
2. **Quota apps field names corrected** — CF v3 uses
   `per_process_memory_in_mb` / `per_app_tasks`; the previous names
   (`total_instance_memory_in_mb` / `total_app_tasks`) don't exist in the
   API, so quota create/update from the UI always failed with 422 and the
   per-process/tasks limits read back as Unlimited. Frontend wire bodies,
   jetstream accessors, and test mocks (which simulated the same wrong
   names) all corrected.
3. **Space-quota create no longer sends an invalid empty spaces
   relationship** (fw-capi side; no Stratos code change needed beyond the
   version bump).

go.mod pins `fivetwenty-io/capi/v3` to the fork tag
`norman-abramovitz/fw-capi/v3 v3.216.7-quota-fixes.1` via the same
`/v3`-suffix replace pattern used for the earlier delete-wave fixes;
drop the directive when the fixes land in a tagged upstream release.

## Testing

- `go build ./...` and the cloudfoundry plugin suite pass against the
  published fork tag (no local overrides)
- Live verification on a real CF through the UI: org quota create (201)
  and delete (204); space quota create (201) and delete (204) — both
  delete jobs observed via the Location header
- Mock-vocabulary sweep against the documented CF contract found no
  further latent field-name discrepancies in the plugin test fixtures