### PR TITLE
CF Users: faster role load, view toggle, mixed-role summary, role-cell links

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.spec.ts
@@ -139,6 +139,37 @@ describe('CloudFoundryUsersComponent', () => {
     expect(text).toContain('developer');
   });
 
+  it('Space Roles compound: links from guids and uses the payload space name before maps resolve', () => {
+    const cfg = component.listConfig();
+    const spaceCol = cfg!.columns.find(c => c.key === 'spaceRoles');
+    // org-9 / space-9 are NOT in the lookup maps (simulates pre-loadDetails),
+    // but the bucket carries spaceName from the include=space payload.
+    const u: any = {
+      cnsiGuid: 'cnsi-1', guid: 'user-9', username: 'dave',
+      orgRoles: [],
+      spaceRoles: [{ orgGuid: 'org-9', spaceGuid: 'space-9', spaceName: 'PayloadSpace', roles: ['developer'] }],
+    };
+    const segs = spaceCol!.compound!(u);
+    // Space name comes straight from the payload (no map lookup needed).
+    expect(segs[0].text).toContain('PayloadSpace');
+    // Link is built from guids, so it's present even though the org name hasn't resolved.
+    expect(segs[0].link).toEqual(['/cloud-foundry', 'cnsi-1', 'organizations', 'org-9', 'spaces', 'space-9']);
+  });
+
+  it('Org Roles compound: links from the org guid before the name resolves', () => {
+    const cfg = component.listConfig();
+    const orgCol = cfg!.columns.find(c => c.key === 'orgRoles');
+    // org-9 is not in the lookup map — text falls back to the short guid, but
+    // the cell must still be a link (target is guid-based).
+    const u: any = {
+      cnsiGuid: 'cnsi-1', guid: 'user-9', username: 'dave',
+      orgRoles: [{ orgGuid: 'org-9', roles: ['manager'] }],
+      spaceRoles: [],
+    };
+    const segs = orgCol!.compound!(u);
+    expect(segs[0].link).toEqual(['/cloud-foundry', 'cnsi-1', 'organizations', 'org-9']);
+  });
+
   // Note: a previous test asserted on `cfg.headerActions` for an "Invite
   // User" placeholder action. SignalListConfig.headerActions was removed
   // (see commit "Sweep remaining headerActions consumers"); a framework

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.ts
@@ -215,7 +215,10 @@ export class CloudFoundryUsersComponent {
       for (const r of roles) {
         const orgName = this.usersConfig.orgNameByGuid().get(r.orgGuid);
         const labelText = `${orgName ?? this.shortGuid(r.orgGuid)}: ${(r.roles ?? []).join(', ')}`;
-        if (orgName) {
+        // Link target is guid-based, so link from the first render rather than
+        // waiting for the org name to resolve — the text upgrades guid → name
+        // reactively when the org map loads.
+        if (r.orgGuid) {
           out.push({
             text: labelText,
             link: ['/cloud-foundry', u.cnsiGuid, 'organizations', r.orgGuid],
@@ -238,13 +241,17 @@ export class CloudFoundryUsersComponent {
       if (roles.length === 0) return [{ text: '—' }];
       const out: SignalListCompoundSegment[] = [];
       for (const r of roles) {
-        const spaceName = this.usersConfig.spaceNameByGuid().get(r.spaceGuid);
+        // Prefer the space name carried in the role payload (include=space) so
+        // it shows immediately; fall back to the endpoint-data map.
+        const spaceName = r.spaceName ?? this.usersConfig.spaceNameByGuid().get(r.spaceGuid);
         const orgName = r.orgGuid ? this.usersConfig.orgNameByGuid().get(r.orgGuid) : undefined;
         const display = spaceName
           ? (orgName ? `${orgName} / ${spaceName}` : spaceName)
           : this.shortGuid(r.spaceGuid);
         const labelText = `${display}: ${(r.roles ?? []).join(', ')}`;
-        if (spaceName && r.orgGuid) {
+        // Link target is guid-based — link from the first render rather than
+        // gating on name resolution; the label upgrades reactively.
+        if (r.orgGuid && r.spaceGuid) {
           out.push({
             text: labelText,
             link: ['/cloud-foundry', u.cnsiGuid, 'organizations', r.orgGuid, 'spaces', r.spaceGuid],
@@ -416,7 +423,7 @@ export class CloudFoundryUsersComponent {
   }
 
   private spaceLabel(r: StUserSpaceRole): string {
-    const spaceName = this.usersConfig.spaceNameByGuid().get(r.spaceGuid);
+    const spaceName = r.spaceName ?? this.usersConfig.spaceNameByGuid().get(r.spaceGuid);
     if (!spaceName) return this.shortGuid(r.spaceGuid);
     const orgName = r.orgGuid ? this.usersConfig.orgNameByGuid().get(r.orgGuid) : undefined;
     return orgName ? `${orgName} / ${spaceName}` : spaceName;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/cf-roles.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/cf-roles.service.spec.ts
@@ -129,17 +129,17 @@ describe('CfRolesService', () => {
     const user = stUser({
       guid: 'user-1',
       orgRoles: [{ orgGuid: 'org-1', roles: ['manager', 'user'] }],
-      spaceRoles: [{ orgGuid: 'org-1', spaceGuid: 'space-1', roles: ['developer'] }],
+      spaceRoles: [{ orgGuid: 'org-1', spaceGuid: 'space-1', spaceName: 'My Space', roles: ['developer'] }],
     });
 
     const result = firstValueFrom(service.populateRoles('cf-1', [user]).pipe(take(1)));
 
-    // Names are sourced via the native list endpoints (no per-user re-fetch),
-    // drained page-by-page (page 1 here covers the full result set).
+    // Org names still come from the (bounded) native org list. Space names now
+    // ride in on the StUser bucket (include=space), so the full /pp/v1/cf/spaces
+    // drain is gone.
     httpMock.expectOne('/pp/v1/cf/orgs/cf-1?per_page=500&page=1')
       .flush({ resources: [{ guid: 'org-1', name: 'My Org', cnsiGuid: 'cf-1' }], totalResults: 1 });
-    httpMock.expectOne('/pp/v1/cf/spaces/cf-1?per_page=500&page=1')
-      .flush({ resources: [{ guid: 'space-1', name: 'My Space', orgGuid: 'org-1', cnsiGuid: 'cf-1' }], totalResults: 1 });
+    httpMock.expectNone('/pp/v1/cf/spaces/cf-1?per_page=500&page=1');
 
     const roles = await result;
     const org = roles['user-1']['org-1'];
@@ -161,15 +161,14 @@ describe('CfRolesService', () => {
     const user = stUser({
       guid: 'user-9',
       orgRoles: [],
-      spaceRoles: [{ orgGuid: 'org-2', spaceGuid: 'space-2', roles: ['auditor'] }],
+      spaceRoles: [{ orgGuid: 'org-2', spaceGuid: 'space-2', spaceName: 'Space Two', roles: ['auditor'] }],
     });
 
     const result = firstValueFrom(service.populateRoles('cf-1', [user]).pipe(take(1)));
 
     httpMock.expectOne('/pp/v1/cf/orgs/cf-1?per_page=500&page=1')
       .flush({ resources: [], totalResults: 0 });
-    httpMock.expectOne('/pp/v1/cf/spaces/cf-1?per_page=500&page=1')
-      .flush({ resources: [{ guid: 'space-2', name: 'Space Two', orgGuid: 'org-2', cnsiGuid: 'cf-1' }], totalResults: 1 });
+    httpMock.expectNone('/pp/v1/cf/spaces/cf-1?per_page=500&page=1');
 
     const roles = await result;
     expect(Object.keys(roles)).toEqual(['user-9']);
@@ -194,8 +193,7 @@ describe('CfRolesService', () => {
       .flush({ resources: [], totalResults: 600 });
     httpMock.expectOne('/pp/v1/cf/orgs/cf-1?per_page=500&page=2')
       .flush({ resources: [{ guid: 'org-far', name: 'Far Org', cnsiGuid: 'cf-1' }], totalResults: 600 });
-    httpMock.expectOne('/pp/v1/cf/spaces/cf-1?per_page=500&page=1')
-      .flush({ resources: [], totalResults: 0 });
+    httpMock.expectNone('/pp/v1/cf/spaces/cf-1?per_page=500&page=1');
 
     const roles = await result;
     expect(roles['user-1']['org-far'].name).toBe('Far Org');
@@ -291,9 +289,8 @@ describe('CfRolesService', () => {
       .flush({ resources: [], totalResults: 600 });
     httpMock.expectOne('/pp/v1/cf/orgs/cf-total?per_page=500&page=2')
       .flush({ resources: [{ guid: 'org-far', name: 'Far Org', cnsiGuid: 'cf-total' }], totalResults: 600 });
-    // Spaces: totalResults=0 → 1 page (fast path, single)
-    httpMock.expectOne('/pp/v1/cf/spaces/cf-total?per_page=500&page=1')
-      .flush({ resources: [], totalResults: 0 });
+    // Space names ride in on the StUser bucket now — no /pp/v1/cf/spaces drain.
+    httpMock.expectNone('/pp/v1/cf/spaces/cf-total?per_page=500&page=1');
 
     const roles = await result;
     expect(roles['user-1']['org-far'].name).toBe('Far Org');

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/cf-roles.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/cf-roles.service.ts
@@ -62,7 +62,6 @@ export class CfRolesService {
   loading$: Observable<boolean>;
   cfOrgs: { [cfGuid: string]: Observable<APIResource<IOrganization>[]>, } = {};
   private cfOrgNames: { [cfGuid: string]: Observable<StOrg[]>, } = {};
-  private cfSpaces: { [cfGuid: string]: Observable<StSpace[]>, } = {};
   // Per-org space cache (keyed `${cfGuid}:${orgGuid}`). Survives re-subscription
   // (shareReplay, no refCount) so re-expanding a section reuses the result.
   private cfOrgSpaces: { [key: string]: Observable<{ guid: string; name: string }[]>, } = {};
@@ -149,19 +148,20 @@ export class CfRolesService {
 
     // The picked users are already the fully-drained StUser rows (org/space
     // role buckets carry the prefix-stripped role names per scope), so there's
-    // no per-user re-fetch. The buckets hold guids only, so the org/space
-    // *names* are resolved from the native list endpoints via the unfiltered
-    // name-lookup fetches (fetchOrgNames / fetchSpaces). These deliberately
-    // bypass fetchOrgs' editability filter — that filter belongs where roles
-    // are applied, not where display names are resolved, and it would otherwise
-    // leave existingRoles$ never emitting for empty/non-editable org lists.
-    return combineLatest([this.fetchOrgNames(cfGuid), this.fetchSpaces(cfGuid)]).pipe(
+    // no per-user re-fetch. Space *names* now ride in on the space buckets
+    // (resolved server-side from the /v3/roles include=space block), so the
+    // wizard no longer drains the whole /pp/v1/cf/spaces list — that drain was
+    // the dominant cost of "Loading existing roles…". Org names still come from
+    // the bounded native org list (fetchOrgNames), which deliberately bypasses
+    // fetchOrgs' editability filter — display-name resolution isn't where role
+    // editability belongs, and filtering would leave existingRoles$ never
+    // emitting for empty/non-editable org lists.
+    return this.fetchOrgNames(cfGuid).pipe(
       take(1),
-      map(([orgs, spaces]) => {
+      map(orgs => {
         const orgNameByGuid = new Map<string, string>(orgs.map(o => [o.guid, o.name]));
-        const spaceNameByGuid = new Map<string, string>(spaces.map(s => [s.guid, s.name]));
         const roles: CfUserRolesSelected = {};
-        selectedUsers.forEach(user => this.populateUserRoles(user, roles, orgNameByGuid, spaceNameByGuid));
+        selectedUsers.forEach(user => this.populateUserRoles(user, roles, orgNameByGuid));
         return roles;
       }),
     );
@@ -171,11 +171,10 @@ export class CfRolesService {
     user: StUser,
     roles: CfUserRolesSelected,
     orgNameByGuid: Map<string, string>,
-    spaceNameByGuid: Map<string, string>,
   ) {
     const mappedUser: { [orgGuid: string]: IUserPermissionInOrg, } = {};
     const orgRoles = orgRolesFromStUser(user, orgNameByGuid);
-    const spaceRoles = spaceRolesFromStUser(user, orgNameByGuid, spaceNameByGuid);
+    const spaceRoles = spaceRolesFromStUser(user, orgNameByGuid);
     // ... populate org roles ...
     orgRoles.forEach(org => {
       mappedUser[org.orgGuid] = {
@@ -400,23 +399,6 @@ export class CfRolesService {
         );
       }),
     );
-  }
-
-  /**
-   * Native space list used purely as a guid→name lookup when mapping a user's
-   * StUser space-role buckets into the wizard's `existingRoles` shape. Unlike
-   * fetchOrgs this is not editable-filtered — it only supplies display names;
-   * role editability is enforced downstream where the changes are applied.
-   */
-  private fetchSpaces(cfGuid: string): Observable<StSpace[]> {
-    if (!this.cfSpaces[cfGuid]) {
-      this.cfSpaces[cfGuid] = this.drainCfList<StSpace>(`/pp/v1/cf/spaces/${cfGuid}`).pipe(
-        catchError(() => of([] as StSpace[])),
-        publishReplay(1),
-        refCount(),
-      );
-    }
-    return this.cfSpaces[cfGuid];
   }
 
   /**

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
@@ -582,6 +582,9 @@ export interface StUserOrgRole {
 export interface StUserSpaceRole {
   orgGuid: string;
   spaceGuid: string;
+  // Resolved server-side from the /v3/roles include=space block so the role
+  // editor can label spaces without draining the full /pp/v1/cf/spaces list.
+  spaceName?: string;
   roles: string[];
 }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.html
@@ -61,7 +61,13 @@
         <span class="truncate">{{ org.entity.name }}</span>
       </button>
       <span class="role-assignment__summary shrink-0 text-xs text-content-muted" data-testid="org-role-summary">
-        {{ roleCountForOrg(org.metadata.guid) }} role{{ roleCountForOrg(org.metadata.guid) === 1 ? '' : 's' }} set
+        @let setCount = roleCountForOrg(org.metadata.guid);
+        @let mixedCount = mixedRoleCountForOrg(org.metadata.guid);
+        @if (mixedCount > 0) {
+          {{ setCount }} set · {{ mixedCount }} mixed
+        } @else {
+          {{ setCount }} role{{ setCount === 1 ? '' : 's' }} set
+        }
       </span>
       @if (!lockedOrg) {
         <button

--- a/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.html
@@ -35,6 +35,24 @@
   </div>
 }
 
+<!-- View toggle: accordion ↔ split. Hidden for lockedOrg (single org) and
+     until at least one org is picked. -->
+@if (!lockedOrg && pickedOrgs().length > 0) {
+  <div class="role-assignment__toolbar flex items-center justify-end mt-3">
+    <button
+      type="button"
+      data-testid="view-toggle"
+      (click)="setViewMode(viewMode() === 'accordion' ? 'split' : 'accordion')"
+      [title]="viewMode() === 'accordion' ? 'Two-pane view' : 'Stacked view'"
+      [attr.aria-pressed]="viewMode() === 'split'"
+      class="role-assignment__view-toggle flex items-center gap-1.5 px-2 py-1 text-xs rounded border border-content-border bg-content-bg text-content-text hover:bg-primary-50"
+    >
+      <span class="material-icons text-base leading-5">{{ viewMode() === 'accordion' ? 'view_column' : 'view_agenda' }}</span>
+      {{ viewMode() === 'accordion' ? 'Two-pane' : 'Stacked' }}
+    </button>
+  </div>
+}
+
 <!-- Roles still resolving and nothing seeded yet -->
 @if (loading() && pickedOrgs().length === 0) {
   <div class="flex items-center gap-2 mt-3 px-3 py-4 text-sm text-content-muted">
@@ -43,102 +61,169 @@
   </div>
 }
 
-<!-- Accordion: one section per picked org -->
-@for (org of pickedOrgs(); track org.metadata.guid) {
-  <div
-    class="role-assignment__org-section mt-3 rounded border border-content-border bg-content-bg-alt overflow-hidden"
-    [attr.data-org]="org.metadata.guid"
-  >
-    <!-- Accordion header -->
-    <div class="role-assignment__org-header flex items-center gap-3 px-3 py-2">
-      <button
-        type="button"
-        (click)="toggleExpanded(org.metadata.guid)"
-        class="role-assignment__accordion-btn flex-1 flex items-center gap-2 min-w-0 text-left text-sm font-semibold text-content-text"
-        [attr.aria-expanded]="isExpanded(org.metadata.guid)"
-      >
-        <span class="role-assignment__chevron shrink-0 text-xs text-primary">{{ isExpanded(org.metadata.guid) ? '▲' : '▼' }}</span>
-        <span class="truncate">{{ org.entity.name }}</span>
-      </button>
-      <span class="role-assignment__summary shrink-0 text-xs text-content-muted" data-testid="org-role-summary">
-        @let setCount = roleCountForOrg(org.metadata.guid);
-        @let mixedCount = mixedRoleCountForOrg(org.metadata.guid);
-        @if (mixedCount > 0) {
-          {{ setCount }} set · {{ mixedCount }} mixed
-        } @else {
-          {{ setCount }} role{{ setCount === 1 ? '' : 's' }} set
+<!-- Shared org+space role editor body, reused by both layouts. -->
+<ng-template #orgRolesBody let-org="org">
+  <div class="role-assignment__org-body px-3 py-3 flex flex-col gap-5">
+    <!-- Org-level role cells -->
+    <div class="role-assignment__org-roles flex flex-col gap-2">
+      <h4 class="m-0 text-xs font-semibold uppercase tracking-wide text-content-muted">Org Roles</h4>
+      <div class="role-assignment__role-row flex flex-wrap gap-x-6 gap-y-2">
+        @for (def of orgRoleDefs; track def.name) {
+          <div data-testid="org-role-cell" class="role-assignment__role-cell">
+            <app-role-tristate-checkbox
+              [checked]="checkedForOrg(org.metadata.guid, def.name)"
+              [disabled]="!canEditOrg(org.metadata.guid) || (def.name === orgUserRole && isOrgUserDisabled(org.metadata.guid))"
+              [label]="def.label"
+              (toggled)="onToggleOrgRole(org, def.name, $event)"
+            ></app-role-tristate-checkbox>
+          </div>
         }
-      </span>
-      @if (!lockedOrg) {
-        <button
-          type="button"
-          (click)="removePickedOrg(org.metadata.guid)"
-          class="role-assignment__remove-btn shrink-0 w-6 h-6 flex items-center justify-center rounded text-content-muted hover:text-danger hover:bg-danger-50"
-          aria-label="Remove {{ org.entity.name }}"
-        >✕</button>
+      </div>
+    </div>
+
+    <!-- Space-level role cells -->
+    <div class="role-assignment__spaces flex flex-col gap-2">
+      <h4 class="m-0 text-xs font-semibold uppercase tracking-wide text-content-muted">Space Roles</h4>
+      @if (spacesLoadingFor(org.metadata.guid)) {
+        <div class="flex items-center gap-2 py-2 text-sm text-content-muted">
+          <div class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+          Loading spaces…
+        </div>
+      } @else {
+        <input
+          type="text"
+          placeholder="Filter spaces…"
+          [value]="spaceFilterFor(org.metadata.guid)"
+          (input)="setSpaceFilter(org.metadata.guid, $any($event.target).value)"
+          class="role-assignment__space-search w-full max-w-xs px-3 py-1.5 text-sm rounded border border-content-border bg-transparent text-content-text placeholder:text-content-muted focus:outline-none"
+        />
+        <div class="flex flex-col gap-4 mt-1">
+          @for (space of filteredSpacesFor(org.metadata.guid); track space.guid) {
+            <div class="role-assignment__space-section pl-3" [attr.data-space]="space.guid">
+              <div class="role-assignment__space-name text-sm font-medium text-content-text mb-1.5">{{ space.name }}</div>
+              <div class="role-assignment__role-row flex flex-wrap gap-x-6 gap-y-2">
+                @for (def of spaceRoleDefs; track def.name) {
+                  <div data-testid="space-role-cell" class="role-assignment__role-cell">
+                    <app-role-tristate-checkbox
+                      [checked]="checkedForSpace(org.metadata.guid, space.guid, def.name)"
+                      [disabled]="!canChangeSpaceRoles(org.metadata.guid, space.guid)"
+                      [label]="def.label"
+                      (toggled)="onToggleSpaceRole(org, space, def.name, $event)"
+                    ></app-role-tristate-checkbox>
+                  </div>
+                }
+              </div>
+            </div>
+          }
+          @if (filteredSpacesFor(org.metadata.guid).length === 0) {
+            <div class="pl-3 text-sm text-content-muted">No spaces in this organization.</div>
+          }
+        </div>
+      }
+    </div>
+  </div>
+</ng-template>
+
+<!-- Summary badge (set/mixed counts), reused by both layouts. -->
+<ng-template #orgSummary let-orgGuid="orgGuid">
+  @let setCount = roleCountForOrg(orgGuid);
+  @let mixedCount = mixedRoleCountForOrg(orgGuid);
+  @if (mixedCount > 0) {
+    {{ setCount }} set · {{ mixedCount }} mixed
+  } @else {
+    {{ setCount }} role{{ setCount === 1 ? '' : 's' }} set
+  }
+</ng-template>
+
+@if (viewMode() === 'split' && !lockedOrg) {
+  <!-- Two-pane master/detail. Panes stack on narrow widths (grid-cols-1). -->
+  <div
+    data-testid="role-pane-split"
+    class="role-assignment__split mt-3 grid grid-cols-1 md:grid-cols-[minmax(11rem,16rem)_1fr] gap-3"
+  >
+    <!-- Master: picked-org list -->
+    <div
+      data-testid="role-pane-list"
+      class="role-assignment__pane-list rounded border border-content-border bg-content-bg-alt overflow-hidden max-h-96 overflow-y-auto"
+    >
+      @for (org of pickedOrgs(); track org.metadata.guid) {
+        <div
+          class="role-assignment__pane-row flex items-center gap-2 px-2 py-1.5 border-b border-content-border last:border-b-0"
+          [class.bg-primary-50]="activeOrg() === org.metadata.guid"
+          [attr.data-org]="org.metadata.guid"
+        >
+          <button
+            type="button"
+            (click)="setActiveOrg(org.metadata.guid)"
+            class="flex-1 flex items-center gap-2 min-w-0 text-left text-sm text-content-text"
+            [attr.aria-current]="activeOrg() === org.metadata.guid"
+          >
+            <span class="truncate font-medium">{{ org.entity.name }}</span>
+            <span class="role-assignment__summary ml-auto shrink-0 text-xs text-content-muted" data-testid="org-role-summary">
+              <ng-container [ngTemplateOutlet]="orgSummary" [ngTemplateOutletContext]="{ orgGuid: org.metadata.guid }"></ng-container>
+            </span>
+          </button>
+          <button
+            type="button"
+            (click)="removePickedOrg(org.metadata.guid)"
+            class="role-assignment__remove-btn shrink-0 w-6 h-6 flex items-center justify-center rounded text-content-muted hover:text-danger hover:bg-danger-50"
+            aria-label="Remove {{ org.entity.name }}"
+          >✕</button>
+        </div>
       }
     </div>
 
-    @if (isExpanded(org.metadata.guid)) {
-      <div class="role-assignment__org-body px-3 py-3 border-t border-content-border flex flex-col gap-5">
-        <!-- Org-level role cells -->
-        <div class="role-assignment__org-roles flex flex-col gap-2">
-          <h4 class="m-0 text-xs font-semibold uppercase tracking-wide text-content-muted">Org Roles</h4>
-          <div class="role-assignment__role-row flex flex-wrap gap-x-6 gap-y-2">
-            @for (def of orgRoleDefs; track def.name) {
-              <div data-testid="org-role-cell" class="role-assignment__role-cell">
-                <app-role-tristate-checkbox
-                  [checked]="checkedForOrg(org.metadata.guid, def.name)"
-                  [disabled]="!canEditOrg(org.metadata.guid) || (def.name === orgUserRole && isOrgUserDisabled(org.metadata.guid))"
-                  [label]="def.label"
-                  (toggled)="onToggleOrgRole(org, def.name, $event)"
-                ></app-role-tristate-checkbox>
-              </div>
-            }
-          </div>
+    <!-- Detail: the active org's role editor -->
+    <div
+      data-testid="role-pane-detail"
+      class="role-assignment__pane-detail rounded border border-content-border bg-content-bg-alt overflow-hidden"
+    >
+      @if (activeOrgResource(); as org) {
+        <div class="role-assignment__pane-detail-header px-3 py-2 border-b border-content-border text-sm font-semibold text-content-text">
+          {{ org.entity.name }}
         </div>
-
-        <!-- Space-level role cells -->
-        <div class="role-assignment__spaces flex flex-col gap-2">
-          <h4 class="m-0 text-xs font-semibold uppercase tracking-wide text-content-muted">Space Roles</h4>
-          @if (spacesLoadingFor(org.metadata.guid)) {
-            <div class="flex items-center gap-2 py-2 text-sm text-content-muted">
-              <div class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
-              Loading spaces…
-            </div>
-          } @else {
-            <input
-              type="text"
-              placeholder="Filter spaces…"
-              [value]="spaceFilterFor(org.metadata.guid)"
-              (input)="setSpaceFilter(org.metadata.guid, $any($event.target).value)"
-              class="role-assignment__space-search w-full max-w-xs px-3 py-1.5 text-sm rounded border border-content-border bg-transparent text-content-text placeholder:text-content-muted focus:outline-none"
-            />
-            <div class="flex flex-col gap-4 mt-1">
-              @for (space of filteredSpacesFor(org.metadata.guid); track space.guid) {
-                <div class="role-assignment__space-section pl-3" [attr.data-space]="space.guid">
-                  <div class="role-assignment__space-name text-sm font-medium text-content-text mb-1.5">{{ space.name }}</div>
-                  <div class="role-assignment__role-row flex flex-wrap gap-x-6 gap-y-2">
-                    @for (def of spaceRoleDefs; track def.name) {
-                      <div data-testid="space-role-cell" class="role-assignment__role-cell">
-                        <app-role-tristate-checkbox
-                          [checked]="checkedForSpace(org.metadata.guid, space.guid, def.name)"
-                          [disabled]="!canChangeSpaceRoles(org.metadata.guid, space.guid)"
-                          [label]="def.label"
-                          (toggled)="onToggleSpaceRole(org, space, def.name, $event)"
-                        ></app-role-tristate-checkbox>
-                      </div>
-                    }
-                  </div>
-                </div>
-              }
-              @if (filteredSpacesFor(org.metadata.guid).length === 0) {
-                <div class="pl-3 text-sm text-content-muted">No spaces in this organization.</div>
-              }
-            </div>
-          }
-        </div>
-      </div>
-    }
+        <ng-container [ngTemplateOutlet]="orgRolesBody" [ngTemplateOutletContext]="{ org }"></ng-container>
+      } @else {
+        <div class="px-3 py-4 text-sm text-content-muted">Select an organization to edit its roles.</div>
+      }
+    </div>
   </div>
+} @else {
+  <!-- Accordion: one section per picked org -->
+  @for (org of pickedOrgs(); track org.metadata.guid) {
+    <div
+      class="role-assignment__org-section mt-3 rounded border border-content-border bg-content-bg-alt overflow-hidden"
+      [attr.data-org]="org.metadata.guid"
+    >
+      <!-- Accordion header -->
+      <div class="role-assignment__org-header flex items-center gap-3 px-3 py-2">
+        <button
+          type="button"
+          (click)="toggleExpanded(org.metadata.guid)"
+          class="role-assignment__accordion-btn flex-1 flex items-center gap-2 min-w-0 text-left text-sm font-semibold text-content-text"
+          [attr.aria-expanded]="isExpanded(org.metadata.guid)"
+        >
+          <span class="role-assignment__chevron shrink-0 text-xs text-primary">{{ isExpanded(org.metadata.guid) ? '▲' : '▼' }}</span>
+          <span class="truncate">{{ org.entity.name }}</span>
+        </button>
+        <span class="role-assignment__summary shrink-0 text-xs text-content-muted" data-testid="org-role-summary">
+          <ng-container [ngTemplateOutlet]="orgSummary" [ngTemplateOutletContext]="{ orgGuid: org.metadata.guid }"></ng-container>
+        </span>
+        @if (!lockedOrg) {
+          <button
+            type="button"
+            (click)="removePickedOrg(org.metadata.guid)"
+            class="role-assignment__remove-btn shrink-0 w-6 h-6 flex items-center justify-center rounded text-content-muted hover:text-danger hover:bg-danger-50"
+            aria-label="Remove {{ org.entity.name }}"
+          >✕</button>
+        }
+      </div>
+
+      @if (isExpanded(org.metadata.guid)) {
+        <div class="border-t border-content-border">
+          <ng-container [ngTemplateOutlet]="orgRolesBody" [ngTemplateOutletContext]="{ org }"></ng-container>
+        </div>
+      }
+    </div>
+  }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.spec.ts
@@ -517,6 +517,61 @@ describe('RoleAssignmentComponent', () => {
     expect(component.roleCountForOrg('o1')).toBe(2);
   });
 
+  it('E: mixedRoleCountForOrg counts roles only some selected users hold', async () => {
+    // Multi-user: u1 is org manager of o1, u2 is not; both are org users.
+    // The shared 'users' role is counted as set; the 'managers' role is
+    // indeterminate (held by one, not all) and must surface as mixed.
+    await setup({
+      orgs: [{ guid: 'o1', name: 'Org One' }],
+      spacesByOrg: { o1: [] },
+    });
+
+    const u1 = makeUser('u1');
+    const u2 = makeUser('u2');
+    const fixture = TestBed.createComponent(RoleAssignmentComponent);
+    fixture.componentRef.setInput('cfGuid', cfGuid);
+    fixture.componentRef.setInput('users', [u1, u2]);
+    fixture.componentRef.setInput('baseline', {
+      u1: { o1: { name: 'Org One', orgGuid: 'o1', permissions: { managers: true, billing_managers: false, auditors: false, users: true } } },
+      u2: { o1: { name: 'Org One', orgGuid: 'o1', permissions: { managers: false, billing_managers: false, auditors: false, users: true } } },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance;
+
+    // Shared role ('users') counts as set; partial role ('managers') is mixed.
+    expect(component.roleCountForOrg('o1')).toBe(1);
+    expect(component.mixedRoleCountForOrg('o1')).toBe(1);
+  });
+
+  it('E2: collapsed summary renders "N set · M mixed" when roles are divergent', async () => {
+    // Same multi-user divergence as E; the seeded o1 summary must show both the
+    // shared count and the mixed count rather than just "1 role set".
+    await setup({
+      orgs: [{ guid: 'o1', name: 'Org One' }],
+      spacesByOrg: { o1: [] },
+    });
+
+    const u1 = makeUser('u1');
+    const u2 = makeUser('u2');
+    const fixture = TestBed.createComponent(RoleAssignmentComponent);
+    fixture.componentRef.setInput('cfGuid', cfGuid);
+    fixture.componentRef.setInput('users', [u1, u2]);
+    fixture.componentRef.setInput('baseline', {
+      u1: { o1: { name: 'Org One', orgGuid: 'o1', permissions: { managers: true, billing_managers: false, auditors: false, users: true } } },
+      u2: { o1: { name: 'Org One', orgGuid: 'o1', permissions: { managers: false, billing_managers: false, auditors: false, users: true } } },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const summary = fixture.debugElement.query(By.css('[data-testid="org-role-summary"]'));
+    expect(summary).toBeTruthy();
+    expect(summary.nativeElement.textContent.replace(/\s+/g, ' ').trim()).toBe('1 set · 1 mixed');
+  });
+
   it('C: pickOrg prepends — newest pick sits at index 0', async () => {
     await setup({
       orgs: [

--- a/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.spec.ts
@@ -10,7 +10,7 @@ import { CfRoleChange } from '../../../store/types/users-roles.types';
 import { StUser } from '../../../services/endpoint-data/stratos-types';
 import { diffToChanges } from './role-tristate';
 
-import { RoleAssignmentComponent } from './role-assignment.component';
+import { RoleAssignmentComponent, ROLE_ASSIGNMENT_VIEW_MODE_KEY } from './role-assignment.component';
 import { provideRoleAssignmentTestDeps, RoleAssignmentTestCfg } from './role-assignment.test-deps';
 
 // Minimal StUser factory
@@ -43,6 +43,12 @@ describe('RoleAssignmentComponent', () => {
     permissions: (perm, _cf, org) =>
       perm === CfCurrentUserPermissions.ORGANIZATION_CHANGE_ROLES && org === 'o1',
   };
+
+  // setViewMode persists to localStorage; clear it so a prior test's choice
+  // doesn't leak into the next instance's initial view mode.
+  beforeEach(() => {
+    try { localStorage.removeItem(ROLE_ASSIGNMENT_VIEW_MODE_KEY); } catch { /* storage disabled */ }
+  });
 
   async function setup(cfg: RoleAssignmentTestCfg = defaultCfg): Promise<void> {
     await TestBed.configureTestingModule({
@@ -570,6 +576,108 @@ describe('RoleAssignmentComponent', () => {
     const summary = fixture.debugElement.query(By.css('[data-testid="org-role-summary"]'));
     expect(summary).toBeTruthy();
     expect(summary.nativeElement.textContent.replace(/\s+/g, ' ').trim()).toBe('1 set · 1 mixed');
+  });
+
+  it('F: switching to split view activates the first picked org', async () => {
+    await setup({
+      orgs: [{ guid: 'o1', name: 'Org One' }, { guid: 'o2', name: 'Org Two' }],
+      spacesByOrg: { o1: [], o2: [] },
+    });
+    const fixture = createFixture();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const c = fixture.componentInstance;
+
+    c.pickOrg(o1);
+    c.pickOrg(o2); // prepended → pickedOrgs is [o2, o1]
+
+    expect(c.viewMode()).toBe('accordion');
+    c.setViewMode('split');
+    expect(c.viewMode()).toBe('split');
+    expect(c.activeOrg()).toBe('o2');
+  });
+
+  it('G: switching back to accordion expands only the active org', async () => {
+    await setup({
+      orgs: [{ guid: 'o1', name: 'Org One' }, { guid: 'o2', name: 'Org Two' }],
+      spacesByOrg: { o1: [], o2: [] },
+    });
+    const fixture = createFixture();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const c = fixture.componentInstance;
+
+    c.pickOrg(o1);
+    c.pickOrg(o2);
+    c.setViewMode('split');
+    c.setActiveOrg('o1');
+    c.setViewMode('accordion');
+
+    expect(c.isExpanded('o1')).toBe(true);
+    expect(c.isExpanded('o2')).toBe(false);
+  });
+
+  it('H: view mode initializes from the persisted localStorage choice', async () => {
+    localStorage.setItem(ROLE_ASSIGNMENT_VIEW_MODE_KEY, 'split');
+    await setup({ orgs: [{ guid: 'o1', name: 'Org One' }], spacesByOrg: { o1: [] } });
+    const fixture = createFixture();
+    await fixture.whenStable();
+    expect(fixture.componentInstance.viewMode()).toBe('split');
+  });
+
+  it('H2: setViewMode persists the choice to localStorage', async () => {
+    await setup({ orgs: [{ guid: 'o1', name: 'Org One' }], spacesByOrg: { o1: [] } });
+    const fixture = createFixture();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    fixture.componentInstance.pickOrg(o1);
+    fixture.componentInstance.setViewMode('split');
+    fixture.detectChanges();
+    expect(localStorage.getItem(ROLE_ASSIGNMENT_VIEW_MODE_KEY)).toBe('split');
+  });
+
+  it('I: split view renders a master list pane and a detail pane for the active org', async () => {
+    await setup({
+      orgs: [{ guid: 'o1', name: 'Org One' }, { guid: 'o2', name: 'Org Two' }],
+      spacesByOrg: { o1: [], o2: [] },
+    });
+    const fixture = createFixture();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const c = fixture.componentInstance;
+
+    c.pickOrg(o1);
+    c.pickOrg(o2); // pickedOrgs [o2, o1]
+    c.setViewMode('split'); // active = o2
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const list = fixture.debugElement.query(By.css('[data-testid="role-pane-list"]'));
+    const detail = fixture.debugElement.query(By.css('[data-testid="role-pane-detail"]'));
+    expect(list).toBeTruthy();
+    expect(detail).toBeTruthy();
+    // The detail pane shows the active org's 4 org-role cells.
+    expect(detail.queryAll(By.css('[data-testid="org-role-cell"]')).length).toBe(4);
+  });
+
+  it('I2: the view-toggle button flips accordion ↔ split', async () => {
+    await setup({ orgs: [{ guid: 'o1', name: 'Org One' }], spacesByOrg: { o1: [] } });
+    const fixture = createFixture();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const c = fixture.componentInstance;
+
+    c.pickOrg(o1);
+    fixture.detectChanges();
+
+    const toggle = fixture.debugElement.query(By.css('[data-testid="view-toggle"]'));
+    expect(toggle).toBeTruthy();
+    expect(c.viewMode()).toBe('accordion');
+
+    toggle.nativeElement.click();
+    fixture.detectChanges();
+    expect(c.viewMode()).toBe('split');
   });
 
   it('C: pickOrg prepends — newest pick sits at index 0', async () => {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.ts
@@ -12,6 +12,7 @@ import {
   input,
   signal,
 } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { Subscription, combineLatest } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -46,12 +47,34 @@ interface SpaceEntry {
   name: string;
 }
 
+/** Layout for the picked-org role editor. */
+export type RoleAssignmentViewMode = 'accordion' | 'split';
+
+/**
+ * localStorage key for the persisted view-mode choice. Mirrors the list view
+ * toggle convention (stratos.<feature>.<state>.v<n>) so the choice survives
+ * across sessions, the same way the signal-list card/table toggle does.
+ */
+export const ROLE_ASSIGNMENT_VIEW_MODE_KEY = 'stratos.role-assignment.view-mode.v1';
+
+function readPersistedViewMode(): RoleAssignmentViewMode {
+  if (typeof localStorage === 'undefined') {
+    return 'accordion';
+  }
+  try {
+    const raw = localStorage.getItem(ROLE_ASSIGNMENT_VIEW_MODE_KEY);
+    return raw === 'split' || raw === 'accordion' ? raw : 'accordion';
+  } catch {
+    return 'accordion';
+  }
+}
+
 @Component({
   selector: 'app-role-assignment',
   standalone: true,
   templateUrl: './role-assignment.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RoleTristateCheckboxComponent],
+  imports: [RoleTristateCheckboxComponent, NgTemplateOutlet],
 })
 export class RoleAssignmentComponent implements OnInit, OnDestroy {
   @Input({ required: true }) cfGuid!: string;
@@ -117,6 +140,18 @@ export class RoleAssignmentComponent implements OnInit, OnDestroy {
   /** Accordion open/closed per orgGuid — presentational, never affects selection */
   private readonly expandedByOrg = signal<Set<string>>(new Set());
 
+  /** Layout for the picked-org editor: stacked accordion or two-pane master/detail. */
+  readonly viewMode = signal<RoleAssignmentViewMode>(readPersistedViewMode());
+
+  /** In split view, the org whose roles are shown in the detail pane. */
+  readonly activeOrg = signal<string | null>(null);
+
+  /** The picked-org resource for the active org (split detail pane), or null. */
+  readonly activeOrgResource = computed(() => {
+    const guid = this.activeOrg();
+    return guid ? this.pickedOrgs().find(o => o.metadata.guid === guid) ?? null : null;
+  });
+
   /** Space filter text per orgGuid — presentational only */
   private readonly spaceFilterByOrg = signal<Record<string, string>>({});
 
@@ -172,6 +207,20 @@ export class RoleAssignmentComponent implements OnInit, OnDestroy {
         });
       }
       this.baselineSeeded = true;
+    });
+
+    // Persist the view-mode choice (mirrors the list view toggle) so it
+    // survives across sessions. Writes the initial value too — harmless.
+    effect(() => {
+      const mode = this.viewMode();
+      if (typeof localStorage === 'undefined') {
+        return;
+      }
+      try {
+        localStorage.setItem(ROLE_ASSIGNMENT_VIEW_MODE_KEY, mode);
+      } catch {
+        // Storage disabled / quota — the in-memory signal still drives the UI.
+      }
     });
   }
 
@@ -292,6 +341,36 @@ export class RoleAssignmentComponent implements OnInit, OnDestroy {
 
   isExpanded(orgGuid: string): boolean {
     return this.expandedByOrg().has(orgGuid);
+  }
+
+  // --- View mode (accordion ↔ split) ---
+
+  /**
+   * Switch layout and reconcile the differing "what's open" state between the
+   * two views: the accordion can have many orgs expanded; split shows exactly
+   * one (activeOrg).
+   *  - → split: adopt an active org (keep the current one, else the top of the
+   *    picked list) and ensure its spaces are loaded.
+   *  - → accordion: focus where the user was — expand only the active org.
+   */
+  setViewMode(mode: RoleAssignmentViewMode): void {
+    if (mode === 'split') {
+      const active = this.activeOrg()
+        ?? this.pickedOrgs()[0]?.metadata.guid
+        ?? null;
+      if (active) {
+        this.setActiveOrg(active);
+      }
+    } else if (this.activeOrg()) {
+      const active = this.activeOrg()!;
+      this.expandedByOrg.set(new Set([active]));
+    }
+    this.viewMode.set(mode);
+  }
+
+  setActiveOrg(orgGuid: string): void {
+    this.activeOrg.set(orgGuid);
+    this.loadSpacesFor(orgGuid);
   }
 
   // --- Space loading ---

--- a/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.component.ts
@@ -461,6 +461,38 @@ export class RoleAssignmentComponent implements OnInit, OnDestroy {
     return n;
   }
 
+  /**
+   * Count of this org's roles that are indeterminate (held by some, but not
+   * all, of the selected users) — i.e. computeChecked returns null. Surfaced
+   * alongside roleCountForOrg so a multi-user org with divergent roles doesn't
+   * read as empty in the collapsed summary. Enumerated from baseline + selection
+   * (same as roleCountForOrg) so it stays accurate without loading spaces.
+   */
+  mixedRoleCountForOrg(orgGuid: string): number {
+    let n = 0;
+    for (const def of this.orgRoleDefs) {
+      if (this.checkedForOrg(orgGuid, def.name) === null) { n++; }
+    }
+    const spaceGuids = new Set<string>();
+    const baseline = this.baseline();
+    for (const userGuid of Object.keys(baseline)) {
+      const spaces = baseline[userGuid]?.[orgGuid]?.spaces;
+      if (spaces) {
+        for (const sg of Object.keys(spaces)) { spaceGuids.add(sg); }
+      }
+    }
+    const selSpaces = this.selection()[orgGuid]?.spaces;
+    if (selSpaces) {
+      for (const sg of Object.keys(selSpaces)) { spaceGuids.add(sg); }
+    }
+    for (const sg of spaceGuids) {
+      for (const def of this.spaceRoleDefs) {
+        if (this.checkedForSpace(orgGuid, sg, def.name) === null) { n++; }
+      }
+    }
+    return n;
+  }
+
   canEditOrg(orgGuid: string): boolean {
     return this.canEditByOrg()[orgGuid] ?? false;
   }

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/st-user-roles.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/st-user-roles.ts
@@ -45,7 +45,9 @@ export function spaceRolesFromStUser(
   spaceNameByGuid?: Map<string, string>,
 ): IUserPermissionInSpace[] {
   return user.spaceRoles.map(b => ({
-    name: spaceNameByGuid?.get(b.spaceGuid) ?? '',
+    // The space name rides in on the bucket (include=space); the optional
+    // guid→name map remains a fallback for any older payload without it.
+    name: b.spaceName ?? spaceNameByGuid?.get(b.spaceGuid) ?? '',
     orgGuid: b.orgGuid,
     orgName: orgNameByGuid?.get(b.orgGuid) ?? '',
     spaceGuid: b.spaceGuid,

--- a/src/jetstream/plugins/cloudfoundry/native_current_user_roles_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_current_user_roles_reads.go
@@ -102,7 +102,7 @@ func (c *CloudFoundrySpecification) getNativeCurrentUserRoles(ctx echo.Context) 
 	}
 
 	rStart := time.Now()
-	roles, includedSpaceOrg, rerr := listRolesForUsers(ctx.Request().Context(), cfClient, []string{cfUserGUID})
+	roles, includedSpaces, rerr := listRolesForUsers(ctx.Request().Context(), cfClient, []string{cfUserGUID})
 	rRows := -1
 	if rerr == nil {
 		rRows = len(roles)
@@ -122,7 +122,7 @@ func (c *CloudFoundrySpecification) getNativeCurrentUserRoles(ctx echo.Context) 
 		for _, key := range spaceBucketKeys {
 			for i := range buckets[key] {
 				if buckets[key][i].Entity.OrganizationGUID == "" {
-					buckets[key][i].Entity.OrganizationGUID = includedSpaceOrg[buckets[key][i].Metadata.GUID]
+					buckets[key][i].Entity.OrganizationGUID = includedSpaces[buckets[key][i].Metadata.GUID].orgGUID
 				}
 			}
 		}

--- a/src/jetstream/plugins/cloudfoundry/native_types.go
+++ b/src/jetstream/plugins/cloudfoundry/native_types.go
@@ -497,8 +497,11 @@ type StUserOrgRole struct {
 // render "<orgName>/<spaceName>: <roles>" off a single struct. Roles strip
 // the "space_" prefix.
 type StUserSpaceRole struct {
-	OrgGuid   string   `json:"orgGuid"`
-	SpaceGuid string   `json:"spaceGuid"`
+	OrgGuid   string `json:"orgGuid"`
+	SpaceGuid string `json:"spaceGuid"`
+	// SpaceName is resolved in-band from the /v3/roles include=space block so
+	// the role-assignment UI labels spaces without draining /v3/spaces.
+	SpaceName string   `json:"spaceName,omitempty"`
 	Roles     []string `json:"roles"`
 }
 

--- a/src/jetstream/plugins/cloudfoundry/native_users_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_users_reads.go
@@ -149,7 +149,7 @@ func buildUserRoleBuckets(
 		return orgRolesByUser, spaceRolesByUser
 	}
 
-	roles, includedSpaceOrg, rolesErr := listRolesForUsers(ctx, cfClient, userGUIDs)
+	roles, includedSpaces, rolesErr := listRolesForUsers(ctx, cfClient, userGUIDs)
 	if rolesErr != nil {
 		return orgRolesByUser, spaceRolesByUser
 	}
@@ -213,11 +213,12 @@ func buildUserRoleBuckets(
 				// (rare but defensive) — resolve through the include=space
 				// block that rode along on the /v3/roles response. Still
 				// degrades to empty orgGuid if the space wasn't included.
-				orgGUID = includedSpaceOrg[spaceGUID]
+				orgGUID = includedSpaces[spaceGUID].orgGUID
 			}
 			spaceRolesByUser[uGUID] = append(spaceRolesByUser[uGUID], StUserSpaceRole{
 				OrgGuid:   orgGUID,
 				SpaceGuid: spaceGUID,
+				SpaceName: includedSpaces[spaceGUID].name,
 				Roles:     rolesList,
 			})
 		}
@@ -240,7 +241,7 @@ func buildUserRoleBuckets(
 // pages 2..N concurrently with bounded parallelism. Sequential drain on
 // admin (5K+ grants over ~11 pages) dominated wall time at ~8s; parallel
 // fan-out collapses that to ~max(page latency).
-func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []string) ([]capi.Role, map[string]string, error) {
+func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []string) ([]capi.Role, map[string]includedSpace, error) {
 	if len(userGUIDs) == 0 {
 		return nil, nil, nil
 	}
@@ -249,7 +250,7 @@ func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []st
 	const maxConcurrency = 6
 
 	filter := strings.Join(userGUIDs, ",")
-	fetchPage := func(page int) ([]capi.Role, map[string]string, capi.Pagination, error) {
+	fetchPage := func(page int) ([]capi.Role, map[string]includedSpace, capi.Pagination, error) {
 		params := capi.NewQueryParams().
 			WithFilter("user_guids", filter).
 			WithPerPage(perPage)
@@ -262,30 +263,30 @@ func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []st
 		if derr != nil {
 			return nil, nil, capi.Pagination{}, derr
 		}
-		spaceOrg := make(map[string]string, len(included.Spaces))
+		spaces := make(map[string]includedSpace, len(included.Spaces))
 		for _, s := range included.Spaces {
-			spaceOrg[s.GUID] = relationshipGUID(s.Relationships.Organization)
+			spaces[s.GUID] = includedSpace{orgGUID: relationshipGUID(s.Relationships.Organization), name: s.Name}
 		}
-		return raw.Resources, spaceOrg, raw.Pagination, nil
+		return raw.Resources, spaces, raw.Pagination, nil
 	}
 
-	firstResources, spaceOrg, pagination, err := fetchPage(1)
+	firstResources, spaces, pagination, err := fetchPage(1)
 	if err != nil {
 		return nil, nil, err
 	}
 	totalPages := pagination.TotalPages
 	if totalPages <= 1 {
-		return firstResources, spaceOrg, nil
+		return firstResources, spaces, nil
 	}
 
 	pageRoles := make([][]capi.Role, totalPages)
 	pageRoles[0] = firstResources
 
 	type pageResult struct {
-		page     int
-		roles    []capi.Role
-		spaceOrg map[string]string
-		err      error
+		page   int
+		roles  []capi.Role
+		spaces map[string]includedSpace
+		err    error
 	}
 	sem := make(chan struct{}, maxConcurrency)
 	results := make(chan pageResult, totalPages-1)
@@ -293,8 +294,8 @@ func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []st
 		sem <- struct{}{}
 		go func(pn int) {
 			defer func() { <-sem }()
-			res, pso, _, perr := fetchPage(pn)
-			results <- pageResult{page: pn, roles: res, spaceOrg: pso, err: perr}
+			res, psp, _, perr := fetchPage(pn)
+			results <- pageResult{page: pn, roles: res, spaces: psp, err: perr}
 		}(p)
 	}
 	for i := 0; i < totalPages-1; i++ {
@@ -303,8 +304,8 @@ func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []st
 			return nil, nil, r.err
 		}
 		pageRoles[r.page-1] = r.roles
-		for k, v := range r.spaceOrg {
-			spaceOrg[k] = v
+		for k, v := range r.spaces {
+			spaces[k] = v
 		}
 	}
 
@@ -316,7 +317,15 @@ func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []st
 	for _, p := range pageRoles {
 		all = append(all, p...)
 	}
-	return all, spaceOrg, nil
+	return all, spaces, nil
+}
+
+// includedSpace holds the per-space facts resolved in-band from the
+// /v3/roles include=space block: the parent org GUID (space→org join) and
+// the space name (so the UI labels spaces without a /v3/spaces drain).
+type includedSpace struct {
+	orgGUID string
+	name    string
 }
 
 // stripRolePrefix converts V3 role types (organization_manager,

--- a/src/jetstream/plugins/cloudfoundry/native_users_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_users_reads_test.go
@@ -364,5 +364,8 @@ func TestGetNativeUsers_SpaceOrgFromIncludedSpaces(t *testing.T) {
 	require.Len(t, resp.Resources[0].SpaceRoles, spaceCount)
 	for _, sr := range resp.Resources[0].SpaceRoles {
 		assert.Equal(t, "org-1", sr.OrgGuid, "space bucket %s must carry the include-resolved parent org", sr.SpaceGuid)
+		// The mock sets each space's name == its guid; the bucket must carry
+		// the include-resolved space name so the UI needs no /v3/spaces drain.
+		assert.Equal(t, sr.SpaceGuid, sr.SpaceName, "space bucket %s must carry the include-resolved name", sr.SpaceGuid)
 	}
 }


### PR DESCRIPTION
Follow-up work on the CF Users role-assignment widget, after #5479.

## Changes

- **Faster "Loading existing roles…"** — the wizard drained the entire `/pp/v1/cf/spaces` list (~2500 spaces, 6 pages) only to map space guids to names. The `/v3/roles?include=space` response already carries each space's name, so the backend now emits `spaceName` on the role buckets and the frontend reads it from the payload. The drain is gone; the seed dropped from ~30s to ~2.5s in testing. Org names still come from the bounded native org list.

- **Accordion / two-pane view toggle** — the picked-org editor offers a two-pane master/detail layout alongside the stacked accordion, modeled on the list card/table toggle. A `viewMode` signal, a header toggle, the two layouts sharing one role-editor template, and the choice persisted to `localStorage`. Switching reconciles the open-state (accordion can expand many orgs; split shows one active org). Panes stack on narrow widths; an org/space-scoped entry stays accordion-only.

- **Mixed-role summary for multi-user** — a multi-user org where users held divergent roles read as "0 roles set" because the badge only counted fully-shared roles. It now shows "N set · M mixed" when roles are partial.

- **User role cells link from first render** — the org/space role cells on the users page stayed plain text until the name maps loaded, then became links, even though the link target is guid-based and available immediately. They now link from first paint and the label upgrades guid → name reactively; space roles also read the new payload `spaceName` so the name shows instantly.

## Testing

Full `make check gate` green (2823 frontend tests, backend package, production build). Each change was built test-first and live-verified on a real foundation via the dev backend (load time, no spaces drain, toggle, mixed badge, first-render links).
