### PR TITLE
Bump capi fork to v3.222.1-typed-includes.1 (clean upstream base)

### DIFF
--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -243,4 +243,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/fivetwenty-io/capi/v3 => github.com/norman-abramovitz/fw-capi/v3 v3.216.8-typed-includes.2
+replace github.com/fivetwenty-io/capi/v3 => github.com/norman-abramovitz/fw-capi/v3 v3.222.1-typed-includes.1

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -366,8 +366,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/norman-abramovitz/fw-capi/v3 v3.216.8-typed-includes.2 h1:w/6ljVaPEI2M6qTn5oFHh62ABTGV9RPWIkrUT902Z20=
-github.com/norman-abramovitz/fw-capi/v3 v3.216.8-typed-includes.2/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
+github.com/norman-abramovitz/fw-capi/v3 v3.222.1-typed-includes.1 h1:mMbcLU45vqEgl7M36zFJ1yoLaZx/uf17KUUdzZIFShM=
+github.com/norman-abramovitz/fw-capi/v3 v3.222.1-typed-includes.1/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=


### PR DESCRIPTION
Repoints the `fivetwenty-io/capi` replace directive from the `v3.216.8-typed-includes.2` pre-release to **`v3.222.1-typed-includes.1`**.

The new fork tag is the typed-includes wave **rebased onto upstream's merged async/quota fixes** (`fivetwenty-io/capi` #7/#9/#10), so it's a cleaner base than the prior `216.8` lineage (no fork-private copies of those fixes). It is **verified-compatible with CF API v3.222.0** via the `capi-contract` audit — the 3.216→3.222 contract diff adds no new client surface (description-only param wording + empty request-body markers), and the only real gaps found were the async/quota fixes (now upstream) and the typed includes/fields (the wave itself).

The tag is a **pre-release of `v3.222.1`** by design: the upstream PR ([fivetwenty-io/capi#11](https://github.com/fivetwenty-io/capi/pull/11)) requests a plain `v3.222.1` release, which will cleanly supersede this pre-release so the replace directive can retire in a one-line follow-up.

**Scope:** behavior-equivalent dependency swap. `go.mod` replace + `go.sum` only.

**Verification:** `go mod tidy` resolves the tag; `go build ./...` clean in `src/jetstream`.
