### PR TITLE
Show busy spinners for Service Keys page operations

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -12,8 +12,12 @@
       [value]="newKeyName()" (input)="newKeyName.set($any($event.target).value)"
       (keydown.enter)="createKey()" [disabled]="creating()" />
     <button type="button"
-      class="rounded bg-primary px-3 py-1.5 text-sm text-white disabled:opacity-50"
+      class="inline-flex items-center gap-2 rounded bg-primary px-3 py-1.5 text-sm text-white disabled:opacity-50"
       [disabled]="creating() || !newKeyName().trim()" (click)="createKey()">
+      @if (creating()) {
+        <span class="animate-spin inline-block h-4 w-4 rounded-full border-2 border-current border-t-transparent"
+          aria-hidden="true"></span>
+      }
       {{ creating() ? 'Creating…' : 'Create' }}
     </button>
     <button type="button" class="text-sm text-content-muted hover:underline disabled:opacity-50"
@@ -36,7 +40,11 @@
 
   <!-- List (accordion) -->
   @if (loading()) {
-    <p class="text-content-muted">Loading service keys…</p>
+    <p class="flex items-center gap-2 text-content-muted">
+      <span class="animate-spin inline-block h-4 w-4 rounded-full border-2 border-current border-t-transparent"
+        aria-hidden="true"></span>
+      Loading service keys…
+    </p>
   } @else if (keys().length === 0) {
     <p class="text-content-muted">This service instance has no service keys.</p>
   } @else {
@@ -64,9 +72,13 @@
               {{ copiedAllGuid() === key.guid ? 'Copied' : 'Copy all (JSON)' }}
             </button>
             <button type="button"
-              class="text-danger-strong hover:underline disabled:opacity-50 shrink-0"
+              class="inline-flex items-center gap-1.5 text-danger-strong hover:underline disabled:opacity-50 shrink-0"
               [disabled]="rowStatus(key.guid) === 'busy'"
               (click)="deleteKey(key.guid)">
+              @if (rowStatus(key.guid) === 'busy') {
+                <span class="animate-spin inline-block h-3.5 w-3.5 rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"></span>
+              }
               {{ rowStatus(key.guid) === 'busy' ? 'Deleting…' : 'Delete' }}
             </button>
           </div>
@@ -75,7 +87,11 @@
           @if (isOpen(key.guid)) {
             <div class="px-4 py-3 border-t border-content-border">
               @if (credsLoading(key.guid)) {
-                <p class="text-content-muted">Loading credentials…</p>
+                <p class="flex items-center gap-2 text-content-muted">
+                  <span class="animate-spin inline-block h-4 w-4 rounded-full border-2 border-current border-t-transparent"
+                    aria-hidden="true"></span>
+                  Loading credentials…
+                </p>
               } @else if (credsError(key.guid); as cerr) {
                 <p class="text-danger-strong">Failed to load credentials: {{ cerr }}</p>
               } @else if (credentialFields(key.guid).length === 0) {

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
@@ -1,0 +1,113 @@
+import { provideZonelessChangeDetection, signal, WritableSignal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { ServiceKeysComponent } from './service-keys.component';
+import { ServiceCatalogDataService, ServiceKeyView } from '../../../services/endpoint-data/service-catalog-data.service';
+
+// SignalSource triple with a static value — null instance ⇒ the component
+// builds without firing the offering/bindable fetch.
+function source<T>(value: T) {
+  return {
+    value: signal(value).asReadonly(),
+    isLoading: signal(false).asReadonly(),
+    error: signal(null).asReadonly(),
+  };
+}
+
+const spinner = (el: HTMLElement) => el.querySelector('.animate-spin');
+
+describe('ServiceKeysComponent — busy-state spinners', () => {
+  let component: ServiceKeysComponent;
+  let fixture: ComponentFixture<ServiceKeysComponent>;
+  let keysVal: WritableSignal<ServiceKeyView[]>;
+  let keysLoading: WritableSignal<boolean>;
+
+  beforeEach(async () => {
+    keysVal = signal<ServiceKeyView[]>([]);
+    keysLoading = signal(false);
+
+    await TestBed.configureTestingModule({
+      imports: [ServiceKeysComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        {
+          provide: ServiceCatalogDataService,
+          useValue: {
+            serviceInstance: () => source(null),
+            // Backed by the writable signals above so tests can drive the
+            // list value + loading flag through the component's source.
+            serviceKeysForInstance: () => ({
+              value: keysVal.asReadonly(),
+              isLoading: keysLoading.asReadonly(),
+              error: signal(null).asReadonly(),
+            }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ServiceKeysComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('no spinner when idle', () => {
+    expect(spinner(fixture.nativeElement)).toBeNull();
+  });
+
+  it('shows a spinner while the key list is loading (GET)', () => {
+    keysLoading.set(true);
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).not.toBeNull();
+
+    keysLoading.set(false);
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).toBeNull();
+  });
+
+  it('shows a spinner in the create form while creating', () => {
+    component.isAdding.set(true);
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).toBeNull();
+
+    component.creating.set(true);
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).not.toBeNull();
+
+    component.creating.set(false);
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).toBeNull();
+  });
+
+  it('shows a spinner while a key\'s credentials are loading (GET)', () => {
+    keysVal.set([{ guid: 'k1', name: 'key-one', createdAt: '' }]);
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).toBeNull();
+
+    // Expanding triggers the lazy credential GET; the request stays pending
+    // under HttpTestingController, so credsLoading('k1') stays true.
+    component.toggleOpen('k1');
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).not.toBeNull();
+  });
+
+  it('shows a spinner on the delete action while deleting', () => {
+    keysVal.set([{ guid: 'k1', name: 'key-one', createdAt: '' }]);
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).toBeNull();
+
+    // Fire-and-forget: the DELETE stays pending, rowStatus('k1') === 'busy'.
+    void component.deleteKey('k1');
+    fixture.detectChanges();
+    expect(spinner(fixture.nativeElement)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

On the Service Keys page, every busy state surfaced as text only — "Loading
service keys…", "Creating…", "Deleting…". On a slow async-job create that reads
as an unresponsive page (you click Create, nothing visibly happens for a while).

## Fix

Add an `animate-spin` indicator to all four busy states so each reads as busy:

- list load (GET)
- credential load when expanding a key (GET)
- create
- delete

Each spinner inherits the surrounding text colour via `border-current` (muted on
the load messages, white on the primary Create button, danger on Delete), so it
matches its context. Display-only — the async-job flow is unchanged.

CF service keys have no update/edit operation (create / view-credentials /
delete only), so there is no edit spinner.

## Tests

Adds the component's first unit spec, covering all four states (each asserts the
spinner appears only while its flag is set). Verified live in a running dev
instance: create shows "Creating…" with the spinner, and delete cleans up.

Full `make check gate` green (592 frontend test files, production build).
