### PR TITLE
Clear all remaining ESLint warnings (post-Angular 22)

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/combo-chart/combo-chart.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/combo-chart/combo-chart.component.ts
@@ -27,6 +27,7 @@ export class AppAutoscalerComboChartComponent implements OnChanges {
   @Input() colorSchemeLine: any;
   @Input() scheme: any;
 
+  // eslint-disable-next-line @angular-eslint/no-output-native -- intentional ngx-charts API parity: re-emits the wrapped chart's (select) event under the same name
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();
   @Output() deactivate = new EventEmitter();

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/combo-chart/combo-series-vertical.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/combo-chart/combo-series-vertical.component.ts
@@ -74,6 +74,7 @@ export class AppAutoscalerComboSeriesVerticalComponent implements OnChanges {
   @Input() seriesName!: string;
   @Input() animations = true;
 
+  // eslint-disable-next-line @angular-eslint/no-output-native -- intentional ngx-charts API parity: re-emits the wrapped series' (select) event under the same name
   @Output() select = new EventEmitter();
   @Output() activate = new EventEmitter();
   @Output() deactivate = new EventEmitter();

--- a/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
+++ b/src/frontend/packages/cloud-foundry/src/cf-entity-generator.ts
@@ -393,7 +393,7 @@ function generateCFAppEnvVarEntity(endpointDefinition: StratosEndpointExtensionD
       // Observable<number> contract holds without fabricating list data.
       maxedStateStartAt: () => of(0),
     },
-    successfulRequestDataMapper: (data, endpointGuid, guid, entityType, endpointType, action) => {
+    successfulRequestDataMapper: (data, endpointGuid, guid, _entityType, _endpointType, _action) => {
       return {
         entity: {
           ...(data || {}),

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/signal/signal-relation-fetcher.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/signal/signal-relation-fetcher.service.ts
@@ -18,7 +18,7 @@
 // single in-flight Promise (epoch-token de-dup mirrors
 // cnsi-entity-source.ts).
 
-import { inject, Injectable, signal, Signal, WritableSignal } from '@angular/core';
+import { Injectable, signal, Signal, WritableSignal } from '@angular/core';
 import {
   RelationDescriptor,
   RelationFetchContext,
@@ -53,7 +53,8 @@ export class SignalRelationFetcherService {
   private readonly childSignals = new Map<string, WritableSignal<unknown[]>>();
   private readonly inFlight = new Map<string, Promise<unknown[]>>();
 
-  private readonly postProcessors = inject(SignalRelationPostProcessorRegistry);
+  // eslint-disable-next-line @angular-eslint/prefer-inject -- constructor injection retained: the deliberately pure-TS spec (signal-relation-fetcher.spec.ts) directly `new`s this service with a mock registry, which an inject() field initializer can't support
+  constructor(private readonly postProcessors: SignalRelationPostProcessorRegistry) {}
 
   /** Register a single descriptor. Idempotent on (parent, child, paramName). */
   register(descriptor: RelationDescriptor): void {

--- a/src/frontend/packages/cloud-foundry/src/entity-relations/signal/signal-relation-fetcher.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/entity-relations/signal/signal-relation-fetcher.service.ts
@@ -18,7 +18,7 @@
 // single in-flight Promise (epoch-token de-dup mirrors
 // cnsi-entity-source.ts).
 
-import { Injectable, signal, Signal, WritableSignal } from '@angular/core';
+import { inject, Injectable, signal, Signal, WritableSignal } from '@angular/core';
 import {
   RelationDescriptor,
   RelationFetchContext,
@@ -53,7 +53,7 @@ export class SignalRelationFetcherService {
   private readonly childSignals = new Map<string, WritableSignal<unknown[]>>();
   private readonly inFlight = new Map<string, Promise<unknown[]>>();
 
-  constructor(private readonly postProcessors: SignalRelationPostProcessorRegistry) {}
+  private readonly postProcessors = inject(SignalRelationPostProcessorRegistry);
 
   /** Register a single descriptor. Idempotent on (parent, child, paramName). */
   register(descriptor: RelationDescriptor): void {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/instances-accordion/instances-accordion.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/instances-accordion/instances-accordion.component.html
@@ -59,8 +59,9 @@
 
         <div class="flex items-center gap-4 flex-wrap">
           <!-- Momentary shared selection across all three usage charts. -->
-          <label class="flex items-center gap-2 text-sm text-content-muted">
+          <label for="instances-all-metrics" class="flex items-center gap-2 text-sm text-content-muted">
             <input
+              id="instances-all-metrics"
               type="checkbox"
               class="accent-primary"
               [checked]="allActive()"
@@ -68,9 +69,10 @@
             All metrics
           </label>
 
-          <label class="flex items-center gap-2 text-sm text-content-muted">
+          <label for="instances-sample-interval" class="flex items-center gap-2 text-sm text-content-muted">
             Sample every
             <select
+              id="instances-sample-interval"
               class="rounded border border-content-border bg-content-bg px-2 py-1 text-content-text"
               (change)="setSampleInterval(+$any($event.target).value)">
               <option [value]="5000" [selected]="intervalMs() === 5000">5s</option>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/instances-accordion/instances-accordion.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/instances-accordion/instances-accordion.component.ts
@@ -214,7 +214,11 @@ export class InstancesAccordionComponent implements OnDestroy {
   /** Flip an instance in the shared overlay set (drives all three charts). */
   onToggleLinked(index: number): void {
     const next = new Set(this.unifiedHidden());
-    next.has(index) ? next.delete(index) : next.add(index);
+    if (next.has(index)) {
+      next.delete(index);
+    } else {
+      next.add(index);
+    }
     this.unifiedHidden.set(next);
   }
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.html
@@ -2,8 +2,8 @@
   <!-- Deploy the latest commit on the branch without pinning a specific SHA.
        When on, the commit list is hidden and the deploy sends an empty commit
        so CF builds whatever HEAD currently points at. -->
-  <label class="flex items-center gap-2 mb-3 text-sm text-content-text cursor-pointer">
-    <input type="checkbox" [checked]="useLatestHead()"
+  <label for="deploy-latest-head" class="flex items-center gap-2 mb-3 text-sm text-content-text cursor-pointer">
+    <input id="deploy-latest-head" type="checkbox" [checked]="useLatestHead()"
       (change)="setUseLatestHead($any($event.target).checked)">
     <span>Deploy the latest commit on <b>{{ branchName() || 'the branch' }}</b> (don't pin a commit)</span>
   </label>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
@@ -101,7 +101,7 @@ export class EditApplicationComponent implements OnInit, OnDestroy {
     });
 
     // Track form valid+dirty as a signal so signalHandle.valid is reactive
-    // without the legacy onValidChange emitter chain. Combine statusChanges
+    // without the legacy validChange emitter chain. Combine statusChanges
     // and valueChanges so we react to BOTH validator transitions and dirty-
     // flag flips (markAsDirty fires on valueChanges, not statusChanges).
     const formChanges$ = this.editAppForm.statusChanges.pipe(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-space.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/services/cloud-foundry-space.service.ts
@@ -155,7 +155,7 @@ export class CloudFoundrySpaceService {
       switchMap(def => def ? of(def) : this.cfOrgService.quotaDefinition$.pipe(map(q => q ?? null))),
     );
     this.quotaLink$ = combineLatest(this.quotaDefinition$, this.spaceQuotaDefinition$).pipe(
-      map(([quota, spaceQuota]) => {
+      map(([_quota, spaceQuota]) => {
         if (!spaceQuota) {
           return [
             '/cloud-foundry',

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
@@ -469,7 +469,7 @@ export interface StServiceCredentialBindingsResponse {
   pagination?: { totalResults?: number };
 }
 
-export interface StOrgDetailResponse extends StOrgDetail {}
+export type StOrgDetailResponse = StOrgDetail;
 
 export interface StSpacesResponse {
   resources: StSpace[];

--- a/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
+import { Component, inject, provideZonelessChangeDetection, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
@@ -44,10 +44,7 @@ import { AppApplicationActionBarComponent } from './application-action-bar.compo
   `,
 })
 class ActionBarTestHostComponent {
-  portal$;
-  constructor(tabNav: TabNavService) {
-    this.portal$ = tabNav.tabSubNav$;
-  }
+  portal$ = inject(TabNavService).tabSubNav$;
 }
 
 describe('AppApplicationActionBarComponent', () => {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.html
@@ -13,7 +13,9 @@
       <ng-template appSignalListCell="type" let-row>
         <div class="flex flex-col gap-1 py-1">
           @if (hasDetails(row)) {
-            <a class="cursor-pointer text-primary hover:underline break-all" (click)="openEventDetails(row)">{{ row.type }}</a>
+            <a class="cursor-pointer text-primary hover:underline break-all" role="button" tabindex="0"
+              (click)="openEventDetails(row)" (keydown.enter)="openEventDetails(row)"
+              (keydown.space)="$event.preventDefault(); openEventDetails(row)">{{ row.type }}</a>
           } @else {
             <span class="break-all">{{ row.type }}</span>
           }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/instance-usage-chart/instance-usage-chart.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/instance-usage-chart/instance-usage-chart.component.ts
@@ -101,7 +101,11 @@ export class InstanceUsageChartComponent {
    *  makes the signal emit so `chartData()` recomputes and the plugin re-runs. */
   private toggleInstanceHidden(index: number): void {
     const next = new Set(this.hiddenInstances());
-    next.has(index) ? next.delete(index) : next.add(index);
+    if (next.has(index)) {
+      next.delete(index);
+    } else {
+      next.add(index);
+    }
     this.hiddenInstances.set(next);
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
@@ -14,7 +14,7 @@
     </div>
     @if (schemaView === 'schemaForm') {
       <div class="schema-form__form">
-        <json-schema-form loadExternalAssets="false" [options]="{ addSubmit: false }" [schema]="cleanSchema" [framework]="'material-design'" [data]="formInitialData" (validationErrors)="onFormValidationErrors($event)" (onChanges)="onFormChange($event)">
+        <json-schema-form loadExternalAssets="false" [options]="{ addSubmit: false }" [schema]="cleanSchema" [framework]="'material-design'" [data]="formInitialData" (validationErrors)="onFormValidationErrors($event)" (changes)="onFormChange($event)">
         </json-schema-form>
         @if (!!formValidationErrorsStr) {
           <div class="schema-form__form--data-bad" [innerHTML]="formValidationErrorsStr"></div>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.html
@@ -46,7 +46,7 @@
         [options]="editorOptions"
         [ngModel]="value()"
         (ngModelChange)="value.set($event)"
-        (onInit)="onEditorInit($event)">
+        (editorInit)="onEditorInit($event)">
       </app-monaco-editor>
     </div>
     @if (jsonWarning()) {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/variable-edit-dialog/variable-edit-dialog.component.ts
@@ -88,7 +88,7 @@ export class VariableEditDialogComponent {
     fontSize: 16,
   };
 
-  /** Captured Monaco editor instance (undefined until onInit fires; never
+  /** Captured Monaco editor instance (undefined until editorInit fires; never
    *  fires in unit tests, where Monaco isn't loaded). */
   private editor: any;
 

--- a/src/frontend/packages/cloud-foundry/src/shared/directives/cf-user-permission/cf-user-permission.directive.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/directives/cf-user-permission/cf-user-permission.directive.spec.ts
@@ -9,7 +9,7 @@ import { cfCurrentUserPermissionsService } from '@stratosui/cloud-foundry';
 import { CfUserPermissionDirective } from './cf-user-permission.directive';
 
 @Component({
-  standalone: false,
+  imports: [CfUserPermissionDirective],
   template: `
     <div *appCfUserPermission="permission">
       Test Content
@@ -29,8 +29,6 @@ describe('CfUserPermissionDirective', () => {
       imports: [
         NoopAnimationsModule,
         CfUserPermissionDirective,
-      ],
-      declarations: [
         TestUserPermissionComponent,
       ],
       providers: [

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -170,7 +170,9 @@ export class CfAppsSignalConfigService {
   private readonly errorEvents = inject(EndpointErrorEventsService);
   private _errorEffect?: EffectRef;
 
-  constructor(private readonly http: HttpClient) {
+  private readonly http = inject(HttpClient);
+
+  constructor() {
     const cfService = inject(CloudFoundryService, { optional: true });
     this.connectedEndpoints = cfService
       ? toSignal(cfService.connectedCFEndpoints$, { initialValue: [] as EndpointModel[] })

--- a/src/frontend/packages/cloud-foundry/src/store/types/cf-api.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/store/types/cf-api.types.ts
@@ -11,6 +11,7 @@ export function createEmptyCfResponse<T = any>(): CFResponse<T> {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional: T is part of the public generic API surface (mirrors PaginationResponse<T>/CFResponse<T>); the entity body is an open string-keyed map so T is not referenced internally.
 export interface CfAPIResource<T = any> extends APIResource {
   entity: {
     [entityKey: string]: any,
@@ -26,5 +27,4 @@ export interface PaginationResponse<T = any> {
   resources: T[];
 }
 
-export interface CFResponse<T = any> extends PaginationResponse<APIResource<T>> {
-}
+export type CFResponse<T = any> = PaginationResponse<APIResource<T>>;

--- a/src/frontend/packages/core/src/app.component.ts
+++ b/src/frontend/packages/core/src/app.component.ts
@@ -15,6 +15,7 @@ import { LoggedInService } from './logged-in.service';
   selector: 'app-root',
   templateUrl: './app.component.html',
   host: { class: 'flex flex-col flex-1 h-screen min-h-0' },
+  // eslint-disable-next-line @angular-eslint/prefer-standalone -- declared and bootstrapped in NgModule AppModule (app.module.ts, out of scope); standalone migration tracked separately
   standalone: false,
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/frontend/packages/core/src/core/button-blur-on-click.directive.spec.ts
+++ b/src/frontend/packages/core/src/core/button-blur-on-click.directive.spec.ts
@@ -6,7 +6,7 @@ import { ButtonBlurOnClickDirective } from './button-blur-on-click.directive';
 
 
 @Component({
-  standalone: false,
+  imports: [ButtonBlurOnClickDirective],
   template: `<button mat-icon-button aria-label="Test button"></button>`
 })
 class TestButtonComponent {
@@ -30,10 +30,8 @@ describe('ButtonBlurOnClickDirective', () => {
         { provide: Renderer2, useClass: MockRenderer },
         provideZonelessChangeDetection(),
       ],
-      declarations: [
-        TestButtonComponent,
-      ],
       imports: [
+        TestButtonComponent,
         ButtonBlurOnClickDirective,
       ],
     }).compileComponents();

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/auth-forms/none-auth-form.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/auth-forms/none-auth-form.component.ts
@@ -6,7 +6,7 @@ import { IAuthForm } from '@stratosui/store';
  * Type definition for the None Auth Form
  * No fields are required as this auth type requires no user input
  */
-export interface NoneAuthFormValue {}
+export type NoneAuthFormValue = Record<string, never>;
 
 @Component({
   selector: 'app-none-auth-form',

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/auth-forms/sso-auth-form.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/auth-forms/sso-auth-form.component.ts
@@ -4,9 +4,8 @@ import { IAuthForm } from '@stratosui/store';
 
 import { ProductNameComponent } from '../../../../shared/components/product-name.ccomponent';
 
-interface SsoAuthFormValues {
-  // SSO form has an empty authValues group - no additional fields required
-}
+// SSO form has an empty authValues group - no additional fields required
+type SsoAuthFormValues = Record<string, never>;
 
 interface SsoAuthForm {
   authValues: FormGroup<SsoAuthFormValues>;

--- a/src/frontend/packages/core/src/shared/components/custom-button-toggle/custom-button-toggle.component.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-button-toggle/custom-button-toggle.component.ts
@@ -20,6 +20,7 @@ export class CustomButtonToggleComponent {
   @Input() disabled = false;
   @Input() checked = false;
 
+  // eslint-disable-next-line @angular-eslint/no-output-native -- intentional Material API parity: drop-in for mat-button-toggle which emits (change)
   @Output() change = new EventEmitter<CustomButtonToggleComponent>();
 
   toggle() {
@@ -50,6 +51,7 @@ export class CustomButtonToggleGroupComponent implements ControlValueAccessor, A
   @Input() name!: string;
 
   @Output() valueChange = new EventEmitter<any>();
+  // eslint-disable-next-line @angular-eslint/no-output-native -- intentional Material API parity: drop-in for mat-button-toggle-group which emits (change)
   @Output() change = new EventEmitter<MatButtonToggleChange>();
 
   // strict: @ContentChildren is populated by Angular before ngAfterContentInit

--- a/src/frontend/packages/core/src/shared/components/custom-checkbox/custom-checkbox.component.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-checkbox/custom-checkbox.component.ts
@@ -35,6 +35,7 @@ export class CustomCheckboxComponent implements ControlValueAccessor {
   @Input() invalid = false;
   @Input() errorMessage = '';
 
+  // eslint-disable-next-line @angular-eslint/no-output-native -- intentional Material API parity: drop-in for mat-checkbox which emits (change)
   @Output() change = new EventEmitter<MatCheckboxChange>();
   @Output() indeterminateChange = new EventEmitter<boolean>();
 

--- a/src/frontend/packages/core/src/shared/components/custom-slide-toggle/custom-slide-toggle.component.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-slide-toggle/custom-slide-toggle.component.ts
@@ -36,6 +36,7 @@ export class CustomSlideToggleComponent implements ControlValueAccessor {
   @Input() invalid = false;
   @Input() errorMessage = '';
 
+  // eslint-disable-next-line @angular-eslint/no-output-native -- intentional Material API parity: drop-in for mat-slide-toggle which emits (change)
   @Output() change = new EventEmitter<MatSlideToggleChange>();
 
   private _onChange = (_value: any) => {};

--- a/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
@@ -10,6 +10,7 @@ export class CustomTooltipDirective implements OnDestroy {
 
   @Input('matTooltip') tooltipText: string = '';
   @Input('matTooltipPosition') position: 'above' | 'below' | 'left' | 'right' = 'above';
+  // eslint-disable-next-line @angular-eslint/no-input-rename -- intentional: drop-in replacement for Angular Material's matTooltip; the matTooltipClass alias IS the public API
   @Input('matTooltipClass') tooltipClass: string = '';
   @Input('matTooltipShowDelay') showDelay: number = 250;
   @Input('matTooltipHideDelay') hideDelay: number = 100;

--- a/src/frontend/packages/core/src/shared/components/file-input/file-input.component.ts
+++ b/src/frontend/packages/core/src/shared/components/file-input/file-input.component.ts
@@ -23,8 +23,8 @@ export class FileInputComponent implements OnInit, OnDestroy {
 
   @Input() accept!: string;
   @Input() placeholder = '';
-  @Output() onFileSelect: EventEmitter<File> = new EventEmitter();
-  @Output() onFileData: EventEmitter<string> = new EventEmitter();
+  @Output() fileSelect: EventEmitter<File> = new EventEmitter();
+  @Output() fileData: EventEmitter<string> = new EventEmitter();
 
   @Input() fileFormControlName!: string;
 
@@ -60,12 +60,12 @@ export class FileInputComponent implements OnInit, OnDestroy {
     const fs = getEventFiles($event);
     if (fs && fs.length > 0) {
       this.files = Array.from(fs);
-      this.onFileSelect.emit(this.files[0]);
+      this.fileSelect.emit(this.files[0]);
 
       if (this.formGroupControl) {
         this.handleFileData(this.files[0], (value: string | ArrayBuffer | null) => this.updateFileState(value));
       } else {
-        this.handleFileData(this.files[0], (value: string | ArrayBuffer | null) => this.onFileData.emit(value as string));
+        this.handleFileData(this.files[0], (value: string | ArrayBuffer | null) => this.fileData.emit(value as string));
       }
       if (this.files.length > 0) {
         this.name = this.files[0].name;
@@ -87,7 +87,7 @@ export class FileInputComponent implements OnInit, OnDestroy {
     if (this.formGroupControl) {
       this.formGroupControl.control.controls[this.fileFormControlName].setValue('');
     }
-    this.onFileData.emit('');
+    this.fileData.emit('');
   }
 
   onPathInput($event: Event) {
@@ -96,7 +96,7 @@ export class FileInputComponent implements OnInit, OnDestroy {
     if (this.formGroupControl) {
       this.formGroupControl.control.controls[this.fileFormControlName].setValue(input.value);
     }
-    this.onFileData.emit(input.value);
+    this.fileData.emit(input.value);
   }
 
   handleFileData(file: File, done: (value: string | ArrayBuffer | null) => void) {

--- a/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.ts
+++ b/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.ts
@@ -25,14 +25,14 @@ export class MarkdownPreviewComponent implements PreviewableComponent {
 
 
   markdownHtml!: string;
-  documentUrl!: string;
+  private _documentUrl!: string;
   // null is a sentinel meaning "title not yet derived from the document"
   title: string | null = '';
 
-  @Input('documentUrl')
-  set setDocumentUrl(value: string) {
-    if (value && this.documentUrl !== value) {
-      this.documentUrl = value;
+  @Input()
+  set documentUrl(value: string) {
+    if (value && this._documentUrl !== value) {
+      this._documentUrl = value;
       this.title = null;
       this.loadDocument();
     }
@@ -51,11 +51,11 @@ export class MarkdownPreviewComponent implements PreviewableComponent {
   }
 
   setProps(props: { [key: string]: any, }) {
-    this.setDocumentUrl = props.documentUrl;
+    this.documentUrl = props.documentUrl;
   }
 
   private loadDocument() {
-    this.httpClient.get(this.documentUrl, { responseType: 'text' }).subscribe(
+    this.httpClient.get(this._documentUrl, { responseType: 'text' }).subscribe(
       (markText: string) => {
         if (markText && markText.length > 0) {
           // Basic sanitization - Note: marked no longer supports sanitize option
@@ -69,7 +69,7 @@ export class MarkdownPreviewComponent implements PreviewableComponent {
           this.markdownHtml = typeof result === 'string' ? result : '';
         }
       },
-      (error: any) => console.warn(`Failed to fetch markdown with url ${this.documentUrl}: `, error));
+      (error: any) => console.warn(`Failed to fetch markdown with url ${this._documentUrl}: `, error));
   }
 
   public markdownRendered() {

--- a/src/frontend/packages/core/src/shared/components/meta-card/meta-card-base/meta-card.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/meta-card/meta-card-base/meta-card.component.spec.ts
@@ -10,7 +10,7 @@ import { MetaCardComponent } from './meta-card.component';
 import { MetaCardTitleComponent } from '../meta-card-title/meta-card-title.component';
 
 @Component({
-  standalone: false,
+  imports: [MetaCardComponent, MetaCardTitleComponent],
   template: `
     <app-meta-card>
       <app-meta-card-title>Title</app-meta-card-title>
@@ -57,8 +57,8 @@ describe('MetaCardComponent', () => {
         CoreTestingModule,
         NoopAnimationsModule,
         createBasicStoreModule(),
+        WrapperComponent,
       ],
-      declarations: [WrapperComponent],
       providers: [
         { provide: UserFavoriteManager, useClass: UserFavoriteManagerMock },
         provideZonelessChangeDetection(),

--- a/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
+++ b/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
@@ -50,7 +50,7 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
 
   @Input() options: MonacoEditorOptions = {};
   @Input() model?: MonacoEditorModel;
-  @Output() onInit = new EventEmitter<any>();
+  @Output() editorInit = new EventEmitter<any>();
 
   private editor: any;
   private value = '';
@@ -122,7 +122,7 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
     }
 
     // Emit initialization event
-    this.onInit.emit(this.editor);
+    this.editorInit.emit(this.editor);
   }
 
   private setupResizeObserver(): void {

--- a/src/frontend/packages/core/src/shared/components/signal-list/list-action.types.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/list-action.types.ts
@@ -1,6 +1,7 @@
 import { Observable } from 'rxjs';
 import { ActionState } from '@stratosui/store';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional public-API generic: T is propagated to extending action interfaces (IListAction/IOptionalAction/etc.) so the whole family shares one row type
 export interface IBaseListAction<T> {
   icon?: string;
   label: string;

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list-cell-template.directive.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list-cell-template.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, TemplateRef } from '@angular/core';
+import { Directive, inject, Input, TemplateRef } from '@angular/core';
 
 // Tags an <ng-template> as a named cell renderer for a SignalList column
 // of `kind: 'template'`. SignalListComponent collects every directive
@@ -20,5 +20,5 @@ import { Directive, Input, TemplateRef } from '@angular/core';
 export class SignalListCellTemplateDirective<T = unknown> {
   @Input('appSignalListCell') name!: string;
 
-  constructor(public readonly template: TemplateRef<{ $implicit: T; row: T }>) {}
+  public readonly template = inject<TemplateRef<{ $implicit: T; row: T }>>(TemplateRef);
 }

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -287,6 +287,7 @@
                             <span class="material-icons text-xl leading-none">more_vert</span>
                           </button>
                           @if (openActionsRowKey() === config.getRowKey(row)) {
+                            <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -- not interactive; (click) is only a stopPropagation guard so a click inside the menu doesn't bubble to the outside-click closer. Actions are real focusable <button>s below. -->
                             <div
                               data-test="row-actions-menu"
                               (click)="$event.stopPropagation()"
@@ -499,6 +500,7 @@
                           <span class="material-icons text-xl leading-none">more_vert</span>
                         </button>
                         @if (openActionsRowKey() === config.getRowKey(row)) {
+                          <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -- not interactive; (click) is only a stopPropagation guard so a click inside the menu doesn't bubble to the outside-click closer. Actions are real focusable <button>s below. -->
                           <div
                             data-test="row-actions-menu"
                             (click)="$event.stopPropagation()"
@@ -594,6 +596,7 @@
                         <span class="material-icons text-xl leading-none">more_vert</span>
                       </button>
                       @if (openActionsRowKey() === config.getRowKey(row)) {
+                        <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -- not interactive; (click) is only a stopPropagation guard so a click inside the menu doesn't bubble to the outside-click closer. Actions are real focusable <button>s below. -->
                         <div
                           data-test="row-actions-menu"
                           (click)="$event.stopPropagation()"

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -308,6 +308,7 @@ export interface SignalListHeaderAction {
  * to act on the selection — leaving bulk operations unmigratable. This is
  * the slot, no consumers wired by this commit.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional public-API generic: T keeps bulk-action row type aligned with SignalListConfig<T> at the consumer call site
 export interface SignalListBulkAction<T> {
   /** Display label inside the button. */
   readonly label: string;

--- a/src/frontend/packages/core/src/shared/components/signal-list/simple-list-config.types.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/simple-list-config.types.ts
@@ -6,4 +6,5 @@
  * once aliased is gone with the list framework; consumers only use it as an
  * opaque, `any`-typed holder.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional public-API generic: T is retained from the legacy ISimpleListConfig<T> signature so existing call sites keep compiling; the alias is an opaque any-typed holder
 export type ISimpleListConfig<T = any> = Record<string, any>;

--- a/src/frontend/packages/core/src/shared/components/stepper/step/step.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/step/step.component.ts
@@ -97,15 +97,15 @@ export class StepComponent {
   // busy gates the parent stepper's Next/Apply [disabled] binding, but the
   // steppers component is OnPush and busy mutations happen outside its CD
   // scope (the destructive-entry timer below, goNext teardown). Mirror the
-  // onValidChange pattern so the stepper can markForCheck — a bare property
+  // validChange pattern so the stepper can markForCheck — a bare property
   // write is invisible to it (a step's markForCheck walks the declaration
   // tree, which doesn't include the steppers view). Without this the
   // destructive confirm step's Apply stayed disabled forever under zoneless.
-  @Output() onBusyChange = new EventEmitter<boolean>();
+  @Output() busyChange = new EventEmitter<boolean>();
   set busy(v: boolean) {
     if (this._busy !== v) {
       this._busy = v;
-      this.onBusyChange.emit(v);
+      this.busyChange.emit(v);
     }
   }
   get busy(): boolean { return this._busy; }
@@ -116,12 +116,12 @@ export class StepComponent {
   @Input()
   title!: string;
 
-  @Output() onHidden = new EventEmitter<boolean>();
+  @Output() hiddenChange = new EventEmitter<boolean>();
 
   @Input()
   set hidden(hidden: boolean) {
     this.pHidden = hidden;
-    this.onHidden.emit(this.pHidden);
+    this.hiddenChange.emit(this.pHidden);
   }
 
   // Signal-handle `hidden` overrides legacy storage. Signal reads inside the
@@ -136,19 +136,19 @@ export class StepComponent {
     if (this._valid !== value) {
       this._valid = value;
       // Emit event to notify parent stepper of validation change
-      this.onValidChange.emit(value);
+      this.validChange.emit(value);
     }
   }
   // When `signalHandle` is set, the stepper reads validity from
   // `signalHandle.valid()` — the legacy `_valid` storage is ignored.
   // Signal reads are tracked by Angular's CD so this is reactive without
-  // the manual `onValidChange` emitter pattern.
+  // the manual `validChange` emitter pattern.
   get valid(): boolean {
     return this.signalHandle ? this.signalHandle.valid() : this._valid;
   }
   private _valid = true;
 
-  @Output() onValidChange = new EventEmitter<boolean>();
+  @Output() validChange = new EventEmitter<boolean>();
 
   // Setter-backed inputs that emit change events so the parent stepper
   // component can re-run change detection. Under OnPush + zoneless change
@@ -164,13 +164,13 @@ export class StepComponent {
   set canClose(v: boolean) {
     if (this._canClose !== v) {
       this._canClose = v;
-      this.onCanCloseChange.emit(v);
+      this.canCloseChange.emit(v);
     }
   }
   get canClose(): boolean {
     return this.signalHandle?.canClose ? this.signalHandle.canClose() : this._canClose;
   }
-  @Output() onCanCloseChange = new EventEmitter<boolean>();
+  @Output() canCloseChange = new EventEmitter<boolean>();
 
   private _hideCloseButton = false;
   @Input()
@@ -208,13 +208,13 @@ export class StepComponent {
   set disablePrevious(v: boolean) {
     if (this._disablePrevious !== v) {
       this._disablePrevious = v;
-      this.onDisablePreviousChange.emit(v);
+      this.disablePreviousChange.emit(v);
     }
   }
   get disablePrevious(): boolean {
     return this.signalHandle?.disablePrevious ? this.signalHandle.disablePrevious() : this._disablePrevious;
   }
-  @Output() onDisablePreviousChange = new EventEmitter<boolean>();
+  @Output() disablePreviousChange = new EventEmitter<boolean>();
 
   private _blocked = false;
   @Input()

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.spec.ts
@@ -54,7 +54,7 @@ describe('SteppersComponent', () => {
   // Regression: dev.56 shipped a template change that swapped @if-wrapped
   // steps for [hidden] bindings so the stepper's one-shot @ContentChildren
   // capture sees all steps at ngAfterContentInit. That exposed a second
-  // zoneless-CD bug: onHidden → filterSteps reassigns this.steps but
+  // zoneless-CD bug: hiddenChange → filterSteps reassigns this.steps but
   // without markForCheck the template kept rendering the step list from
   // the initial filter. Routes step would never appear even after routes
   // loaded. This test pins the filter path to mark for check.

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -110,7 +110,7 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
     this.setActive(0);
 
     this.allSteps.forEach((step => {
-      this.hiddenSubs.push(step.onHidden.subscribe((_hidden) => {
+      this.hiddenSubs.push(step.hiddenChange.subscribe((_hidden) => {
         this.filterSteps();
       }));
       // Listen for validation/canClose/disablePrevious changes to trigger
@@ -120,19 +120,19 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
       // template bindings that read from `this.steps[i].canClose` etc.
       // Without these markForCheck calls the Previous/Close button
       // disabled state stays frozen at the initial bind state.
-      this.hiddenSubs.push(step.onValidChange.subscribe(() => {
+      this.hiddenSubs.push(step.validChange.subscribe(() => {
         this.cdr.markForCheck();
       }));
       // busy gates the Next/Apply [disabled] binding; its mutations (e.g.
       // the destructive-entry delay timer in StepComponent.pOnEnter) happen
       // outside this component's CD scope. See StepComponent.busy.
-      this.hiddenSubs.push(step.onBusyChange.subscribe(() => {
+      this.hiddenSubs.push(step.busyChange.subscribe(() => {
         this.cdr.markForCheck();
       }));
-      this.hiddenSubs.push(step.onCanCloseChange.subscribe(() => {
+      this.hiddenSubs.push(step.canCloseChange.subscribe(() => {
         this.cdr.markForCheck();
       }));
-      this.hiddenSubs.push(step.onDisablePreviousChange.subscribe(() => {
+      this.hiddenSubs.push(step.disablePreviousChange.subscribe(() => {
         this.cdr.markForCheck();
       }));
     }));

--- a/src/frontend/packages/core/src/shared/components/tailwind-json-schema-form/tailwind-json-schema-form.component.ts
+++ b/src/frontend/packages/core/src/shared/components/tailwind-json-schema-form/tailwind-json-schema-form.component.ts
@@ -25,7 +25,7 @@ export class TailwindJsonSchemaFormComponent implements OnInit, OnChanges {
   @Input() options: TailwindJsonSchemaFormConfig = { addSubmit: false };
   @Input() loadExternalAssets: boolean = false;
 
-  @Output() onChanges = new EventEmitter<any>();
+  @Output() changes = new EventEmitter<any>();
   @Output() validationErrors = new EventEmitter<any[]>();
 
   form!: FormGroup<any>;
@@ -85,7 +85,7 @@ export class TailwindJsonSchemaFormComponent implements OnInit, OnChanges {
     // Subscribe to form changes
     this.form.valueChanges.subscribe(value => {
       this.formData = value;
-      this.onChanges.emit(value);
+      this.changes.emit(value);
       this.checkValidation();
     });
   }

--- a/src/frontend/packages/core/src/shared/components/unlimited-input/unlimited-input.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/unlimited-input/unlimited-input.component.spec.ts
@@ -1,14 +1,14 @@
 import {  Component, ViewChild, provideZonelessChangeDetection, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
-import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { ReactiveFormsModule, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { CoreModule } from '../../../core/core.module';
 import { UnlimitedInputComponent } from './unlimited-input.component';
 
 @Component({
-  standalone: false,
+  imports: [ReactiveFormsModule, UnlimitedInputComponent],
   template: `
     <form [formGroup]="formGroup">
       <app-unlimited-input name="inputName"
@@ -38,11 +38,11 @@ describe('UnlimitedInputComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [provideZonelessChangeDetection()],
-      declarations: [WrapperComponent],
       imports: [
         BrowserAnimationsModule,
         CoreModule,
         UnlimitedInputComponent,
+        WrapperComponent,
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });

--- a/src/frontend/packages/core/src/shared/services/tailwind-json-schema-form.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-json-schema-form.service.ts
@@ -47,14 +47,14 @@ export class TailwindJsonSchemaFormComponent implements OnInit {
   @Input() options: any;
   @Input() framework: string = "tailwind";
 
-  @Output() onChanges = new EventEmitter<any>();
-  @Output() onSubmit = new EventEmitter<any>();
+  @Output() changes = new EventEmitter<any>();
+  @Output() formSubmit = new EventEmitter<any>();
   @Output() isValid = new EventEmitter<boolean>();
 
   ngOnInit(): void {
     // Basic initialization
     if (this.data) {
-      this.onChanges.emit(this.data);
+      this.changes.emit(this.data);
     }
     this.isValid.emit(true);
   }
@@ -70,7 +70,7 @@ export class TailwindJsonSchemaFormComponent implements OnInit {
   }
 
   submitForm(): void {
-    this.onSubmit.emit(this.data);
+    this.formSubmit.emit(this.data);
   }
 }
 

--- a/src/frontend/packages/core/src/shared/services/tailwind-snackbar.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-snackbar.service.ts
@@ -7,6 +7,7 @@ export interface TailwindSnackBarConfig {
   panelClass?: string | string[];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional public-API generic: T mirrors MatSnackBarRef<T> (the attached component-instance type) so callers can type the ref; the impl propagates it via implements TailwindSnackBarRef<T>
 export interface TailwindSnackBarRef<T> {
   afterDismissed(): Observable<any>;
   onAction(): Observable<any>;

--- a/src/frontend/packages/core/src/shared/user-permission.directive.spec.ts
+++ b/src/frontend/packages/core/src/shared/user-permission.directive.spec.ts
@@ -12,7 +12,7 @@ import { UserPermissionDirective } from './user-permission.directive';
 import { CurrentUserPermissionsService } from '../core/permissions/current-user-permissions.service';
 
 @Component({
-  standalone: false,
+  imports: [UserPermissionDirective],
   template: `<div *appUserPermission="['test.permission']">Test Content</div>`
 })
 class TestUserPermissionComponent {
@@ -43,9 +43,9 @@ describe('UserPermissionDirective', () => {
         },
         createBasicStoreModule(),
         AppTestModule,
-        UserPermissionDirective
-      ],
-      declarations: [TestUserPermissionComponent]
+        UserPermissionDirective,
+        TestUserPermissionComponent
+      ]
     });
     fixture = TestBed.createComponent(TestUserPermissionComponent);
     component = fixture.componentInstance;

--- a/src/frontend/packages/core/src/shared/validators/validation.types.ts
+++ b/src/frontend/packages/core/src/shared/validators/validation.types.ts
@@ -47,6 +47,7 @@ export interface UrlValidatorConfig {
 /**
  * Configuration for async uniqueness validator
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional public-API generic: T is the validated-value type carried by the config so call sites can parameterize it; the alias keeps the existing signature stable
 export interface UniquenessValidatorConfig<T = any> {
   /** Function to check if value exists */
   checkFn: (value: string) => Promise<boolean> | Observable<boolean>;

--- a/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.ts
+++ b/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.ts
@@ -61,8 +61,8 @@ interface GithubType {
 enum GitTypeKeys {
   GITHUB_COM = 'githubdotcom',
   GITHUB_ENTERPRISE = 'githubenterprize',
-  GITLAB_COM = 'githubdotcom',
-  GITLAB_ENTERPRISE = 'githubenterprize' }
+  GITLAB_COM = 'gitlabdotcom',
+  GITLAB_ENTERPRISE = 'gitlabenterprise' }
 
 interface GitRegistrationForm {
   selectedType: FormControl<string>;

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-selection.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-selection.component.html
@@ -1,16 +1,4 @@
-@if (!(helper.clusters$ | async)) {
-  <div class="flex flex-1 items-center justify-center">
-    <div class="text-center">
-      <app-custom-icon class="text-[96px] h-24 w-24 opacity-70">insert_drive_file</app-custom-icon>
-      <h1 class="text-2xl text-center">Select a Kube Config file to import clusters</h1>
-      <div class="kube-config-auth__form">
-        <app-file-input placeholder="kubeconfig" (onFileData)="clustersParse($event)"
-          buttonLabel="Select Kube Config file">
-        </app-file-input>
-      </div>
-    </div>
-  </div>
-} @else {
+@if ((helper.clusters$ | async)) {
   <div class="flex-1">
     <app-signal-list [config]="listConfig">
       <ng-template appSignalListCell="name" let-row>
@@ -53,5 +41,17 @@
         <app-kube-config-table-cert [row]="row"></app-kube-config-table-cert>
       </ng-template>
     </app-signal-list>
+  </div>
+} @else {
+  <div class="flex flex-1 items-center justify-center">
+    <div class="text-center">
+      <app-custom-icon class="text-[96px] h-24 w-24 opacity-70">insert_drive_file</app-custom-icon>
+      <h1 class="text-2xl text-center">Select a Kube Config file to import clusters</h1>
+      <div class="kube-config-auth__form">
+        <app-file-input placeholder="kubeconfig" (fileData)="clustersParse($event)"
+          buttonLabel="Select Kube Config file">
+        </app-file-input>
+      </div>
+    </div>
   </div>
 }

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-metric.types.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-metric.types.ts
@@ -36,6 +36,5 @@ export interface IKubernetesMetric {
 /**
  * Extended ChartSeries metadata for Kubernetes metrics
  */
-export interface IKubernetesChartMetadata extends IKubernetesMetric {
-  // Metadata can include all metric properties
-}
+// Metadata can include all metric properties
+export type IKubernetesChartMetadata = IKubernetesMetric;

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-resource-viewer/kubernetes-resource-viewer.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-resource-viewer/kubernetes-resource-viewer.component.ts
@@ -31,7 +31,7 @@ import { KubePodDataService } from '../../services/domain-data/kube-pod-data.ser
 import { KubeServiceDataService } from '../../services/domain-data/kube-service-data.service';
 import { KUBERNETES_ENDPOINT_TYPE } from '../kubernetes-entity-factory';
 import { KubernetesEndpointService } from '../services/kubernetes-endpoint.service';
-import { BasicKubeAPIResource, KubeAPIResource, KubeResourceEntityDefinition, KubeStatus } from '../store/kube.types';
+import { BasicKubeAPIResource, KubeAPIResource, KubeResourceEntityDefinition } from '../store/kube.types';
 import { ConfirmationDialogService } from './../../../../core/src/shared/components/confirmation-dialog.service';
 import { SidePanelService } from './../../../../core/src/shared/services/side-panel.service';
 import { entityCatalog } from './../../../../store/src/entity-catalog/entity-catalog';

--- a/src/frontend/packages/kubernetes/src/kubernetes/services/kubernetes-expanded-state.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/services/kubernetes-expanded-state.ts
@@ -63,7 +63,8 @@ export class KubernetesPodExpandedStatusHelper {
       const state = container.state || {};
 
       if (!!state.terminated && state.terminated.exitCode === 0) {
-
+        // Init container completed successfully (exit code 0) — no reason
+        // to surface, fall through and leave the running reason as-is.
       } else if (state.terminated) {
         if (state.terminated.reason.length === 0) {
           if (state.terminated.signal !== 0) {

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.html
@@ -89,14 +89,14 @@
       </div>
     }
     @if (hasSchema) {
-      <json-schema-form (onChanges)="formChanged($event)" #schemaForm loadExternalAssets="false"
+      <json-schema-form (changes)="formChanged($event)" #schemaForm loadExternalAssets="false"
         [options]="{ addSubmit: false }" [schema]="schema" framework="tailwind" [data]="initialFormData">
       </json-schema-form>
     }
   </div>
   <div [ngClass]="{'editor-hidden': mode !== 'editor'}" class="editor-monaco" #monacoContainer>
     <app-monaco-editor #monacoEditor class="editor-monaco-edit " [options]="editorOptions" [model]="model"
-    [(ngModel)]="code" (onInit)="onMonacoInit($event)"></app-monaco-editor>
+    [(ngModel)]="code" (editorInit)="onMonacoInit($event)"></app-monaco-editor>
   </div>
 
 </div>

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/diffvalues.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/diffvalues.ts
@@ -11,7 +11,7 @@ function arraysAreEqual(a1: unknown[], a2: unknown[]): boolean {
       if (!arraysAreEqual(a1[i] as unknown[], a2[i] as unknown[])) {
         return false;
       }
-    } else if (typeof (a1[i] === 'object')) {
+    } else if (typeof a1[i] === 'object') {
       if (!objectsAreEqual(a1[i] as Record<string, unknown>, a2[i] as Record<string, unknown>)) {
         return false;
       }

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/json-schema-generator.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/json-schema-generator.ts
@@ -19,7 +19,7 @@ const BUILT_IN_TYPES = [
 
 const toString = ({}).toString;
 
-function isBuiltIn(constructor: Function): boolean {
+function isBuiltIn(constructor: new (...args: any[]) => any): boolean {
   for (const bit of BUILT_IN_TYPES) {
     if (bit === constructor) {
       return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/helm-release-tab-base/helm-release-socket-service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/helm-release-tab-base/helm-release-socket-service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy, inject } from '@angular/core';
 import { of, Subject, Subscription } from 'rxjs';
 import makeWebSocketObservable, { GetWebSocketResponses } from 'rxjs-websockets';
-import { catchError, map, share, switchMap } from 'rxjs/operators';
+import { catchError, share, switchMap } from 'rxjs/operators';
 
 import { SnackBarService } from '../../../../../../core/src/shared/services/snackbar.service';
 import {

--- a/src/frontend/packages/shared/src/components/stratos-title/stratos-title.component.ts
+++ b/src/frontend/packages/shared/src/components/stratos-title/stratos-title.component.ts
@@ -4,6 +4,7 @@ import { Component, Input, ChangeDetectionStrategy } from "@angular/core";
   selector: "app-stratos-title",
   templateUrl: "./stratos-title.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // eslint-disable-next-line @angular-eslint/prefer-standalone -- declared in NgModule StratosComponentsModule (components.module.ts, out of scope); standalone migration tracked separately
   standalone: false,
 })
 export class StratosTitleComponent {

--- a/src/frontend/packages/store/src/entity-catalog/entity-catalog.types.ts
+++ b/src/frontend/packages/store/src/entity-catalog/entity-catalog.types.ts
@@ -182,7 +182,7 @@ export interface IStratosEndpointDefinition<T = EntityCatalogSchemas | EntitySch
   readonly homeCard?: HomeCardMetadata;
 }
 
-export interface StratosEndpointExtensionDefinition extends Omit<IStratosEndpointDefinition, 'schema'> { }
+export type StratosEndpointExtensionDefinition = Omit<IStratosEndpointDefinition, 'schema'>;
 export interface EntityTableConfig<T = any> {
   rowBuilders: EntityRowBuilder<T>[];
   showHeader?: boolean;

--- a/src/frontend/packages/store/src/types/request.types.ts
+++ b/src/frontend/packages/store/src/types/request.types.ts
@@ -15,6 +15,7 @@ export interface SingleEntityAction {
   guid?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- intentional class/interface merge: the abstract RequestAction class (below) is augmented with these optional action fields
 export interface RequestAction extends Action, BasePipelineRequestAction, SingleEntityAction {
   updatingKey?: string;
 }
@@ -84,6 +85,7 @@ export abstract class StartAction implements Action {
   type = ApiActionTypes.API_REQUEST_START;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- intentional class/interface merge: this abstract class carries the same-named interface's optional action fields
 export abstract class RequestAction implements Action {
   type = RequestTypes.START;
 }


### PR DESCRIPTION
## What

Drives the frontend lint (`bun run lint`) from **69 warnings → 0** (0 errors, no unused-disable-directives). Continuation of the post-Angular-22 ESLint-tail effort. **Closes #5447.**

## Verification

- `bun run lint` → 0 warnings / 0 errors
- AOT production build (`bun run build`) → clean, no template binding errors (validates the output/input renames + standalone migrations)
- Affected `.spec.ts` files (standalone migrations, inject conversions) → pass

## Highlights — real fixes

- **Bugs found & fixed:** `typeof` precedence bug in `diffvalues.ts` (`typeof (a === 'object')` → `typeof a === 'object'`); duplicate enum values in `git-registration` (GitLab entries were copy-pasted GitHub string values); bare-ternary statements rewritten as `if/else`.
- **Type-structural:** empty `interface X extends Y {}` → type aliases; `Function` → explicit constructor signature.
- **Angular:** `prefer-inject` conversions to `inject()`; 5 test-host components migrated to standalone.
- **Template a11y:** keyboard handlers + `role`/`tabindex` for click-only elements, `label`/`for` associations, negated-async rewrite.

## Output/input renames (consumers swept, AOT-verified)

- Dropped `on` prefix: `file-input` (`fileSelect`/`fileData`), `monaco-editor` (`editorInit`), `step` (`busyChange`/`hiddenChange`/`validChange`/`canCloseChange`/`disablePreviousChange`), `json-schema-form` (`changes`/`formSubmit`).
- `markdown-preview`: input setter de-aliased, public `documentUrl` binding name preserved.

## Documented suppressions (intentional, with rationale comments)

Renaming these would break deliberate API compatibility, so each carries an `eslint-disable-next-line ... -- <reason>`:
- Native-named outputs (`change`/`select`) on the custom widgets that are **drop-in replacements for `mat-checkbox`/`mat-slide-toggle`/`mat-button-toggle`** and the ngx-charts wrappers.
- The `matTooltip*` input alias (the directive exists to provide Material's `matTooltip` syntax).
- Two production components (`AppComponent`, `StratosTitleComponent`) declared in NgModules — standalone migration tracked separately.
- Intentional public-API generics and class/interface merges; non-interactive propagation-guard `<div>`s.