### PR TITLE
Sanitize tooltip HTML instead of stripping it to text

### DIFF
--- a/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.spec.ts
@@ -32,17 +32,31 @@ describe('CustomTooltipDirective', () => {
     document.querySelectorAll('.custom-tooltip').forEach(n => n.remove());
   });
 
-  // Tooltip text can carry untrusted values (e.g. CF usernames). The directive
-  // must render it as text, never parse it as HTML.
-  it('renders tooltip text as plain text, not parsed HTML (XSS-safe)', () => {
-    const payload = '<img src=x onerror="alert(1)">alice';
-    directive.tooltipText = payload;
+  // Tooltips carry simple HTML markup (e.g. <b> for emphasis), so the
+  // directive renders sanitized HTML rather than plain text — formatting is
+  // preserved while XSS vectors are stripped.
+  it('preserves safe HTML formatting such as <b>', () => {
+    directive.tooltipText = 'roles for <b>alice</b>';
     directive.onMouseEnter(new MouseEvent('mouseenter'));
     vi.advanceTimersByTime(300);
 
     const tip = document.body.querySelector('.custom-tooltip');
     expect(tip).toBeTruthy();
-    expect(tip?.textContent).toBe(payload);
-    expect(tip?.querySelector('img')).toBeNull();
+    expect(tip?.querySelector('b')?.textContent).toBe('alice');
+    expect(tip?.textContent).toBe('roles for alice');
+  });
+
+  // Tooltip text can carry untrusted values (e.g. CF usernames). The
+  // sanitizer must drop scripts and event handlers while keeping the text.
+  it('strips XSS vectors (scripts, event handlers) from tooltip text', () => {
+    directive.tooltipText = '<img src=x onerror="alert(1)"><script>alert(2)</script>alice';
+    directive.onMouseEnter(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(300);
+
+    const tip = document.body.querySelector('.custom-tooltip');
+    expect(tip).toBeTruthy();
+    expect(tip?.querySelector('script')).toBeNull();
+    expect(tip?.innerHTML.toLowerCase()).not.toContain('onerror');
+    expect(tip?.textContent).toContain('alice');
   });
 });

--- a/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, Input, ElementRef, Renderer2, OnDestroy, HostListener, inject } from '@angular/core';
+import { Directive, Input, ElementRef, Renderer2, OnDestroy, HostListener, SecurityContext, inject } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Directive({
   selector: '[matTooltip]',
@@ -7,6 +8,7 @@ import { Directive, Input, ElementRef, Renderer2, OnDestroy, HostListener, injec
 export class CustomTooltipDirective implements OnDestroy {
   private elementRef = inject(ElementRef);
   private renderer = inject(Renderer2);
+  private sanitizer = inject(DomSanitizer);
 
   @Input('matTooltip') tooltipText: string = '';
   @Input('matTooltipPosition') position: 'above' | 'below' | 'left' | 'right' = 'above';
@@ -48,10 +50,14 @@ export class CustomTooltipDirective implements OnDestroy {
     if (this.tooltipClass) {
       this.renderer.addClass(el, this.tooltipClass);
     }
-    // Use textContent, not innerHTML: tooltip text can carry untrusted values
-    // (e.g. CF usernames) and Renderer2.setProperty(innerHTML) bypasses Angular's
-    // sanitizer. No tooltip relies on HTML markup, so this is a behaviour-neutral fix.
-    this.renderer.setProperty(el, 'textContent', this.tooltipText);
+    // Tooltips DO carry simple HTML markup (e.g. <b> for emphasis), so plain
+    // textContent isn't an option. But tooltip text can also carry untrusted
+    // values (e.g. CF usernames), and Renderer2.setProperty(innerHTML) bypasses
+    // Angular's sanitizer. Run the value through DomSanitizer first: it keeps
+    // the safe formatting subset (<b>, <strong>, <i>, <em>, <br>, …) while
+    // stripping scripts, event handlers, and other XSS vectors.
+    const safeHtml = this.sanitizer.sanitize(SecurityContext.HTML, this.tooltipText) ?? '';
+    this.renderer.setProperty(el, 'innerHTML', safeHtml);
 
     // Apply visual styles BEFORE positioning so getBoundingClientRect()
     // measures the content-sized box. A bare `<div>` with no styling is


### PR DESCRIPTION
## Problem

PR #5467 switched `CustomTooltipDirective` from `innerHTML` to `textContent`
on the premise that no tooltip relies on HTML markup. That premise was wrong:
tooltips carry simple formatting such as `<b>`, which `textContent` renders as
literal angle-bracket text (`roles for <b>alice</b>` shows the tags).

## Fix

Render the tooltip value through `DomSanitizer.sanitize(SecurityContext.HTML, …)`
and set the sanitized result via `innerHTML`. Angular's sanitizer keeps the safe
formatting subset (`<b>`, `<strong>`, `<i>`, `<em>`, `<br>`, …) while stripping
scripts, event handlers, and other XSS vectors — so untrusted values (e.g. CF
usernames) remain safe and legitimate formatting is preserved.

This keeps the security property the original change was after (`innerHTML`
bypasses the sanitizer; `sanitize()` does not) without the formatting
regression.

## Tests

- `<b>` formatting is preserved in the rendered tooltip.
- Scripts and inline event handlers (`onerror`) are stripped from untrusted text.

Follow-up to #5467 (merged).
