### PR TITLE
Preview service plan parameters from the marketplace Plans tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratos",
-  "version": "v5.0.0-dev.122+build.20260625.0edbe7e28d",
+  "version": "v5.0.0-dev.123+build.20260625.f930bdbafa",
   "type": "module",
   "description": "Stratos Console",
   "main": "index.js",

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-plans/service-plans.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-plans/service-plans.component.ts
@@ -17,10 +17,15 @@ import {
   SignalListColumn,
   SignalListComponent,
   SignalListConfig,
+  TailwindDialogService,
 } from '@stratosui/core';
 
 import { getIdFromRoute } from '../../../../../core/src/core/utils.service';
 import { SERVICE_PLAN_URL_PARAM } from '../../../shared/components/add-service-instance/add-service-instance-base-step/add-service-instance.types';
+import {
+  PlanParametersPreviewData,
+  PlanParametersPreviewDialogComponent,
+} from '../../../shared/components/plan-parameters-preview-dialog/plan-parameters-preview-dialog.component';
 import {
   CfServicePlansSignalConfigService,
 } from '../../../shared/signal-list-configs/service-plans/cf-service-plans-signal-config.service';
@@ -63,6 +68,7 @@ export class ServicePlansComponent implements OnInit {
   private readonly plansConfig = inject(CfServicePlansSignalConfigService);
   private readonly datePipe = inject(DatePipe);
   private readonly permissionsService = inject(CurrentUserPermissionsService);
+  private readonly dialog = inject(TailwindDialogService);
 
   private readonly cfGuid: string = getIdFromRoute(this.route, 'endpointId');
   private readonly serviceGuid: string = getIdFromRoute(this.route, 'serviceId');
@@ -102,6 +108,29 @@ export class ServicePlansComponent implements OnInit {
                 ['/marketplace', this.cfGuid, this.serviceGuid, 'create'],
                 { queryParams: { [SERVICE_PLAN_URL_PARAM]: p.guid } },
               );
+            },
+          },
+          {
+            // Lazy schema preview: the plans list is summary-tier (no schemas),
+            // so the dialog fetches this one plan at details and shows what the
+            // create wizard would prompt for — no commitment required (#5493).
+            label: 'View parameters',
+            icon: 'tune',
+            invoke: () => {
+              this.dialog.open(PlanParametersPreviewDialogComponent, {
+                ariaLabelledBy: 'plan-parameters-preview-title',
+                width: '40rem',
+                height: '32rem',
+                maxWidth: '92vw',
+                maxHeight: '90vh',
+                resizable: true,
+                draggable: true,
+                data: {
+                  cnsiGuid: p.cnsiGuid,
+                  planGuid: p.guid,
+                  planName: p.name,
+                } as PlanParametersPreviewData,
+              });
             },
           },
         ],

--- a/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview-dialog.component.html
@@ -1,0 +1,20 @@
+<div class="p-6 w-full flex-1 flex flex-col min-h-0">
+  <h1 id="plan-parameters-preview-title" data-dialog-drag-handle
+      class="text-lg font-semibold mb-4 text-content-text">{{ title }}</h1>
+
+  <div class="flex-1 min-h-0 overflow-auto">
+    @if (loading()) {
+      <p class="text-content-muted">Loading plan parameters…</p>
+    } @else if (error()) {
+      <p class="text-danger">Could not load this plan's parameters.</p>
+    } @else if (schema(); as s) {
+      <app-json-viewer [json]="s" [expanded]="true"></app-json-viewer>
+    } @else {
+      <p class="text-content-muted">This plan has no configurable parameters.</p>
+    }
+  </div>
+
+  <div class="flex gap-2 justify-end mt-6">
+    <button type="button" class="btn btn-primary" (click)="close()">Close</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview-dialog.component.spec.ts
@@ -1,0 +1,62 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, TailwindDialogRef } from '@stratosui/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ServiceCatalogDataService } from '../../../services/endpoint-data/service-catalog-data.service';
+import type { StServicePlan } from '../../../services/endpoint-data/stratos-types';
+import { PlanParametersPreviewDialogComponent } from './plan-parameters-preview-dialog.component';
+
+function make(source: { value?: StServicePlan | null; isLoading?: boolean; error?: unknown }) {
+  const close = vi.fn();
+  const servicePlan = vi.fn().mockReturnValue({
+    value: signal(source.value ?? null),
+    isLoading: signal(source.isLoading ?? false),
+    error: signal(source.error ?? null),
+  });
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [
+      provideZonelessChangeDetection(),
+      { provide: MAT_DIALOG_DATA, useValue: { cnsiGuid: 'cnsi-1', planGuid: 'plan-1', planName: 'free' } },
+      { provide: TailwindDialogRef, useValue: { close } },
+      { provide: ServiceCatalogDataService, useValue: { servicePlan } },
+    ],
+  });
+  const fixture = TestBed.createComponent(PlanParametersPreviewDialogComponent);
+  return { cmp: fixture.componentInstance, close, servicePlan };
+}
+
+const planWith = (parameters: object): StServicePlan =>
+  ({ schemas: { serviceInstance: { create: { parameters } } } } as unknown as StServicePlan);
+
+describe('PlanParametersPreviewDialogComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('fetches the named plan at details tier and titles the dialog', () => {
+    const { cmp, servicePlan } = make({});
+    expect(servicePlan).toHaveBeenCalledWith('cnsi-1', 'plan-1');
+    expect(cmp.title).toContain('free');
+  });
+
+  it('exposes the cleaned create-parameters schema', () => {
+    const { cmp } = make({ value: planWith({ $schema: 'x', properties: { region: { type: 'string' } } }) });
+    expect(cmp.schema()).toEqual({ properties: { region: { type: 'string' } } });
+  });
+
+  it('reports no schema for a plan without configurable parameters', () => {
+    const { cmp } = make({ value: planWith({}) });
+    expect(cmp.schema()).toBeNull();
+  });
+
+  it('surfaces loading and error states', () => {
+    expect(make({ isLoading: true }).cmp.loading()).toBe(true);
+    expect(make({ error: new Error('boom') }).cmp.error()).toBe(true);
+  });
+
+  it('closes via the dialog ref', () => {
+    const { cmp, close } = make({});
+    cmp.close();
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview-dialog.component.ts
@@ -1,0 +1,55 @@
+import { ChangeDetectionStrategy, Component, Signal, computed, inject } from '@angular/core';
+
+import { MAT_DIALOG_DATA, TailwindDialogRef } from '@stratosui/core';
+
+import { JsonViewerComponent } from '../../../../../core/src/shared/components/json-viewer/json-viewer.component';
+import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import type { StServicePlan } from '../../../services/endpoint-data/stratos-types';
+import { extractCreateParameters, previewSchema } from './plan-parameters-preview.util';
+
+/** Input to the dialog: which plan to fetch + show. */
+export interface PlanParametersPreviewData {
+  cnsiGuid: string;
+  planGuid: string;
+  planName?: string;
+}
+
+/**
+ * PlanParametersPreviewDialogComponent — read-only preview of a service plan's
+ * create-instance parameter schema, opened from the marketplace Plans tab so a
+ * user can see what they'd configure BEFORE committing to the create wizard
+ * (#5493).
+ *
+ * The plans list is summary-tier (no `schemas`), so this fetches the one plan
+ * at `?return=details` on open and renders the schema as a read-only json-viewer
+ * tree. No schema → "no configurable parameters". Read-only: no editor, the
+ * schema is broker-defined and not something to change here.
+ */
+@Component({
+  selector: 'app-plan-parameters-preview-dialog',
+  templateUrl: './plan-parameters-preview-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [JsonViewerComponent],
+})
+export class PlanParametersPreviewDialogComponent {
+  private readonly dialogRef = inject<TailwindDialogRef<PlanParametersPreviewDialogComponent>>(TailwindDialogRef);
+  private readonly data = inject<PlanParametersPreviewData>(MAT_DIALOG_DATA);
+  private readonly serviceCatalog = inject(ServiceCatalogDataService);
+
+  private readonly source: SignalSource<StServicePlan | null> =
+    this.serviceCatalog.servicePlan(this.data.cnsiGuid, this.data.planGuid);
+
+  readonly title = this.data.planName ? `Parameters — ${this.data.planName}` : 'Plan parameters';
+  readonly loading: Signal<boolean> = this.source.isLoading;
+  readonly error: Signal<boolean> = computed(() => this.source.error() != null);
+
+  /** Cleaned create-parameters schema, or null when the plan advertises none. */
+  readonly schema: Signal<object | null> = computed(() =>
+    previewSchema(extractCreateParameters(this.source.value())),
+  );
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.spec.ts
@@ -1,0 +1,36 @@
+import { extractCreateParameters, previewSchema } from './plan-parameters-preview.util';
+import type { StServicePlan } from '../../../services/endpoint-data/stratos-types';
+
+describe('plan-parameters-preview.util', () => {
+  describe('extractCreateParameters', () => {
+    it('returns the create.parameters schema when present', () => {
+      const schema = { properties: { region: { type: 'string' } } };
+      const plan = { schemas: { serviceInstance: { create: { parameters: schema } } } } as unknown as StServicePlan;
+      expect(extractCreateParameters(plan)).toBe(schema);
+    });
+
+    it('returns null for a summary-tier plan with no schemas', () => {
+      expect(extractCreateParameters({ guid: 'p1' } as unknown as StServicePlan)).toBeNull();
+      expect(extractCreateParameters(null)).toBeNull();
+      expect(extractCreateParameters(undefined)).toBeNull();
+    });
+  });
+
+  describe('previewSchema', () => {
+    it('drops the $schema plumbing key', () => {
+      const out = previewSchema({ $schema: 'http://json-schema.org/draft-04/schema#', properties: { a: {} } });
+      expect(out).toEqual({ properties: { a: {} } });
+    });
+
+    it('returns null for an empty or schema-only object (nothing to show)', () => {
+      expect(previewSchema({})).toBeNull();
+      expect(previewSchema({ $schema: 'x' })).toBeNull();
+      expect(previewSchema(null)).toBeNull();
+    });
+
+    it('keeps a meaningful schema intact', () => {
+      const raw = { type: 'object', properties: { region: { type: 'string' } }, required: ['region'] };
+      expect(previewSchema(raw)).toEqual(raw);
+    });
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.ts
@@ -1,0 +1,31 @@
+import type { StServicePlan } from '../../../services/endpoint-data/stratos-types';
+
+/**
+ * Pull the create-instance parameter JSON Schema off a details-tier plan.
+ * `schemas` only ships at `?return=details`, so a summary-tier plan returns
+ * null here (the dialog fetches the details tier before calling this).
+ */
+export function extractCreateParameters(plan: StServicePlan | null | undefined): object | null {
+  const params = plan?.schemas?.serviceInstance?.create?.parameters;
+  return params && typeof params === 'object' ? params as object : null;
+}
+
+/**
+ * Clean a raw parameter schema for the read-only json-viewer tree, returning
+ * null when there's nothing worth showing. Drops `$schema` plumbing (matches
+ * schema-form's filterSchema) and treats an otherwise-empty object as "no
+ * configurable parameters".
+ *
+ * ponytail: strips only top-level `$schema` and gates on key-count. If live
+ * verify shows nested noise (`additionalProperties: false`, bare `type:object`
+ * with no `properties`), extend the strip/gate here rather than per-caller.
+ */
+export function previewSchema(raw: object | null | undefined): object | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const cleaned = Object.fromEntries(
+    Object.entries(raw as Record<string, unknown>).filter(([k]) => k !== '$schema'),
+  );
+  return Object.keys(cleaned).length > 0 ? cleaned : null;
+}

--- a/src/frontend/packages/core/src/shared/components/json-viewer/json-viewer.component.scss
+++ b/src/frontend/packages/core/src/shared/components/json-viewer/json-viewer.component.scss
@@ -39,7 +39,7 @@ $type-colors: (
         font-size: 0.8em;
         line-height: 1.2em;
         vertical-align: middle;
-        color: #787878;
+        color: var(--content-muted);
 
         &::after {
           display: inline-block;
@@ -48,16 +48,19 @@ $type-colors: (
         }
       }
 
+      // Structural colors resolve via theme tokens so the tree is legible in
+      // both light and dark (the syntax-accent hues below stay static — they
+      // read on both). Keys were a fixed purple, values a fixed black.
       .segment-key {
-        color: #4E187C;
+        color: var(--content-text);
       }
 
       .segment-separator {
-        color: #999;
+        color: var(--content-muted);
       }
 
       .segment-value {
-        color: #000;
+        color: var(--content-text);
       }
     }
 

--- a/src/jetstream/VERSION
+++ b/src/jetstream/VERSION
@@ -1,1 +1,1 @@
-5.0.0-dev.122+build.20260625.0edbe7e28d
+5.0.0-dev.123+build.20260625.f930bdbafa


### PR DESCRIPTION
The marketplace Plans tab lists plans at the summary tier, which omits the broker-advertised parameter schemas. A user evaluating a service therefore could not see what a plan would prompt for without committing to the create-instance wizard.

This adds a View parameters action to each plan row. It lazily fetches the selected plan at the details tier (the only tier that carries `schemas`) and shows its create-instance parameter schema as a read-only tree, or "This plan has no configurable parameters" when the broker advertises none. The summary-tier list fetch is unchanged, so the list stays light — the schema is pulled only when asked, one plan at a time.

While verifying in dark mode, the shared json-viewer component turned out to hard-code its tree colors for the light theme (keys a fixed purple, value fallback black), leaving them low-contrast or invisible on dark. Its structural colors now resolve through the content theme tokens, which also fixes the Kubernetes resource viewer and Helm release values views that share the component.

Verified in a running stack against an example broker (free/rich schema and paid/deeply-nested schema) and a real Blacksmith broker plan (no schema), in both light and dark themes.

Closes #5493