### PR TITLE
Adapt remaining light-only placeholder and chart colors to dark theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratos",
-  "version": "v5.0.0-dev.123+build.20260625.f930bdbafa",
+  "version": "v5.0.0-dev.124+build.20260625.4deaedc5b2",
   "type": "module",
   "description": "Stratos Console",
   "main": "index.js",

--- a/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/compact-app-card/compact-app-card.component.scss
+++ b/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/compact-app-card/compact-app-card.component.scss
@@ -74,6 +74,12 @@ $ph-animation-duration: 0.8s !default;
   overflow: hidden;
   position: relative;
 
+  // Dark theme: the light placeholder bars flash bright on the dark card.
+  // Mirror the dark border treatment above with a subtle light-on-dark fill.
+  :host-context(.dark) & {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
   &::before {
     animation: phAnimation $ph-animation-duration linear infinite;
     background: linear-gradient(to right, rgba($ph-bg, 0) 46%, rgba($ph-bg, .35) 50%, rgba($ph-bg, 0) 54%) 50% 50%;

--- a/src/frontend/packages/core/src/shared/components/simple-usage-chart/simple-usage-chart.component.scss
+++ b/src/frontend/packages/core/src/shared/components/simple-usage-chart/simple-usage-chart.component.scss
@@ -8,7 +8,7 @@
   &--warning-background { background-color: color-mix(in srgb, var(--color-warning) 20%, transparent); }
   &--danger { background-color: var(--color-danger); }
   &--danger-background { background-color: color-mix(in srgb, var(--color-danger) 20%, transparent); }
-  &--unknown { background-color: #9ca3af; }
+  &--unknown { background-color: var(--color-content-muted); }
 }
 
 .simple-graph {

--- a/src/jetstream/VERSION
+++ b/src/jetstream/VERSION
@@ -1,1 +1,1 @@
-5.0.0-dev.123+build.20260625.f930bdbafa
+5.0.0-dev.124+build.20260625.4deaedc5b2


### PR DESCRIPTION
Follow-up to the theme-token color sweep. Triaging the component SCSS files the sweep left with raw hex turned up two colors that genuinely do not adapt to the dark theme:

- The recent-apps loading placeholder bars (`compact-app-card`) stayed light grey on the dark card. Given a dark-theme fill, matching the dark border treatment already in that file.
- The usage chart `unknown` swatch (`simple-usage-chart`) was a fixed grey while its sibling state swatches (ok/warning/danger) already resolve via tokens. Routed through the muted content token.

The other raw-hex matches were checked and left deliberately: white text on coloured alert/step backgrounds (intentional inverse), chart gridline internals (the separate getComputedStyle convention), and the example-extensions demo package.

Build verified. These two states are transient/data-dependent (a brief loading flash; an unknown-usage segment) so they were not reproduced live; the changes are minimal and consistent with each file’s existing dark mechanism.

Closes #5494