### PR TITLE
Service keys UI (#4301 frontend)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
@@ -40,6 +40,7 @@ function makeStubSignalConfigService() {
     registerSortExtractor: vi.fn(),
     registerFilterExtractor: vi.fn(),
     deleteServiceInstance: vi.fn().mockResolvedValue(undefined),
+    isOfferingBindable: vi.fn().mockReturnValue(undefined),
     clearFilters: vi.fn(),
     filter: filterSig,
     sort: sortSig,
@@ -139,11 +140,12 @@ describe('CloudFoundrySpaceServiceInstancesSignalComponent', () => {
     );
   });
 
-  it('row actions are Edit / Detach / Delete', () => {
+  it('row actions are Edit / Detach / Service Keys / Delete (managed, bindable)', () => {
     const cfg = component.listConfig();
     const actionsCol: any = cfg!.columns.find(c => c.key === 'actions');
+    // Managed + isOfferingBindable undefined (cold) → fail open → Service Keys shown.
     const managed: any = { cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'cache', type: 'managed' };
-    expect(actionsCol.actions(managed).map((a: any) => a.label)).toEqual(['Edit', 'Detach', 'Delete']);
+    expect(actionsCol.actions(managed).map((a: any) => a.label)).toEqual(['Edit', 'Detach', 'Service Keys', 'Delete']);
   });
 
   it('omits CF/Org/Space dropdowns and toolbar Type column', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
@@ -5,7 +5,6 @@ import { Router, RouterModule } from '@angular/router';
 import { map } from 'rxjs/operators';
 
 import {
-  ConfirmationDialogConfig,
   ConfirmationDialogService,
   CurrentUserPermissionsService,
   ListSubNavAddAction,
@@ -26,8 +25,8 @@ import {
 import { CloudFoundryEndpointService } from '../../../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryOrganizationService } from '../../../../../services/cloud-foundry-organization.service';
 import { CloudFoundrySpaceService } from '../../../../../services/cloud-foundry-space.service';
-import { extractHttpErrorMessage } from '../../../../../../../services/extract-error-message';
 import { boundAppSegments, renderBoundApps } from '../../../../../../../shared/signal-list-configs/bound-apps-cell';
+import { buildServiceInstanceRowActions } from '../../../../../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../../../../../services/endpoint-data/stratos-types';
 
 // Scoped to one space under one org under one CF endpoint. Reuses the wall's
@@ -246,44 +245,14 @@ export class CloudFoundrySpaceServiceInstancesSignalComponent {
   // signal-native migration dropped (catalog 2026-05-26 Space-scope row).
   // Every row on this tab is managed (page is scoped via
   // initializeForSpace + type='managed'), so siType is always 'service'.
-  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] => {
-    return [
-      {
-        label: 'Edit', icon: 'edit',
-        invoke: () => {
-          void this.router.navigate([
-            '/services', 'service', si.cnsiGuid, si.guid, 'edit',
-          ]);
-        },
-      },
-      {
-        label: 'Detach', icon: 'link_off',
-        invoke: () => {
-          void this.router.navigate([
-            '/services', 'service', si.cnsiGuid, si.guid, 'detach',
-          ]);
-        },
-      },
-      {
-        label: 'Delete', icon: 'delete', danger: true,
-        invoke: () => {
-          const confirm = new ConfirmationDialogConfig(
-            'Delete Service Instance',
-            `Delete the service instance "${si.name}"? This cannot be undone and will detach any apps bound to it.`,
-            'Delete',
-            true,
-          );
-          this.confirmDialog.open(confirm, async () => {
-            try {
-              await this.instancesConfig.deleteServiceInstance(si.cnsiGuid, si.guid);
-            } catch (err: unknown) {
-              this.snackBar.error(`Delete failed: ${extractHttpErrorMessage(err)}`);
-            }
-          });
-        },
-      },
-    ];
-  };
+  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] =>
+    buildServiceInstanceRowActions(si, {
+      router: this.router,
+      confirmDialog: this.confirmDialog,
+      snackBar: this.snackBar,
+      deleteServiceInstance: (cnsiGuid, guid) => this.instancesConfig.deleteServiceInstance(cnsiGuid, guid),
+      isOfferingBindable: (si) => this.instancesConfig.isOfferingBindable(si),
+    });
 
   static formatDate(iso: string | null | undefined): string {
     if (!iso) return '';

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.spec.ts
@@ -40,6 +40,7 @@ function makeStubSignalConfigService() {
     registerSortExtractor: vi.fn(),
     registerFilterExtractor: vi.fn(),
     deleteServiceInstance: vi.fn().mockResolvedValue(undefined),
+    isOfferingBindable: vi.fn().mockReturnValue(undefined),
     clearFilters: vi.fn(),
     filter: filterSig,
     sort: sortSig,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.ts
@@ -5,7 +5,6 @@ import { Router, RouterModule } from '@angular/router';
 import { map } from 'rxjs/operators';
 
 import {
-  ConfirmationDialogConfig,
   ConfirmationDialogService,
   CurrentUserPermissionsService,
   ListSubNavAddAction,
@@ -26,7 +25,7 @@ import {
 import { CloudFoundryEndpointService } from '../../../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryOrganizationService } from '../../../../../services/cloud-foundry-organization.service';
 import { CloudFoundrySpaceService } from '../../../../../services/cloud-foundry-space.service';
-import { extractHttpErrorMessage } from '../../../../../../../services/extract-error-message';
+import { buildServiceInstanceRowActions } from '../../../../../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../../../../../services/endpoint-data/stratos-types';
 
 // Scoped to one space under one org under one CF endpoint, narrowed to
@@ -230,44 +229,14 @@ export class CloudFoundrySpaceUserServiceInstancesSignalComponent {
   // actions from cf-user-service-instances-list-config that the signal-
   // native migration dropped (catalog 2026-05-26 Space-scope row).
   // Every row on this tab is user-provided, so siType is 'user-service'.
-  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] => {
-    return [
-      {
-        label: 'Edit', icon: 'edit',
-        invoke: () => {
-          void this.router.navigate([
-            '/services', 'user-service', si.cnsiGuid, si.guid, 'edit',
-          ]);
-        },
-      },
-      {
-        label: 'Detach', icon: 'link_off',
-        invoke: () => {
-          void this.router.navigate([
-            '/services', 'user-service', si.cnsiGuid, si.guid, 'detach',
-          ]);
-        },
-      },
-      {
-        label: 'Delete', icon: 'delete', danger: true,
-        invoke: () => {
-          const confirm = new ConfirmationDialogConfig(
-            'Delete Service Instance',
-            `Delete the service instance "${si.name}"? This cannot be undone and will detach any apps bound to it.`,
-            'Delete',
-            true,
-          );
-          this.confirmDialog.open(confirm, async () => {
-            try {
-              await this.instancesConfig.deleteServiceInstance(si.cnsiGuid, si.guid);
-            } catch (err: unknown) {
-              this.snackBar.error(`Delete failed: ${extractHttpErrorMessage(err)}`);
-            }
-          });
-        },
-      },
-    ];
-  };
+  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] =>
+    buildServiceInstanceRowActions(si, {
+      router: this.router,
+      confirmDialog: this.confirmDialog,
+      snackBar: this.snackBar,
+      deleteServiceInstance: (cnsiGuid, guid) => this.instancesConfig.deleteServiceInstance(cnsiGuid, guid),
+      isOfferingBindable: (si) => this.instancesConfig.isOfferingBindable(si),
+    });
 
   static formatDate(iso: string | null | undefined): string {
     if (!iso) return '';

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
@@ -5,7 +5,6 @@ import { Router, RouterModule } from '@angular/router';
 import { map } from 'rxjs/operators';
 
 import {
-  ConfirmationDialogConfig,
   ConfirmationDialogService,
   CurrentUserPermissionsService,
   ListSubNavAddAction,
@@ -28,6 +27,7 @@ import {
 } from '../../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
 import { CfCurrentUserPermissions } from '../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
+import { buildServiceInstanceRowActions } from '../../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../../services/endpoint-data/stratos-types';
 
 // Per-CF Services tab. Single-CNSI variant of the top-level Services Wall.
@@ -257,49 +257,14 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
     void this.instancesConfig.loadAll();
   }
 
-  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] => {
-    const runAction = async (label: string, op: () => Promise<void>) => {
-      try {
-        await op();
-      } catch (err: any) {
-        this.snackBar.error(`${label} failed: ${err?.message ?? err}`);
-      }
-    };
-    // This surface mixes managed and user-provided instances, so the
-    // edit/detach route's :type segment branches on the row kind:
-    // 'service' for managed, 'user-service' for user-provided. Mirrors
-    // the per-space tabs that already restored Edit + Detach.
-    const siType = si.type === 'user-provided' ? 'user-service' : 'service';
-    return [
-      {
-        label: 'Edit', icon: 'edit',
-        invoke: () => {
-          void this.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'edit']);
-        },
-      },
-      {
-        label: 'Detach', icon: 'link_off',
-        invoke: () => {
-          void this.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'detach']);
-        },
-      },
-      {
-        label: 'Delete', icon: 'delete', danger: true,
-        invoke: () => {
-          const confirm = new ConfirmationDialogConfig(
-            'Delete Service Instance',
-            `Delete the service instance "${si.name}"? This cannot be undone and will detach any apps bound to it.`,
-            'Delete',
-            true,
-          );
-          this.confirmDialog.open(confirm, async () => {
-            await runAction('Delete', () =>
-              this.instancesConfig.deleteServiceInstance(si.cnsiGuid, si.guid));
-          });
-        },
-      },
-    ];
-  };
+  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] =>
+    buildServiceInstanceRowActions(si, {
+      router: this.router,
+      confirmDialog: this.confirmDialog,
+      snackBar: this.snackBar,
+      deleteServiceInstance: (cnsiGuid, guid) => this.instancesConfig.deleteServiceInstance(cnsiGuid, guid),
+      isOfferingBindable: (si) => this.instancesConfig.isOfferingBindable(si),
+    });
 
   static formatDate(iso: string | null | undefined): string {
     if (!iso) return '';

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.spec.ts
@@ -41,6 +41,7 @@ describe('ServiceInstancesComponent (signal-native)', () => {
       refresh: vi.fn(async () => undefined),
       clearFilters: vi.fn(),
       deleteServiceInstance: vi.fn(async () => undefined),
+      isOfferingBindable: vi.fn(() => undefined),
     };
   };
 

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.ts
@@ -12,7 +12,6 @@ import {
 import { ActivatedRoute, Router } from '@angular/router';
 
 import {
-  ConfirmationDialogConfig,
   ConfirmationDialogService,
   SignalListColumn,
   SignalListComponent,
@@ -27,8 +26,8 @@ import {
   CfServiceInstancesSignalConfigService,
 } from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
 import { boundAppSegments, renderBoundApps } from '../../../shared/signal-list-configs/bound-apps-cell';
+import { buildServiceInstanceRowActions } from '../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
-import { extractHttpErrorMessage } from '../../../services/extract-error-message';
 
 /**
  * ServiceInstancesComponent — service-catalog Instances tab on a service
@@ -205,43 +204,12 @@ export class ServiceInstancesComponent implements OnInit {
   // vanishes.
   private readonly buildRowActions = (
     si: StServiceInstance,
-  ): readonly SignalListRowAction<StServiceInstance>[] => {
-    const siType = si.type === 'user-provided' ? 'user-service' : 'service';
-    return [
-      {
-        label: 'Edit', icon: 'edit',
-        invoke: () => {
-          void this.router.navigate([
-            '/services', siType, si.cnsiGuid, si.guid, 'edit',
-          ]);
-        },
-      },
-      {
-        label: 'Detach', icon: 'link_off',
-        invoke: () => {
-          void this.router.navigate([
-            '/services', siType, si.cnsiGuid, si.guid, 'detach',
-          ]);
-        },
-      },
-      {
-        label: 'Delete', icon: 'delete', danger: true,
-        invoke: () => {
-          const confirm = new ConfirmationDialogConfig(
-            'Delete Service Instance',
-            `Delete the service instance "${si.name}"? This cannot be undone and will detach any apps bound to it.`,
-            'Delete',
-            true,
-          );
-          this.confirmDialog.open(confirm, async () => {
-            try {
-              await this.instancesConfig.deleteServiceInstance(si.cnsiGuid, si.guid);
-            } catch (err: unknown) {
-              this.snackBar.error(`Delete failed: ${extractHttpErrorMessage(err)}`);
-            }
-          });
-        },
-      },
-    ];
-  };
+  ): readonly SignalListRowAction<StServiceInstance>[] =>
+    buildServiceInstanceRowActions(si, {
+      router: this.router,
+      confirmDialog: this.confirmDialog,
+      snackBar: this.snackBar,
+      deleteServiceInstance: (cnsiGuid, guid) => this.instancesConfig.deleteServiceInstance(cnsiGuid, guid),
+      isOfferingBindable: (si) => this.instancesConfig.isOfferingBindable(si),
+    });
 }

--- a/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.html
@@ -1,4 +1,4 @@
-<app-page-header>
+<app-page-header [breadcrumbs]="breadcrumbs">
   {{ title() }}
 </app-page-header>
 <div class="detach-service-instance">

--- a/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.ts
@@ -4,6 +4,7 @@ import { Component, OnDestroy, Signal, signal, ChangeDetectionStrategy, computed
 import { ActivatedRoute, Router } from '@angular/router';
 
 import {
+  IHeaderBreadcrumb,
   PageHeaderComponent,
   SignalStepHandle,
   StepComponent,
@@ -58,6 +59,9 @@ export class DetachServiceInstanceComponent implements OnDestroy {
     const name = this._instanceSource?.value()?.name;
     return name ? `Unbind apps from '${name}'` : '';
   });
+  readonly breadcrumbs: IHeaderBreadcrumb[] = [
+    { breadcrumbs: [{ value: 'Services', routerLink: '/services' }] },
+  ];
   cfGuid!: string;
   deleteStarted = signal(false);
 

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -10,7 +10,7 @@
   }
 
   <!-- Create -->
-  <form class="flex items-end gap-2" (ngSubmit)="createKey()">
+  <form class="flex items-end gap-2" (submit)="$event.preventDefault(); createKey()">
     <label class="flex flex-col text-sm">
       <span class="mb-1 text-content-2">New key name</span>
       <input class="rounded border border-content-3 bg-content px-2 py-1"

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -1,0 +1,69 @@
+<app-page-header>
+  {{ title() }}
+</app-page-header>
+
+<div class="p-4 space-y-4">
+  @if (errorMessage(); as err) {
+    <div class="rounded border border-danger-strong bg-danger-subtle px-3 py-2 text-danger-strong" role="alert">
+      {{ err }}
+    </div>
+  }
+
+  <!-- Create -->
+  <form class="flex items-end gap-2" (ngSubmit)="createKey()">
+    <label class="flex flex-col text-sm">
+      <span class="mb-1 text-content-2">New key name</span>
+      <input class="rounded border border-content-3 bg-content px-2 py-1"
+        type="text" name="keyName" autocomplete="off"
+        [value]="newKeyName()" (input)="newKeyName.set($any($event.target).value)"
+        [disabled]="creating()" />
+    </label>
+    <button class="rounded bg-primary px-3 py-1.5 text-on-primary disabled:opacity-50"
+      type="submit" [disabled]="creating() || !newKeyName().trim()">
+      {{ creating() ? 'Creating…' : 'Create Service Key' }}
+    </button>
+  </form>
+
+  <!-- List -->
+  @if (loading()) {
+    <p class="text-content-2">Loading service keys…</p>
+  } @else if (keys().length === 0) {
+    <p class="text-content-2">This service instance has no service keys.</p>
+  } @else {
+    <table class="w-full text-left">
+      <thead>
+        <tr class="border-b border-content-2 text-sm uppercase tracking-wide">
+          <th class="py-2">Name</th>
+          <th class="py-2">Created</th>
+          <th class="py-2">Last Operation</th>
+          <th class="py-2 text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (key of keys(); track key.guid) {
+          <tr class="border-b border-content-3">
+            <td class="py-2">{{ key.name }}</td>
+            <td class="py-2 text-content-2">{{ key.createdAt | date:'medium' }}</td>
+            <td class="py-2 text-content-2">{{ key.lastOperationState || '—' }}</td>
+            <td class="py-2 text-right">
+              <button class="text-link hover:underline" type="button" (click)="revealCredentials(key.guid)">
+                {{ revealedCredentials(key.guid) !== undefined ? 'Hide' : 'Reveal' }} credentials
+              </button>
+              <button class="ml-3 text-danger-strong hover:underline disabled:opacity-50" type="button"
+                [disabled]="rowStatus(key.guid) === 'busy'" (click)="deleteKey(key.guid)">
+                {{ rowStatus(key.guid) === 'busy' ? 'Deleting…' : 'Delete' }}
+              </button>
+            </td>
+          </tr>
+          @if (revealedCredentials(key.guid); as creds) {
+            <tr class="border-b border-content-3">
+              <td class="py-2" colspan="4">
+                <pre class="overflow-x-auto rounded bg-content-2 p-3 text-xs">{{ creds }}</pre>
+              </td>
+            </tr>
+          }
+        }
+      </tbody>
+    </table>
+  }
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -59,6 +59,11 @@
               <span class="text-sm text-content-muted shrink-0">{{ key.lastOperationState || '—' }}</span>
             </button>
             <button type="button"
+              class="text-link hover:underline shrink-0"
+              (click)="copyAllCredentials(key.guid)">
+              {{ copiedAllGuid() === key.guid ? 'Copied' : 'Copy all (JSON)' }}
+            </button>
+            <button type="button"
               class="text-danger-strong hover:underline disabled:opacity-50 shrink-0"
               [disabled]="rowStatus(key.guid) === 'busy'"
               (click)="deleteKey(key.guid)">
@@ -76,30 +81,30 @@
               } @else if (credentialFields(key.guid).length === 0) {
                 <p class="text-content-muted">No credentials returned for this key.</p>
               } @else {
-                <div class="flex items-center justify-end gap-1 mb-1">
-                  <span class="text-sm text-content-muted">Copy all (JSON)</span>
-                  <app-copy-to-clipboard class="w-5" [text]="allCredsJson(key.guid)"
-                    tooltip="Copy all credentials as JSON"
-                    [showSuccessText]="false" [compact]="true"></app-copy-to-clipboard>
-                </div>
-                <table class="w-full text-left text-sm">
+                <!-- Not w-full: columns size to content so the key/value/actions
+                     align in tidy columns packed to the left, with the copy
+                     controls in one aligned column right after the values. -->
+                <table class="text-left text-sm">
                   <tbody>
                     @for (field of credentialFields(key.guid); track field.key) {
                       <tr class="border-b border-content-border last:border-0">
-                        <td class="py-1 pr-4 align-top font-medium text-content-muted whitespace-nowrap">{{ field.key }}</td>
-                        <td class="py-1 align-top">
-                          <div class="flex items-start gap-2">
-                            <span class="grow min-w-0 break-all font-mono">{{ displayValue(key.guid, field) }}</span>
-                            @if (field.sensitive) {
-                              <button type="button" class="shrink-0 text-link hover:underline text-xs"
-                                (click)="toggleField(key.guid, field.key)">
-                                {{ fieldShown(key.guid, field.key) ? 'Hide' : 'Show' }}
-                              </button>
-                            }
-                            <app-copy-to-clipboard class="shrink-0 w-5" [text]="field.value"
-                              [tooltip]="'Copy ' + field.key"
-                              [showSuccessText]="false" [compact]="true"></app-copy-to-clipboard>
-                          </div>
+                        <td class="py-1 pr-8 align-top font-medium text-content-muted whitespace-nowrap">{{ field.key }}</td>
+                        <td class="py-1 pr-4 align-top break-all font-mono">{{ displayValue(key.guid, field) }}</td>
+                        <td class="py-1 align-top whitespace-nowrap text-right">
+                          @if (field.sensitive) {
+                            <button type="button" class="text-link hover:underline text-xs"
+                              (click)="toggleField(key.guid, field.key)">
+                              {{ fieldShown(key.guid, field.key) ? 'Hide' : 'Show' }}
+                            </button>
+                          }
+                        </td>
+                        <!-- pl-8: the copy component renders its icon absolute-left of
+                             its own (0-width) box, so reserve space here so it doesn't
+                             overlap the Show column. -->
+                        <td class="py-1 pl-10 align-top">
+                          <app-copy-to-clipboard class="inline-block w-5" [text]="field.value"
+                            [tooltip]="'Copy ' + field.key"
+                            [showSuccessText]="false" [compact]="true"></app-copy-to-clipboard>
                         </td>
                       </tr>
                     }

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -10,7 +10,7 @@
   }
 
   @if (notBindable()) {
-    <div class="rounded border border-content-3 bg-content-2 px-3 py-2 text-content-2" role="status">
+    <div class="rounded border border-content-border bg-content-bg px-3 py-2 text-content-muted" role="status">
       This service does not support service keys (the offering is not bindable).
     </div>
   }
@@ -18,8 +18,8 @@
   <!-- Create -->
   <form class="flex items-end gap-2" (submit)="$event.preventDefault(); createKey()">
     <label class="flex flex-col text-sm">
-      <span class="mb-1 text-content-2">New key name</span>
-      <input class="rounded border border-content-3 bg-content px-2 py-1"
+      <span class="mb-1 text-content-muted">New key name</span>
+      <input class="rounded border border-content-border bg-content-bg px-2 py-1"
         type="text" name="keyName" autocomplete="off"
         [value]="newKeyName()" (input)="newKeyName.set($any($event.target).value)"
         [disabled]="creating()" />
@@ -30,46 +30,78 @@
     </button>
   </form>
 
-  <!-- List -->
+  <!-- List (accordion) -->
   @if (loading()) {
-    <p class="text-content-2">Loading service keys…</p>
+    <p class="text-content-muted">Loading service keys…</p>
   } @else if (keys().length === 0) {
-    <p class="text-content-2">This service instance has no service keys.</p>
+    <p class="text-content-muted">This service instance has no service keys.</p>
   } @else {
-    <table class="w-full text-left">
-      <thead>
-        <tr class="border-b border-content-2 text-sm uppercase tracking-wide">
-          <th class="py-2">Name</th>
-          <th class="py-2">Created</th>
-          <th class="py-2">Last Operation</th>
-          <th class="py-2 text-right">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        @for (key of keys(); track key.guid) {
-          <tr class="border-b border-content-3">
-            <td class="py-2">{{ key.name }}</td>
-            <td class="py-2 text-content-2">{{ key.createdAt | date:'medium' }}</td>
-            <td class="py-2 text-content-2">{{ key.lastOperationState || '—' }}</td>
-            <td class="py-2 text-right">
-              <button class="text-link hover:underline" type="button" (click)="revealCredentials(key.guid)">
-                {{ revealedCredentials(key.guid) !== undefined ? 'Hide' : 'Reveal' }} credentials
-              </button>
-              <button class="ml-3 text-danger-strong hover:underline disabled:opacity-50" type="button"
-                [disabled]="rowStatus(key.guid) === 'busy'" (click)="deleteKey(key.guid)">
-                {{ rowStatus(key.guid) === 'busy' ? 'Deleting…' : 'Delete' }}
-              </button>
-            </td>
-          </tr>
-          @if (revealedCredentials(key.guid); as creds) {
-            <tr class="border-b border-content-3">
-              <td class="py-2" colspan="4">
-                <pre class="overflow-x-auto rounded bg-content-2 p-3 text-xs">{{ creds }}</pre>
-              </td>
-            </tr>
+    <div class="flex flex-col gap-2">
+      @for (key of keys(); track key.guid) {
+        <section class="border border-content-border rounded-md overflow-hidden">
+          <!-- Header row: toggle area + delete (siblings, not nested buttons). -->
+          <div class="w-full flex items-center gap-3 px-4 py-3 bg-content-bg">
+            <button type="button"
+              class="flex items-center gap-3 grow min-w-0 text-left hover:opacity-80"
+              [attr.aria-expanded]="isOpen(key.guid)"
+              (click)="toggleOpen(key.guid)">
+              <svg class="w-5 h-5 shrink-0 text-content-muted transition-transform duration-200"
+                [class.rotate-90]="isOpen(key.guid)"
+                viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z" />
+              </svg>
+              <span class="font-medium text-content-text truncate">{{ key.name }}</span>
+              <span class="text-sm text-content-muted shrink-0">{{ key.createdAt | date:'medium' }}</span>
+              <span class="text-sm text-content-muted shrink-0">{{ key.lastOperationState || '—' }}</span>
+            </button>
+            <button type="button"
+              class="text-danger-strong hover:underline disabled:opacity-50 shrink-0"
+              [disabled]="rowStatus(key.guid) === 'busy'"
+              (click)="deleteKey(key.guid)">
+              {{ rowStatus(key.guid) === 'busy' ? 'Deleting…' : 'Delete' }}
+            </button>
+          </div>
+
+          <!-- Body: credentials, lazily loaded on first expand. -->
+          @if (isOpen(key.guid)) {
+            <div class="px-4 py-4 border-t border-content-border">
+              @if (credsLoading(key.guid)) {
+                <p class="text-content-muted">Loading credentials…</p>
+              } @else if (credsError(key.guid); as cerr) {
+                <p class="text-danger-strong">Failed to load credentials: {{ cerr }}</p>
+              } @else if (credentialFields(key.guid).length === 0) {
+                <p class="text-content-muted">No credentials returned for this key.</p>
+              } @else {
+                <div class="flex items-center justify-end mb-2">
+                  <app-copy-to-clipboard [text]="allCredsJson(key.guid)"
+                    tooltip="Copy all credentials as JSON"></app-copy-to-clipboard>
+                  <span class="ml-1 text-sm text-content-muted">Copy all (JSON)</span>
+                </div>
+                <table class="w-full text-left text-sm">
+                  <tbody>
+                    @for (field of credentialFields(key.guid); track field.key) {
+                      <tr class="border-b border-content-border last:border-0">
+                        <td class="py-2 pr-4 align-top font-medium text-content-muted whitespace-nowrap">{{ field.key }}</td>
+                        <td class="py-2 pr-4 align-top break-all font-mono">{{ displayValue(key.guid, field) }}</td>
+                        <td class="py-2 align-top whitespace-nowrap">
+                          @if (field.sensitive) {
+                            <button type="button" class="text-link hover:underline mr-3"
+                              (click)="toggleField(key.guid, field.key)">
+                              {{ fieldShown(key.guid, field.key) ? 'Hide' : 'Show' }}
+                            </button>
+                          }
+                          <app-copy-to-clipboard [text]="field.value"
+                            [tooltip]="'Copy ' + field.key" compact></app-copy-to-clipboard>
+                        </td>
+                      </tr>
+                    }
+                  </tbody>
+                </table>
+              }
+            </div>
           }
-        }
-      </tbody>
-    </table>
+        </section>
+      }
+    </div>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -1,4 +1,4 @@
-<app-page-header>
+<app-page-header [breadcrumbs]="breadcrumbs">
   {{ title() }}
 </app-page-header>
 
@@ -6,6 +6,12 @@
   @if (errorMessage(); as err) {
     <div class="rounded border border-danger-strong bg-danger-subtle px-3 py-2 text-danger-strong" role="alert">
       {{ err }}
+    </div>
+  }
+
+  @if (notBindable()) {
+    <div class="rounded border border-content-3 bg-content-2 px-3 py-2 text-content-2" role="status">
+      This service does not support service keys (the offering is not bindable).
     </div>
   }
 
@@ -19,7 +25,7 @@
         [disabled]="creating()" />
     </label>
     <button class="rounded bg-primary px-3 py-1.5 text-on-primary disabled:opacity-50"
-      type="submit" [disabled]="creating() || !newKeyName().trim()">
+      type="submit" [disabled]="creating() || !newKeyName().trim() || notBindable()">
       {{ creating() ? 'Creating…' : 'Create Service Key' }}
     </button>
   </form>

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -2,7 +2,26 @@
   {{ title() }}
 </app-page-header>
 
-<div class="p-4 space-y-4">
+<!-- L5 sub-nav: count + Add button that swaps in an inline create form
+     (same pattern as the Variables tab). -->
+<app-list-sub-nav title="Total Service Keys" [count]="keyCount"
+  [addAction]="addKeyAction" [isAdding]="isAdding">
+  <div subNavForm class="flex items-center gap-2">
+    <input class="rounded border border-content-border bg-content-bg px-2 py-1 text-sm"
+      type="text" name="keyName" autocomplete="off" placeholder="Key name"
+      [value]="newKeyName()" (input)="newKeyName.set($any($event.target).value)"
+      (keydown.enter)="createKey()" [disabled]="creating()" />
+    <button type="button"
+      class="rounded bg-primary px-3 py-1.5 text-sm text-white disabled:opacity-50"
+      [disabled]="creating() || !newKeyName().trim()" (click)="createKey()">
+      {{ creating() ? 'Creating…' : 'Create' }}
+    </button>
+    <button type="button" class="text-sm text-content-muted hover:underline disabled:opacity-50"
+      [disabled]="creating()" (click)="cancelCreate()">Cancel</button>
+  </div>
+</app-list-sub-nav>
+
+<div class="px-6 py-4 space-y-4">
   @if (errorMessage(); as err) {
     <div class="rounded border border-danger-strong bg-danger-subtle px-3 py-2 text-danger-strong" role="alert">
       {{ err }}
@@ -14,21 +33,6 @@
       This service does not support service keys (the offering is not bindable).
     </div>
   }
-
-  <!-- Create -->
-  <form class="flex items-end gap-2" (submit)="$event.preventDefault(); createKey()">
-    <label class="flex flex-col text-sm">
-      <span class="mb-1 text-content-muted">New key name</span>
-      <input class="rounded border border-content-border bg-content-bg px-2 py-1"
-        type="text" name="keyName" autocomplete="off"
-        [value]="newKeyName()" (input)="newKeyName.set($any($event.target).value)"
-        [disabled]="creating()" />
-    </label>
-    <button class="rounded bg-primary px-3 py-1.5 text-on-primary disabled:opacity-50"
-      type="submit" [disabled]="creating() || !newKeyName().trim() || notBindable()">
-      {{ creating() ? 'Creating…' : 'Create Service Key' }}
-    </button>
-  </form>
 
   <!-- List (accordion) -->
   @if (loading()) {
@@ -64,7 +68,7 @@
 
           <!-- Body: credentials, lazily loaded on first expand. -->
           @if (isOpen(key.guid)) {
-            <div class="px-4 py-4 border-t border-content-border">
+            <div class="px-4 py-3 border-t border-content-border">
               @if (credsLoading(key.guid)) {
                 <p class="text-content-muted">Loading credentials…</p>
               } @else if (credsError(key.guid); as cerr) {
@@ -72,26 +76,30 @@
               } @else if (credentialFields(key.guid).length === 0) {
                 <p class="text-content-muted">No credentials returned for this key.</p>
               } @else {
-                <div class="flex items-center justify-end mb-2">
-                  <app-copy-to-clipboard [text]="allCredsJson(key.guid)"
-                    tooltip="Copy all credentials as JSON"></app-copy-to-clipboard>
-                  <span class="ml-1 text-sm text-content-muted">Copy all (JSON)</span>
+                <div class="flex items-center justify-end gap-1 mb-1">
+                  <span class="text-sm text-content-muted">Copy all (JSON)</span>
+                  <app-copy-to-clipboard class="w-5" [text]="allCredsJson(key.guid)"
+                    tooltip="Copy all credentials as JSON"
+                    [showSuccessText]="false" [compact]="true"></app-copy-to-clipboard>
                 </div>
                 <table class="w-full text-left text-sm">
                   <tbody>
                     @for (field of credentialFields(key.guid); track field.key) {
                       <tr class="border-b border-content-border last:border-0">
-                        <td class="py-2 pr-4 align-top font-medium text-content-muted whitespace-nowrap">{{ field.key }}</td>
-                        <td class="py-2 pr-4 align-top break-all font-mono">{{ displayValue(key.guid, field) }}</td>
-                        <td class="py-2 align-top whitespace-nowrap">
-                          @if (field.sensitive) {
-                            <button type="button" class="text-link hover:underline mr-3"
-                              (click)="toggleField(key.guid, field.key)">
-                              {{ fieldShown(key.guid, field.key) ? 'Hide' : 'Show' }}
-                            </button>
-                          }
-                          <app-copy-to-clipboard [text]="field.value"
-                            [tooltip]="'Copy ' + field.key" compact></app-copy-to-clipboard>
+                        <td class="py-1 pr-4 align-top font-medium text-content-muted whitespace-nowrap">{{ field.key }}</td>
+                        <td class="py-1 align-top">
+                          <div class="flex items-start gap-2">
+                            <span class="grow min-w-0 break-all font-mono">{{ displayValue(key.guid, field) }}</span>
+                            @if (field.sensitive) {
+                              <button type="button" class="shrink-0 text-link hover:underline text-xs"
+                                (click)="toggleField(key.guid, field.key)">
+                                {{ fieldShown(key.guid, field.key) ? 'Hide' : 'Show' }}
+                              </button>
+                            }
+                            <app-copy-to-clipboard class="shrink-0 w-5" [text]="field.value"
+                              [tooltip]="'Copy ' + field.key"
+                              [showSuccessText]="false" [compact]="true"></app-copy-to-clipboard>
+                          </div>
                         </td>
                       </tr>
                     }

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -1,10 +1,10 @@
 import { DatePipe } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, Signal, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Signal, computed, effect, inject, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 
-import { PageHeaderComponent } from '@stratosui/core';
+import { IHeaderBreadcrumb, PageHeaderComponent } from '@stratosui/core';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
 import { ServiceCatalogDataService, ServiceKeyView, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
@@ -14,6 +14,10 @@ type RowStatus = 'idle' | 'busy' | 'error';
 
 interface KeyDetailsResponse {
   credentials?: Record<string, unknown>;
+}
+
+interface OfferingBindableResponse {
+  bindable?: boolean;
 }
 
 // ServiceKeysComponent — per-instance Service Keys page, reached via the
@@ -41,6 +45,12 @@ export class ServiceKeysComponent {
     return name ? `Service keys for '${name}'` : 'Service keys';
   });
 
+  // Breadcrumb back to the services wall (no per-instance detail page exists
+  // to link the instance itself; the title carries the instance name).
+  readonly breadcrumbs: IHeaderBreadcrumb[] = [
+    { breadcrumbs: [{ value: 'Services', routerLink: '/services' }] },
+  ];
+
   // Reloadable list source: swapping the signal re-derives keys/loading.
   private keysSource = signal<SignalSource<ServiceKeyView[]>>(
     // placeholder replaced in the constructor once guids are read
@@ -52,6 +62,16 @@ export class ServiceKeysComponent {
   readonly newKeyName = signal('');
   readonly creating = signal(false);
   readonly errorMessage = signal<string | null>(null);
+
+  // Authoritative bindability backup. The list row-action gate is best-effort
+  // off the warmed offerings store (which can be cold/slow on multi-CF
+  // foundations), so it may fail open and show the action for a non-bindable
+  // service. Here we fetch the offering directly once the instance loads and
+  // block create if the broker doesn't support keys. undefined = not yet known
+  // (fail open); false = confirmed not supported.
+  readonly bindable = signal<boolean | undefined>(undefined);
+  readonly notBindable = computed(() => this.bindable() === false);
+  private bindableFetchStarted = false;
 
   // Per-row delete status + revealed credentials, keyed by key guid.
   private statusByGuid = signal<Record<string, RowStatus>>({});
@@ -66,15 +86,38 @@ export class ServiceKeysComponent {
     this.siGuid = route.snapshot.params.serviceInstanceId;
     this.instanceSource = this.catalog.serviceInstance(this.cfGuid, this.siGuid);
     this.reload();
+
+    // Once the instance summary lands we know the offering guid; fetch the
+    // offering once to resolve bindability authoritatively (the backup for the
+    // best-effort list gate). Runs in the injection context so the effect is
+    // cleaned up with the component.
+    effect(() => {
+      const offeringGuid = this.instanceSource.value()?.servicePlan?.serviceOffering?.guid;
+      if (this.bindableFetchStarted || !offeringGuid) return;
+      this.bindableFetchStarted = true;
+      void this.loadBindable(offeringGuid);
+    });
   }
 
   reload(): void {
     this.keysSource.set(this.catalog.serviceKeysForInstance(this.cfGuid, this.siGuid));
   }
 
+  private async loadBindable(offeringGuid: string): Promise<void> {
+    try {
+      const offering = await firstValueFrom(
+        this.http.get<OfferingBindableResponse>(`/pp/v1/cf/service_offerings/${this.cfGuid}/${offeringGuid}`),
+      );
+      // Absent flag → treat as supported (fail open); explicit false → blocked.
+      this.bindable.set(offering?.bindable ?? true);
+    } catch {
+      // Leave undefined (fail open) — don't block create on a lookup failure.
+    }
+  }
+
   async createKey(): Promise<void> {
     const name = this.newKeyName().trim();
-    if (!name || this.creating()) {
+    if (!name || this.creating() || this.notBindable()) {
       return;
     }
     this.creating.set(true);

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -4,7 +4,7 @@ import { ChangeDetectionStrategy, Component, Signal, computed, effect, inject, s
 import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 
-import { CopyToClipboardComponent, IHeaderBreadcrumb, PageHeaderComponent } from '@stratosui/core';
+import { CopyToClipboardComponent, IHeaderBreadcrumb, ListSubNavAddAction, ListSubNavComponent, PageHeaderComponent } from '@stratosui/core';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
 import { ServiceCatalogDataService, ServiceKeyView, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
@@ -61,7 +61,7 @@ function toCredentialFields(creds: Record<string, unknown>): CredentialField[] {
   templateUrl: './service-keys.component.html',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe, PageHeaderComponent, CopyToClipboardComponent],
+  imports: [DatePipe, PageHeaderComponent, CopyToClipboardComponent, ListSubNavComponent],
 })
 export class ServiceKeysComponent {
   private http = inject(HttpClient);
@@ -92,6 +92,10 @@ export class ServiceKeysComponent {
   readonly newKeyName = signal('');
   readonly creating = signal(false);
   readonly errorMessage = signal<string | null>(null);
+  // Inline create form on the sub-nav row (revealed by the Add button),
+  // mirroring the Variables tab pattern rather than an always-visible form.
+  readonly isAdding = signal(false);
+  readonly keyCount = computed(() => this.keys().length);
 
   // Authoritative bindability backup. The list row-action gate is best-effort
   // off the warmed offerings store (which can be cold/slow on multi-CF
@@ -102,6 +106,15 @@ export class ServiceKeysComponent {
   readonly bindable = signal<boolean | undefined>(undefined);
   readonly notBindable = computed(() => this.bindable() === false);
   private bindableFetchStarted = false;
+
+  // Sub-nav "Add Service Key" button → reveals the inline create form.
+  // Disabled when the offering isn't bindable (no keys possible).
+  readonly addKeyAction: ListSubNavAddAction = {
+    label: 'Add Service Key',
+    icon: 'add',
+    invoke: () => { this.errorMessage.set(null); this.newKeyName.set(''); this.isAdding.set(true); },
+    disabled: this.notBindable,
+  };
 
   // Accordion + per-key credential state, all keyed by key guid.
   private openByGuid = signal<Record<string, boolean>>({});
@@ -210,12 +223,18 @@ export class ServiceKeysComponent {
         this.http.post(`/pp/v1/cf/service_keys/${this.cfGuid}`, body, { observe: 'response' as const }),
       );
       this.newKeyName.set('');
+      this.isAdding.set(false);
       this.reload();
     } catch (err: unknown) {
       this.errorMessage.set(`Failed to create key: ${this.messageOf(err)}`);
     } finally {
       this.creating.set(false);
     }
+  }
+
+  cancelCreate(): void {
+    this.isAdding.set(false);
+    this.newKeyName.set('');
   }
 
   async deleteKey(guid: string): Promise<void> {

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -1,0 +1,151 @@
+import { DatePipe } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, Signal, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+
+import { PageHeaderComponent } from '@stratosui/core';
+import { writeWithJob } from '../../../services/async-jobs/write-with-job';
+import { StratosJobError } from '../../../services/async-jobs/async-job.types';
+import { ServiceCatalogDataService, ServiceKeyView, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+
+type RowStatus = 'idle' | 'busy' | 'error';
+
+interface KeyDetailsResponse {
+  credentials?: Record<string, unknown>;
+}
+
+// ServiceKeysComponent — per-instance Service Keys page, reached via the
+// /services/:type/:endpointId/:serviceInstanceId/keys route (sibling to the
+// existing edit/detach action routes). Lists the instance's service keys
+// (credential bindings with type=key), with create / reveal-credentials /
+// delete. Create and delete ride the writeWithJob async-job contract.
+@Component({
+  selector: 'app-service-keys',
+  templateUrl: './service-keys.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DatePipe, PageHeaderComponent],
+})
+export class ServiceKeysComponent {
+  private http = inject(HttpClient);
+  private catalog = inject(ServiceCatalogDataService);
+
+  readonly cfGuid: string;
+  readonly siGuid: string;
+
+  private instanceSource: SignalSource<StServiceInstance | null>;
+  readonly title: Signal<string> = computed(() => {
+    const name = this.instanceSource.value()?.name;
+    return name ? `Service keys for '${name}'` : 'Service keys';
+  });
+
+  // Reloadable list source: swapping the signal re-derives keys/loading.
+  private keysSource = signal<SignalSource<ServiceKeyView[]>>(
+    // placeholder replaced in the constructor once guids are read
+    { value: signal<ServiceKeyView[]>([]).asReadonly(), isLoading: signal(false).asReadonly(), error: signal(null).asReadonly() },
+  );
+  readonly keys: Signal<ServiceKeyView[]> = computed(() => this.keysSource().value());
+  readonly loading: Signal<boolean> = computed(() => this.keysSource().isLoading());
+
+  readonly newKeyName = signal('');
+  readonly creating = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  // Per-row delete status + revealed credentials, keyed by key guid.
+  private statusByGuid = signal<Record<string, RowStatus>>({});
+  private credentialsByGuid = signal<Record<string, string>>({});
+
+  rowStatus = (guid: string): RowStatus => this.statusByGuid()[guid] ?? 'idle';
+  revealedCredentials = (guid: string): string | undefined => this.credentialsByGuid()[guid];
+
+  constructor() {
+    const route = inject(ActivatedRoute);
+    this.cfGuid = route.snapshot.params.endpointId;
+    this.siGuid = route.snapshot.params.serviceInstanceId;
+    this.instanceSource = this.catalog.serviceInstance(this.cfGuid, this.siGuid);
+    this.reload();
+  }
+
+  reload(): void {
+    this.keysSource.set(this.catalog.serviceKeysForInstance(this.cfGuid, this.siGuid));
+  }
+
+  async createKey(): Promise<void> {
+    const name = this.newKeyName().trim();
+    if (!name || this.creating()) {
+      return;
+    }
+    this.creating.set(true);
+    this.errorMessage.set(null);
+    const body = {
+      name,
+      relationships: { service_instance: { data: { guid: this.siGuid } } },
+    };
+    try {
+      await writeWithJob(
+        this.http,
+        this.http.post(`/pp/v1/cf/service_keys/${this.cfGuid}`, body, { observe: 'response' as const }),
+      );
+      this.newKeyName.set('');
+      this.reload();
+    } catch (err: unknown) {
+      this.errorMessage.set(`Failed to create key: ${this.messageOf(err)}`);
+    } finally {
+      this.creating.set(false);
+    }
+  }
+
+  async deleteKey(guid: string): Promise<void> {
+    if (this.rowStatus(guid) === 'busy') {
+      return;
+    }
+    this.setStatus(guid, 'busy');
+    try {
+      await writeWithJob(
+        this.http,
+        this.http.delete(`/pp/v1/cf/service_keys/${this.cfGuid}/${guid}`, { observe: 'response' as const }),
+      );
+      this.reload();
+    } catch (err: unknown) {
+      this.setStatus(guid, 'error');
+      this.errorMessage.set(`Failed to delete key: ${this.messageOf(err)}`);
+    }
+  }
+
+  async revealCredentials(guid: string): Promise<void> {
+    if (this.revealedCredentials(guid) !== undefined) {
+      // Toggle off.
+      this.credentialsByGuid.update(prev => {
+        const next = { ...prev };
+        delete next[guid];
+        return next;
+      });
+      return;
+    }
+    try {
+      const details = await firstValueFrom(
+        this.http.get<KeyDetailsResponse>(`/pp/v1/cf/service_keys/${this.cfGuid}/${guid}/details`),
+      );
+      const creds = JSON.stringify(details?.credentials ?? {}, null, 2);
+      this.credentialsByGuid.update(prev => ({ ...prev, [guid]: creds }));
+    } catch (err: unknown) {
+      this.errorMessage.set(`Failed to load credentials: ${this.messageOf(err)}`);
+    }
+  }
+
+  private setStatus(guid: string, status: RowStatus): void {
+    this.statusByGuid.update(prev => ({ ...prev, [guid]: status }));
+  }
+
+  private messageOf(err: unknown): string {
+    if (err instanceof StratosJobError) {
+      return err.message;
+    }
+    if (err instanceof Error) {
+      return err.message;
+    }
+    return 'unknown error';
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -125,6 +125,8 @@ export class ServiceKeysComponent {
   private shownFields = signal<ReadonlySet<string>>(new Set<string>());
   // Per-key delete status.
   private statusByGuid = signal<Record<string, RowStatus>>({});
+  // Transient "Copied" feedback for the header Copy-all button, by key guid.
+  readonly copiedAllGuid = signal<string | null>(null);
 
   isOpen = (guid: string): boolean => this.openByGuid()[guid] ?? false;
   credsLoading = (guid: string): boolean => this.credsLoadingByGuid()[guid] ?? false;
@@ -137,7 +139,6 @@ export class ServiceKeysComponent {
   fieldShown = (guid: string, key: string): boolean => this.shownFields().has(`${guid}::${key}`);
   displayValue = (guid: string, field: CredentialField): string =>
     field.sensitive && !this.fieldShown(guid, field.key) ? '••••••••' : field.value;
-  allCredsJson = (guid: string): string => JSON.stringify(this.credsByGuid()[guid] ?? {}, null, 2);
 
   constructor() {
     const route = inject(ActivatedRoute);
@@ -179,6 +180,28 @@ export class ServiceKeysComponent {
     });
   }
 
+  // Header "Copy all (JSON)" — works without expanding the panel: loads the
+  // credentials on demand if they aren't cached yet, then copies. (The copy
+  // component copies synchronously, so it can't drive a lazy fetch — hence
+  // this async handler.)
+  async copyAllCredentials(guid: string): Promise<void> {
+    if (this.credsByGuid()[guid] === undefined) {
+      await this.loadCredentials(guid);
+    }
+    const creds = this.credsByGuid()[guid];
+    if (creds === undefined) {
+      this.errorMessage.set(`Failed to load credentials: ${this.credsError(guid) ?? 'unknown error'}`);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(creds, null, 2));
+      this.copiedAllGuid.set(guid);
+      setTimeout(() => { if (this.copiedAllGuid() === guid) this.copiedAllGuid.set(null); }, 2000);
+    } catch {
+      this.errorMessage.set('Failed to copy credentials to clipboard.');
+    }
+  }
+
   private async loadCredentials(guid: string): Promise<void> {
     this.credsLoadingByGuid.update(prev => ({ ...prev, [guid]: true }));
     this.credsErrorByGuid.update(prev => { const n = { ...prev }; delete n[guid]; return n; });
@@ -196,8 +219,10 @@ export class ServiceKeysComponent {
 
   private async loadBindable(offeringGuid: string): Promise<void> {
     try {
+      // ?return=summary — bindable is only populated at summary+ tier; the
+      // base tier omits it (which would leave the guard fail-open).
       const offering = await firstValueFrom(
-        this.http.get<OfferingBindableResponse>(`/pp/v1/cf/service_offerings/${this.cfGuid}/${offeringGuid}`),
+        this.http.get<OfferingBindableResponse>(`/pp/v1/cf/service_offerings/${this.cfGuid}/${offeringGuid}?return=summary`),
       );
       // Absent flag → treat as supported (fail open); explicit false → blocked.
       this.bindable.set(offering?.bindable ?? true);

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -4,7 +4,7 @@ import { ChangeDetectionStrategy, Component, Signal, computed, effect, inject, s
 import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 
-import { IHeaderBreadcrumb, PageHeaderComponent } from '@stratosui/core';
+import { CopyToClipboardComponent, IHeaderBreadcrumb, PageHeaderComponent } from '@stratosui/core';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
 import { ServiceCatalogDataService, ServiceKeyView, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
@@ -20,17 +20,48 @@ interface OfferingBindableResponse {
   bindable?: boolean;
 }
 
+// One displayable credential entry. `sensitive` drives on-screen masking;
+// `value` always holds the real value so copy works even while masked.
+interface CredentialField {
+  key: string;
+  value: string;
+  sensitive: boolean;
+}
+
+// Mask credential keys that look like secrets. We iterate every field (rather
+// than hardcoding username/password/url) so the list survives broker key-name
+// changes; only the display is masked, never the copied value.
+const SENSITIVE_KEY = /pass|secret|token|private|key|cred/i;
+// Connection strings frequently embed the password as scheme://user:pass@host
+// (e.g. a postgres `uri`). Mask by VALUE too so these don't leak even though
+// the key ("uri"/"read_uri") looks innocuous; a plain URL without credentials
+// stays visible.
+const EMBEDDED_CREDENTIAL = /:\/\/[^/\s:@]+:[^/\s@]+@/;
+
+function toCredentialFields(creds: Record<string, unknown>): CredentialField[] {
+  return Object.entries(creds).map(([key, raw]) => {
+    const value = typeof raw === 'string' ? raw : JSON.stringify(raw);
+    return {
+      key,
+      value,
+      sensitive: SENSITIVE_KEY.test(key) || EMBEDDED_CREDENTIAL.test(value),
+    };
+  });
+}
+
 // ServiceKeysComponent — per-instance Service Keys page, reached via the
 // /services/:type/:endpointId/:serviceInstanceId/keys route (sibling to the
-// existing edit/detach action routes). Lists the instance's service keys
-// (credential bindings with type=key), with create / reveal-credentials /
-// delete. Create and delete ride the writeWithJob async-job contract.
+// edit/detach action routes). Service keys are credential bindings (type=key).
+// Each key renders as an accordion panel (mirroring the app instances
+// accordion); expanding lazily loads its credentials, shown as a masked,
+// per-field-copyable list. Create/delete ride the writeWithJob async-job
+// contract.
 @Component({
   selector: 'app-service-keys',
   templateUrl: './service-keys.component.html',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe, PageHeaderComponent],
+  imports: [DatePipe, PageHeaderComponent, CopyToClipboardComponent],
 })
 export class ServiceKeysComponent {
   private http = inject(HttpClient);
@@ -53,7 +84,6 @@ export class ServiceKeysComponent {
 
   // Reloadable list source: swapping the signal re-derives keys/loading.
   private keysSource = signal<SignalSource<ServiceKeyView[]>>(
-    // placeholder replaced in the constructor once guids are read
     { value: signal<ServiceKeyView[]>([]).asReadonly(), isLoading: signal(false).asReadonly(), error: signal(null).asReadonly() },
   );
   readonly keys: Signal<ServiceKeyView[]> = computed(() => this.keysSource().value());
@@ -67,18 +97,34 @@ export class ServiceKeysComponent {
   // off the warmed offerings store (which can be cold/slow on multi-CF
   // foundations), so it may fail open and show the action for a non-bindable
   // service. Here we fetch the offering directly once the instance loads and
-  // block create if the broker doesn't support keys. undefined = not yet known
-  // (fail open); false = confirmed not supported.
+  // block create when the broker doesn't support keys. undefined = not yet
+  // known (fail open); false = confirmed not supported.
   readonly bindable = signal<boolean | undefined>(undefined);
   readonly notBindable = computed(() => this.bindable() === false);
   private bindableFetchStarted = false;
 
-  // Per-row delete status + revealed credentials, keyed by key guid.
+  // Accordion + per-key credential state, all keyed by key guid.
+  private openByGuid = signal<Record<string, boolean>>({});
+  private credsByGuid = signal<Record<string, Record<string, unknown>>>({});
+  private credsLoadingByGuid = signal<Record<string, boolean>>({});
+  private credsErrorByGuid = signal<Record<string, string>>({});
+  // Revealed sensitive fields, keyed `${guid}::${fieldKey}`.
+  private shownFields = signal<ReadonlySet<string>>(new Set<string>());
+  // Per-key delete status.
   private statusByGuid = signal<Record<string, RowStatus>>({});
-  private credentialsByGuid = signal<Record<string, string>>({});
 
+  isOpen = (guid: string): boolean => this.openByGuid()[guid] ?? false;
+  credsLoading = (guid: string): boolean => this.credsLoadingByGuid()[guid] ?? false;
+  credsError = (guid: string): string | undefined => this.credsErrorByGuid()[guid];
   rowStatus = (guid: string): RowStatus => this.statusByGuid()[guid] ?? 'idle';
-  revealedCredentials = (guid: string): string | undefined => this.credentialsByGuid()[guid];
+  credentialFields = (guid: string): CredentialField[] => {
+    const creds = this.credsByGuid()[guid];
+    return creds ? toCredentialFields(creds) : [];
+  };
+  fieldShown = (guid: string, key: string): boolean => this.shownFields().has(`${guid}::${key}`);
+  displayValue = (guid: string, field: CredentialField): string =>
+    field.sensitive && !this.fieldShown(guid, field.key) ? '••••••••' : field.value;
+  allCredsJson = (guid: string): string => JSON.stringify(this.credsByGuid()[guid] ?? {}, null, 2);
 
   constructor() {
     const route = inject(ActivatedRoute);
@@ -88,7 +134,7 @@ export class ServiceKeysComponent {
     this.reload();
 
     // Once the instance summary lands we know the offering guid; fetch the
-    // offering once to resolve bindability authoritatively (the backup for the
+    // offering once to resolve bindability authoritatively (backup for the
     // best-effort list gate). Runs in the injection context so the effect is
     // cleaned up with the component.
     effect(() => {
@@ -101,6 +147,38 @@ export class ServiceKeysComponent {
 
   reload(): void {
     this.keysSource.set(this.catalog.serviceKeysForInstance(this.cfGuid, this.siGuid));
+  }
+
+  toggleOpen(guid: string): void {
+    const opening = !this.isOpen(guid);
+    this.openByGuid.update(prev => ({ ...prev, [guid]: opening }));
+    if (opening && this.credsByGuid()[guid] === undefined && !this.credsLoading(guid)) {
+      void this.loadCredentials(guid);
+    }
+  }
+
+  toggleField(guid: string, key: string): void {
+    const id = `${guid}::${key}`;
+    this.shownFields.update(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) { next.delete(id); } else { next.add(id); }
+      return next;
+    });
+  }
+
+  private async loadCredentials(guid: string): Promise<void> {
+    this.credsLoadingByGuid.update(prev => ({ ...prev, [guid]: true }));
+    this.credsErrorByGuid.update(prev => { const n = { ...prev }; delete n[guid]; return n; });
+    try {
+      const details = await firstValueFrom(
+        this.http.get<KeyDetailsResponse>(`/pp/v1/cf/service_keys/${this.cfGuid}/${guid}/details`),
+      );
+      this.credsByGuid.update(prev => ({ ...prev, [guid]: details?.credentials ?? {} }));
+    } catch (err: unknown) {
+      this.credsErrorByGuid.update(prev => ({ ...prev, [guid]: this.messageOf(err) }));
+    } finally {
+      this.credsLoadingByGuid.update(prev => ({ ...prev, [guid]: false }));
+    }
   }
 
   private async loadBindable(offeringGuid: string): Promise<void> {
@@ -154,27 +232,6 @@ export class ServiceKeysComponent {
     } catch (err: unknown) {
       this.setStatus(guid, 'error');
       this.errorMessage.set(`Failed to delete key: ${this.messageOf(err)}`);
-    }
-  }
-
-  async revealCredentials(guid: string): Promise<void> {
-    if (this.revealedCredentials(guid) !== undefined) {
-      // Toggle off.
-      this.credentialsByGuid.update(prev => {
-        const next = { ...prev };
-        delete next[guid];
-        return next;
-      });
-      return;
-    }
-    try {
-      const details = await firstValueFrom(
-        this.http.get<KeyDetailsResponse>(`/pp/v1/cf/service_keys/${this.cfGuid}/${guid}/details`),
-      );
-      const creds = JSON.stringify(details?.credentials ?? {}, null, 2);
-      this.credentialsByGuid.update(prev => ({ ...prev, [guid]: creds }));
-    } catch (err: unknown) {
-      this.errorMessage.set(`Failed to load credentials: ${this.messageOf(err)}`);
     }
   }
 

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.spec.ts
@@ -37,6 +37,7 @@ function makeStubSignalConfigService() {
     registerSortExtractor: vi.fn(),
     registerFilterExtractor: vi.fn(),
     deleteServiceInstance: vi.fn().mockResolvedValue(undefined),
+    isOfferingBindable: vi.fn().mockReturnValue(undefined),
     filter: filterSig,
     sort: sortSig,
     pageSize,
@@ -141,13 +142,18 @@ describe('ServicesWallComponent', () => {
     expect(serviceCol!.render!(ups)).toBe('User Provided');
   });
 
-  it('row actions are Edit / Detach / Delete', async () => {
+  it('row actions: managed gets Service Keys (bindable), user-provided does not', async () => {
     await component.ngOnInit();
     const cfg = component.listConfig();
     const actionsCol = cfg!.columns.find(c => c.key === 'actions');
     expect(actionsCol).toBeDefined();
+    // isOfferingBindable returns undefined here (cache cold) → fail open, so a
+    // managed instance shows Service Keys; user-provided never does.
     const managed: any = { cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'cache', type: 'managed' };
     expect((actionsCol as any).actions!(managed).map((a: any) => a.label))
+      .toEqual(['Edit', 'Detach', 'Service Keys', 'Delete']);
+    const ups: any = { cnsiGuid: 'cnsi-1', guid: 'si-2', name: 'legacy-db', type: 'user-provided' };
+    expect((actionsCol as any).actions!(ups).map((a: any) => a.label))
       .toEqual(['Edit', 'Detach', 'Delete']);
   });
 

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -7,7 +7,6 @@ import { Observable, firstValueFrom } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 
 import {
-  ConfirmationDialogConfig,
   ConfirmationDialogService,
   ListSubNavAddAction,
   ListSubNavComponent,
@@ -31,6 +30,7 @@ import {
 } from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
 import { CloudFoundryService } from '../../../shared/data-services/cloud-foundry.service';
 import { boundAppSegments, renderBoundApps } from '../../../shared/signal-list-configs/bound-apps-cell';
+import { buildServiceInstanceRowActions } from '../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 
 // Stratos Services Wall — multi-CNSI service instances list (managed +
@@ -330,57 +330,14 @@ export class ServicesWallComponent implements OnInit {
     }
   }
 
-  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] => {
-    const runAction = async (label: string, op: () => Promise<void>) => {
-      try {
-        await op();
-      } catch (err: any) {
-        this.snackBar.error(`${label} failed: ${err?.message ?? err}`);
-      }
-    };
-    // The wall mixes managed and user-provided instances, so the
-    // edit/detach route's :type segment branches on the row kind:
-    // 'service' for managed, 'user-service' for user-provided. Mirrors
-    // the per-space tabs that already restored Edit + Detach.
-    const siType = si.type === 'user-provided' ? 'user-service' : 'service';
-    return [
-      {
-        label: 'Edit', icon: 'edit',
-        invoke: () => {
-          void this.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'edit']);
-        },
-      },
-      {
-        label: 'Detach', icon: 'link_off',
-        invoke: () => {
-          void this.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'detach']);
-        },
-      },
-      // Service keys are broker-mediated, so only managed instances get the
-      // action; user-provided instances have no keys.
-      ...(si.type === 'user-provided' ? [] : [{
-        label: 'Service Keys', icon: 'vpn_key',
-        invoke: () => {
-          void this.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'keys']);
-        },
-      }]),
-      {
-        label: 'Delete', icon: 'delete', danger: true,
-        invoke: () => {
-          const confirm = new ConfirmationDialogConfig(
-            'Delete Service Instance',
-            `Delete the service instance "${si.name}"? This cannot be undone and will detach any apps bound to it.`,
-            'Delete',
-            true,
-          );
-          this.confirmDialog.open(confirm, async () => {
-            await runAction('Delete', () =>
-              this.instancesConfig.deleteServiceInstance(si.cnsiGuid, si.guid));
-          });
-        },
-      },
-    ];
-  };
+  private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] =>
+    buildServiceInstanceRowActions(si, {
+      router: this.router,
+      confirmDialog: this.confirmDialog,
+      snackBar: this.snackBar,
+      deleteServiceInstance: (cnsiGuid, guid) => this.instancesConfig.deleteServiceInstance(cnsiGuid, guid),
+      isOfferingBindable: (si) => this.instancesConfig.isOfferingBindable(si),
+    });
 
   static formatDate(iso: string | null | undefined): string {
     if (!iso) return '';

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -356,6 +356,14 @@ export class ServicesWallComponent implements OnInit {
           void this.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'detach']);
         },
       },
+      // Service keys are broker-mediated, so only managed instances get the
+      // action; user-provided instances have no keys.
+      ...(si.type === 'user-provided' ? [] : [{
+        label: 'Service Keys', icon: 'vpn_key',
+        invoke: () => {
+          void this.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'keys']);
+        },
+      }]),
       {
         label: 'Delete', icon: 'delete', danger: true,
         invoke: () => {

--- a/src/frontend/packages/cloud-foundry/src/features/services/services.routes.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services.routes.ts
@@ -7,6 +7,7 @@ import {
   AddServiceInstanceComponent,
 } from '../../shared/components/add-service-instance/add-service-instance/add-service-instance.component';
 import { DetachServiceInstanceComponent } from './detach-service-instance/detach-service-instance.component';
+import { ServiceKeysComponent } from './service-keys/service-keys.component';
 import { ServicesWallComponent } from './services-wall/services-wall.component';
 
 export const SERVICES_ROUTES: Routes = [
@@ -29,5 +30,9 @@ export const SERVICES_ROUTES: Routes = [
   {
     path: ':type/:endpointId/:serviceInstanceId/detach',
     component: DetachServiceInstanceComponent
+  },
+  {
+    path: ':type/:endpointId/:serviceInstanceId/keys',
+    component: ServiceKeysComponent
   }
 ];

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
@@ -19,6 +19,36 @@ interface PagedResp<T> {
   pagination?: { totalResults?: number };
 }
 
+// Service keys come back from GH#4301's native handler as raw v3
+// service_credential_binding resources (type=key). We only render a few
+// fields, so map to this view model rather than the full St shape.
+export interface ServiceKeyView {
+  guid: string;
+  name: string;
+  createdAt: string;
+  lastOperationState?: string;
+}
+
+interface RawServiceKey {
+  guid: string;
+  name?: string;
+  created_at?: string;
+  last_operation?: { state?: string };
+}
+
+interface RawServiceKeysResponse {
+  resources?: RawServiceKey[];
+}
+
+function toServiceKeyView(raw: RawServiceKey): ServiceKeyView {
+  return {
+    guid: raw.guid,
+    name: raw.name ?? '',
+    createdAt: raw.created_at ?? '',
+    lastOperationState: raw.last_operation?.state,
+  };
+}
+
 // Per-call loadable signal triple — value + lifecycle signals so
 // consumers with loading-state machinery (e.g. cf-service-plans-signal
 // -config) can wire UI states without re-implementing the pieces.
@@ -150,6 +180,21 @@ export class ServiceCatalogDataService {
         `/pp/v1/cf/service_instances/${cnsiGuid}/${instanceGuid}/service_bindings`,
         { params },
       ).pipe(map(resp => resp?.resources ?? [])),
+      [],
+    );
+  }
+
+  // Service keys for a single instance — credential bindings with type=key
+  // (filtered server-side by GH#4301's native handler). Maps the raw v3
+  // binding resources to a small view model the keys page renders. The keys
+  // management page (and its reload after create/delete) consume this.
+  serviceKeysForInstance(cnsiGuid: string, instanceGuid: string): SignalSource<ServiceKeyView[]> {
+    const params = new HttpParams().set('service_instance_guids', instanceGuid);
+    return this.signalize(
+      this.http.get<RawServiceKeysResponse>(
+        `/pp/v1/cf/service_keys/${cnsiGuid}`,
+        { params },
+      ).pipe(map(resp => (resp?.resources ?? []).map(toServiceKeyView))),
       [],
     );
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.ts
@@ -550,4 +550,19 @@ export class CfServiceInstancesSignalConfigService {
     });
     this.orchestrator?.removeRow(cnsiGuid, siGuid);
   }
+
+  // isOfferingBindable resolves the instance's service-offering bindability
+  // from the registry's already-warmed services-details cache (offerings are
+  // fetched alongside instances on acquire → loadServicesDetails, the same
+  // source as the marketplace Bindable column). Returns:
+  //   true/false — offering known and (not) bindable
+  //   undefined  — offering not in cache yet (cold) → callers fail open
+  // Avoids a per-row HTTP fetch; gates the Service Keys row action.
+  isOfferingBindable(si: StServiceInstance): boolean | undefined {
+    const offeringGuid = si.servicePlan?.serviceOffering?.guid;
+    if (!offeringGuid) return undefined;
+    const offering = this.registry?.peek(si.cnsiGuid)?.serviceOfferings()
+      .find(o => o.guid === offeringGuid);
+    return offering?.bindable;
+  }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/service-instance-row-actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/service-instance-row-actions.ts
@@ -1,0 +1,100 @@
+import { Router } from '@angular/router';
+
+import {
+  ConfirmationDialogConfig,
+  ConfirmationDialogService,
+  SignalListRowAction,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+
+// Services this builder needs from the host list component. Each list already
+// injects these; passing them in keeps the builder free of Angular DI so it
+// stays a plain, testable function.
+export interface ServiceInstanceRowActionDeps {
+  router: Router;
+  confirmDialog: ConfirmationDialogService;
+  snackBar: TailwindSnackBarService;
+  // The host's delete chokepoint (CfServiceInstancesSignalConfigService
+  // .deleteServiceInstance), so cache invalidation stays owned by the config.
+  deleteServiceInstance: (cnsiGuid: string, guid: string) => Promise<void>;
+  // Resolves the instance's offering bindability from the warmed
+  // services-details store (CfServiceInstancesSignalConfigService
+  // .isOfferingBindable). undefined → offering not cached yet (fail open).
+  isOfferingBindable: (si: StServiceInstance) => boolean | undefined;
+}
+
+// supportsServiceKeys — service keys are broker-mediated credential bindings
+// (type=key); CF only permits them on managed instances whose offering is
+// bindable. Bindability comes from the already-fetched offerings cache, not
+// the instance payload (broker_catalog isn't allowed in the instance list's
+// sparse fieldset). We fail OPEN when bindability is unknown (cache cold) so
+// the action isn't hidden during the brief warm-up; a non-bindable create
+// still fails safely at the broker.
+function supportsServiceKeys(
+  si: StServiceInstance,
+  isOfferingBindable: (si: StServiceInstance) => boolean | undefined,
+): boolean {
+  return si.type !== 'user-provided' && isOfferingBindable(si) !== false;
+}
+
+// buildServiceInstanceRowActions — the single source of truth for the per-row
+// action menu on every service-instance list (services wall, CF services tab,
+// space service-instances tab, marketplace offering instances). Previously each
+// list pasted its own near-identical Edit/Detach/Delete builder, which let the
+// Service Keys action drift in (it was only on the wall). Centralising here
+// keeps them consistent and gates Service Keys uniformly.
+export function buildServiceInstanceRowActions(
+  si: StServiceInstance,
+  deps: ServiceInstanceRowActionDeps,
+): SignalListRowAction<StServiceInstance>[] {
+  // The edit/detach/keys routes' :type segment branches on the row kind:
+  // 'service' for managed, 'user-service' for user-provided.
+  const siType = si.type === 'user-provided' ? 'user-service' : 'service';
+
+  const actions: SignalListRowAction<StServiceInstance>[] = [
+    {
+      label: 'Edit', icon: 'edit',
+      invoke: () => {
+        void deps.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'edit']);
+      },
+    },
+    {
+      label: 'Detach', icon: 'link_off',
+      invoke: () => {
+        void deps.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'detach']);
+      },
+    },
+  ];
+
+  if (supportsServiceKeys(si, deps.isOfferingBindable)) {
+    actions.push({
+      label: 'Service Keys', icon: 'vpn_key',
+      invoke: () => {
+        void deps.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'keys']);
+      },
+    });
+  }
+
+  actions.push({
+    label: 'Delete', icon: 'delete', danger: true,
+    invoke: () => {
+      const confirm = new ConfirmationDialogConfig(
+        'Delete Service Instance',
+        `Delete the service instance "${si.name}"? This cannot be undone and will detach any apps bound to it.`,
+        'Delete',
+        true,
+      );
+      deps.confirmDialog.open(confirm, async () => {
+        try {
+          await deps.deleteServiceInstance(si.cnsiGuid, si.guid);
+        } catch (err: unknown) {
+          deps.snackBar.error(`Delete failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      });
+    },
+  });
+
+  return actions;
+}

--- a/src/jetstream/plugins/cloudfoundry/native_routes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_routes.go
@@ -40,6 +40,18 @@ func (c *CloudFoundrySpecification) addNativeRoutes(echoGroup *echo.Group) {
 	nativeGroup.POST("/cf/service_bindings/:cnsiGuid", c.createServiceBinding)
 	nativeGroup.DELETE("/cf/service_bindings/:cnsiGuid/:bindingGuid", c.deleteServiceBinding)
 	nativeGroup.GET("/cf/apps/:cnsiGuid/:appGuid/service_bindings", c.getAppServiceBindings)
+	// Service route bindings (GH#4302) + service keys (GH#4301): registered
+	// for forward-wiring; capi already ships both clients. Async create/delete
+	// follow the RunFastPath / writeWithJob contract (see the handler files).
+	nativeGroup.GET("/cf/service_route_bindings/:cnsiGuid", c.getNativeServiceRouteBindings)
+	nativeGroup.POST("/cf/service_route_bindings/:cnsiGuid", c.createServiceRouteBinding)
+	nativeGroup.DELETE("/cf/service_route_bindings/:cnsiGuid/:bindingGuid", c.deleteServiceRouteBinding)
+	nativeGroup.GET("/cf/service_route_bindings/:cnsiGuid/:bindingGuid/parameters", c.getNativeServiceRouteBindingParameters)
+	nativeGroup.GET("/cf/service_keys/:cnsiGuid", c.getNativeServiceKeys)
+	nativeGroup.POST("/cf/service_keys/:cnsiGuid", c.createServiceKey)
+	nativeGroup.DELETE("/cf/service_keys/:cnsiGuid/:keyGuid", c.deleteServiceKey)
+	nativeGroup.GET("/cf/service_keys/:cnsiGuid/:keyGuid/details", c.getNativeServiceKeyDetails)
+	nativeGroup.GET("/cf/service_keys/:cnsiGuid/:keyGuid/parameters", c.getNativeServiceKeyParameters)
 	nativeGroup.GET("/cf/org/:cnsiGuid/:orgGuid", c.getNativeOrgDetail)
 	nativeGroup.GET("/cf/org/:cnsiGuid/:orgGuid/spaces", c.getNativeOrgSpaces)
 	nativeGroup.GET("/cf/org/:cnsiGuid/:orgGuid/private_domains", c.getNativeOrgDomains)

--- a/src/jetstream/plugins/cloudfoundry/native_service_keys.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_keys.go
@@ -1,0 +1,270 @@
+// src/jetstream/plugins/cloudfoundry/native_service_keys.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/fivetwenty-io/capi/v3/pkg/capi"
+	"github.com/labstack/echo/v4"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+)
+
+// Service keys (GH#4301) — Stratos-shape wrappers around CF v3 service keys.
+//
+// In v3 a "service key" is a service_credential_binding with type="key" (vs
+// "app"), so these handlers reuse capi's ServiceCredentialBindingsClient and
+// pin type=key. create/delete share the same async RunFastPath / writeWithJob
+// contract as native_service_bindings.go; GetDetails surfaces the credentials a
+// key exists to expose.
+//
+// Registered but not yet consumed by the frontend — they give the eventual
+// service-keys UI a stable contract to wire to. The generic credential-binding
+// create/delete handlers already accept type=key bodies; these key-scoped
+// endpoints make the surface explicit (and add list + details + parameters).
+
+// createServiceKey handles POST /pp/v1/cf/service_keys/{cnsiGuid}.
+//
+// The frontend sends a v3-shaped credential-binding body naming the service
+// instance:
+//
+//	{"name":"my-key","relationships":{
+//	   "service_instance":{"data":{"guid":"<siGuid>"}}},
+//	 "parameters":{...optional...}}
+//
+// We decode it into capi.ServiceCredentialBindingCreateRequest and force
+// Type="key" (ignoring any client-supplied type) so this endpoint can only ever
+// mint keys. capi's Create returns *ServiceCredentialBinding (sync 201) or *Job
+// (async); the async path drives RunFastPath like createServiceBinding.
+func (cf *CloudFoundrySpecification) createServiceKey(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	var req capi.ServiceCredentialBindingCreateRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid body: %v", err))
+	}
+	// This endpoint mints keys only — pin the type regardless of the client body.
+	req.Type = "key"
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	result, createErr := cfClient.ServiceCredentialBindings().Create(reqCtx, &req)
+	if createErr != nil {
+		return handleCapiError(c, createErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	// Sync path: key returned directly. Surface 201 Created with the body.
+	job, isJob := result.(*capi.Job)
+	if !isJob {
+		return c.JSON(http.StatusCreated, result)
+	}
+
+	// Async path: broker key returned 202 + Location; drive RunFastPath.
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_key.create",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// deleteServiceKey handles DELETE /pp/v1/cf/service_keys/{cnsiGuid}/{keyGuid}.
+//
+// Delegates to ServiceCredentialBindings().Delete (a key is just a credential
+// binding). Async 202 + Location → *Job → RunFastPath; nil job → synthetic
+// COMPLETE so writeWithJob resolves without polling.
+func (cf *CloudFoundrySpecification) deleteServiceKey(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	keyGUID := c.Param("keyGuid")
+	if cnsiGUID == "" || keyGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and keyGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	job, deleteErr := cfClient.ServiceCredentialBindings().Delete(reqCtx, keyGUID)
+	if deleteErr != nil {
+		return handleCapiError(c, deleteErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	if job == nil {
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  stratosjobs.JobStateComplete,
+			"result": map[string]string{"operation": "service_key.delete"},
+		})
+	}
+
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_key.delete",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// getNativeServiceKeys handles GET /pp/v1/cf/service_keys/{cnsiGuid}.
+//
+// Lists credential bindings filtered to type=key. Optional query filter:
+// service_instance_guids (scope to one SI). Returns a StratosPagedResponse of
+// the raw v3 bindings; the frontend adapter shapes them when the UI is wired.
+func (cf *CloudFoundrySpecification) getNativeServiceKeys(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	perPage, page, present := parsePerPageAndPage(c)
+	params := applyPagingParams(capi.NewQueryParams().WithFilter("type", "key"), perPage, page, present)
+	if si := c.QueryParam("service_instance_guids"); si != "" {
+		params = params.WithFilter("service_instance_guids", si)
+	}
+
+	raw, listErr := cfClient.ServiceCredentialBindings().List(reqCtx, params)
+	if listErr != nil {
+		return handleCapiError(c, listErr)
+	}
+
+	return c.JSON(http.StatusOK, StratosPagedResponse[capi.ServiceCredentialBinding]{
+		Resources:  raw.Resources,
+		Pagination: BuildPaginationMeta(c, page, perPage, raw.Pagination.TotalResults),
+	})
+}
+
+// getNativeServiceKeyDetails handles
+// GET /pp/v1/cf/service_keys/{cnsiGuid}/{keyGuid}/details.
+//
+// Surfaces the key's credentials (v3 GET .../details) — the reason service keys
+// exist. Read-only; no job handoff. Sensitive payload: returned verbatim to the
+// authenticated caller, never logged.
+func (cf *CloudFoundrySpecification) getNativeServiceKeyDetails(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	keyGUID := c.Param("keyGuid")
+	if cnsiGUID == "" || keyGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and keyGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	details, detErr := cfClient.ServiceCredentialBindings().GetDetails(reqCtx, keyGUID)
+	if detErr != nil {
+		return handleCapiError(c, detErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, details)
+}
+
+// getNativeServiceKeyParameters handles
+// GET /pp/v1/cf/service_keys/{cnsiGuid}/{keyGuid}/parameters.
+//
+// Surfaces the broker-specific parameters the key was created with (v3 GET
+// .../parameters). Read-only; no job handoff.
+func (cf *CloudFoundrySpecification) getNativeServiceKeyParameters(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	keyGUID := c.Param("keyGuid")
+	if cnsiGUID == "" || keyGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and keyGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	params, paramErr := cfClient.ServiceCredentialBindings().GetParameters(reqCtx, keyGUID)
+	if paramErr != nil {
+		return handleCapiError(c, paramErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, params)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_keys_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_keys_test.go
@@ -1,0 +1,238 @@
+// src/jetstream/plugins/cloudfoundry/native_service_keys_test.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func serviceKeyCtx(method, target, body string, paramNames, paramVals []string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, target, nil)
+	} else {
+		req = httptest.NewRequest(method, target, strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames(paramNames...)
+	c.SetParamValues(paramVals...)
+	return c, rec
+}
+
+// TestCreateServiceKey_ForcesTypeKey verifies the handler pins type=key on the
+// upstream credential-binding create even if the client body says otherwise.
+func TestCreateServiceKey_ForcesTypeKey(t *testing.T) {
+	var receivedBody map[string]interface{}
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings" && r.Method == http.MethodPost:
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"guid":"key-1","type":"key"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	// Client deliberately sends type=app — handler must override to "key".
+	body := `{"type":"app","name":"my-key","relationships":{"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := serviceKeyCtx(http.MethodPost, "/pp/v1/cf/service_keys/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceKey(c))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, "key", receivedBody["type"], "handler must force type=key")
+	assert.Equal(t, "my-key", receivedBody["name"])
+}
+
+// TestCreateServiceKey_FastPathResolvesAsync covers the async create branch.
+func TestCreateServiceKey_FastPathResolvesAsync(t *testing.T) {
+	var jobGets atomic.Int32
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings" && r.Method == http.MethodPost:
+			w.Header().Set("Location", "/v3/jobs/job-key-1")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"guid":"job-key-1","operation":"service_credential_binding.create","state":"PROCESSING"}`))
+		case r.URL.Path == "/v3/jobs/job-key-1" && r.Method == http.MethodGet:
+			jobGets.Add(1)
+			_, _ = w.Write([]byte(`{"guid":"job-key-1","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	body := `{"name":"my-key","relationships":{"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := serviceKeyCtx(http.MethodPost, "/pp/v1/cf/service_keys/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceKey(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+	assert.GreaterOrEqual(t, jobGets.Load(), int32(1))
+}
+
+// TestDeleteServiceKey_FastPathResolves covers the async delete branch.
+func TestDeleteServiceKey_FastPathResolves(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings/key-9" && r.Method == http.MethodDelete:
+			w.Header().Set("Location", "/v3/jobs/job-keydel-1")
+			w.WriteHeader(http.StatusAccepted)
+		case r.URL.Path == "/v3/jobs/job-keydel-1" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"guid":"job-keydel-1","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	c, rec := serviceKeyCtx(http.MethodDelete, "/pp/v1/cf/service_keys/cnsi-1/key-9", "",
+		[]string{"cnsiGuid", "keyGuid"}, []string{"cnsi-1", "key-9"})
+
+	require.NoError(t, plugin.deleteServiceKey(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+}
+
+// TestGetNativeServiceKeys_FiltersTypeKey verifies the list handler pins
+// the type=key filter on the upstream query.
+func TestGetNativeServiceKeys_FiltersTypeKey(t *testing.T) {
+	var gotQuery string
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings" && r.Method == http.MethodGet:
+			gotQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"pagination":{"total_results":1,"total_pages":1},"resources":[{"guid":"key-1","type":"key"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := serviceKeyCtx(http.MethodGet, "/pp/v1/cf/service_keys/cnsi-1?service_instance_guids=si-1", "",
+		[]string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.getNativeServiceKeys(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, gotQuery, "type=key")
+	assert.Contains(t, gotQuery, "service_instance_guids=si-1")
+}
+
+// TestGetNativeServiceKeyDetails returns the key credentials.
+func TestGetNativeServiceKeyDetails(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings/key-1/details" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"credentials":{"username":"u","password":"p"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := serviceKeyCtx(http.MethodGet, "/pp/v1/cf/service_keys/cnsi-1/key-1/details", "",
+		[]string{"cnsiGuid", "keyGuid"}, []string{"cnsi-1", "key-1"})
+
+	require.NoError(t, plugin.getNativeServiceKeyDetails(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	creds, ok := resp["credentials"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "u", creds["username"])
+}
+
+// TestGetNativeServiceKeyParameters returns the broker parameters.
+func TestGetNativeServiceKeyParameters(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_credential_bindings/key-1/parameters" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"parameters":{"foo":"bar"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := serviceKeyCtx(http.MethodGet, "/pp/v1/cf/service_keys/cnsi-1/key-1/parameters", "",
+		[]string{"cnsiGuid", "keyGuid"}, []string{"cnsi-1", "key-1"})
+
+	require.NoError(t, plugin.getNativeServiceKeyParameters(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "foo")
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_route_bindings.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_route_bindings.go
@@ -1,0 +1,251 @@
+// src/jetstream/plugins/cloudfoundry/native_service_route_bindings.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/fivetwenty-io/capi/v3/pkg/capi"
+	"github.com/labstack/echo/v4"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+)
+
+// Service route bindings (GH#4302) — Stratos-shape write/read wrappers around
+// CF v3 /v3/service_route_bindings via capi's ServiceRouteBindingsClient.
+//
+// These handlers are registered but not yet consumed by the frontend; they
+// exist so the eventual route-service UI can wire to a stable contract. The
+// async create/delete paths follow the same RunFastPath / writeWithJob
+// contract as native_service_bindings.go so no consumer changes are needed
+// when the UI lands.
+
+// createServiceRouteBinding handles
+// POST /pp/v1/cf/service_route_bindings/{cnsiGuid}.
+//
+// The frontend sends the v3-shaped body directly:
+//
+//	{"relationships":{
+//	   "route":{"data":{"guid":"<routeGuid>"}},
+//	   "service_instance":{"data":{"guid":"<siGuid>"}}},
+//	 "parameters":{...optional...}}
+//
+// which matches capi.ServiceRouteBindingCreateRequest one-for-one, so we decode
+// the client body into that request struct and forward it unmodified.
+//
+// capi's Create returns interface{} — *ServiceRouteBinding for synchronous
+// responses (201 Created, e.g. a non-route-service binding) or *Job for
+// asynchronous ones (202 Accepted). We surface 201 on the sync path and drive
+// the async path through RunFastPath so the handoff body is a StratosJob
+// matching the frontend writeWithJob contract.
+//
+// Graceful fallback: if the stratosjobs plugin isn't wired, async creates
+// return bare 202 (frontend 404-on-poll treats that as UNKNOWN).
+func (cf *CloudFoundrySpecification) createServiceRouteBinding(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	var req capi.ServiceRouteBindingCreateRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid body: %v", err))
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	result, createErr := cfClient.ServiceRouteBindings().Create(reqCtx, &req)
+	if createErr != nil {
+		return handleCapiError(c, createErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	// Sync path: binding returned directly. Surface 201 Created with the body.
+	job, isJob := result.(*capi.Job)
+	if !isJob {
+		return c.JSON(http.StatusCreated, result)
+	}
+
+	// Async path: managed route binding returned 202 + Location; drive RunFastPath.
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_route_binding.create",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// deleteServiceRouteBinding handles
+// DELETE /pp/v1/cf/service_route_bindings/{cnsiGuid}/{bindingGuid}.
+//
+// capi's Delete returns (*Job, error). Route-service unbinds are broker-mediated
+// and async (202 + Location → *Job) — we hand the job to RunFastPath for the
+// fast-path/handoff contract. The nil-job branch mirrors deleteServiceBinding:
+// a synchronous 204 would surface a synthetic COMPLETE so writeWithJob resolves
+// without polling.
+//
+// Graceful fallback: if the stratosjobs plugin isn't wired, async deletes
+// return bare 202 (frontend 404-on-poll treats that as UNKNOWN).
+func (cf *CloudFoundrySpecification) deleteServiceRouteBinding(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	bindingGUID := c.Param("bindingGuid")
+	if cnsiGUID == "" || bindingGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and bindingGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	job, deleteErr := cfClient.ServiceRouteBindings().Delete(reqCtx, bindingGUID)
+	if deleteErr != nil {
+		return handleCapiError(c, deleteErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	// Sync path: nil job → synthesize a COMPLETE terminal state.
+	if job == nil {
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  stratosjobs.JobStateComplete,
+			"result": map[string]string{"operation": "service_route_binding.delete"},
+		})
+	}
+
+	// Async path: managed route binding returned 202 + Location; drive RunFastPath.
+	if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+		c.Response().WriteHeader(http.StatusAccepted)
+		return nil
+	}
+
+	ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+	res := stratosjobs.RunFastPath(reqCtx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+		Kind: "cf.service_route_binding.delete",
+	})
+
+	if res.Resolved {
+		if res.State == stratosjobs.JobStateFailed {
+			return c.JSON(http.StatusBadGateway, map[string]interface{}{
+				"state":  res.State,
+				"errors": res.Errors,
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"state":  res.State,
+			"result": res.Result,
+		})
+	}
+	return c.JSON(http.StatusAccepted, res.HandoffJob)
+}
+
+// getNativeServiceRouteBindings handles
+// GET /pp/v1/cf/service_route_bindings/{cnsiGuid}.
+//
+// Optional query filters (passed straight to v3): service_instance_guids,
+// route_guids. Returns a StratosPagedResponse of the raw v3 route bindings;
+// the frontend adapter shapes them when the UI is wired.
+func (cf *CloudFoundrySpecification) getNativeServiceRouteBindings(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+
+	perPage, page, present := parsePerPageAndPage(c)
+	params := applyPagingParams(capi.NewQueryParams(), perPage, page, present)
+	if si := c.QueryParam("service_instance_guids"); si != "" {
+		params = params.WithFilter("service_instance_guids", si)
+	}
+	if rg := c.QueryParam("route_guids"); rg != "" {
+		params = params.WithFilter("route_guids", rg)
+	}
+
+	raw, listErr := cfClient.ServiceRouteBindings().List(reqCtx, params)
+	if listErr != nil {
+		return handleCapiError(c, listErr)
+	}
+
+	return c.JSON(http.StatusOK, StratosPagedResponse[capi.ServiceRouteBinding]{
+		Resources:  raw.Resources,
+		Pagination: BuildPaginationMeta(c, page, perPage, raw.Pagination.TotalResults),
+	})
+}
+
+// getNativeServiceRouteBindingParameters handles
+// GET /pp/v1/cf/service_route_bindings/{cnsiGuid}/{bindingGuid}/parameters.
+//
+// Surfaces the broker-specific route-binding parameters (v3 GET
+// .../parameters). Read-only; no job handoff.
+func (cf *CloudFoundrySpecification) getNativeServiceRouteBindingParameters(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	bindingGUID := c.Param("bindingGuid")
+	if cnsiGUID == "" || bindingGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and bindingGuid are required")
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	params, paramErr := cfClient.ServiceRouteBindings().GetParameters(reqCtx, bindingGUID)
+	if paramErr != nil {
+		return handleCapiError(c, paramErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, params)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_route_bindings_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_route_bindings_test.go
@@ -1,0 +1,220 @@
+// src/jetstream/plugins/cloudfoundry/native_service_route_bindings_test.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// routeBindingCtx wires an echo context for the route-binding handlers.
+func routeBindingCtx(method, target, body string, paramNames, paramVals []string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, target, nil)
+	} else {
+		req = httptest.NewRequest(method, target, strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames(paramNames...)
+	c.SetParamValues(paramVals...)
+	return c, rec
+}
+
+// TestCreateServiceRouteBinding_ForwardsBody verifies the v3-shape body is
+// forwarded to POST /v3/service_route_bindings and the sync 201 surfaced.
+func TestCreateServiceRouteBinding_ForwardsBody(t *testing.T) {
+	capiHits := 0
+	var receivedBody map[string]interface{}
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings" && r.Method == http.MethodPost:
+			capiHits++
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"guid":"srb-1"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	body := `{"relationships":{"route":{"data":{"guid":"route-1"}},"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := routeBindingCtx(http.MethodPost, "/pp/v1/cf/service_route_bindings/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceRouteBinding(c))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, 1, capiHits)
+
+	rels, ok := receivedBody["relationships"].(map[string]interface{})
+	require.True(t, ok, "upstream body missing relationships")
+	route, ok := rels["route"].(map[string]interface{})
+	require.True(t, ok, "upstream body missing relationships.route")
+	data, ok := route["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "route-1", data["guid"])
+}
+
+// TestCreateServiceRouteBinding_FastPathResolvesAsync exercises the async
+// (202 + Job) branch resolving to COMPLETE within the fast-path window.
+func TestCreateServiceRouteBinding_FastPathResolvesAsync(t *testing.T) {
+	var jobGets atomic.Int32
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings" && r.Method == http.MethodPost:
+			w.Header().Set("Location", "/v3/jobs/job-srb-1")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"guid":"job-srb-1","operation":"service_route_binding.create","state":"PROCESSING"}`))
+		case r.URL.Path == "/v3/jobs/job-srb-1" && r.Method == http.MethodGet:
+			jobGets.Add(1)
+			_, _ = w.Write([]byte(`{"guid":"job-srb-1","operation":"service_route_binding.create","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	body := `{"relationships":{"route":{"data":{"guid":"route-1"}},"service_instance":{"data":{"guid":"si-1"}}}}`
+	c, rec := routeBindingCtx(http.MethodPost, "/pp/v1/cf/service_route_bindings/cnsi-1", body, []string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.createServiceRouteBinding(c))
+	assert.Equal(t, http.StatusOK, rec.Code, "fast-path resolve should surface 200")
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+	assert.GreaterOrEqual(t, jobGets.Load(), int32(1))
+}
+
+// TestDeleteServiceRouteBinding_FastPathResolves covers the async delete path.
+func TestDeleteServiceRouteBinding_FastPathResolves(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings/srb-9" && r.Method == http.MethodDelete:
+			w.Header().Set("Location", "/v3/jobs/job-del-1")
+			w.WriteHeader(http.StatusAccepted)
+		case r.URL.Path == "/v3/jobs/job-del-1" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"guid":"job-del-1","operation":"service_route_binding.delete","state":"COMPLETE"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+		asyncTracker: stratosjobs.NewInMemoryTracker(stratosjobs.InMemoryTrackerConfig{}),
+	}
+	plugin.asyncTranslator = NewCFJobTranslator(plugin)
+
+	c, rec := routeBindingCtx(http.MethodDelete, "/pp/v1/cf/service_route_bindings/cnsi-1/srb-9", "",
+		[]string{"cnsiGuid", "bindingGuid"}, []string{"cnsi-1", "srb-9"})
+
+	require.NoError(t, plugin.deleteServiceRouteBinding(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, string(stratosjobs.JobStateComplete), resp["state"])
+}
+
+// TestGetNativeServiceRouteBindings_List verifies the list handler forwards
+// filters and returns a paged envelope.
+func TestGetNativeServiceRouteBindings_List(t *testing.T) {
+	var gotQuery string
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings" && r.Method == http.MethodGet:
+			gotQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"pagination":{"total_results":1,"total_pages":1},"resources":[{"guid":"srb-1"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := routeBindingCtx(http.MethodGet, "/pp/v1/cf/service_route_bindings/cnsi-1?service_instance_guids=si-1", "",
+		[]string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.getNativeServiceRouteBindings(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, gotQuery, "service_instance_guids=si-1")
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	resources, ok := resp["resources"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, resources, 1)
+}
+
+// TestGetNativeServiceRouteBindingParameters returns the broker parameters.
+func TestGetNativeServiceRouteBindingParameters(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_route_bindings/srb-1/parameters" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"parameters":{"foo":"bar"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{testProxy: &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+		tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+	}}
+
+	c, rec := routeBindingCtx(http.MethodGet, "/pp/v1/cf/service_route_bindings/cnsi-1/srb-1/parameters", "",
+		[]string{"cnsiGuid", "bindingGuid"}, []string{"cnsi-1", "srb-1"})
+
+	require.NoError(t, plugin.getNativeServiceRouteBindingParameters(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "foo")
+}


### PR DESCRIPTION
Frontend for service keys (#4301), completing the end-to-end feature on top of
the native handlers in #5460.

Stacked on #5460 — this branch includes that backend commit until #5460 merges,
after which the diff reduces to the frontend only.

## What this adds

A per-instance Service Keys page at /services/:type/:endpointId/:siId/keys
(sibling to the edit/detach routes), reachable from the Service Keys row action
on every managed service-instance list (services wall, CF endpoint Services tab,
space Service Instances tab, marketplace offering Instances).

- **Shared row actions**: extracts one buildServiceInstanceRowActions used by all
  five service-instance lists (removing the duplicated per-component builders),
  with the Service Keys action gated to managed + bindable offerings (resolved
  from the already-warmed offerings store; page-level guard fetches the offering
  as an authoritative backup).
- **Keys page**: house layout (page-header + list-sub-nav with an inline
  create form), each key an accordion panel; expanding lazily loads its
  credentials.
- **Credentials**: masked by key name AND by value (connection strings that
  embed scheme://user:pass@host), per-field Show + copy, and a header
  "Copy all (JSON)" that works without expanding (loads on demand).
- Breadcrumbs added to the service-keys and detach pages.

## Verification

eslint + production build clean; exercised live against a real CF (create →
list → reveal → copy → delete; masking; gating; copy-all from collapsed).

Closes #4301