### PR TITLE
v3-only CF: source auth endpoints from root links when /v2/info absent

### DIFF
--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -27,8 +27,24 @@ type LogCacheLink struct {
 	Href string `json:"href"`
 }
 
+type ApiRootLink struct {
+	Href string `json:"href"`
+}
+
+type CloudControllerV3Link struct {
+	Href string `json:"href"`
+	Meta struct {
+		Version string `json:"version"`
+	} `json:"meta"`
+}
+
 type ApiRootLinks struct {
-	LogCache LogCacheLink `json:"log_cache"`
+	LogCache          LogCacheLink          `json:"log_cache"`
+	Login             ApiRootLink           `json:"login"`
+	Uaa               ApiRootLink           `json:"uaa"`
+	Logging           ApiRootLink           `json:"logging"`
+	Routing           ApiRootLink           `json:"routing"`
+	CloudControllerV3 CloudControllerV3Link `json:"cloud_controller_v3"`
 }
 
 type ApiRoot struct {

--- a/src/jetstream/plugins/cloudfoundry/endpoint_info.go
+++ b/src/jetstream/plugins/cloudfoundry/endpoint_info.go
@@ -1,0 +1,50 @@
+package cloudfoundry
+
+import "github.com/cloudfoundry/stratos/src/jetstream/api"
+
+// rootEndpoints holds the CF endpoints discoverable from the unversioned
+// root `/` links — the v3-only equivalent of the /v2/info fields.
+type rootEndpoints struct {
+	AuthorizationEndpoint  string
+	TokenEndpoint          string
+	DopplerLoggingEndpoint string
+	RoutingEndpoint        string
+	APIVersion             string
+}
+
+// deriveEndpointsFromRoot extracts the auth/uaa/logging/routing endpoints and
+// the CC API version from the CF root `/` links. It is the fallback source used
+// when /v2/info is absent (V2 API disabled), so endpoint registration and
+// cf push remain functional on a v3-only foundation.
+func deriveEndpointsFromRoot(root api.ApiRoot) rootEndpoints {
+	return rootEndpoints{
+		AuthorizationEndpoint:  root.Links.Login.Href,
+		TokenEndpoint:          root.Links.Uaa.Href,
+		DopplerLoggingEndpoint: root.Links.Logging.Href,
+		RoutingEndpoint:        root.Links.Routing.Href,
+		APIVersion:             root.Links.CloudControllerV3.Meta.Version,
+	}
+}
+
+// backfillFromRoot populates the CNSI record's auth/token/doppler endpoints and
+// the V2Info struct from the root `/` links when /v2/info did not supply them
+// (V2 API disabled). When /v2/info responded (supportsV2), it remains the source
+// of truth and this is a no-op so v2-enabled foundations keep their existing
+// behavior.
+func backfillFromRoot(newCNSI *api.CNSIRecord, v2Info *api.V2Info, root api.ApiRoot, supportsV2 bool) {
+	if supportsV2 {
+		return
+	}
+
+	ep := deriveEndpointsFromRoot(root)
+
+	newCNSI.AuthorizationEndpoint = ep.AuthorizationEndpoint
+	newCNSI.TokenEndpoint = ep.TokenEndpoint
+	newCNSI.DopplerLoggingEndpoint = ep.DopplerLoggingEndpoint
+
+	v2Info.AuthorizationEndpoint = ep.AuthorizationEndpoint
+	v2Info.TokenEndpoint = ep.TokenEndpoint
+	v2Info.DopplerLoggingEndpoint = ep.DopplerLoggingEndpoint
+	v2Info.RoutingEndpoint = ep.RoutingEndpoint
+	v2Info.APIVersion = ep.APIVersion
+}

--- a/src/jetstream/plugins/cloudfoundry/endpoint_info_test.go
+++ b/src/jetstream/plugins/cloudfoundry/endpoint_info_test.go
@@ -1,0 +1,89 @@
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A v3-only CF (V2 API disabled) still exposes auth/uaa/logging/routing and
+// the CC API version through the unversioned root `/` links. deriveEndpointsFromRoot
+// must read them so registration + push work without /v2/info.
+func TestDeriveEndpointsFromRoot_V3OnlyLinks(t *testing.T) {
+	rootJSON := `{
+		"links": {
+			"cloud_controller_v3": {"href": "https://cf.example.com/v3", "meta": {"version": "3.180.0"}},
+			"login":     {"href": "https://login.example.com"},
+			"uaa":       {"href": "https://uaa.example.com"},
+			"logging":   {"href": "wss://doppler.example.com:443"},
+			"routing":   {"href": "https://cf.example.com/routing"},
+			"log_cache": {"href": "https://log-cache.example.com"}
+		}
+	}`
+	var root api.ApiRoot
+	require.NoError(t, json.Unmarshal([]byte(rootJSON), &root))
+
+	ep := deriveEndpointsFromRoot(root)
+
+	assert.Equal(t, "https://login.example.com", ep.AuthorizationEndpoint)
+	assert.Equal(t, "https://uaa.example.com", ep.TokenEndpoint)
+	assert.Equal(t, "wss://doppler.example.com:443", ep.DopplerLoggingEndpoint)
+	assert.Equal(t, "https://cf.example.com/routing", ep.RoutingEndpoint)
+	assert.Equal(t, "3.180.0", ep.APIVersion)
+}
+
+// When the root carries no auth links (pre-targeting / unreachable), the
+// derived endpoints are empty rather than panicking.
+func TestDeriveEndpointsFromRoot_EmptyLinks(t *testing.T) {
+	var root api.ApiRoot
+	require.NoError(t, json.Unmarshal([]byte(`{"links":{}}`), &root))
+
+	ep := deriveEndpointsFromRoot(root)
+
+	assert.Empty(t, ep.AuthorizationEndpoint)
+	assert.Empty(t, ep.TokenEndpoint)
+	assert.Empty(t, ep.APIVersion)
+}
+
+// On a v3-only CF (/v2/info absent → supportsV2 false), backfillFromRoot fills
+// the CNSI record's token/auth endpoints (needed for token refresh) and the
+// V2Info struct (consumed by cfapppush) from the root links.
+func TestBackfillFromRoot_V3OnlyPopulatesCNSIAndV2Info(t *testing.T) {
+	var root api.ApiRoot
+	require.NoError(t, json.Unmarshal([]byte(`{"links":{
+		"cloud_controller_v3": {"href": "https://cf.example.com/v3", "meta": {"version": "3.180.0"}},
+		"login":   {"href": "https://login.example.com"},
+		"uaa":     {"href": "https://uaa.example.com"},
+		"logging": {"href": "wss://doppler.example.com:443"},
+		"routing": {"href": "https://cf.example.com/routing"}
+	}}`), &root))
+
+	var cnsi api.CNSIRecord
+	var v2 api.V2Info
+	backfillFromRoot(&cnsi, &v2, root, false /* supportsV2 */)
+
+	assert.Equal(t, "https://login.example.com", cnsi.AuthorizationEndpoint)
+	assert.Equal(t, "https://uaa.example.com", cnsi.TokenEndpoint)
+	assert.Equal(t, "wss://doppler.example.com:443", cnsi.DopplerLoggingEndpoint)
+	assert.Equal(t, "https://login.example.com", v2.AuthorizationEndpoint)
+	assert.Equal(t, "https://uaa.example.com", v2.TokenEndpoint)
+	assert.Equal(t, "https://cf.example.com/routing", v2.RoutingEndpoint)
+	assert.Equal(t, "3.180.0", v2.APIVersion)
+}
+
+// When /v2/info responded (supportsV2 true), it stays the source of truth —
+// backfillFromRoot must not clobber the V2-supplied endpoints with root links.
+func TestBackfillFromRoot_V2PresentDoesNotOverwrite(t *testing.T) {
+	var root api.ApiRoot
+	require.NoError(t, json.Unmarshal([]byte(`{"links":{"login":{"href":"https://root-login.example.com"}}}`), &root))
+
+	cnsi := api.CNSIRecord{AuthorizationEndpoint: "https://v2-auth.example.com"}
+	v2 := api.V2Info{AuthorizationEndpoint: "https://v2-auth.example.com"}
+	backfillFromRoot(&cnsi, &v2, root, true /* supportsV2 */)
+
+	assert.Equal(t, "https://v2-auth.example.com", cnsi.AuthorizationEndpoint)
+	assert.Equal(t, "https://v2-auth.example.com", v2.AuthorizationEndpoint)
+}

--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -390,6 +390,12 @@ func (c *CloudFoundrySpecification) Info(apiEndpoint string, skipSSLValidation b
 		metadata.Assumed = true
 	}
 
+	// When /v2/info is absent (V2 API disabled), source the auth/token/doppler/
+	// routing endpoints and CC API version from the root `/` links so endpoint
+	// registration (token refresh) and cf push work on a v3-only foundation.
+	// No-op when /v2/info responded — it stays the source of truth (#5047).
+	backfillFromRoot(&newCNSI, &v2InfoResponse, apiRootResponse, metadata.SupportsV2)
+
 	if metaBytes, err := json.Marshal(metadata); err == nil {
 		newCNSI.Metadata = string(metaBytes)
 	}


### PR DESCRIPTION
Toward #5047. Makes CF endpoint registration and `cf push` work on a foundation with the V2 API disabled (no `/v2/info`).

## Problem

The original startup-fatal on a `/v2/info` 404 is already fixed (soft-fail dual-probe). Two residual `/v2/info` dependencies remained:

- **Registration** (`main.go Info()`): `newCNSI.AuthorizationEndpoint`/`TokenEndpoint` were only set inside the `/v2/info` block, so they were empty on a v3-only CF — breaking token refresh (`connection_wrapper.go` uses `cnsiRecord.TokenEndpoint`).
- **App push** (`cfapppush`): the push *API calls* are V3 (cf-cli v8 `v7pushaction` over `ccClientV3`), but cf-cli v8 *client setup* still reads auth/uaa/routing/version from config — `uaaClient.SetupResources(config.UAAEndpoint(), config.AuthorizationEndpoint())`, `config.RoutingEndpoint()`, `MinimumCCAPIVersionCheck(config.APIVersion(), …)`. Those were sourced from `V2Info`, which is empty without `/v2/info`.

A cf-cli upgrade does not help: v8.18.3 client-setup is byte-identical to v8.18.2, and v9 is unreleased. The endpoints are all exposed by the V3 root `/` links — they were just being read from the wrong place.

## Change

- Decode `login`/`uaa`/`logging`/`routing`/`cloud_controller_v3` from the root `/` links (`api.ApiRootLinks`).
- In `Info()`, when `/v2/info` is absent, backfill the CNSI record and `V2Info` from those links. When `/v2/info` responds it stays the source of truth, so v2-enabled foundations are unchanged.
- `cfapppush` needs no change — it reads the now-backfilled `V2Info.*`.

## Tests

New unit tests for the root-link derivation and the backfill decision (v3-only populates the record + V2Info; v2-present is a no-op). Full backend suite and `go vet` green.

## Verification limitation

No fully-`/v2/info`-stripped CF was available to exercise a live v2-disabled push end to end, so this is covered by unit tests plus code-path analysis. #5047 stays open as the tracker until that is confirmed.