### PR TITLE
Add native service route-bindings + service-keys handlers (#4301/#4302)

### DIFF
--- a/src/jetstream/plugins/cloudfoundry/native_routes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_routes.go
@@ -40,6 +40,18 @@ func (c *CloudFoundrySpecification) addNativeRoutes(echoGroup *echo.Group) {
 	nativeGroup.POST("/cf/service_bindings/:cnsiGuid", c.createServiceBinding)
 	nativeGroup.DELETE("/cf/service_bindings/:cnsiGuid/:bindingGuid", c.deleteServiceBinding)
 	nativeGroup.GET("/cf/apps/:cnsiGuid/:appGuid/service_bindings", c.getAppServiceBindings)
+	// Service route bindings (GH#4302) + service keys (GH#4301): registered
+	// for forward-wiring; capi already ships both clients. Async create/delete
+	// follow the RunFastPath / writeWithJob contract (see the handler files).
+	nativeGroup.GET("/cf/service_route_bindings/:cnsiGuid", c.getNativeServiceRouteBindings)
+	nativeGroup.POST("/cf/service_route_bindings/:cnsiGuid", c.createServiceRouteBinding)
+	nativeGroup.DELETE("/cf/service_route_bindings/:cnsiGuid/:bindingGuid", c.deleteServiceRouteBinding)
+	nativeGroup.GET("/cf/service_route_bindings/:cnsiGuid/:bindingGuid/parameters", c.getNativeServiceRouteBindingParameters)
+	nativeGroup.GET("/cf/service_keys/:cnsiGuid", c.getNativeServiceKeys)
+	nativeGroup.POST("/cf/service_keys/:cnsiGuid", c.createServiceKey)
+	nativeGroup.DELETE("/cf/service_keys/:cnsiGuid/:keyGuid", c.deleteServiceKey)
+	nativeGroup.GET("/cf/service_keys/:cnsiGuid/:keyGuid/details", c.getNativeServiceKeyDetails)
+	nativeGroup.GET("/cf/service_keys/:cnsiGuid/:keyGuid/parameters", c.getNativeServiceKeyParameters)
 	nativeGroup.GET("/cf/org/:cnsiGuid/:orgGuid", c.getNativeOrgDetail)
 	nativeGroup.GET("/cf/org/:cnsiGuid/:orgGuid/spaces", c.getNativeOrgSpaces)
 	nativeGroup.GET("/cf/org/:cnsiGuid/:orgGuid/private_domains", c.getNativeOrgDomains)

--- a/src/jetstream/plugins/cloudfoundry/native_service_keys.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_keys.go
@@ -1,0 +1,270 @@
+// src/jetstream/plugins/cloudfoundry/native_service_keys.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/fivetwenty-io/capi/v3/pkg/capi"
+	"github.com/labstack/echo/v4"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+)
+
+// Service keys (GH#4301) — Stratos-shape wrappers around CF v3 service keys.
+//
+// In v3 a "service key" is a service_credential_binding with type="key" (vs
+// "app"), so these handlers reuse capi's ServiceCredentialBindingsClient and
+// pin type=key. create/delete share the same async RunFastPath / writeWithJob
+// contract as native_service_bindings.go; GetDetails surfaces the credentials a
+// key exists to expose.
+//
+// Registered but not yet consumed by the frontend — they give the eventual
+// service-keys UI a stable contract to wire to. The generic credential-binding
+// create/delete handlers already accept type=key bodies; these key-scoped
+// endpoints make the surface explicit (and add list + details + parameters).
+
+// createServiceKey handles POST /pp/v1/cf/service_keys/{cnsiGuid}.
+//
+// The frontend sends a v3-shaped credential-binding body naming the service
+// instance:
+//
+//	{"name":"my-key","relationships":{
+//	   "service_instance":{"data":{"guid":"<siGuid>"}}},
+//	 "parameters":{...optional...}}
+//
+// We decode it into capi.ServiceCredentialBindingCreateRequest and force
+// Type="key" (ignoring any client-supplied type) so this endpoint can only ever
+// mint keys. capi's Create returns *ServiceCredentialBinding (sync 201) or *Job
+// (async); the async path drives RunFastPath like createServiceBinding.
+func (cf *CloudFoundrySpecification) createServiceKey(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	var req capi.ServiceCredentialBindingCreateRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid body: %v", err))
+	}
+	// This endpoint mints keys only — pin the type regardless of the client body.
+	req.Type = "key"
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	result, createErr := cfClient.ServiceCredentialBindings().Create(reqCtx, &req)
+	if createErr != nil {
+		return handleCapiError(c, createErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	// Sync path: key returned directly. Surface 201 Created with the body.
+	job, isJob := result.(*capi.Job)
+	if !isJob {
+		return c.JSON(http.StatusCreated, result)
+	}
+
+	// Async path: broker key returned 202 + Location; drive RunFastPath.
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_key.create",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// deleteServiceKey handles DELETE /pp/v1/cf/service_keys/{cnsiGuid}/{keyGuid}.
+//
+// Delegates to ServiceCredentialBindings().Delete (a key is just a credential
+// binding). Async 202 + Location → *Job → RunFastPath; nil job → synthetic
+// COMPLETE so writeWithJob resolves without polling.
+func (cf *CloudFoundrySpecification) deleteServiceKey(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	keyGUID := c.Param("keyGuid")
+	if cnsiGUID == "" || keyGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and keyGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	job, deleteErr := cfClient.ServiceCredentialBindings().Delete(reqCtx, keyGUID)
+	if deleteErr != nil {
+		return handleCapiError(c, deleteErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	if job == nil {
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  stratosjobs.JobStateComplete,
+			"result": map[string]string{"operation": "service_key.delete"},
+		})
+	}
+
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_key.delete",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// getNativeServiceKeys handles GET /pp/v1/cf/service_keys/{cnsiGuid}.
+//
+// Lists credential bindings filtered to type=key. Optional query filter:
+// service_instance_guids (scope to one SI). Returns a StratosPagedResponse of
+// the raw v3 bindings; the frontend adapter shapes them when the UI is wired.
+func (cf *CloudFoundrySpecification) getNativeServiceKeys(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	perPage, page, present := parsePerPageAndPage(c)
+	params := applyPagingParams(capi.NewQueryParams().WithFilter("type", "key"), perPage, page, present)
+	if si := c.QueryParam("service_instance_guids"); si != "" {
+		params = params.WithFilter("service_instance_guids", si)
+	}
+
+	raw, listErr := cfClient.ServiceCredentialBindings().List(reqCtx, params)
+	if listErr != nil {
+		return handleCapiError(c, listErr)
+	}
+
+	return c.JSON(http.StatusOK, StratosPagedResponse[capi.ServiceCredentialBinding]{
+		Resources:  raw.Resources,
+		Pagination: BuildPaginationMeta(c, page, perPage, raw.Pagination.TotalResults),
+	})
+}
+
+// getNativeServiceKeyDetails handles
+// GET /pp/v1/cf/service_keys/{cnsiGuid}/{keyGuid}/details.
+//
+// Surfaces the key's credentials (v3 GET .../details) — the reason service keys
+// exist. Read-only; no job handoff. Sensitive payload: returned verbatim to the
+// authenticated caller, never logged.
+func (cf *CloudFoundrySpecification) getNativeServiceKeyDetails(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	keyGUID := c.Param("keyGuid")
+	if cnsiGUID == "" || keyGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and keyGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	details, detErr := cfClient.ServiceCredentialBindings().GetDetails(reqCtx, keyGUID)
+	if detErr != nil {
+		return handleCapiError(c, detErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, details)
+}
+
+// getNativeServiceKeyParameters handles
+// GET /pp/v1/cf/service_keys/{cnsiGuid}/{keyGuid}/parameters.
+//
+// Surfaces the broker-specific parameters the key was created with (v3 GET
+// .../parameters). Read-only; no job handoff.
+func (cf *CloudFoundrySpecification) getNativeServiceKeyParameters(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	keyGUID := c.Param("keyGuid")
+	if cnsiGUID == "" || keyGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and keyGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	params, paramErr := cfClient.ServiceCredentialBindings().GetParameters(reqCtx, keyGUID)
+	if paramErr != nil {
+		return handleCapiError(c, paramErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, params)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_keys_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_keys_test.go
@@ -1,0 +1,238 @@
+// src/jetstream/plugins/cloudfoundry/native_service_keys_test.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func serviceKeyCtx(method, target, body string, paramNames, paramVals []string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, target, nil)
+	} else {
+		req = httptest.NewRequest(method, target, strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames(paramNames...)
+	c.SetParamValues(paramVals...)
+	return c, rec
+}
+
+// TestCreateServiceKey_ForcesTypeKey verifies the handler pins type=key on the
+// upstream credential-binding create even if the client body says otherwise.
+func TestCreateServiceKey_ForcesTypeKey(t *testing.T) {
+	var receivedBody map[string]interface{}
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings" && r.Method == http.MethodPost:
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"guid":"key-1","type":"key"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	// Client deliberately sends type=app — handler must override to "key".
+	body := `{"type":"app","name":"my-key","relationships":{"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := serviceKeyCtx(http.MethodPost, "/pp/v1/cf/service_keys/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceKey(c))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, "key", receivedBody["type"], "handler must force type=key")
+	assert.Equal(t, "my-key", receivedBody["name"])
+}
+
+// TestCreateServiceKey_FastPathResolvesAsync covers the async create branch.
+func TestCreateServiceKey_FastPathResolvesAsync(t *testing.T) {
+	var jobGets atomic.Int32
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings" && r.Method == http.MethodPost:
+			w.Header().Set("Location", "/v3/jobs/job-key-1")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"guid":"job-key-1","operation":"service_credential_binding.create","state":"PROCESSING"}`))
+		case r.URL.Path == "/v3/jobs/job-key-1" && r.Method == http.MethodGet:
+			jobGets.Add(1)
+			_, _ = w.Write([]byte(`{"guid":"job-key-1","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	body := `{"name":"my-key","relationships":{"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := serviceKeyCtx(http.MethodPost, "/pp/v1/cf/service_keys/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceKey(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+	assert.GreaterOrEqual(t, jobGets.Load(), int32(1))
+}
+
+// TestDeleteServiceKey_FastPathResolves covers the async delete branch.
+func TestDeleteServiceKey_FastPathResolves(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings/key-9" && r.Method == http.MethodDelete:
+			w.Header().Set("Location", "/v3/jobs/job-keydel-1")
+			w.WriteHeader(http.StatusAccepted)
+		case r.URL.Path == "/v3/jobs/job-keydel-1" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"guid":"job-keydel-1","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	c, rec := serviceKeyCtx(http.MethodDelete, "/pp/v1/cf/service_keys/cnsi-1/key-9", "",
+		[]string{"cnsiGuid", "keyGuid"}, []string{"cnsi-1", "key-9"})
+
+	require.NoError(t, plugin.deleteServiceKey(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+}
+
+// TestGetNativeServiceKeys_FiltersTypeKey verifies the list handler pins
+// the type=key filter on the upstream query.
+func TestGetNativeServiceKeys_FiltersTypeKey(t *testing.T) {
+	var gotQuery string
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings" && r.Method == http.MethodGet:
+			gotQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"pagination":{"total_results":1,"total_pages":1},"resources":[{"guid":"key-1","type":"key"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := serviceKeyCtx(http.MethodGet, "/pp/v1/cf/service_keys/cnsi-1?service_instance_guids=si-1", "",
+		[]string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.getNativeServiceKeys(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, gotQuery, "type=key")
+	assert.Contains(t, gotQuery, "service_instance_guids=si-1")
+}
+
+// TestGetNativeServiceKeyDetails returns the key credentials.
+func TestGetNativeServiceKeyDetails(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings/key-1/details" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"credentials":{"username":"u","password":"p"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := serviceKeyCtx(http.MethodGet, "/pp/v1/cf/service_keys/cnsi-1/key-1/details", "",
+		[]string{"cnsiGuid", "keyGuid"}, []string{"cnsi-1", "key-1"})
+
+	require.NoError(t, plugin.getNativeServiceKeyDetails(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	creds, ok := resp["credentials"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "u", creds["username"])
+}
+
+// TestGetNativeServiceKeyParameters returns the broker parameters.
+func TestGetNativeServiceKeyParameters(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings/key-1/parameters" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"parameters":{"foo":"bar"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := serviceKeyCtx(http.MethodGet, "/pp/v1/cf/service_keys/cnsi-1/key-1/parameters", "",
+		[]string{"cnsiGuid", "keyGuid"}, []string{"cnsi-1", "key-1"})
+
+	require.NoError(t, plugin.getNativeServiceKeyParameters(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "foo")
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_route_bindings.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_route_bindings.go
@@ -1,0 +1,251 @@
+// src/jetstream/plugins/cloudfoundry/native_service_route_bindings.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/fivetwenty-io/capi/v3/pkg/capi"
+	"github.com/labstack/echo/v4"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+)
+
+// Service route bindings (GH#4302) — Stratos-shape write/read wrappers around
+// CF v3 /v3/service_route_bindings via capi's ServiceRouteBindingsClient.
+//
+// These handlers are registered but not yet consumed by the frontend; they
+// exist so the eventual route-service UI can wire to a stable contract. The
+// async create/delete paths follow the same RunFastPath / writeWithJob
+// contract as native_service_bindings.go so no consumer changes are needed
+// when the UI lands.
+
+// createServiceRouteBinding handles
+// POST /pp/v1/cf/service_route_bindings/{cnsiGuid}.
+//
+// The frontend sends the v3-shaped body directly:
+//
+//	{"relationships":{
+//	   "route":{"data":{"guid":"<routeGuid>"}},
+//	   "service_instance":{"data":{"guid":"<siGuid>"}}},
+//	 "parameters":{...optional...}}
+//
+// which matches capi.ServiceRouteBindingCreateRequest one-for-one, so we decode
+// the client body into that request struct and forward it unmodified.
+//
+// capi's Create returns interface{} — *ServiceRouteBinding for synchronous
+// responses (201 Created, e.g. a non-route-service binding) or *Job for
+// asynchronous ones (202 Accepted). We surface 201 on the sync path and drive
+// the async path through RunFastPath so the handoff body is a StratosJob
+// matching the frontend writeWithJob contract.
+//
+// Graceful fallback: if the stratosjobs plugin isn't wired, async creates
+// return bare 202 (frontend 404-on-poll treats that as UNKNOWN).
+func (cf *CloudFoundrySpecification) createServiceRouteBinding(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	var req capi.ServiceRouteBindingCreateRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid body: %v", err))
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	result, createErr := cfClient.ServiceRouteBindings().Create(reqCtx, &req)
+	if createErr != nil {
+		return handleCapiError(c, createErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	// Sync path: binding returned directly. Surface 201 Created with the body.
+	job, isJob := result.(*capi.Job)
+	if !isJob {
+		return c.JSON(http.StatusCreated, result)
+	}
+
+	// Async path: managed route binding returned 202 + Location; drive RunFastPath.
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_route_binding.create",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// deleteServiceRouteBinding handles
+// DELETE /pp/v1/cf/service_route_bindings/{cnsiGuid}/{bindingGuid}.
+//
+// capi's Delete returns (*Job, error). Route-service unbinds are broker-mediated
+// and async (202 + Location → *Job) — we hand the job to RunFastPath for the
+// fast-path/handoff contract. The nil-job branch mirrors deleteServiceBinding:
+// a synchronous 204 would surface a synthetic COMPLETE so writeWithJob resolves
+// without polling.
+//
+// Graceful fallback: if the stratosjobs plugin isn't wired, async deletes
+// return bare 202 (frontend 404-on-poll treats that as UNKNOWN).
+func (cf *CloudFoundrySpecification) deleteServiceRouteBinding(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	bindingGUID := c.Param("bindingGuid")
+	if cnsiGUID == "" || bindingGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and bindingGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	job, deleteErr := cfClient.ServiceRouteBindings().Delete(reqCtx, bindingGUID)
+	if deleteErr != nil {
+		return handleCapiError(c, deleteErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	// Sync path: nil job → synthesize a COMPLETE terminal state.
+	if job == nil {
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  stratosjobs.JobStateComplete,
+			"result": map[string]string{"operation": "service_route_binding.delete"},
+		})
+	}
+
+	// Async path: managed route binding returned 202 + Location; drive RunFastPath.
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_route_binding.delete",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// getNativeServiceRouteBindings handles
+// GET /pp/v1/cf/service_route_bindings/{cnsiGuid}.
+//
+// Optional query filters (passed straight to v3): service_instance_guids,
+// route_guids. Returns a StratosPagedResponse of the raw v3 route bindings;
+// the frontend adapter shapes them when the UI is wired.
+func (cf *CloudFoundrySpecification) getNativeServiceRouteBindings(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	perPage, page, present := parsePerPageAndPage(c)
+	params := applyPagingParams(capi.NewQueryParams(), perPage, page, present)
+	if si := c.QueryParam("service_instance_guids"); si != "" {
+		params = params.WithFilter("service_instance_guids", si)
+	}
+	if rg := c.QueryParam("route_guids"); rg != "" {
+		params = params.WithFilter("route_guids", rg)
+	}
+
+	raw, listErr := cfClient.ServiceRouteBindings().List(reqCtx, params)
+	if listErr != nil {
+		return handleCapiError(c, listErr)
+	}
+
+	return c.JSON(http.StatusOK, StratosPagedResponse[capi.ServiceRouteBinding]{
+		Resources:  raw.Resources,
+		Pagination: BuildPaginationMeta(c, page, perPage, raw.Pagination.TotalResults),
+	})
+}
+
+// getNativeServiceRouteBindingParameters handles
+// GET /pp/v1/cf/service_route_bindings/{cnsiGuid}/{bindingGuid}/parameters.
+//
+// Surfaces the broker-specific route-binding parameters (v3 GET
+// .../parameters). Read-only; no job handoff.
+func (cf *CloudFoundrySpecification) getNativeServiceRouteBindingParameters(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	bindingGUID := c.Param("bindingGuid")
+	if cnsiGUID == "" || bindingGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and bindingGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	params, paramErr := cfClient.ServiceRouteBindings().GetParameters(reqCtx, bindingGUID)
+	if paramErr != nil {
+		return handleCapiError(c, paramErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, params)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_route_bindings_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_route_bindings_test.go
@@ -1,0 +1,220 @@
+// src/jetstream/plugins/cloudfoundry/native_service_route_bindings_test.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// routeBindingCtx wires an echo context for the route-binding handlers.
+func routeBindingCtx(method, target, body string, paramNames, paramVals []string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, target, nil)
+	} else {
+		req = httptest.NewRequest(method, target, strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames(paramNames...)
+	c.SetParamValues(paramVals...)
+	return c, rec
+}
+
+// TestCreateServiceRouteBinding_ForwardsBody verifies the v3-shape body is
+// forwarded to POST /v3/service_route_bindings and the sync 201 surfaced.
+func TestCreateServiceRouteBinding_ForwardsBody(t *testing.T) {
+	capiHits := 0
+	var receivedBody map[string]interface{}
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings" && r.Method == http.MethodPost:
+			capiHits++
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"guid":"srb-1"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	body := `{"relationships":{"route":{"data":{"guid":"route-1"}},"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := routeBindingCtx(http.MethodPost, "/pp/v1/cf/service_route_bindings/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceRouteBinding(c))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, 1, capiHits)
+
+	rels, ok := receivedBody["relationships"].(map[string]interface{})
+	require.True(t, ok, "upstream body missing relationships")
+	route, ok := rels["route"].(map[string]interface{})
+	require.True(t, ok, "upstream body missing relationships.route")
+	data, ok := route["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "route-1", data["guid"])
+}
+
+// TestCreateServiceRouteBinding_FastPathResolvesAsync exercises the async
+// (202 + Job) branch resolving to COMPLETE within the fast-path window.
+func TestCreateServiceRouteBinding_FastPathResolvesAsync(t *testing.T) {
+	var jobGets atomic.Int32
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings" && r.Method == http.MethodPost:
+			w.Header().Set("Location", "/v3/jobs/job-srb-1")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"guid":"job-srb-1","operation":"service_route_binding.create","state":"PROCESSING"}`))
+		case r.URL.Path == "/v3/jobs/job-srb-1" && r.Method == http.MethodGet:
+			jobGets.Add(1)
+			_, _ = w.Write([]byte(`{"guid":"job-srb-1","operation":"service_route_binding.create","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	body := `{"relationships":{"route":{"data":{"guid":"route-1"}},"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := routeBindingCtx(http.MethodPost, "/pp/v1/cf/service_route_bindings/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceRouteBinding(c))
+	assert.Equal(t, http.StatusOK, rec.Code, "fast-path resolve should surface 200")
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+	assert.GreaterOrEqual(t, jobGets.Load(), int32(1))
+}
+
+// TestDeleteServiceRouteBinding_FastPathResolves covers the async delete path.
+func TestDeleteServiceRouteBinding_FastPathResolves(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings/srb-9" && r.Method == http.MethodDelete:
+			w.Header().Set("Location", "/v3/jobs/job-del-1")
+			w.WriteHeader(http.StatusAccepted)
+		case r.URL.Path == "/v3/jobs/job-del-1" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"guid":"job-del-1","operation":"service_route_binding.delete","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	c, rec := routeBindingCtx(http.MethodDelete, "/pp/v1/cf/service_route_bindings/cnsi-1/srb-9", "",
+		[]string{"cnsiGuid", "bindingGuid"}, []string{"cnsi-1", "srb-9"})
+
+	require.NoError(t, plugin.deleteServiceRouteBinding(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+}
+
+// TestGetNativeServiceRouteBindings_List verifies the list handler forwards
+// filters and returns a paged envelope.
+func TestGetNativeServiceRouteBindings_List(t *testing.T) {
+	var gotQuery string
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings" && r.Method == http.MethodGet:
+			gotQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"pagination":{"total_results":1,"total_pages":1},"resources":[{"guid":"srb-1"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := routeBindingCtx(http.MethodGet, "/pp/v1/cf/service_route_bindings/cnsi-1?service_instance_guids=si-1", "",
+		[]string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.getNativeServiceRouteBindings(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, gotQuery, "service_instance_guids=si-1")
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	resources, ok := resp["resources"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, resources, 1)
+}
+
+// TestGetNativeServiceRouteBindingParameters returns the broker parameters.
+func TestGetNativeServiceRouteBindingParameters(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings/srb-1/parameters" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"parameters":{"foo":"bar"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := routeBindingCtx(http.MethodGet, "/pp/v1/cf/service_route_bindings/cnsi-1/srb-1/parameters", "",
+		[]string{"cnsiGuid", "bindingGuid"}, []string{"cnsi-1", "srb-1"})
+
+	require.NoError(t, plugin.getNativeServiceRouteBindingParameters(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "foo")
+}


### PR DESCRIPTION
Adds Jetstream native handlers for CF v3 service route bindings (#4302) and
service keys (#4301), built on the capi v3.222.1 ServiceRouteBindings and
ServiceCredentialBindings clients.

These are backend-only. The handlers are registered in addNativeRoutes but not
yet consumed by the frontend — they give the eventual route-service and
service-keys UI a stable contract to wire to.

## Service route bindings (#4302)

`/pp/v1/cf/service_route_bindings`:
- `POST` create
- `DELETE /:bindingGuid`
- `GET` list (optional `service_instance_guids` / `route_guids` filters)
- `GET /:bindingGuid/parameters`

## Service keys (#4301)

`/pp/v1/cf/service_keys` — service_credential_bindings pinned to `type=key`:
- `POST` create (forces `type=key` regardless of body)
- `DELETE /:keyGuid`
- `GET` list (`type=key` filter, optional `service_instance_guids`)
- `GET /:keyGuid/details` (credentials)
- `GET /:keyGuid/parameters`

## Async contract

Async create/delete reuse the existing RunFastPath / writeWithJob contract
already used by native_service_bindings.go: 200 on fast-path resolve, 202
handoff with a StratosJob otherwise, and a graceful bare-202 fallback when the
stratosjobs plugin is unwired. No consumer changes are needed when the UI lands.

## Tests

11 capture-server unit tests covering sync create, async fast-path resolve,
delete, list filter forwarding, and the details/parameters reads. Full
cloudfoundry plugin suite passes; go vet and gofmt clean.

Frontend wiring (data sources + dialogs) is tracked separately, so this does
not fully close #4301/#4302.