### PR TITLE
Adopt go1.26 across CI and formatting

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   test_suite:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ on:
 env:
   NODE_OPTIONS: --max-old-space-size=5500
   NODE_VERSION: '24'
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   BUN_VERSION: 'latest'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 env:
   NODE_OPTIONS: --max-old-space-size=5500
   NODE_VERSION: '24'
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.26'
   BUN_VERSION: 'latest'
 
 jobs:

--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -278,10 +278,10 @@ type Info struct {
 	PluginConfig  map[string]string                     `json:"plugin-config,omitempty"`
 	Diagnostics   *Diagnostics                          `json:"diagnostics,omitempty"`
 	Configuration struct {
-		TechPreview               bool   `json:"enableTechPreview"`
-		ListMaxSize               int64  `json:"listMaxSize,omitempty"`
-		ListAllowLoadMaxed        bool   `json:"listAllowLoadMaxed,omitempty"`
-		APIKeysEnabled            string `json:"APIKeysEnabled"`
+		TechPreview                bool   `json:"enableTechPreview"`
+		ListMaxSize                int64  `json:"listMaxSize,omitempty"`
+		ListAllowLoadMaxed         bool   `json:"listAllowLoadMaxed,omitempty"`
+		APIKeysEnabled             string `json:"APIKeysEnabled"`
 		HomeViewShowFavoritesOnly  bool   `json:"homeViewShowFavoritesOnly"`
 		UserEndpointsEnabled       string `json:"userEndpointsEnabled"`
 		EndpointCardConcurrency    int    `json:"endpointCardConcurrency"`
@@ -458,7 +458,7 @@ type PortalConfig struct {
 	// DiagnosticsEnabled gates the admin-only /pp/v1/admin/diagnostics endpoint.
 	// Off by default in production; opt-in per deployment (dev, staging) via the
 	// DIAGNOSTICS_ENABLED env var. FWT-934.
-	DiagnosticsEnabled                 bool                         `configName:"DIAGNOSTICS_ENABLED"`
+	DiagnosticsEnabled bool `configName:"DIAGNOSTICS_ENABLED"`
 	// CanMigrateDatabaseSchema indicates if we can safely perform migrations
 	// This depends on the deployment mechanism and the database config
 	// e.g. if running in Cloud Foundry with a shared DB, then only the 0-index application instance

--- a/src/jetstream/plugins/cfapppush/vcs.go
+++ b/src/jetstream/plugins/cfapppush/vcs.go
@@ -23,6 +23,7 @@ import (
 //     it as a pathspec and "--hard" rejects paths ("Cannot do hard reset with
 //     paths", exit 128). "--end-of-options" (git 2.24+) stops option parsing
 //     while still treating the value as a revision.
+//
 // See FWT-922.
 var vcsGit = &vcsCmd{
 	name:             "Git",


### PR DESCRIPTION
Aligns the repo on the Go version `go.mod` already declares (`go 1.26.3`).

## Changes

- **CI Go version → 1.26** in all three workflows: `pr.yml` and `backend_tests.yml` (were 1.25) and `release.yml` (was 1.21). `go.mod` requires `1.26.3`, so the older pins were inconsistent with the module's minimum — release at 1.21 was either failing the version requirement or silently auto-downloading 1.26.
- **gofmt under go1.26** for the two files that still carried go1.25 formatting: `api/structs.go` (struct field alignment) and `plugins/cfapppush/vcs.go` (standalone comment). Whitespace and comment only, no behavior change. The rest of the backend tree was already 1.26-clean.

No functional code changes.