### PR TITLE
Remove dead onNext from detach-apps step component

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-apps/detach-apps.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-apps/detach-apps.component.ts
@@ -10,7 +10,6 @@ import {
   inject,
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { of as observableOf } from 'rxjs';
 
 import {
   BoundListSelectionState,
@@ -96,6 +95,4 @@ export class DetachAppsComponent {
   toggleRow(b: StServiceCredentialBinding): void {
     this.selection.toggle(b);
   }
-
-  onNext = () => observableOf({ success: true });
 }


### PR DESCRIPTION
The `detach-apps` step drives its validity through `signalHandle` (`valid: selection.isSelecting`). Its `onNext` arrow was vestigial — no parent delegates to it, and the `observableOf` import existed only to feed it. Both are removed here.

Pure dead-code removal, no behaviour change. It's the last leftover from the signal-native stepper migration: an audit of all 41 `<app-step>` sites confirmed every other step is on a `SignalStepHandle`, and the `onNext` functions retained elsewhere are intentionally reused by each handle's `submit`.

Verified: `vitest --project=cloud-foundry detach` (2 files, 6 tests) green; a repo-wide search confirms `onNext` was never called on a `DetachApps` reference.