### PR TITLE
Service Keys page polish + per-instance key-count column

### DIFF
--- a/e2e/tests/marketplace/service-keys.spec.ts
+++ b/e2e/tests/marketplace/service-keys.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '../../fixtures/test-base';
+
+/**
+ * Service Keys E2E Tests (GH#4301)
+ *
+ * Covers the per-instance Service Keys management page introduced in #4301,
+ * reached from a service instance's row-action menu:
+ *   /services/:type/:endpointId/:serviceInstanceId/keys
+ *
+ * The page lists a managed instance's service keys (credential bindings of
+ * type=key), shows an empty state when there are none, exposes an "Add Service
+ * Key" action, and renders each key's credentials in a masked accordion.
+ *
+ * Security note: these tests assert that credential values are NOT rendered in
+ * plaintext by default. They never reveal or print a credential value.
+ */
+
+// Locate a managed (bindable) service instance in the test space via the V3
+// proxy. Returns its guid, or null when none is available (broker-dependent).
+async function findManagedInstanceGuid(
+  request: import('@playwright/test').APIRequestContext,
+  cfGuid: string,
+  spaceGuid: string,
+): Promise<{ guid: string; name: string } | null> {
+  const res = await request.get(
+    `/pp/v1/proxy/v3/cf/${cfGuid}/service_instances?type=managed&space_guids=${spaceGuid}&per_page=50`,
+  );
+  if (!res.ok()) return null;
+  const body = await res.json();
+  const resources = Array.isArray(body?.resources) ? body.resources : [];
+  const inst = resources.find((r: any) => r?.guid);
+  return inst ? { guid: inst.guid, name: inst.name } : null;
+}
+
+test.describe('Service Keys (#4301)', () => {
+
+  test('service keys page renders for a managed instance', async ({ connectedEndpointsAdminPage, secrets }) => {
+    const { page, cfGuid } = connectedEndpointsAdminPage;
+    const spaceGuid = secrets.getCloudfoundryEndpoint(0).testSpaceGuid;
+
+    const instance = await findManagedInstanceGuid(page.request, cfGuid, spaceGuid);
+    if (!instance) {
+      test.skip(true, 'No managed service instance available (broker-dependent)');
+      return;
+    }
+
+    await page.goto(`/services/service/${cfGuid}/${instance.guid}/keys`);
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    // Header names the instance, count summary + Add action are present.
+    await expect(page.getByText(/Service keys for/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Total Service Keys:/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Add Service Key/i })).toBeVisible();
+  });
+
+  test('shows the empty state OR a key list (never a stuck spinner)', async ({ connectedEndpointsAdminPage, secrets }) => {
+    const { page, cfGuid } = connectedEndpointsAdminPage;
+    const spaceGuid = secrets.getCloudfoundryEndpoint(0).testSpaceGuid;
+
+    const instance = await findManagedInstanceGuid(page.request, cfGuid, spaceGuid);
+    if (!instance) {
+      test.skip(true, 'No managed service instance available (broker-dependent)');
+      return;
+    }
+
+    await page.goto(`/services/service/${cfGuid}/${instance.guid}/keys`);
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    const totalText = await page.getByText(/Total Service Keys:\s*\d+/i).innerText();
+    const total = parseInt(totalText.replace(/\D+/g, ''), 10) || 0;
+
+    if (total === 0) {
+      await expect(page.getByText(/no service keys/i)).toBeVisible();
+    } else {
+      // At least one key row/accordion is rendered.
+      const keyRows = page.locator('mat-expansion-panel, [data-test="service-key"], app-accordion');
+      await expect(keyRows.first()).toBeVisible({ timeout: 10000 });
+    }
+  });
+
+  test('credentials are masked by default (not shown in plaintext)', async ({ connectedEndpointsAdminPage, secrets }) => {
+    const { page, cfGuid } = connectedEndpointsAdminPage;
+    const spaceGuid = secrets.getCloudfoundryEndpoint(0).testSpaceGuid;
+
+    const instance = await findManagedInstanceGuid(page.request, cfGuid, spaceGuid);
+    if (!instance) {
+      test.skip(true, 'No managed service instance available (broker-dependent)');
+      return;
+    }
+
+    await page.goto(`/services/service/${cfGuid}/${instance.guid}/keys`);
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    const totalText = await page.getByText(/Total Service Keys:\s*\d+/i).innerText();
+    const total = parseInt(totalText.replace(/\D+/g, ''), 10) || 0;
+    if (total === 0) {
+      test.skip(true, 'Instance has no service keys to assert masking against');
+      return;
+    }
+
+    // A masked credentials view should expose a reveal/show affordance and
+    // must NOT render the raw credential up-front. We assert the presence of
+    // the masking control rather than reading any secret value.
+    const revealControl = page.getByRole('button', { name: /show|reveal|visibility/i });
+    await expect(revealControl.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('Add Service Key opens the create form and cancels cleanly', async ({ connectedEndpointsAdminPage, secrets }) => {
+    const { page, cfGuid } = connectedEndpointsAdminPage;
+    const spaceGuid = secrets.getCloudfoundryEndpoint(0).testSpaceGuid;
+
+    const instance = await findManagedInstanceGuid(page.request, cfGuid, spaceGuid);
+    if (!instance) {
+      test.skip(true, 'No managed service instance available (broker-dependent)');
+      return;
+    }
+
+    await page.goto(`/services/service/${cfGuid}/${instance.guid}/keys`);
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    await page.getByRole('button', { name: /Add Service Key/i }).click();
+
+    // A create dialog / form with a name field should appear. Don't submit —
+    // creating a key provisions real credentials.
+    const nameField = page.getByRole('textbox').first();
+    await expect(nameField).toBeVisible({ timeout: 10000 });
+
+    const cancel = page.getByRole('button', { name: /cancel/i }).first();
+    if (await cancel.isVisible().catch(() => false)) {
+      await cancel.click();
+    } else {
+      await page.keyboard.press('Escape');
+    }
+  });
+
+  test('Service Keys action is gated to bindable (managed) instances', async ({ connectedEndpointsAdminPage, secrets }) => {
+    const { page, cfGuid } = connectedEndpointsAdminPage;
+    const spaceGuid = secrets.getCloudfoundryEndpoint(0).testSpaceGuid;
+
+    const instance = await findManagedInstanceGuid(page.request, cfGuid, spaceGuid);
+    if (!instance) {
+      test.skip(true, 'No managed service instance available (broker-dependent)');
+      return;
+    }
+
+    // Reaching the keys route at all is the gated capability: the page must
+    // render its management surface (not redirect / error) for a bindable
+    // instance. Non-bindable (user-provided) instances do not expose the
+    // Service Keys row action that leads here.
+    await page.goto(`/services/service/${cfGuid}/${instance.guid}/keys`);
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+
+    await expect(page).toHaveURL(/\/keys$/);
+    await expect(page.getByRole('button', { name: /Add Service Key/i })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
@@ -41,6 +41,8 @@ function makeStubSignalConfigService() {
     registerFilterExtractor: vi.fn(),
     deleteServiceInstance: vi.fn().mockResolvedValue(undefined),
     isOfferingBindable: vi.fn().mockReturnValue(undefined),
+    serviceKeyCount: vi.fn().mockReturnValue(undefined),
+    ensureServiceKeyCounts: vi.fn(),
     clearFilters: vi.fn(),
     filter: filterSig,
     sort: sortSig,
@@ -98,8 +100,13 @@ describe('CloudFoundrySpaceServiceInstancesSignalComponent', () => {
     const cfg = component.listConfig();
     expect(cfg).toBeDefined();
     expect(cfg!.columns.map(c => c.header)).toEqual([
-      'Name', 'Service', 'Last Operation', 'Attached Apps', 'Tags', 'Created', '', '',
+      'Name', 'Service', 'Last Operation', 'Attached Apps', 'Service Keys', 'Tags', 'Created', '', '',
     ]);
+    const keysCol: any = cfg!.columns.find(c => c.key === 'serviceKeys');
+    expect(keysCol.kind).toBe('link');
+    const si: any = { cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'cache', type: 'managed' };
+    expect(keysCol.link(si)).toEqual(['/services', 'service', 'cnsi-1', 'si-1', 'keys']);
+    expect(keysCol.render(si)).toBe('—');
     expect(cfg!.getRowKey({
       cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'cache', type: 'managed',
       tags: [], createdAt: '',
@@ -146,6 +153,11 @@ describe('CloudFoundrySpaceServiceInstancesSignalComponent', () => {
     // Managed + isOfferingBindable undefined (cold) → fail open → Service Keys shown.
     const managed: any = { cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'cache', type: 'managed' };
     expect(actionsCol.actions(managed).map((a: any) => a.label)).toEqual(['Edit', 'Detach', 'Service Keys', 'Delete']);
+  });
+
+  it('triggers the lazy key-count fetch after the instances load', async () => {
+    await Promise.resolve();
+    expect(stubSignalConfig.ensureServiceKeyCounts).toHaveBeenCalled();
   });
 
   it('Service Keys action keeps CF context via ?breadcrumbs=space-services', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
@@ -148,6 +148,21 @@ describe('CloudFoundrySpaceServiceInstancesSignalComponent', () => {
     expect(actionsCol.actions(managed).map((a: any) => a.label)).toEqual(['Edit', 'Detach', 'Service Keys', 'Delete']);
   });
 
+  it('Service Keys action keeps CF context via ?breadcrumbs=space-services', () => {
+    const router = TestBed.inject(Router);
+    const navSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const cfg = component.listConfig();
+    const actionsCol: any = cfg!.columns.find(c => c.key === 'actions');
+    const managed: any = { cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'cache', type: 'managed' };
+
+    actionsCol.actions(managed).find((a: any) => a.label === 'Service Keys').invoke();
+
+    expect(navSpy).toHaveBeenCalledWith(
+      ['/services', 'service', 'cnsi-1', 'si-1', 'keys'],
+      { queryParams: { breadcrumbs: 'space-services' } },
+    );
+  });
+
   it('omits CF/Org/Space dropdowns and toolbar Type column', () => {
     const cfg = component.listConfig();
     expect(cfg!.filterDropdowns).toBeUndefined();

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
@@ -26,6 +26,7 @@ import { CloudFoundryEndpointService } from '../../../../../services/cloud-found
 import { CloudFoundryOrganizationService } from '../../../../../services/cloud-foundry-organization.service';
 import { CloudFoundrySpaceService } from '../../../../../services/cloud-foundry-space.service';
 import { boundAppSegments, renderBoundApps } from '../../../../../../../shared/signal-list-configs/bound-apps-cell';
+import { renderServiceKeyCount, serviceKeysLink } from '../../../../../../../shared/signal-list-configs/service-keys-count-cell';
 import { buildServiceInstanceRowActions } from '../../../../../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../../../../../services/endpoint-data/stratos-types';
 
@@ -185,6 +186,12 @@ export class CloudFoundrySpaceServiceInstancesSignalComponent {
           widthHint: '14rem',
         },
         {
+          header: 'Service Keys', key: 'serviceKeys', kind: 'link',
+          render: (si) => renderServiceKeyCount(si, this.instancesConfig.serviceKeyCount(si.guid)),
+          link: serviceKeysLink,
+          widthHint: '8rem',
+        },
+        {
           header: 'Tags', key: 'tags', sortField: renderTags,
           render: renderTags,
           widthHint: '14rem',
@@ -232,7 +239,7 @@ export class CloudFoundrySpaceServiceInstancesSignalComponent {
     this.instancesConfig.registerSortExtractor('tags', renderTags);
     this.instancesConfig.registerFilterExtractor('name', (si: StServiceInstance) => si.name ?? '');
 
-    void this.instancesConfig.loadAll();
+    void this.instancesConfig.loadAll().then(() => this.instancesConfig.ensureServiceKeyCounts());
   }
 
   private toggleFavorite(si: StServiceInstance): void {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
@@ -252,6 +252,9 @@ export class CloudFoundrySpaceServiceInstancesSignalComponent {
       snackBar: this.snackBar,
       deleteServiceInstance: (cnsiGuid, guid) => this.instancesConfig.deleteServiceInstance(cnsiGuid, guid),
       isOfferingBindable: (si) => this.instancesConfig.isOfferingBindable(si),
+      // Keep the keys page anchored in this space's CF context (endpoint → org
+      // → space → service-instances) rather than the global /services wall.
+      breadcrumbKey: 'space-services',
     });
 
   static formatDate(iso: string | null | undefined): string {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
@@ -28,6 +28,7 @@ import {
 import { CfCurrentUserPermissions } from '../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import { buildServiceInstanceRowActions } from '../../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
+import { renderServiceKeyCount, serviceKeysLink } from '../../../../shared/signal-list-configs/service-keys-count-cell';
 import type { StServiceInstance } from '../../../../services/endpoint-data/stratos-types';
 
 // Per-CF Services tab. Single-CNSI variant of the top-level Services Wall.
@@ -194,6 +195,14 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
           widthHint: '10rem',
         },
         {
+          // This list has no Attached Apps column; the keys count sits right
+          // after Last Operation, the same neighbourhood it occupies elsewhere.
+          header: 'Service Keys', key: 'serviceKeys', kind: 'link',
+          render: (si) => renderServiceKeyCount(si, this.instancesConfig.serviceKeyCount(si.guid)),
+          link: serviceKeysLink,
+          widthHint: '8rem',
+        },
+        {
           header: 'Tags', key: 'tags', sortField: renderTags,
           render: renderTags,
           widthHint: '14rem',
@@ -254,7 +263,7 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
     this.instancesConfig.registerFilterExtractor('service', renderService);
     this.instancesConfig.registerFilterExtractor('tags', renderTags);
 
-    void this.instancesConfig.loadAll();
+    void this.instancesConfig.loadAll().then(() => this.instancesConfig.ensureServiceKeyCounts());
   }
 
   private buildInstanceActions = (si: StServiceInstance): readonly SignalListRowAction<StServiceInstance>[] =>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
@@ -264,6 +264,9 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
       snackBar: this.snackBar,
       deleteServiceInstance: (cnsiGuid, guid) => this.instancesConfig.deleteServiceInstance(cnsiGuid, guid),
       isOfferingBindable: (si) => this.instancesConfig.isOfferingBindable(si),
+      // Keep the keys page anchored in this endpoint's CF services tab rather
+      // than popping out to the global /services wall.
+      breadcrumbKey: 'cf',
     });
 
   static formatDate(iso: string | null | undefined): string {

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.spec.ts
@@ -42,6 +42,8 @@ describe('ServiceInstancesComponent (signal-native)', () => {
       clearFilters: vi.fn(),
       deleteServiceInstance: vi.fn(async () => undefined),
       isOfferingBindable: vi.fn(() => undefined),
+      serviceKeyCount: vi.fn(() => undefined as number | undefined),
+      ensureServiceKeyCounts: vi.fn(),
     };
   };
 
@@ -87,7 +89,32 @@ describe('ServiceInstancesComponent (signal-native)', () => {
     expect(component.listConfig).toBeTruthy();
     expect(component.listConfig!.pagedItems).toBe(configStub.view.pagedItems);
     const keys = component.listConfig!.columns.map(c => c.key);
-    expect(keys).toEqual(['name', 'plan', 'lastOp', 'boundApps', 'tags', 'createdAt', 'type', 'actions']);
+    expect(keys).toEqual(['name', 'plan', 'lastOp', 'boundApps', 'serviceKeys', 'tags', 'createdAt', 'type', 'actions']);
+  });
+
+  it('Service Keys column links to the keys page and renders the lazy count', () => {
+    fixture.detectChanges();
+    const cols = component.listConfig!.columns;
+    const idx = cols.findIndex(c => c.key === 'serviceKeys');
+    // Positioned right after Attached Apps, and a whole-cell link.
+    expect(cols[idx - 1].key).toBe('boundApps');
+    const col = cols[idx] as any;
+    expect(col.header).toBe('Service Keys');
+    expect(col.kind).toBe('link');
+
+    const si = { guid: 'si-7', cnsiGuid: 'cnsi-1', name: 'redis', type: 'managed' };
+    expect(col.link(si)).toEqual(['/services', 'service', 'cnsi-1', 'si-7', 'keys']);
+
+    // Unknown count → em-dash; resolved count → the number.
+    expect(col.render(si)).toBe('—');
+    configStub.serviceKeyCount.mockReturnValue(3);
+    expect(col.render(si)).toBe('3');
+  });
+
+  it('triggers the lazy key-count fetch after the instances load', async () => {
+    fixture.detectChanges();
+    await Promise.resolve();
+    expect(configStub.ensureServiceKeyCounts).toHaveBeenCalled();
   });
 
   it('Delete row action opens confirm and on confirm calls deleteServiceInstance', async () => {

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.ts
@@ -26,6 +26,7 @@ import {
   CfServiceInstancesSignalConfigService,
 } from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
 import { boundAppSegments, renderBoundApps } from '../../../shared/signal-list-configs/bound-apps-cell';
+import { renderServiceKeyCount, serviceKeysLink } from '../../../shared/signal-list-configs/service-keys-count-cell';
 import { buildServiceInstanceRowActions } from '../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 
@@ -139,6 +140,12 @@ export class ServiceInstancesComponent implements OnInit {
         widthHint: '14rem',
       },
       {
+        header: 'Service Keys', key: 'serviceKeys', kind: 'link',
+        render: (si) => renderServiceKeyCount(si, this.instancesConfig.serviceKeyCount(si.guid)),
+        link: serviceKeysLink,
+        widthHint: '8rem',
+      },
+      {
         header: 'Tags', key: 'tags', sortField: renderTags,
         render: renderTags,
         widthHint: '14rem',
@@ -192,7 +199,7 @@ export class ServiceInstancesComponent implements OnInit {
     this.instancesConfig.registerSortExtractor('type', renderType);
     this.instancesConfig.registerFilterExtractor('name', (si) => si.name ?? '');
 
-    void this.instancesConfig.loadAll();
+    void this.instancesConfig.loadAll().then(() => this.instancesConfig.ensureServiceKeyCounts());
   }
 
   // Per-row Edit / Detach / Delete. Restores the V2-era listActionEdit

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs">
+<app-page-header [breadcrumbs]="breadcrumbs()">
   {{ title() }}
 </app-page-header>
 

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
@@ -6,7 +6,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
-import { ServiceKeysComponent } from './service-keys.component';
+import { ServiceKeysComponent, toCredentialFields } from './service-keys.component';
 import { ServiceCatalogDataService, ServiceKeyView } from '../../../services/endpoint-data/service-catalog-data.service';
 import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
 import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
@@ -176,5 +176,63 @@ describe('ServiceKeysComponent — context-aware breadcrumbs', () => {
   it('omits the space-services trail until the instance (with its space/org) has loaded', () => {
     const c = setup(null, [{ guid: 'cf-1', name: 'prod-cf' }]);
     expect(c.breadcrumbs().find(b => b.key === 'space-services')).toBeUndefined();
+  });
+});
+
+describe('toCredentialFields — credential masking', () => {
+  const fieldFor = (key: string, value: unknown) =>
+    toCredentialFields({ [key]: value }).find(f => f.key === key)!;
+
+  it('redacts only the password in an embedded-credential URL, keeping the rest visible', () => {
+    const f = fieldFor('uri', 'postgres://user:s3cr3t@host:5432/db');
+    expect(f.sensitive).toBe(true);
+    expect(f.displayMasked).toBe('postgres://user:<redacted>@host:5432/db');
+    // The real value is preserved for copy / reveal.
+    expect(f.value).toBe('postgres://user:s3cr3t@host:5432/db');
+  });
+
+  it('fully masks a key-sensitive non-URL secret', () => {
+    const f = fieldFor('password', 's3cr3t');
+    expect(f.sensitive).toBe(true);
+    expect(f.displayMasked).toBe('••••••••');
+  });
+
+  it('leaves a plain non-sensitive value unmasked', () => {
+    const f = fieldFor('host', 'db.example.com');
+    expect(f.sensitive).toBe(false);
+  });
+
+  it('does not mask a URL that carries no embedded credentials', () => {
+    const f = fieldFor('dashboard_url', 'https://dashboard.example.com/db');
+    expect(f.sensitive).toBe(false);
+  });
+});
+
+describe('ServiceKeysComponent — displayValue masking toggle', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ServiceKeysComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        {
+          provide: ServiceCatalogDataService,
+          useValue: { serviceInstance: () => source(null), serviceKeysForInstance: () => source([] as ServiceKeyView[]) },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('shows the partial mask when hidden and the real value once revealed', () => {
+    const c = TestBed.createComponent(ServiceKeysComponent).componentInstance;
+    const field = { key: 'uri', value: 'postgres://user:s3cr3t@host/db', sensitive: true, displayMasked: 'postgres://user:<redacted>@host/db' };
+
+    expect(c.displayValue('k1', field)).toBe('postgres://user:<redacted>@host/db');
+
+    c.toggleField('k1', 'uri');
+    expect(c.displayValue('k1', field)).toBe('postgres://user:s3cr3t@host/db');
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
@@ -1,13 +1,15 @@
 import { provideZonelessChangeDetection, signal, WritableSignal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideRouter } from '@angular/router';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { ServiceKeysComponent } from './service-keys.component';
 import { ServiceCatalogDataService, ServiceKeyView } from '../../../services/endpoint-data/service-catalog-data.service';
+import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
+import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 
 // SignalSource triple with a static value — null instance ⇒ the component
 // builds without firing the offering/bindable fetch.
@@ -109,5 +111,70 @@ describe('ServiceKeysComponent — busy-state spinners', () => {
     void component.deleteKey('k1');
     fixture.detectChanges();
     expect(spinner(fixture.nativeElement)).not.toBeNull();
+  });
+});
+
+describe('ServiceKeysComponent — context-aware breadcrumbs', () => {
+  // A managed instance carrying its space + organization (populated at the
+  // summary tier the keys page fetches), so the CF trail is buildable.
+  const instanceWithSpace = (): StServiceInstance => ({
+    guid: 'si-1', cnsiGuid: 'cf-1', name: 'cache', type: 'managed',
+    tags: [], lastOperation: {}, createdAt: '',
+    space: { guid: 'sp-1', name: 'dev', organization: { guid: 'org-1', name: 'acme' } },
+  } as StServiceInstance);
+
+  function setup(
+    instance: StServiceInstance | null,
+    endpoints: { guid?: string; name: string }[],
+  ): ServiceKeysComponent {
+    TestBed.configureTestingModule({
+      imports: [ServiceKeysComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { endpointId: 'cf-1', serviceInstanceId: 'si-1' } } } },
+        {
+          provide: ServiceCatalogDataService,
+          useValue: {
+            serviceInstance: () => source(instance),
+            serviceKeysForInstance: () => source([] as ServiceKeyView[]),
+          },
+        },
+        { provide: CfEndpointsDataService, useValue: { connectedCfList: signal(endpoints).asReadonly() } },
+      ],
+    });
+    return TestBed.createComponent(ServiceKeysComponent).componentInstance;
+  }
+
+  it('always offers the global wall as the default (no-key) breadcrumb', () => {
+    const c = setup(null, []);
+    const def = c.breadcrumbs().find(b => b.key === undefined);
+    expect(def?.breadcrumbs).toEqual([{ value: 'Services', routerLink: '/services' }]);
+  });
+
+  it('cf key points back to this endpoint\'s CF services tab, labelled with the endpoint name', () => {
+    const c = setup(instanceWithSpace(), [{ guid: 'cf-1', name: 'prod-cf' }]);
+    const cf = c.breadcrumbs().find(b => b.key === 'cf');
+    expect(cf?.breadcrumbs).toEqual([
+      { value: 'prod-cf', routerLink: '/cloud-foundry/cf-1/services' },
+    ]);
+  });
+
+  it('space-services key renders the full endpoint -> org -> space trail to the space\'s service-instances tab', () => {
+    const c = setup(instanceWithSpace(), [{ guid: 'cf-1', name: 'prod-cf' }]);
+    const trail = c.breadcrumbs().find(b => b.key === 'space-services');
+    expect(trail?.breadcrumbs).toEqual([
+      { value: 'prod-cf', routerLink: '/cloud-foundry/cf-1/organizations' },
+      { value: 'acme', routerLink: '/cloud-foundry/cf-1/organizations/org-1/spaces' },
+      { value: 'dev', routerLink: '/cloud-foundry/cf-1/organizations/org-1/spaces/sp-1/service-instances' },
+    ]);
+  });
+
+  it('omits the space-services trail until the instance (with its space/org) has loaded', () => {
+    const c = setup(null, [{ guid: 'cf-1', name: 'prod-cf' }]);
+    expect(c.breadcrumbs().find(b => b.key === 'space-services')).toBeUndefined();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -22,11 +22,15 @@ interface OfferingBindableResponse {
 }
 
 // One displayable credential entry. `sensitive` drives on-screen masking;
-// `value` always holds the real value so copy works even while masked.
-interface CredentialField {
+// `value` always holds the real value so copy works even while masked;
+// `displayMasked` is what to show while hidden — a full bullet mask for plain
+// secrets, or a URL with only its password redacted so the host/port/db stay
+// readable.
+export interface CredentialField {
   key: string;
   value: string;
   sensitive: boolean;
+  displayMasked: string;
 }
 
 // Mask credential keys that look like secrets. We iterate every field (rather
@@ -38,14 +42,25 @@ const SENSITIVE_KEY = /pass|secret|token|private|key|cred/i;
 // the key ("uri"/"read_uri") looks innocuous; a plain URL without credentials
 // stays visible.
 const EMBEDDED_CREDENTIAL = /:\/\/[^/\s:@]+:[^/\s@]+@/;
+const FULL_MASK = '••••••••';
 
-function toCredentialFields(creds: Record<string, unknown>): CredentialField[] {
+// Redact only the password run in a scheme://user:pass@host URL, leaving the
+// scheme, user, host, port and path readable. Non-URL values (or URLs without
+// embedded credentials) pass through unchanged.
+function redactEmbeddedCredential(value: string): string {
+  return value.replace(/(:\/\/[^/\s:@]+:)[^/\s@]+(@)/, '$1<redacted>$2');
+}
+
+export function toCredentialFields(creds: Record<string, unknown>): CredentialField[] {
   return Object.entries(creds).map(([key, raw]) => {
     const value = typeof raw === 'string' ? raw : JSON.stringify(raw);
+    const embedsCredential = EMBEDDED_CREDENTIAL.test(value);
+    const sensitive = SENSITIVE_KEY.test(key) || embedsCredential;
     return {
       key,
       value,
-      sensitive: SENSITIVE_KEY.test(key) || EMBEDDED_CREDENTIAL.test(value),
+      sensitive,
+      displayMasked: embedsCredential ? redactEmbeddedCredential(value) : FULL_MASK,
     };
   });
 }
@@ -171,7 +186,7 @@ export class ServiceKeysComponent {
   };
   fieldShown = (guid: string, key: string): boolean => this.shownFields().has(`${guid}::${key}`);
   displayValue = (guid: string, field: CredentialField): string =>
-    field.sensitive && !this.fieldShown(guid, field.key) ? '••••••••' : field.value;
+    field.sensitive && !this.fieldShown(guid, field.key) ? field.displayMasked : field.value;
 
   constructor() {
     const route = inject(ActivatedRoute);

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -9,6 +9,7 @@ import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
 import { ServiceCatalogDataService, ServiceKeyView, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
 import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
 
 type RowStatus = 'idle' | 'busy' | 'error';
 
@@ -66,6 +67,7 @@ function toCredentialFields(creds: Record<string, unknown>): CredentialField[] {
 export class ServiceKeysComponent {
   private http = inject(HttpClient);
   private catalog = inject(ServiceCatalogDataService);
+  private endpoints = inject(CfEndpointsDataService);
 
   readonly cfGuid: string;
   readonly siGuid: string;
@@ -76,11 +78,42 @@ export class ServiceKeysComponent {
     return name ? `Service keys for '${name}'` : 'Service keys';
   });
 
-  // Breadcrumb back to the services wall (no per-instance detail page exists
-  // to link the instance itself; the title carries the instance name).
-  readonly breadcrumbs: IHeaderBreadcrumb[] = [
-    { breadcrumbs: [{ value: 'Services', routerLink: '/services' }] },
-  ];
+  // Context-aware breadcrumbs. The keys page is reached from several lists, so
+  // it offers one breadcrumb set per origin and lets PageHeader pick by the
+  // ?breadcrumbs= query hint the row action set (see buildServiceInstanceRowActions):
+  //   - default (no key): the global /services wall.
+  //   - 'cf': back to this endpoint's CF Services tab.
+  //   - 'space-services': the full endpoint -> org -> space trail back to the
+  //     space's Service Instances tab.
+  // The CF trail is built from the instance's space/organization (populated at
+  // the summary tier this page fetches) and the endpoint name from the
+  // registry; the space-services set is omitted until that data has loaded, so
+  // PageHeader transiently falls back to the default until it re-resolves.
+  readonly breadcrumbs: Signal<IHeaderBreadcrumb[]> = computed(() => {
+    const cfGuid = this.cfGuid;
+    const cfBase = `/cloud-foundry/${cfGuid}`;
+    const endpointName = this.endpoints.connectedCfList().find(e => e.guid === cfGuid)?.name ?? 'Services';
+
+    const crumbs: IHeaderBreadcrumb[] = [
+      { breadcrumbs: [{ value: 'Services', routerLink: '/services' }] },
+      { key: 'cf', breadcrumbs: [{ value: endpointName, routerLink: `${cfBase}/services` }] },
+    ];
+
+    const space = this.instanceSource.value()?.space;
+    const org = space?.organization;
+    if (space?.guid && org?.guid) {
+      const orgBase = `${cfBase}/organizations/${org.guid}`;
+      crumbs.push({
+        key: 'space-services',
+        breadcrumbs: [
+          { value: endpointName, routerLink: `${cfBase}/organizations` },
+          { value: org.name ?? 'Organization', routerLink: `${orgBase}/spaces` },
+          { value: space.name ?? 'Space', routerLink: `${orgBase}/spaces/${space.guid}/service-instances` },
+        ],
+      });
+    }
+    return crumbs;
+  });
 
   // Reloadable list source: swapping the signal re-derives keys/loading.
   private keysSource = signal<SignalSource<ServiceKeyView[]>>(

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.spec.ts
@@ -38,6 +38,8 @@ function makeStubSignalConfigService() {
     registerFilterExtractor: vi.fn(),
     deleteServiceInstance: vi.fn().mockResolvedValue(undefined),
     isOfferingBindable: vi.fn().mockReturnValue(undefined),
+    serviceKeyCount: vi.fn().mockReturnValue(undefined),
+    ensureServiceKeyCounts: vi.fn(),
     filter: filterSig,
     sort: sortSig,
     pageSize,
@@ -116,12 +118,23 @@ describe('ServicesWallComponent', () => {
     const cfg = component.listConfig();
     expect(cfg).toBeDefined();
     expect(cfg!.columns.map(c => c.header)).toEqual([
-      'Name', 'Service', 'Last Operation', 'Attached Apps', 'Tags', 'Created', 'Type', 'CF', '', '',
+      'Name', 'Service', 'Last Operation', 'Attached Apps', 'Service Keys', 'Tags', 'Created', 'Type', 'CF', '', '',
     ]);
     expect(cfg!.getRowKey({
       cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'redis', type: 'managed',
       tags: [], createdAt: '',
     } as any)).toBe('cnsi-1:si-1');
+  });
+
+  it('Service Keys column links to the keys page, renders the lazy count, and triggers the fetch', async () => {
+    await component.ngOnInit();
+    await Promise.resolve();
+    const col: any = component.listConfig()!.columns.find(c => c.key === 'serviceKeys');
+    expect(col.kind).toBe('link');
+    const si: any = { cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'redis', type: 'managed' };
+    expect(col.link(si)).toEqual(['/services', 'service', 'cnsi-1', 'si-1', 'keys']);
+    expect(col.render(si)).toBe('—');
+    expect(stubSignalConfig.ensureServiceKeyCounts).toHaveBeenCalled();
   });
 
   it('renders Service column from offering name for managed and label for user-provided', async () => {

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -30,6 +30,7 @@ import {
 } from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
 import { CloudFoundryService } from '../../../shared/data-services/cloud-foundry.service';
 import { boundAppSegments, renderBoundApps } from '../../../shared/signal-list-configs/bound-apps-cell';
+import { renderServiceKeyCount, serviceKeysLink } from '../../../shared/signal-list-configs/service-keys-count-cell';
 import { buildServiceInstanceRowActions } from '../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import type { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 
@@ -253,6 +254,12 @@ export class ServicesWallComponent implements OnInit {
           widthHint: '14rem',
         },
         {
+          header: 'Service Keys', key: 'serviceKeys', kind: 'link',
+          render: (si) => renderServiceKeyCount(si, this.instancesConfig.serviceKeyCount(si.guid)),
+          link: serviceKeysLink,
+          widthHint: '8rem',
+        },
+        {
           header: 'Tags', key: 'tags', sortField: renderTags,
           render: renderTags,
           widthHint: '14rem',
@@ -326,7 +333,7 @@ export class ServicesWallComponent implements OnInit {
     this.instancesConfig.registerFilterExtractor('tags', renderTags);
 
     if (cnsiGuids.length > 0) {
-      void this.instancesConfig.loadAll();
+      void this.instancesConfig.loadAll().then(() => this.instancesConfig.ensureServiceKeyCounts());
     }
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HttpClient } from '@angular/common/http';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
 import { CfServiceInstancesSignalConfigService } from './cf-service-instances-signal-config.service';
 import { CloudFoundryService } from '../../data-services/cloud-foundry.service';
@@ -194,5 +194,102 @@ describe('CfServiceInstancesSignalConfigService cache wiring', () => {
     await svc.loadAll();
     expect((http.get as any)).toHaveBeenCalled();
     expect(svc.orchestrator.sources[0].items().map(s => s.guid)).toEqual(['si-1']);
+  });
+});
+
+// Routes instance loads vs the batched service_keys count fetch onto one mock,
+// branching on the URL so a single test can drive both.
+function makeRoutingHttp(opts: {
+  instances: StServiceInstance[];
+  keys?: Array<{ owner: string }>;
+  keysFail?: boolean;
+}): HttpClient {
+  const instancesBody = {
+    resources: opts.instances,
+    pagination: {
+      totalResults: opts.instances.length, totalPages: 1,
+      next: null, previous: null, first: { href: '' }, last: { href: '' },
+    },
+  };
+  const keysBody = {
+    resources: (opts.keys ?? []).map((k, i) => ({
+      guid: `key-${i}`,
+      relationships: { service_instance: { data: { guid: k.owner } } },
+    })),
+  };
+  return {
+    get: vi.fn((url: string) => {
+      if (typeof url === 'string' && url.includes('/service_keys/')) {
+        return opts.keysFail ? throwError(() => new Error('boom')) : of(keysBody);
+      }
+      return of(instancesBody);
+    }),
+  } as unknown as HttpClient;
+}
+
+const flush = () => new Promise(r => setTimeout(r));
+
+describe('CfServiceInstancesSignalConfigService — lazy service-key counts', () => {
+  it('counts keys per instance from one batched request (2 / 0 split)', async () => {
+    const instances = [
+      makeInstance({ guid: 'si-a', cnsiGuid: 'cnsi-1' }),
+      makeInstance({ guid: 'si-b', cnsiGuid: 'cnsi-1' }),
+    ];
+    const http = makeRoutingHttp({ instances, keys: [{ owner: 'si-a' }, { owner: 'si-a' }] });
+    const svc = makeSvc(http);
+    svc.initialize(['cnsi-1']);
+    await svc.loadAll();
+
+    svc.ensureServiceKeyCounts();
+    await flush();
+
+    expect(svc.serviceKeyCount('si-a')).toBe(2);
+    expect(svc.serviceKeyCount('si-b')).toBe(0);
+  });
+
+  it('issues a single batched service_keys request for the CNSI', async () => {
+    const instances = [
+      makeInstance({ guid: 'si-a', cnsiGuid: 'cnsi-1' }),
+      makeInstance({ guid: 'si-b', cnsiGuid: 'cnsi-1' }),
+    ];
+    const http = makeRoutingHttp({ instances, keys: [] });
+    const svc = makeSvc(http);
+    svc.initialize(['cnsi-1']);
+    await svc.loadAll();
+
+    svc.ensureServiceKeyCounts();
+    svc.ensureServiceKeyCounts(); // idempotent: no duplicate fetch
+    await flush();
+
+    const keyCalls = (http.get as any).mock.calls.filter((c: any[]) => String(c[0]).includes('/service_keys/'));
+    expect(keyCalls.length).toBe(1);
+  });
+
+  it('leaves counts undefined when the batched request fails (tolerated)', async () => {
+    const instances = [makeInstance({ guid: 'si-a', cnsiGuid: 'cnsi-1' })];
+    const http = makeRoutingHttp({ instances, keysFail: true });
+    const svc = makeSvc(http);
+    svc.initialize(['cnsi-1']);
+    await svc.loadAll();
+
+    svc.ensureServiceKeyCounts();
+    await flush();
+
+    expect(svc.serviceKeyCount('si-a')).toBeUndefined();
+  });
+
+  it('does not fetch counts for user-provided instances (no keys page)', async () => {
+    const instances = [makeInstance({ guid: 'ups-1', cnsiGuid: 'cnsi-1', type: 'user-provided' })];
+    const http = makeRoutingHttp({ instances });
+    const svc = makeSvc(http);
+    svc.initialize(['cnsi-1']);
+    await svc.loadAll();
+
+    svc.ensureServiceKeyCounts();
+    await flush();
+
+    const keyCalls = (http.get as any).mock.calls.filter((c: any[]) => String(c[0]).includes('/service_keys/'));
+    expect(keyCalls.length).toBe(0);
+    expect(svc.serviceKeyCount('ups-1')).toBeUndefined();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service.ts
@@ -1,6 +1,7 @@
 import { DestroyRef, EffectRef, Injectable, Injector, Signal, WritableSignal, computed, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import type { EndpointModel } from '@stratosui/store';
 import { EndpointErrorEventsService } from '@stratosui/store';
 import { CnsiServiceInstancesSource } from '../../../services/data-sources/cnsi-service-instances-source';
@@ -148,6 +149,15 @@ export class CfServiceInstancesSignalConfigService {
   // orchestrator's HTTP drain on revisit by pre-seeding each per-CNSI
   // source from the registry's pre-warmed services-details cache.
   private readonly registry = inject(EndpointDataRegistry, { optional: true });
+
+  // Lazy per-instance service-key counts. guid → count; absent = not yet
+  // loaded / failed (rendered as "—"). Filled by ensureServiceKeyCounts via a
+  // batched fetch per CNSI; read reactively by the list's Service Keys column
+  // render. Deliberately an explicit method + cache (not an effect) so the
+  // root-singleton config never leaks an uncaptured effect across re-entry.
+  private readonly _keyCountByGuid: WritableSignal<Map<string, number>> = signal(new Map());
+  // CNSIs with a count fetch in flight — dedupes ensureServiceKeyCounts() calls.
+  private readonly _keyCountCnsiInFlight = new Set<string>();
 
   constructor() {
     const cfService = inject(CloudFoundryService, { optional: true });
@@ -426,6 +436,9 @@ export class CfServiceInstancesSignalConfigService {
   // releases everything.
   private _destroyHookRegistered = false;
   private swapAcquiredEds(cnsiGuids: readonly string[]): void {
+    // New scope ⇒ drop stale key counts so a re-bound list re-fetches fresh.
+    this._keyCountByGuid.set(new Map());
+    this._keyCountCnsiInFlight.clear();
     if (!this.registry) {
       this._edsByCnsi.set(new Map());
       return;
@@ -549,6 +562,65 @@ export class CfServiceInstancesSignalConfigService {
       path: `/pp/v1/cf/service_instances/${cnsiGuid}/${siGuid}`,
     });
     this.orchestrator?.removeRow(cnsiGuid, siGuid);
+  }
+
+  // Read a previously-fetched key count. undefined = not yet loaded or the
+  // fetch failed — callers render "—" rather than a misleading "0".
+  serviceKeyCount(guid: string): number | undefined {
+    return this._keyCountByGuid().get(guid);
+  }
+
+  // Lazily fetch service-key counts for the currently-loaded managed
+  // instances, batched one request per CNSI. Idempotent: skips guids already
+  // counted and CNSIs whose fetch is in flight, so the consuming list can call
+  // it freely after each load without duplicate requests. User-provided
+  // instances are skipped (they have no service keys / keys page).
+  ensureServiceKeyCounts(): void {
+    if (!this.orchestrator) return;
+    const known = this._keyCountByGuid();
+    const guidsByCnsi = new Map<string, string[]>();
+    for (const si of this.orchestrator.allItems()) {
+      if (si.type === 'user-provided' || known.has(si.guid)) continue;
+      const list = guidsByCnsi.get(si.cnsiGuid) ?? [];
+      list.push(si.guid);
+      guidsByCnsi.set(si.cnsiGuid, list);
+    }
+    for (const [cnsiGuid, guids] of guidsByCnsi) {
+      if (this._keyCountCnsiInFlight.has(cnsiGuid)) continue;
+      this._keyCountCnsiInFlight.add(cnsiGuid);
+      void this.fetchKeyCounts(cnsiGuid, guids);
+    }
+  }
+
+  // One batched GET per CNSI: ask for every requested instance's keys in a
+  // single call, then group the returned bindings by their owning instance
+  // guid. A requested guid with no returned bindings is a real 0; a failed
+  // request leaves every guid undefined (tolerated → "—"). per_page is set
+  // high so the single page covers all of the page's instances' keys.
+  private async fetchKeyCounts(cnsiGuid: string, guids: string[]): Promise<void> {
+    try {
+      const params = new HttpParams()
+        .set('service_instance_guids', guids.join(','))
+        .set('per_page', '5000');
+      const res = await firstValueFrom(
+        this.http.get<{ resources?: Array<{ relationships?: { service_instance?: { data?: { guid?: string } } } }> }>(
+          `/pp/v1/cf/service_keys/${cnsiGuid}`, { params }),
+      );
+      const counts = new Map<string, number>(guids.map(g => [g, 0]));
+      for (const binding of res?.resources ?? []) {
+        const owner = binding?.relationships?.service_instance?.data?.guid;
+        if (owner && counts.has(owner)) counts.set(owner, (counts.get(owner) ?? 0) + 1);
+      }
+      this._keyCountByGuid.update(prev => {
+        const next = new Map(prev);
+        for (const [g, c] of counts) next.set(g, c);
+        return next;
+      });
+    } catch {
+      // Tolerated: leave the counts undefined so the column shows "—".
+    } finally {
+      this._keyCountCnsiInFlight.delete(cnsiGuid);
+    }
   }
 
   // isOfferingBindable resolves the instance's service-offering bindability

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/service-instance-row-actions.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/service-instance-row-actions.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+import { buildServiceInstanceRowActions, ServiceInstanceRowActionDeps } from './service-instance-row-actions';
+
+// A managed instance so the gated "Service Keys" action is present.
+const managed = (): StServiceInstance => ({
+  guid: 'si-1',
+  cnsiGuid: 'cf-1',
+  name: 'my-db',
+  type: 'managed',
+} as StServiceInstance);
+
+function deps(overrides: Partial<ServiceInstanceRowActionDeps> = {}): ServiceInstanceRowActionDeps {
+  return {
+    router: { navigate: vi.fn() } as unknown as ServiceInstanceRowActionDeps['router'],
+    confirmDialog: { open: vi.fn() } as unknown as ServiceInstanceRowActionDeps['confirmDialog'],
+    snackBar: { error: vi.fn() } as unknown as ServiceInstanceRowActionDeps['snackBar'],
+    deleteServiceInstance: vi.fn(),
+    isOfferingBindable: () => true,
+    ...overrides,
+  };
+}
+
+const keysAction = (si: StServiceInstance, d: ServiceInstanceRowActionDeps) =>
+  buildServiceInstanceRowActions(si, d).find(a => a.label === 'Service Keys');
+
+describe('buildServiceInstanceRowActions — Service Keys breadcrumb context', () => {
+  it('tags the keys nav with ?breadcrumbs=<key> when a breadcrumbKey is given', () => {
+    const d = deps({ breadcrumbKey: 'space-services' });
+    keysAction(managed(), d)!.invoke();
+
+    expect(d.router.navigate).toHaveBeenCalledWith(
+      ['/services', 'service', 'cf-1', 'si-1', 'keys'],
+      { queryParams: { breadcrumbs: 'space-services' } },
+    );
+  });
+
+  it('navigates without a breadcrumbs query param when no key is given (global wall)', () => {
+    const d = deps();
+    keysAction(managed(), d)!.invoke();
+
+    expect(d.router.navigate).toHaveBeenCalledWith(
+      ['/services', 'service', 'cf-1', 'si-1', 'keys'],
+    );
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/service-instance-row-actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-instance/service-instance-row-actions.ts
@@ -23,6 +23,12 @@ export interface ServiceInstanceRowActionDeps {
   // services-details store (CfServiceInstancesSignalConfigService
   // .isOfferingBindable). undefined → offering not cached yet (fail open).
   isOfferingBindable: (si: StServiceInstance) => boolean | undefined;
+  // Origin breadcrumb hint for the Service Keys page. CF-scoped lists pass a
+  // key (e.g. 'cf', 'space-services') that the keys page's PageHeader reads
+  // from ?breadcrumbs= to render a breadcrumb back into the originating CF
+  // context, instead of popping out to the global /services wall. Omitted by
+  // the global wall and marketplace lists, which want that default.
+  breadcrumbKey?: string;
 }
 
 // supportsServiceKeys — service keys are broker-mediated credential bindings
@@ -72,7 +78,10 @@ export function buildServiceInstanceRowActions(
     actions.push({
       label: 'Service Keys', icon: 'vpn_key',
       invoke: () => {
-        void deps.router.navigate(['/services', siType, si.cnsiGuid, si.guid, 'keys']);
+        const route = ['/services', siType, si.cnsiGuid, si.guid, 'keys'];
+        void (deps.breadcrumbKey
+          ? deps.router.navigate(route, { queryParams: { breadcrumbs: deps.breadcrumbKey } })
+          : deps.router.navigate(route));
       },
     });
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-keys-count-cell.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-keys-count-cell.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+
+import type { StServiceInstance } from '../../services/endpoint-data/stratos-types';
+import { renderServiceKeyCount, serviceKeysLink } from './service-keys-count-cell';
+
+const managed = (): StServiceInstance => ({
+  guid: 'si-1', cnsiGuid: 'cf-1', name: 'cache', type: 'managed',
+} as StServiceInstance);
+
+describe('renderServiceKeyCount', () => {
+  it('renders an em-dash when the count is not yet known', () => {
+    expect(renderServiceKeyCount(managed(), undefined)).toBe('—');
+  });
+
+  it('renders 0 distinctly from unknown', () => {
+    expect(renderServiceKeyCount(managed(), 0)).toBe('0');
+  });
+
+  it('renders a known positive count', () => {
+    expect(renderServiceKeyCount(managed(), 3)).toBe('3');
+  });
+});
+
+describe('serviceKeysLink', () => {
+  it('links a managed instance to its keys page', () => {
+    expect(serviceKeysLink(managed())).toEqual(['/services', 'service', 'cf-1', 'si-1', 'keys']);
+  });
+
+  it('returns null for a user-provided instance (no keys page)', () => {
+    const ups = { guid: 'ups-1', cnsiGuid: 'cf-1', name: 'ups', type: 'user-provided' } as StServiceInstance;
+    expect(serviceKeysLink(ups)).toBeNull();
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-keys-count-cell.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/service-keys-count-cell.ts
@@ -1,0 +1,25 @@
+import type { StServiceInstance } from '../../services/endpoint-data/stratos-types';
+
+// Shared "Service Keys" count cell over a per-instance key count resolved
+// lazily by the list config (CfServiceInstancesSignalConfigService
+// .serviceKeyCount). The count rides in as an argument rather than off the row
+// so the column's render stays a pure function the signal-list can re-invoke
+// reactively when the count map fills in. Used by every service-instance list
+// for consistency (services wall, CF services tab, space service-instances,
+// offering instances). Mirrors the shape of bound-apps-cell.ts.
+//
+// The same module will later host the service-routes (route bindings) count —
+// keep it generic enough to clone.
+
+// undefined = count not yet loaded (or the fetch failed) → an em-dash so it
+// reads as "unknown", distinct from a real "0" (instance has no keys).
+export function renderServiceKeyCount(_si: StServiceInstance, count: number | undefined): string {
+  return count === undefined ? '—' : String(count);
+}
+
+// Whole-cell link target to the instance's keys page, or null for
+// user-provided instances (not bindable → no keys page exists for them).
+export function serviceKeysLink(si: StServiceInstance): readonly (string | number)[] | null {
+  if (si.type === 'user-provided') return null;
+  return ['/services', 'service', si.cnsiGuid, si.guid, 'keys'];
+}


### PR DESCRIPTION
Six commits on one branch, two related threads of Service Keys work.

## Service Keys page

- E2E coverage for the #4301 keys page: six broker-dependent specs (page render, empty-or-list, default credential masking, add-form open/cancel, bindable gating). They skip when no managed instance is available and never print credential values.
- Context-aware breadcrumbs. Opening Service Keys from a CF endpoint or space list previously popped the user out to the global `/services` wall. The row action now tags the keys nav with `?breadcrumbs=cf|space-services` and the keys page builds the matching trail (endpoint Services tab, or the full endpoint - org - space trail back to the space's Service Instances tab) from the loaded instance plus the endpoint registry, using the existing keyed-breadcrumb convention from `application-tabs-base`.
- Partial URL masking. Connection-string credentials (`uri`/`jdbc_uri`/`read_uri`) were masked whole, hiding the readable host/port/db along with the password. They now redact only the password run, e.g. `postgres://user:<redacted>@host:5432/db`; plain key-sensitive secrets stay fully masked. The copied value and the Show toggle still expose the real credential.

## Per-instance Service Keys count

- A "Service Keys" count column on every service-instance list: the offering Instances tab, the services wall, the CF space service-instances tab, and the CF services tab. Each cell is a whole-cell link to that instance's keys page and shows an em-dash until the count loads.
- Counts are fetched lazily, one batched request per CNSI (`?service_instance_guids=...`), grouped by each binding's owning service instance, and cached in a signal the column reads. The fetch is idempotent (skips already-counted guids and in-flight CNSIs), tolerant (a failed request leaves the dash), skips user-provided instances, and uses an explicit method plus cache rather than a root-injector effect.

Developed test-first throughout. Full `make check gate` is green: 2639 frontend unit tests pass, the production build is clean, and the Go test suite passes.
