### PR TITLE
Fix Doppler TLS verification, SSL-error panic, autoscaler cooldown, tooltip sink

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-transform-policy.spec.ts
+++ b/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-transform-policy.spec.ts
@@ -327,4 +327,27 @@ describe('Autoscaler Transform Policy Helper', () => {
     mapPolicy.scaling_rules_form = [];
     expect(isEqual(arrayPolicy, autoscalerTransformMapToArray(mapPolicy))).toBe(true);
   });
+
+  it('preserves cool_down_secs distinct from breach_duration_secs (regression)', () => {
+    const local = {
+      instance_min_count: 1,
+      instance_max_count: 5,
+      scaling_rules_form: [
+        {
+          metric_type: 'memoryused',
+          breach_duration_secs: 600,
+          cool_down_secs: 120,
+          threshold: 30,
+          operator: '>=',
+          adjustment: '+1'
+        }
+      ]
+    } as AppAutoscalerPolicyLocal;
+
+    const rule = autoscalerTransformMapToArray(local).scaling_rules?.[0];
+    // Previously cool_down_secs was serialized from breach_duration_secs,
+    // silently discarding the user's entered cooldown.
+    expect(rule?.cool_down_secs).toBe(120);
+    expect(rule?.breach_duration_secs).toBe(600);
+  });
 });

--- a/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-transform-policy.ts
+++ b/src/frontend/packages/cf-autoscaler/src/core/autoscaler-helpers/autoscaler-transform-policy.ts
@@ -84,7 +84,7 @@ export function autoscalerTransformMapToArray(oldPolicy: AppAutoscalerPolicyLoca
     const newTrigger: AppScalingRule = {
       adjustment: trigger.adjustment,
       breach_duration_secs: trigger.breach_duration_secs,
-      cool_down_secs: trigger.breach_duration_secs,
+      cool_down_secs: trigger.cool_down_secs,
       metric_type: trigger.metric_type,
       operator: trigger.operator,
       threshold: trigger.threshold

--- a/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.spec.ts
@@ -1,0 +1,48 @@
+import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { By } from '@angular/platform-browser';
+import { CustomTooltipDirective } from './custom-tooltip.directive';
+
+@Component({
+  imports: [CustomTooltipDirective],
+  template: `<button matTooltip="placeholder">host</button>`
+})
+class TestHostComponent { }
+
+describe('CustomTooltipDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let directive: CustomTooltipDirective;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+      imports: [TestHostComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.directive(CustomTooltipDirective));
+    directive = el.injector.get(CustomTooltipDirective);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    document.querySelectorAll('.custom-tooltip').forEach(n => n.remove());
+  });
+
+  // Tooltip text can carry untrusted values (e.g. CF usernames). The directive
+  // must render it as text, never parse it as HTML.
+  it('renders tooltip text as plain text, not parsed HTML (XSS-safe)', () => {
+    const payload = '<img src=x onerror="alert(1)">alice';
+    directive.tooltipText = payload;
+    directive.onMouseEnter(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(300);
+
+    const tip = document.body.querySelector('.custom-tooltip');
+    expect(tip).toBeTruthy();
+    expect(tip?.textContent).toBe(payload);
+    expect(tip?.querySelector('img')).toBeNull();
+  });
+});

--- a/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
@@ -48,7 +48,10 @@ export class CustomTooltipDirective implements OnDestroy {
     if (this.tooltipClass) {
       this.renderer.addClass(el, this.tooltipClass);
     }
-    this.renderer.setProperty(el, 'innerHTML', this.tooltipText);
+    // Use textContent, not innerHTML: tooltip text can carry untrusted values
+    // (e.g. CF usernames) and Renderer2.setProperty(innerHTML) bypasses Angular's
+    // sanitizer. No tooltip relies on HTML markup, so this is a behaviour-neutral fix.
+    this.renderer.setProperty(el, 'textContent', this.tooltipText);
 
     // Apply visual styles BEFORE positioning so getBoundingClientRect()
     // measures the content-sized box. A bare `<div>` with no styling is

--- a/src/jetstream/cnsi.go
+++ b/src/jetstream/cnsi.go
@@ -27,17 +27,17 @@ func isSSLRelatedError(err error) (bool, string) {
 	var urlError *url.Error
 	if errors.As(err, &urlError) {
 		var (
-			certInvalidError      *x509.CertificateInvalidError
-			unknownAuthorityError *x509.UnknownAuthorityError
-			hostnameError         *x509.HostnameError
+			certInvalidError      x509.CertificateInvalidError
+			unknownAuthorityError x509.UnknownAuthorityError
+			hostnameError         x509.HostnameError
 		)
-		if errors.As(urlError.Err, unknownAuthorityError) {
+		if errors.As(urlError.Err, &unknownAuthorityError) {
 			return true, unknownAuthorityError.Error()
 		}
-		if errors.As(urlError.Err, hostnameError) {
+		if errors.As(urlError.Err, &hostnameError) {
 			return true, hostnameError.Error()
 		}
-		if errors.As(urlError.Err, certInvalidError) {
+		if errors.As(urlError.Err, &certInvalidError) {
 			return true, certInvalidError.Error()
 		}
 	}

--- a/src/jetstream/cnsi_ssl_test.go
+++ b/src/jetstream/cnsi_ssl_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+// Regression for isSSLRelatedError: it previously passed nil typed pointers to
+// errors.As, which panics. net/http surfaces certificate failures as a
+// *url.Error wrapping an x509 error (by value), so this exercises that shape.
+func TestIsSSLRelatedErrorDetectsWrappedX509(t *testing.T) {
+	urlErr := &url.Error{Op: "Get", URL: "https://example.com", Err: x509.UnknownAuthorityError{}}
+	isSSL, msg := isSSLRelatedError(urlErr)
+	if !isSSL {
+		t.Fatalf("expected a wrapped x509 cert error to be detected as SSL-related")
+	}
+	if msg == "" {
+		t.Fatalf("expected a non-empty error message")
+	}
+}
+
+func TestIsSSLRelatedErrorIgnoresNonCertErrors(t *testing.T) {
+	if isSSL, _ := isSSLRelatedError(errors.New("some other error")); isSSL {
+		t.Fatalf("expected a plain error to be reported as not SSL-related")
+	}
+	// A url.Error wrapping a non-cert error must not panic or false-positive.
+	urlErr := &url.Error{Op: "Get", URL: "https://example.com", Err: fmt.Errorf("connection refused")}
+	if isSSL, _ := isSSLRelatedError(urlErr); isSSL {
+		t.Fatalf("expected a non-cert url.Error to be reported as not SSL-related")
+	}
+}

--- a/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
+++ b/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
@@ -3,6 +3,7 @@ package cloudfoundry
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -76,6 +77,26 @@ type AuthorizedConsumer struct {
 	refreshToken   func() error
 }
 
+// dopplerTLSConfig builds the TLS config for the Doppler/Noaa connection that
+// carries the user's CF OAuth bearer token. It honours the endpoint's
+// SkipSSLValidation setting and CA certificate instead of unconditionally
+// skipping verification (which exposed the bearer token to an on-path MITM),
+// mirroring how every other CF connection for this endpoint is built.
+func dopplerTLSConfig(cnsiRecord api.CNSIRecord) *tls.Config {
+	config := &tls.Config{InsecureSkipVerify: cnsiRecord.SkipSSLValidation}
+	if len(cnsiRecord.CACert) > 0 {
+		rootCAs, err := x509.SystemCertPool()
+		if rootCAs == nil || err != nil {
+			rootCAs = x509.NewCertPool()
+		}
+		if ok := rootCAs.AppendCertsFromPEM([]byte(cnsiRecord.CACert)); !ok {
+			log.Warn("Could not append the CA for the Doppler endpoint - using system certs only")
+		}
+		config.RootCAs = rootCAs
+	}
+	return config
+}
+
 // Refresh the Authorization token if needed and create a new Noaa consumer
 func (c *CloudFoundrySpecification) openNoaaConsumer(echoContext echo.Context) (*AuthorizedConsumer, error) {
 
@@ -120,7 +141,7 @@ func (c *CloudFoundrySpecification) openNoaaConsumer(echoContext echo.Context) (
 
 	// Open a Noaa consumer to the doppler endpoint
 	log.Debugf("Creating Noaa consumer for Doppler endpoint %s", dopplerAddress)
-	ac.consumer = consumer.New(dopplerAddress, &tls.Config{InsecureSkipVerify: true}, http.ProxyFromEnvironment)
+	ac.consumer = consumer.New(dopplerAddress, dopplerTLSConfig(cnsiRecord), http.ProxyFromEnvironment)
 
 	//Open a LogCache client to the log cache endpoint
 	logCacheUrl := strings.Replace(cnsiRecord.APIEndpoint.String(), "api.sys.", "log-cache.sys.", 1)

--- a/src/jetstream/plugins/cloudfoundry/cf_websocket_streams_test.go
+++ b/src/jetstream/plugins/cloudfoundry/cf_websocket_streams_test.go
@@ -1,0 +1,29 @@
+package cloudfoundry
+
+import (
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+)
+
+// The Doppler/Noaa connection carries the user's live CF OAuth bearer token, so
+// it must honour the endpoint's SkipSSLValidation rather than hardcoding
+// InsecureSkipVerify:true (which exposed the token to an on-path MITM).
+func TestDopplerTLSConfigHonoursSkipSSLValidation(t *testing.T) {
+	if c := dopplerTLSConfig(api.CNSIRecord{SkipSSLValidation: true}); !c.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify=true when the endpoint sets SkipSSLValidation")
+	}
+	if c := dopplerTLSConfig(api.CNSIRecord{SkipSSLValidation: false}); c.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify=false by default (regression: was hardcoded true)")
+	}
+}
+
+func TestDopplerTLSConfigLoadsCACert(t *testing.T) {
+	if c := dopplerTLSConfig(api.CNSIRecord{}); c.RootCAs != nil {
+		t.Fatalf("expected no custom RootCAs when CACert is empty")
+	}
+	withCA := dopplerTLSConfig(api.CNSIRecord{CACert: "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"})
+	if withCA.RootCAs == nil {
+		t.Fatalf("expected RootCAs to be set when a CACert is provided")
+	}
+}


### PR DESCRIPTION
Four fixes surfaced by a review of the codebase. Each is independent and ships with a regression test.

## Verify TLS on the Doppler log stream (`be5c6c55c0`)
`openNoaaConsumer` built the Noaa/Doppler connection with `&tls.Config{InsecureSkipVerify: true}`. That connection carries the user's live CF OAuth bearer token, so skipping verification let an on-path observer between the backend and Loggregator capture it. It now builds the TLS config from the endpoint's `SkipSSLValidation` and `CACert`, matching the same function's `RefreshOAuthToken` call and every other CF connection for the endpoint.

## Fix `isSSLRelatedError` panic on cert errors (`53e1b30fcf`)
The inner `errors.As` calls were passed nil typed pointers (`unknownAuthorityError`, `hostnameError`, `certInvalidError`) instead of their addresses, which panics. The path is endpoint register/update, so a routine TLS misconfiguration became a 500. Fixed by declaring the targets as values and passing their addresses (the x509 errors are returned by value, so address-of-pointer would not have matched).

## Preserve autoscaler `cool_down_secs` on save (`b697da4106`)
The policy serializer set `cool_down_secs` from `breach_duration_secs`, silently discarding the user's entered cooldown on every policy save/edit. The existing test never asserted this round-trip; a focused regression test now covers it.

## Render tooltip text via `textContent` (`c4d063dc25`)
`CustomTooltipDirective` (the app-wide `matTooltip` replacement) wrote text with `Renderer2.setProperty(el, 'innerHTML', ...)`, which bypasses Angular's sanitizer. Most call sites pass static strings, but one path renders a CF username (`cf-role-checkbox`), so untrusted text reached an unsanitized sink. No tooltip relies on HTML markup, so switching to `textContent` is behaviour-neutral.

## Testing
- Backend: `go test ./... ` on the two changed packages (jetstream, plugins/cloudfoundry); gofmt + go vet clean.
- Frontend: autoscaler-transform-policy and custom-tooltip.directive specs pass under vitest.

