### PR TITLE
Switch capi to upstream v3.222.1, retire fork replace

### DIFF
--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/kubernetes/auth v0.0.0-20250312201517-2a076063346f
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/monocular v0.0.0-00010101000000-000000000000
 	github.com/domodwyer/mailyak v3.1.1+incompatible
-	github.com/fivetwenty-io/capi/v3 v3.216.6
+	github.com/fivetwenty-io/capi/v3 v3.222.1
 	github.com/go-sql-driver/mysql v1.9.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
@@ -242,5 +242,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/fivetwenty-io/capi/v3 => github.com/norman-abramovitz/fw-capi/v3 v3.222.1-typed-includes.1

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -156,6 +156,8 @@ github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fivetwenty-io/capi/v3 v3.222.1 h1:iVR65dT+G7z9j7m39u2KU/ddgvGCJ9XEvLhKu6iYGbk=
+github.com/fivetwenty-io/capi/v3 v3.222.1/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/foxcpp/go-mockdns v1.2.0 h1:omK3OrHRD1IWJz1FuFBCFquhXslXoF17OvBS6JPzZF0=
 github.com/foxcpp/go-mockdns v1.2.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -366,8 +368,6 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/norman-abramovitz/fw-capi/v3 v3.222.1-typed-includes.1 h1:mMbcLU45vqEgl7M36zFJ1yoLaZx/uf17KUUdzZIFShM=
-github.com/norman-abramovitz/fw-capi/v3 v3.222.1-typed-includes.1/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=


### PR DESCRIPTION
## What

The typed query-options work ([capi PR #11](https://github.com/fivetwenty-io/capi/pull/11)) merged upstream and was tagged `v3.222.1`, so the `norman-abramovitz/fw-capi` fork is no longer needed for the build.

- Bump `github.com/fivetwenty-io/capi/v3` require `v3.216.6` → upstream **`v3.222.1`**
- Drop the `replace … => norman-abramovitz/fw-capi/v3 v3.222.1-typed-includes.1` directive

This completes the fork-retirement: #5449 pinned the fork tag temporarily while the upstream tag was pending; with `v3.222.1` now published upstream, we collapse to a plain dependency.

## Verification

- `go mod tidy` resolves upstream `v3.222.1`; `go.sum` carries only the upstream module hash (no fork reference)
- `go build ./...` clean

Two-file change (`go.mod` / `go.sum`); letting the PR gate validate.
