### PR TITLE
Align copy icon to its row (remove absolute positioning)

### DIFF
--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
@@ -1,17 +1,10 @@
-<div class="relative inline-flex items-center gap-2">
-  <div class="absolute right-0 top-0 flex items-center gap-1 transition-opacity duration-300"
-    [class.opacity-100]="copySuccessWait"
-    [class.opacity-0]="!copySuccessWait">
-    @if (showSuccessText) {
-      <span class="text-sm text-success-shade-600 mr-[5px] whitespace-nowrap">Copied to clipboard</span>
-    }
-    <span class="material-icons text-success-shade-600 mr-[5px]"
-      [ngClass]="{'text-sm': compact, 'text-base': !compact}">
-      check_circle
-    </span>
-  </div>
+<!-- The copy icon and the transient success indicator stack in a single grid
+     cell (no absolute positioning), so the column reserves space for the
+     widest child — the "Copied to clipboard" text when shown — and the copy
+     icon flows in normal layout so it aligns with its row. -->
+<div class="inline-grid items-center">
   @if (canCopy) {
-    <span class="material-icons absolute right-0 top-0 cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
+    <span class="material-icons col-start-1 row-start-1 justify-self-end cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
       [class.opacity-0]="copySuccessWait"
       [class.opacity-100]="!copySuccessWait"
       [ngClass]="{'text-sm': compact, 'text-base': !compact}"
@@ -23,4 +16,15 @@
       content_copy
     </span>
   }
+  <div class="col-start-1 row-start-1 justify-self-end flex items-center gap-1 transition-opacity duration-300"
+    [class.opacity-100]="copySuccessWait"
+    [class.opacity-0]="!copySuccessWait">
+    @if (showSuccessText) {
+      <span class="text-sm text-success-shade-600 whitespace-nowrap">Copied to clipboard</span>
+    }
+    <span class="material-icons text-success-shade-600"
+      [ngClass]="{'text-sm': compact, 'text-base': !compact}">
+      check_circle
+    </span>
+  </div>
 </div>

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
@@ -39,4 +39,22 @@ describe('CopyToClipboardComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('renders the copy icon in normal flow (not absolutely positioned), stacked via grid', () => {
+    component.canCopy = true;
+    fixture.detectChanges();
+
+    const icons = Array.from(
+      fixture.nativeElement.querySelectorAll('.material-icons'),
+    ) as HTMLElement[];
+    const copyIcon = icons.find(el => el.textContent?.trim() === 'content_copy');
+
+    expect(copyIcon).toBeTruthy();
+    // Absolute positioning was the cause of the row-misalignment — the icon
+    // must flow so it tracks its row.
+    expect(copyIcon!.classList.contains('absolute')).toBe(false);
+    // Icon + transient success indicator share one grid cell, so the column
+    // reserves space for the "Copied to clipboard" text without overlap.
+    expect(fixture.nativeElement.querySelector('.inline-grid')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Problem

`CopyToClipboardComponent` positioned both the copy icon and its transient
"Copied" success indicator with `absolute right-0 top-0`. With all children
absolutely positioned the component occupied ~zero layout height, so the icon
didn't track its row. In the Service Keys credentials table this showed up as
the copy icons drifting progressively out of alignment down the column.

## Fix

Stack the copy icon and the success indicator in a single grid cell
(`inline-grid`, both children `col-start-1 row-start-1`):

- Neither child is absolutely positioned — the copy icon flows in normal
  layout, so it lines up with its row.
- The grid column sizes to the wider child, so it reserves space for the
  "Copied to clipboard" text (when `showSuccessText`) without overlap or
  layout shift.

Verified on the credentials table: the copy icon's vertical centre is now a
uniform 2px from each row's centre across all 15 rows (the glyph's optical
baseline) — no drift.

## Tests

Adds a regression test asserting the copy icon carries no `absolute` class and
the component stacks via `inline-grid`. Full `make check gate` green (591
frontend test files, production build).
