### PR TITLE
Destroy root-injector effects on re-entry in signal-config services

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-event/cf-app-autoscaler-events-signal-config.service.spec.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-event/cf-app-autoscaler-events-signal-config.service.spec.ts
@@ -2,7 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ApplicationRef, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppAutoscalerEvent } from '../../../store/app-autoscaler.types';
 import { CfAppAutoscalerEventsSignalConfigService } from './cf-app-autoscaler-events-signal-config.service';
@@ -49,6 +49,34 @@ describe('CfAppAutoscalerEventsSignalConfigService', () => {
     expect(svc.events()).toEqual([]);
     expect(svc.hasLoadedOnce()).toBe(false);
     expect(svc.view.totalFilteredResults()).toBe(0);
+  });
+
+  it('initialize does not stack a filter effect on re-entry', () => {
+    // Regression: root singleton, but the scale-history page calls
+    // initialize() from its constructor per mount. The filter effect was
+    // created uncaptured, so each navigation stacked a live effect on the
+    // root injector. The fix captures the EffectRef and destroys the prior.
+    svc.initialize(CNSI, APP);
+    svc.initialize(CNSI, APP);
+    TestBed.tick();
+
+    const setSpy = vi.spyOn(svc.filter, 'set');
+    svc.nameFilter.set('scale');
+    TestBed.tick();
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('loadAll() resolves (not rejects) when the fetch fails', async () => {
+    // load() rethrows on HTTP error after recording it in its error()
+    // signal; the page calls `void loadAll()`, so loadAll must swallow the
+    // rejection rather than surface it as an unhandled promise rejection.
+    svc.initialize(CNSI, APP);
+    const promise = svc.loadAll();
+    httpMock.expectOne(EVENTS_URL).flush('boom', { status: 500, statusText: 'Server Error' });
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(svc.hasLoadedOnce()).toBe(true);
   });
 
   it('loadAll() fetches events through the autoscaler URL with cnsi headers', async () => {

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-event/cf-app-autoscaler-events-signal-config.service.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-event/cf-app-autoscaler-events-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import { ListStateStore } from '@stratosui/core';
 
@@ -59,6 +59,10 @@ export class CfAppAutoscalerEventsSignalConfigService {
 
   view!: ViewPipeline<AppAutoscalerEvent>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string, appGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.appGuid = appGuid;
@@ -72,8 +76,9 @@ export class CfAppAutoscalerEventsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((ev: AppAutoscalerEvent) => {
           if (!q) return true;
@@ -94,6 +99,11 @@ export class CfAppAutoscalerEventsSignalConfigService {
     if (!this.cnsiGuid || !this.appGuid) return;
     try {
       await this.historyData.load(this.cnsiGuid, this.appGuid);
+    } catch {
+      // load() rethrows after recording the failure in its own error()
+      // signal (which the page renders). Swallow here so the fire-and-
+      // forget `void loadAll()` call site doesn't raise an unhandled
+      // promise rejection.
     } finally {
       this._hasLoadedOnce.set(true);
     }

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-signal-config.service.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import { ListStateStore } from '@stratosui/core';
 
@@ -121,6 +121,10 @@ export class AppAutoscalerMetricChartSignalConfigService {
   // a shared place is a separate refactor outside this wave's scope.
   view!: ViewPipeline<AutoscalerMetricChartRow>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string, appGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.appGuid = appGuid;
@@ -133,8 +137,9 @@ export class AppAutoscalerMetricChartSignalConfigService {
       this.pageIndex,
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((row: AutoscalerMetricChartRow) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -463,6 +463,42 @@ describe('CfAppsSignalConfigService', () => {
     expect(httpMock.get).toHaveBeenCalledTimes(2);
   });
 
+  it('startStatsPolling does not stack a reactive effect on re-entry', () => {
+    // Regression: this service is a root singleton, and the app-wall calls
+    // startStatsPolling() from ngOnInit on every mount. The reactive stats
+    // effect used to be created uncaptured, so each navigation left a live
+    // effect on the root injector — N visits meant N refreshes per page
+    // change, multiplying app-stats traffic across a session. The fix
+    // captures the EffectRef and destroys the prior one on re-entry.
+    const http = makeHttp();
+    const cf = makeStubCfService([{ guid: 'cnsi-1', name: 'Primary CF' }]);
+    const svc = makeSvc(http, cf);
+    svc.initialize(['cnsi-1']);
+    seedApps(svc, [{
+      guid: 'a', name: 'a-app', state: 'STARTED', cnsiGuid: 'cnsi-1',
+      spaceGuid: 'sp-1', instances: 1, routes: [], createdAt: '', updatedAt: '',
+    } as StApp]);
+    TestBed.tick();
+
+    // Simulate two mounts of the app-wall (route re-entry).
+    svc.startStatsPolling();
+    svc.startStatsPolling();
+    TestBed.tick();
+
+    // Count only refreshes driven by the reactive effect on a pagedItems
+    // change — isolate from the synchronous runOnce()/interval legs.
+    const refresh = vi.spyOn(svc as any, 'refreshStatsForKeys');
+    seedApps(svc, [{
+      guid: 'b', name: 'b-app', state: 'STARTED', cnsiGuid: 'cnsi-1',
+      spaceGuid: 'sp-1', instances: 1, routes: [], createdAt: '', updatedAt: '',
+    } as StApp]);
+    TestBed.tick();
+
+    // Exactly one live effect → one reactive refresh. Without the fix the
+    // two stacked effects would each fire, yielding 2.
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
   it('cnsiOptions picks up connected CF endpoints from CloudFoundryService', () => {
     const http = makeHttp();
     const cf = makeStubCfService([

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -75,6 +75,9 @@ export class CfAppsSignalConfigService {
   readonly appStats: Signal<Map<string, { running: number; total: number }>> =
     computed(() => this._appStats());
   private statsTimer?: ReturnType<typeof setInterval>;
+  // Reactive stats refresh effect, captured so a re-entry (root singleton +
+  // per-mount startStatsPolling) destroys the prior one instead of stacking.
+  private statsEffect?: EffectRef;
   // Tracks `${cnsiGuid}:${appGuid}` keys with an in-flight stats request so
   // burst signal updates during initial render don't issue 4× duplicate
   // calls per app — the original symptom on multi-CNSI walls with slow CFs.
@@ -871,8 +874,14 @@ export class CfAppsSignalConfigService {
     this.statsTimer = setInterval(runOnce, intervalMs);
     // effect() requires an injection context; startStatsPolling is called
     // from the component's ngOnInit which isn't one. Wrap it explicitly.
+    //
+    // Tear down any previous mount's effect first. This service is a root
+    // singleton, so a re-entry (app-wall remounted on navigation) would
+    // otherwise stack one live effect per visit, multiplying stats fetches
+    // across a session — same reasoning as the statsTimer reset above.
+    this.statsEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.statsEffect = effect(() => {
         const keys = this.view.pagedItems().map((a) => `${a.cnsiGuid}:${a.guid}`);
         this.refreshStatsForKeys(keys);
       });

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-buildpacks/cf-buildpacks-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-buildpacks/cf-buildpacks-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { ListStateStore } from '@stratosui/core';
@@ -46,6 +46,10 @@ export class CfBuildpacksSignalConfigService {
 
   view!: ViewPipeline<StBuildpack>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.source = new CnsiBuildpacksSource(cnsiGuid, this.http);
@@ -58,8 +62,9 @@ export class CfBuildpacksSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((b: StBuildpack) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-cells/cf-cells-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-cells/cf-cells-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
@@ -105,6 +105,10 @@ export class CfCellsSignalConfigService {
 
   view!: ViewPipeline<CfCellRow>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.view = new ViewPipeline<CfCellRow>(
@@ -116,8 +120,9 @@ export class CfCellsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((c: CfCellRow) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-events/cf-audit-events-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-events/cf-audit-events-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { DestroyRef, EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
@@ -130,6 +130,11 @@ export class CfAuditEventsSignalConfigService {
 
   view!: ViewPipeline<StAuditEvent>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior effects instead of stacking them per navigation.
+  private filterEffect?: EffectRef;
+  private cascadeEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     // Swap CNSI: release the previous EDS handle if a re-initialize() in
     // the same singleton swapped foundations. Refcount-balanced —
@@ -156,8 +161,10 @@ export class CfAuditEventsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
+    this.cascadeEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         const base = this.basePredicate();
         const org = this.selectedOrg();
@@ -180,7 +187,7 @@ export class CfAuditEventsSignalConfigService {
       // different specific org. When Org returns to All, the Space
       // dropdown shows every space (labelled "<space> - <org>"), so the
       // current selection remains valid and must be preserved.
-      effect(() => {
+      this.cascadeEffect = effect(() => {
         const org = this.selectedOrg();
         const space = this.selectedSpace();
         if (!space) return;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-feature-flags/cf-feature-flags-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-feature-flags/cf-feature-flags-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { ListStateStore } from '@stratosui/core';
@@ -44,6 +44,10 @@ export class CfFeatureFlagsSignalConfigService {
 
   view!: ViewPipeline<StFeatureFlag>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.source = new CnsiFeatureFlagsSource(cnsiGuid, this.http);
@@ -56,8 +60,9 @@ export class CfFeatureFlagsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((f: StFeatureFlag) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-quotas/cf-org-quotas-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-quotas/cf-org-quotas-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { ListStateStore } from '@stratosui/core';
@@ -54,6 +54,10 @@ export class CfOrgQuotasSignalConfigService {
 
   view!: ViewPipeline<StOrgQuota>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.source = new CnsiOrgQuotasSource(cnsiGuid, this.http);
@@ -66,8 +70,9 @@ export class CfOrgQuotasSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((quota: StOrgQuota) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { ListStateStore } from '@stratosui/core';
@@ -45,6 +45,10 @@ export class CfSecurityGroupsSignalConfigService {
 
   view!: ViewPipeline<StSecurityGroup>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.source = new CnsiSecurityGroupsSource(cnsiGuid, this.http);
@@ -57,8 +61,9 @@ export class CfSecurityGroupsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((g: StSecurityGroup) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-space-quotas/cf-space-quotas-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-space-quotas/cf-space-quotas-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { ListStateStore } from '@stratosui/core';
@@ -57,6 +57,10 @@ export class CfSpaceQuotasSignalConfigService {
 
   view!: ViewPipeline<StSpaceQuota>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.source = new CnsiSpaceQuotasSource(cnsiGuid, this.http);
@@ -69,8 +73,9 @@ export class CfSpaceQuotasSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         const base = this.basePredicate();
         this.filter.set((quota: StSpaceQuota) => {

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-stacks/cf-stacks-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-stacks/cf-stacks-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { ListStateStore } from '@stratosui/core';
@@ -46,6 +46,10 @@ export class CfStacksSignalConfigService {
 
   view!: ViewPipeline<StStack>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.source = new CnsiStacksSource(cnsiGuid, this.http);
@@ -58,8 +62,9 @@ export class CfStacksSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((s: StStack) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { DestroyRef, EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ListStateStore } from '@stratosui/core';
@@ -61,6 +61,11 @@ export class CfOrgsSignalConfigService {
   // at every call site.
   view!: ViewPipeline<StOrg>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior effects instead of stacking them per navigation.
+  private filterEffect?: EffectRef;
+  private loadedOnceEffect?: EffectRef;
+
   // Sort-extractor map for columns whose sort key doesn't map to a direct
   // property on StOrg (e.g. the Spaces column, which composes over the
   // space lookup). Populated via registerSortExtractor from the component.
@@ -97,15 +102,17 @@ export class CfOrgsSignalConfigService {
     // Effects need an injection context; initialize() is called from a
     // component's ngOnInit which isn't one. Wrap via the injector
     // captured at service construction.
+    this.filterEffect?.destroy();
+    this.loadedOnceEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((o: StOrg) => {
           if (!q) return true;
           return (o.name ?? '').toLowerCase().includes(q);
         });
       });
-      effect(() => {
+      this.loadedOnceEffect = effect(() => {
         const cur = this.endpointDataService();
         if (!cur) return;
         if (cur.orgs().length > 0) this._hasLoadedOnce.set(true);

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/revisions/revisions-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/revisions/revisions-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 
 import { ListStateStore } from '@stratosui/core';
@@ -52,6 +52,10 @@ export class RevisionsSignalConfigService {
 
   view!: ViewPipeline<RevisionRow>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   initialize(cnsiGuid: string, appGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     this.appGuid = appGuid;
@@ -65,8 +69,9 @@ export class RevisionsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((r: RevisionRow) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { DestroyRef, EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import type { SignalListDropdownOption } from '@stratosui/core';
@@ -89,6 +89,11 @@ export class CfRoutesSignalConfigService {
 
   view!: ViewPipeline<StRoute>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior effects instead of stacking them per navigation.
+  private filterEffect?: EffectRef;
+  private cascadeEffect?: EffectRef;
+
   private readonly _sortExtractors: WritableSignal<Map<string, (row: StRoute) => unknown>> = signal(new Map());
 
   private readonly _hasLoadedOnce = signal(false);
@@ -116,8 +121,10 @@ export class CfRoutesSignalConfigService {
     // Fetch the route list itself; errors here do surface because without
     // them the page has nothing to show.
     void this.fetchRoutes();
+    this.filterEffect?.destroy();
+    this.cascadeEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         const org = this.selectedOrg();
         const space = this.selectedSpace();
@@ -134,7 +141,7 @@ export class CfRoutesSignalConfigService {
       });
       // Reset Space when Org changes — the cascade rule. Stale space
       // selections in a now-hidden org would silently filter to empty.
-      effect(() => {
+      this.cascadeEffect = effect(() => {
         const org = this.selectedOrg();
         const space = this.selectedSpace();
         if (!space) return;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/space/cf-spaces-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/space/cf-spaces-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
@@ -69,6 +69,10 @@ export class CfSpacesSignalConfigService {
 
   view!: ViewPipeline<StSpace>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   private readonly _sortExtractors: WritableSignal<Map<string, (row: StSpace) => unknown>> = signal(new Map());
 
   private readonly _hasLoadedOnce = signal(false);
@@ -94,8 +98,9 @@ export class CfSpacesSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
     void this.fetchOrgSpaces();
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((s: StSpace) => {
           if (!q) return true;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/user/cf-users-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/user/cf-users-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { DestroyRef, EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import type { SignalListDropdownOption } from '@stratosui/core';
 import { ListStateStore, naturalCompare } from '@stratosui/core';
@@ -97,6 +97,11 @@ export class CfUsersSignalConfigService {
   });
 
   view!: ViewPipeline<StUser>;
+
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior effects instead of stacking them per navigation.
+  private filterEffect?: EffectRef;
+  private cascadeEffect?: EffectRef;
 
   private readonly _sortExtractors: WritableSignal<Map<string, (row: StUser) => unknown>> = signal(new Map());
 
@@ -221,8 +226,10 @@ export class CfUsersSignalConfigService {
     // fall back to the GUID short-form / em-dash).
     void firstValueFrom(this.endpointDataService.loadDetails()).catch((): void => undefined);
     this.triggerUsersLoad(cnsiGuid);
+    this.filterEffect?.destroy();
+    this.cascadeEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         const org = this.selectedOrg();
         const space = this.selectedSpace();
@@ -250,7 +257,7 @@ export class CfUsersSignalConfigService {
       // returns to All, the Space dropdown shows every space across orgs
       // (labelled "<space> - <org>"), so the current selection is still
       // valid and must be preserved.
-      effect(() => {
+      this.cascadeEffect = effect(() => {
         const org = this.selectedOrg();
         const space = this.selectedSpace();
         if (!space) return;

--- a/src/frontend/packages/core/src/shared/components/signal-list/list-filter-store.service.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/list-filter-store.service.spec.ts
@@ -84,6 +84,25 @@ describe('ListFilterStore', () => {
     expect(bound.multiFilterValue('cf')()).toBeNull();
   });
 
+  it('re-binding a key tears down the prior effect (no orphan persistence)', () => {
+    // Defensive: callers bind a fixed key once today, so this never fires
+    // in practice — but a second bind of the same key must destroy the
+    // first effect so writes to the now-abandoned first binding can't keep
+    // persisting against the shared storage slot.
+    const store = TestBed.inject(ListFilterStore);
+    const first = store.bind(KEY, DEFAULTS);
+    store.bind(KEY, DEFAULTS); // rebind → first's effect destroyed
+    flushEffects();
+
+    first.nameFilter.set('orphan-write');
+    flushEffects();
+
+    // first's effect is dead, so 'orphan-write' is not persisted; the slot
+    // still holds the live (second) binding's default value.
+    const parsed = JSON.parse(localStorage.getItem(STORAGE)!);
+    expect(parsed.nameFilter).toBe('');
+  });
+
   it('multiFilterValue returns null for unknown keys', () => {
     const store = TestBed.inject(ListFilterStore);
     const bound = store.bind(KEY, DEFAULTS);

--- a/src/frontend/packages/core/src/shared/components/signal-list/list-filter-store.service.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/list-filter-store.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 // Persists per-list-type filter selections — name-filter text, the
 // active filter field (when the toolbar offers a column-picker), and
@@ -49,6 +49,12 @@ const EMPTY_FILTERS: Readonly<Record<string, string | null>> = Object.freeze({})
 export class ListFilterStore {
   private readonly injector = inject(Injector);
 
+  // Root singleton: callers bind a fixed key once, so today nothing
+  // accumulates. Capturing the persistence effect per key keeps it that
+  // way defensively — a re-bind of the same key destroys the prior effect
+  // instead of leaving an orphan running against the abandoned signals.
+  private readonly persistEffects = new Map<string, EffectRef>();
+
   bind(key: string, defaults: ListFilterDefaults): BoundListFilterState {
     const persisted = this.read(key);
     const initial: ListFilterDefaults = persisted ?? defaults;
@@ -59,15 +65,16 @@ export class ListFilterStore {
       initial.multiFilters ?? EMPTY_FILTERS,
     );
 
+    this.persistEffects.get(key)?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.persistEffects.set(key, effect(() => {
         const snapshot: ListFilterDefaults = {
           nameFilter: nameFilter(),
           filterField: filterField(),
           multiFilters: multiFilters(),
         };
         this.write(key, snapshot);
-      });
+      }));
     });
 
     const multiFilterValue = (k: string): Signal<string | null> =>

--- a/src/frontend/packages/core/src/shared/components/signal-list/list-state-store.service.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/list-state-store.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import type { SignalListSort, SignalListViewMode } from './signal-list.component';
 
@@ -49,6 +49,12 @@ export interface BoundListState {
 export class ListStateStore {
   private readonly injector = inject(Injector);
 
+  // Root singleton: callers bind a fixed key once, so today nothing
+  // accumulates. Capturing the persistence effect per key keeps it that
+  // way defensively — a re-bind of the same key destroys the prior effect
+  // instead of leaving an orphan running against the abandoned signals.
+  private readonly persistEffects = new Map<string, EffectRef>();
+
   bind(key: string, defaults: ListStateDefaults): BoundListState {
     const persisted = this.read(key);
     const initial: ListStateDefaults = persisted ?? defaults;
@@ -65,8 +71,9 @@ export class ListStateStore {
     // Persist on any change. Effect runs in a dedicated injection context
     // so config services can call bind() outside an injection context
     // (e.g. inside a field initializer).
+    this.persistEffects.get(key)?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.persistEffects.set(key, effect(() => {
         const snapshot: ListStateDefaults = {
           viewMode: viewMode(),
           pageSize: pageSizeByMode(),
@@ -74,7 +81,7 @@ export class ListStateStore {
           sort: sortByMode(),
         };
         this.write(key, snapshot);
-      });
+      }));
     });
 
     return { viewMode, pageSizeByMode, pageIndexByMode, sortByMode, pageSize, pageIndex, sort };

--- a/src/frontend/packages/kubernetes/src/helm/list-types/monocular-charts-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/helm/list-types/monocular-charts-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import { ListStateStore, SignalListSort, naturalCompare } from '@stratosui/core';
 
@@ -107,6 +107,10 @@ export class MonocularChartsSignalConfigService {
 
   view!: KubeViewPipeline<MonocularChart>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     return this.helmData.errors();
   }
@@ -125,8 +129,9 @@ export class MonocularChartsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         const repo = this.repositoryFilter();
         const isHubFilter = repo === 'Artifact Hub';

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/analysis-reports/analysis-reports-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/analysis-reports/analysis-reports-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 
 import { ListStateStore, SignalListSort } from '@stratosui/core';
@@ -129,6 +129,10 @@ export class AnalysisReportsSignalConfigService {
 
   view!: KubeViewPipeline<AnalysisReport>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     return this.analysisData.errors();
   }
@@ -154,8 +158,9 @@ export class AnalysisReportsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((r: AnalysisReport) => {
           if (!q) return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-namespace-pods/kubernetes-namespace-pods-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-namespace-pods/kubernetes-namespace-pods-signal-config.service.ts
@@ -1,4 +1,5 @@
 import {
+  EffectRef,
   Injectable,
   Injector,
   Signal,
@@ -119,6 +120,10 @@ export class KubernetesNamespacePodsSignalConfigService {
 
   view!: KubePodViewPipeline;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     return this.podData.errors();
   }
@@ -142,8 +147,9 @@ export class KubernetesNamespacePodsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((p: KubePod) => {
           if (!q) return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-signal-config.service.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-signal-config.service.spec.ts
@@ -2,7 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { KubeEndpointDataRegistry } from '../../../services/endpoint-data/kube-endpoint-data.registry';
 import { KubeNamespaceDataService } from '../../../services/domain-data/kube-namespace-data.service';
@@ -121,6 +121,26 @@ describe('KubernetesNamespacesSignalConfigService', () => {
     expect(svc.nameFilter()).toBe('');
     expect(svc.sort().direction).toBe('asc');
     expect(svc.pageIndex()).toBe(0);
+  });
+
+  it('initialize does not stack a filter effect on re-entry', () => {
+    // Regression: this service is a root singleton, but the host tab calls
+    // initialize() from its constructor on every mount. The filter effect
+    // was created uncaptured, so each navigation left a live effect on the
+    // root injector — N visits meant the filter predicate was recomputed N
+    // times per keystroke. The fix captures the EffectRef and destroys the
+    // prior one on re-entry.
+    svc.initialize(KUBE_GUID);
+    svc.initialize(KUBE_GUID);
+    TestBed.tick();
+
+    const setSpy = vi.spyOn(svc.filter, 'set');
+    svc.nameFilter.set('abc');
+    TestBed.tick();
+
+    // One live effect → one filter recompute. Without the fix the two
+    // stacked effects would each fire, yielding 2.
+    expect(setSpy).toHaveBeenCalledTimes(1);
   });
 
   it('refresh re-fetches namespaces only', async () => {

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-namespaces/kubernetes-namespaces-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import { ListStateStore, SignalListSort } from '@stratosui/core';
 
@@ -60,6 +60,11 @@ export class KubernetesNamespacesSignalConfigService {
 
   view!: KubeViewPipeline<KubeNamespace>;
 
+  // Captured so a re-entry (this is a root singleton, but components call
+  // initialize() on every mount) destroys the prior filter effect instead
+  // of stacking one live effect per navigation on the root injector.
+  private filterEffect?: EffectRef;
+
   // Tristate visibility — when the kube version / namespace fetch is
   // listed in the endpoint service's `unavailable`, we surface that to
   // the consumer so the page can render "Not Available" rather than a
@@ -87,8 +92,9 @@ export class KubernetesNamespacesSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((ns: KubeNamespace) => {
           if (!q) return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-node-pods/kubernetes-node-pods-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-node-pods/kubernetes-node-pods-signal-config.service.ts
@@ -1,4 +1,5 @@
 import {
+  EffectRef,
   Injectable,
   Injector,
   Signal,
@@ -119,6 +120,10 @@ export class KubernetesNodePodsSignalConfigService {
 
   view!: KubePodViewPipeline;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     return this.podData.errors();
   }
@@ -142,8 +147,9 @@ export class KubernetesNodePodsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((p: KubePod) => {
           if (!q) return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-nodes-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import { ListStateStore, SignalListSort } from '@stratosui/core';
 
@@ -54,6 +54,10 @@ export class KubernetesNodesSignalConfigService {
 
   view!: KubeViewPipeline<KubeNode>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     const svc = this.kubeGuid ? this.registry.getService(this.kubeGuid) : null;
     return computed(() => [...(svc?.errors() ?? []), ...this.nodeData.errors()()]);
@@ -77,8 +81,9 @@ export class KubernetesNodesSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((n: KubeNode) => {
           if (!q) return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-pods/kubernetes-pods-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-pods/kubernetes-pods-signal-config.service.ts
@@ -1,4 +1,5 @@
 import {
+  EffectRef,
   Injectable,
   Injector,
   Signal,
@@ -130,6 +131,10 @@ export class KubernetesPodsSignalConfigService {
 
   view!: KubePodViewPipeline;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     return this.podData.errors();
   }
@@ -152,8 +157,9 @@ export class KubernetesPodsSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((p: KubePod) => {
           if (!q) return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-services/kubernetes-services-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-services/kubernetes-services-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import { ListStateStore, SignalListSort } from '@stratosui/core';
 
@@ -51,6 +51,10 @@ export class KubernetesServicesSignalConfigService {
 
   view!: KubeViewPipeline<KubeService>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     const svc = this.kubeGuid ? this.registry.getService(this.kubeGuid) : null;
     return computed(() => [...(svc?.errors() ?? []), ...this.serviceData.errors()()]);
@@ -74,8 +78,9 @@ export class KubernetesServicesSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         this.filter.set((s: KubeService) => {
           if (!q) return true;

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-releases-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-releases-signal-config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
+import { EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 
 import { ListStateStore, SignalListSort } from '@stratosui/core';
 
@@ -118,6 +118,10 @@ export class HelmReleasesSignalConfigService {
 
   view!: KubeViewPipeline<HelmRelease>;
 
+  // Captured so a re-entry (root singleton, but initialize() runs per mount)
+  // destroys the prior filter effect instead of stacking one per navigation.
+  private filterEffect?: EffectRef;
+
   errors(): Signal<StratosError[]> {
     return this.helmData.errors();
   }
@@ -136,8 +140,9 @@ export class HelmReleasesSignalConfigService {
       this._sortExtractors.asReadonly(),
     );
 
+    this.filterEffect?.destroy();
     runInInjectionContext(this.injector, () => {
-      effect(() => {
+      this.filterEffect = effect(() => {
         const q = this.nameFilter().trim().toLowerCase();
         const kubeId = this.kubeIdFilter();
         const ns = this.namespaceFilter();


### PR DESCRIPTION
## Problem

A single anti-pattern recurs across the signal-config services that drive the
new signal-native lists: a `providedIn:'root'` singleton creates an `effect()`
inside a method (`initialize()` / `startStatsPolling()` / `bind()`) that the
host component calls on **every mount**. The effect is never captured, so each
navigation leaves another live effect on the root injector. Over a session they
accumulate — recomputing filter predicates N times per keystroke after N
visits, and (on the app wall) multiplying app-stats HTTP traffic.

Surfaced by the 2026-06-17 whole-codebase review. The review named a handful of
sites; a sweep of every `providedIn:'root'` signal-config service found the
family is broader — ~20 services across cloud-foundry, kubernetes, cf-autoscaler,
and the core list framework.

## Fix

One sanctioned pattern everywhere: capture the `EffectRef` in a field and
destroy the prior one before re-creating (mirroring the timer reset already in
`startStatsPolling` and the `resolverEffect` pattern `CfAppsSignalConfigService`
already used). State held by these singletons is preserved — only the leaked
effect is torn down — so behaviour is otherwise unchanged.

Scope by package (commit per package):
- **core** — `ListStateStore` / `ListFilterStore` persistence effects (defensive;
  callers bind a fixed key once today, so nothing accumulates yet).
- **cloud-foundry** — apps (stats), orgs, spaces, users, routes, audit-events,
  buildpacks, cells, security-groups, feature-flags, org-quotas, space-quotas,
  revisions, stacks. Multi-effect services (orgs/routes/users/audit-events)
  capture both the filter and the cascade/latch effect.
- **kubernetes** — namespaces, pods, nodes, node-pods, namespace-pods,
  analysis-reports, services, helm-releases, monocular-charts.
- **cf-autoscaler** — metric-chart, scaling-events. Also fixes an unhandled
  promise rejection: `loadAll()` is called as `void loadAll()` but the data
  service's `load()` rethrows on error — now swallowed (the error is already
  surfaced via the data service's `error()` signal).

`kubernetes-endpoints` was already safe (it guards `initialize()` with an
`_initialized` flag) and is untouched.

## Tests

Regression tests added at representative sites, each verified red→green:
- cf-apps: re-entry stacks no second stats refresh (spy on `refreshStatsForKeys`).
- kubernetes-namespaces: re-`initialize()` recomputes the filter once, not twice.
- cf-autoscaler events: re-entry stacks no second filter effect; `loadAll()`
  resolves (not rejects) on HTTP failure.
- list-filter-store: re-bind of a key tears down the prior effect (no orphan
  persistence).

Full `make check gate` green (591 frontend test files, production build, backend).
