### PR TITLE
Toward #5370: service instance detail page — parameters, credentials, uniform linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratos",
-  "version": "v5.0.0-dev.125+build.20260625.954a1b4f86",
+  "version": "v5.0.0-dev.126+build.20260625.89bd8ce7d6",
   "type": "module",
   "description": "Stratos Console",
   "main": "index.js",

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
@@ -125,7 +125,7 @@ describe('CloudFoundrySpaceServiceInstancesSignalComponent', () => {
     expect(serviceCol!.render!(managed)).toBe('redis');
   });
 
-  it('Name column links to the legacy /services/managed/:cnsi/:siGuid detail page', () => {
+  it('Name column links to the /services/service/:cnsi/:siGuid detail page', () => {
     const cfg = component.listConfig();
     const nameCol = cfg!.columns.find(c => c.key === 'name');
     expect(nameCol).toBeDefined();
@@ -133,7 +133,7 @@ describe('CloudFoundrySpaceServiceInstancesSignalComponent', () => {
       cnsiGuid: 'cnsi-1', guid: 'si-1', name: 'cache', type: 'managed',
       tags: [], createdAt: '',
     } as any);
-    expect(link).toEqual(['/services', 'managed', 'cnsi-1', 'si-1']);
+    expect(link).toEqual(['/services', 'service', 'cnsi-1', 'si-1']);
   });
 
   it('Add Service Instance opens the managed wizard pre-selecting this CF', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.ts
@@ -161,9 +161,13 @@ export class CloudFoundrySpaceServiceInstancesSignalComponent {
         {
           header: 'Name', key: 'name', sortField: 'name',
           kind: 'link',
-          // Same legacy detail-page route as the wall — that detail page
-          // stays untouched in this migration.
-          link: (si: StServiceInstance) => ['/services', 'managed', si.cnsiGuid, si.guid],
+          // Per-instance detail page (#5370), uniform with the services wall.
+          // :type is the route segment 'service' (managed) / 'user-service'
+          // (user-provided), derived from the row kind.
+          link: (si: StServiceInstance) => {
+            const siType = si.type === 'user-provided' ? 'user-service' : 'service';
+            return ['/services', siType, si.cnsiGuid, si.guid];
+          },
           render: (si: StServiceInstance) => si.name,
           widthHint: '14rem',
         },

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.spec.ts
@@ -106,7 +106,7 @@ describe('CloudFoundrySpaceUserServiceInstancesSignalComponent', () => {
     } as any)).toBe('cnsi-1:si-2');
   });
 
-  it('Name column links to the legacy /services/user-provided/:cnsi/:siGuid detail page', () => {
+  it('Name column links to the /services/user-service/:cnsi/:siGuid detail page', () => {
     const cfg = component.listConfig();
     const nameCol = cfg!.columns.find(c => c.key === 'name');
     expect(nameCol).toBeDefined();
@@ -114,7 +114,7 @@ describe('CloudFoundrySpaceUserServiceInstancesSignalComponent', () => {
       cnsiGuid: 'cnsi-1', guid: 'si-2', name: 'legacy-db', type: 'user-provided',
       tags: [], createdAt: '',
     } as any);
-    expect(link).toEqual(['/services', 'user-provided', 'cnsi-1', 'si-2']);
+    expect(link).toEqual(['/services', 'user-service', 'cnsi-1', 'si-2']);
   });
 
   it('Add UPS opens the user-provided wizard pre-selecting this CF', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.ts
@@ -157,9 +157,13 @@ export class CloudFoundrySpaceUserServiceInstancesSignalComponent {
         {
           header: 'Name', key: 'name', sortField: 'name',
           kind: 'link',
-          // Same legacy detail-page route as the wall — that detail page
-          // stays untouched in this migration.
-          link: (si: StServiceInstance) => ['/services', 'user-provided', si.cnsiGuid, si.guid],
+          // Per-instance detail page (#5370), uniform with the services wall.
+          // This is the user-provided tab, so the :type segment is always
+          // 'user-service'; derived from the row kind to match the wall.
+          link: (si: StServiceInstance) => {
+            const siType = si.type === 'user-provided' ? 'user-service' : 'service';
+            return ['/services', siType, si.cnsiGuid, si.guid];
+          },
           render: (si: StServiceInstance) => si.name,
           widthHint: '14rem',
         },

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-services/cloud-foundry-services-signal.component.ts
@@ -175,10 +175,14 @@ export class CloudFoundryServicesSignalComponent implements OnInit {
         {
           header: 'Name', key: 'name', sortField: 'name',
           kind: 'link',
+          // Per-instance detail page (#5370), uniform with the services wall.
+          // Previously linked to the offering's marketplace summary and returned
+          // null for user-provided instances (no offering) — leaving UPS names
+          // dead, the dead-link the issue set out to fix. :type is the route
+          // segment 'service' (managed) / 'user-service' (user-provided).
           link: (si: StServiceInstance) => {
-            const offeringGuid = si.servicePlan?.serviceOffering?.guid;
-            if (!offeringGuid) return null;
-            return ['/marketplace', si.cnsiGuid, offeringGuid, 'summary'];
+            const siType = si.type === 'user-provided' ? 'user-service' : 'service';
+            return ['/services', siType, si.cnsiGuid, si.guid];
           },
           render: (si: StServiceInstance) => si.name,
           widthHint: '14rem',

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-instances/service-instances.component.ts
@@ -118,6 +118,12 @@ export class ServiceInstancesComponent implements OnInit {
     const columns: SignalListColumn<StServiceInstance>[] = [
       {
         header: 'Name', key: 'name', sortField: 'name',
+        kind: 'link',
+        // Link to the per-instance detail page (#5370); previously plain text.
+        link: (si) => {
+          const siType = si.type === 'user-provided' ? 'user-service' : 'service';
+          return ['/services', siType, si.cnsiGuid, si.guid];
+        },
         render: (si) => si.name ?? '',
         widthHint: '14rem',
       },

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
@@ -97,5 +97,33 @@
         </app-meta-card-value>
       </app-meta-card-item>
     </app-meta-card>
+
+    <section class="mt-6">
+      <h2 class="text-lg font-semibold text-content-text mb-2">Bound Applications</h2>
+      @if (bindingsLoading()) {
+        <p class="text-content-muted">Loading bindings…</p>
+      } @else if (bindings().length === 0) {
+        <p class="text-content-muted">No applications are bound to this service instance.</p>
+      } @else {
+        <table class="w-full text-left">
+          <thead>
+            <tr class="border-b border-content-border text-sm uppercase tracking-wide text-content-muted">
+              <th class="py-2">Application</th>
+              <th class="py-2 w-24 text-right">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (b of bindings(); track b.guid) {
+              <tr class="border-b border-content-border">
+                <td class="py-2 text-content-text">{{ b.appName }}</td>
+                <td class="py-2 text-right">
+                  <button type="button" class="btn btn-secondary btn-sm" (click)="unbind(b)">Unbind</button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      }
+    </section>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
@@ -1,0 +1,101 @@
+<app-page-header [breadcrumbs]="breadcrumbs">
+  {{ title() }}
+</app-page-header>
+
+<div class="p-4">
+  @if (loading()) {
+    <p class="text-content-muted">Loading service instance…</p>
+  } @else if (error()) {
+    <p class="text-danger">Could not load this service instance.</p>
+  } @else if (view(); as v) {
+    <app-meta-card>
+      <app-meta-card-title>
+        <div>{{ v.name }}</div>
+      </app-meta-card-title>
+
+      <app-meta-card-item>
+        <app-meta-card-key>Type</app-meta-card-key>
+        <app-meta-card-value>{{ v.typeLabel }}</app-meta-card-value>
+      </app-meta-card-item>
+
+      @if (v.status) {
+        <app-meta-card-item>
+          <app-meta-card-key>Status</app-meta-card-key>
+          <app-meta-card-value>
+            {{ v.status }}@if (v.statusDetail) { — {{ v.statusDetail }} }
+          </app-meta-card-value>
+        </app-meta-card-item>
+      }
+
+      @if (v.isManaged) {
+        @if (v.plan) {
+          <app-meta-card-item>
+            <app-meta-card-key>Plan</app-meta-card-key>
+            <app-meta-card-value>{{ v.plan }}</app-meta-card-value>
+          </app-meta-card-item>
+        }
+        @if (v.offering) {
+          <app-meta-card-item>
+            <app-meta-card-key>Service</app-meta-card-key>
+            <app-meta-card-value>{{ v.offering }}</app-meta-card-value>
+          </app-meta-card-item>
+        }
+        @if (v.broker) {
+          <app-meta-card-item>
+            <app-meta-card-key>Broker</app-meta-card-key>
+            <app-meta-card-value>{{ v.broker }}</app-meta-card-value>
+          </app-meta-card-item>
+        }
+        @if (v.dashboardUrl) {
+          <app-meta-card-item>
+            <app-meta-card-key>Dashboard</app-meta-card-key>
+            <app-meta-card-value>
+              <a [href]="v.dashboardUrl" target="_blank" rel="noopener" class="text-accent">
+                <span class="material-icons align-middle">launch</span>
+              </a>
+            </app-meta-card-value>
+          </app-meta-card-item>
+        }
+      } @else {
+        @if (v.routeServiceUrl) {
+          <app-meta-card-item customStyle="long-text">
+            <app-meta-card-key>Route Service URL</app-meta-card-key>
+            <app-meta-card-value>{{ v.routeServiceUrl }}</app-meta-card-value>
+          </app-meta-card-item>
+        }
+        @if (v.syslogDrainUrl) {
+          <app-meta-card-item customStyle="long-text">
+            <app-meta-card-key>Syslog Drain URL</app-meta-card-key>
+            <app-meta-card-value>{{ v.syslogDrainUrl }}</app-meta-card-value>
+          </app-meta-card-item>
+        }
+      }
+
+      @if (v.space) {
+        <app-meta-card-item>
+          <app-meta-card-key>Space</app-meta-card-key>
+          <app-meta-card-value>{{ v.space }}@if (v.org) { ({{ v.org }}) }</app-meta-card-value>
+        </app-meta-card-item>
+      }
+
+      <app-meta-card-item>
+        <app-meta-card-key>Created</app-meta-card-key>
+        <app-meta-card-value>{{ v.createdAt | date:'medium' }}</app-meta-card-value>
+      </app-meta-card-item>
+
+      @if (v.updatedAt) {
+        <app-meta-card-item>
+          <app-meta-card-key>Updated</app-meta-card-key>
+          <app-meta-card-value>{{ v.updatedAt | date:'medium' }}</app-meta-card-value>
+        </app-meta-card-item>
+      }
+
+      <app-meta-card-item customStyle="column">
+        <app-meta-card-key>Tags</app-meta-card-key>
+        <app-meta-card-value>
+          <app-chips [chips]="v.tags"></app-chips>
+        </app-meta-card-value>
+      </app-meta-card-item>
+    </app-meta-card>
+  }
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
@@ -19,123 +19,131 @@
   } @else if (error()) {
     <p class="text-danger">Could not load this service instance.</p>
   } @else if (view(); as v) {
-    <app-meta-card>
-      <app-meta-card-title>
-        <div>{{ v.name }}</div>
-      </app-meta-card-title>
+    <!-- Two-column header: a compact, content-sized metadata card on the left,
+         bound applications on the right. Replaces the shared MetaCard here (its
+         full-width, right-aligned, height:100% layout wasted space and pushed
+         the sections off-screen) with a left-aligned definition list. -->
+    <div class="flex flex-wrap gap-6 items-start">
+      <div class="w-96 max-w-full self-start">
+        <app-meta-card>
+          <app-meta-card-title>
+            <div class="text-lg font-semibold text-content-text">{{ v.name }}</div>
+          </app-meta-card-title>
 
-      <app-meta-card-item>
-        <app-meta-card-key>Type</app-meta-card-key>
-        <app-meta-card-value>{{ v.typeLabel }}</app-meta-card-value>
-      </app-meta-card-item>
+          <app-meta-card-item>
+            <app-meta-card-key>Type</app-meta-card-key>
+            <app-meta-card-value>{{ v.typeLabel }}</app-meta-card-value>
+          </app-meta-card-item>
 
-      @if (v.status) {
-        <app-meta-card-item>
-          <app-meta-card-key>Status</app-meta-card-key>
-          <app-meta-card-value>
-            {{ v.status }}@if (v.statusDetail) { — {{ v.statusDetail }} }
-          </app-meta-card-value>
-        </app-meta-card-item>
-      }
+          @if (v.status) {
+            <app-meta-card-item>
+              <app-meta-card-key>Status</app-meta-card-key>
+              <app-meta-card-value>
+                {{ v.status }}@if (v.statusDetail) { — {{ v.statusDetail }} }
+              </app-meta-card-value>
+            </app-meta-card-item>
+          }
 
-      @if (v.isManaged) {
-        @if (v.plan) {
+          @if (v.isManaged) {
+            @if (v.plan) {
+              <app-meta-card-item>
+                <app-meta-card-key>Plan</app-meta-card-key>
+                <app-meta-card-value>{{ v.plan }}</app-meta-card-value>
+              </app-meta-card-item>
+            }
+            @if (v.offering) {
+              <app-meta-card-item>
+                <app-meta-card-key>Service</app-meta-card-key>
+                <app-meta-card-value>{{ v.offering }}</app-meta-card-value>
+              </app-meta-card-item>
+            }
+            @if (v.broker) {
+              <app-meta-card-item>
+                <app-meta-card-key>Broker</app-meta-card-key>
+                <app-meta-card-value>{{ v.broker }}</app-meta-card-value>
+              </app-meta-card-item>
+            }
+            @if (v.dashboardUrl) {
+              <app-meta-card-item>
+                <app-meta-card-key>Dashboard</app-meta-card-key>
+                <app-meta-card-value>
+                  <a [href]="v.dashboardUrl" target="_blank" rel="noopener" class="text-accent">
+                    <span class="material-icons align-middle">launch</span>
+                  </a>
+                </app-meta-card-value>
+              </app-meta-card-item>
+            }
+          } @else {
+            @if (v.routeServiceUrl) {
+              <app-meta-card-item customStyle="long-text">
+                <app-meta-card-key>Route Service URL</app-meta-card-key>
+                <app-meta-card-value>{{ v.routeServiceUrl }}</app-meta-card-value>
+              </app-meta-card-item>
+            }
+            @if (v.syslogDrainUrl) {
+              <app-meta-card-item customStyle="long-text">
+                <app-meta-card-key>Syslog Drain URL</app-meta-card-key>
+                <app-meta-card-value>{{ v.syslogDrainUrl }}</app-meta-card-value>
+              </app-meta-card-item>
+            }
+          }
+
+          @if (v.space) {
+            <app-meta-card-item>
+              <app-meta-card-key>Space</app-meta-card-key>
+              <app-meta-card-value>{{ v.space }}@if (v.org) { ({{ v.org }}) }</app-meta-card-value>
+            </app-meta-card-item>
+          }
+
           <app-meta-card-item>
-            <app-meta-card-key>Plan</app-meta-card-key>
-            <app-meta-card-value>{{ v.plan }}</app-meta-card-value>
+            <app-meta-card-key>Created</app-meta-card-key>
+            <app-meta-card-value>{{ v.createdAt | date:'medium' }}</app-meta-card-value>
           </app-meta-card-item>
-        }
-        @if (v.offering) {
-          <app-meta-card-item>
-            <app-meta-card-key>Service</app-meta-card-key>
-            <app-meta-card-value>{{ v.offering }}</app-meta-card-value>
-          </app-meta-card-item>
-        }
-        @if (v.broker) {
-          <app-meta-card-item>
-            <app-meta-card-key>Broker</app-meta-card-key>
-            <app-meta-card-value>{{ v.broker }}</app-meta-card-value>
-          </app-meta-card-item>
-        }
-        @if (v.dashboardUrl) {
-          <app-meta-card-item>
-            <app-meta-card-key>Dashboard</app-meta-card-key>
+
+          @if (v.updatedAt) {
+            <app-meta-card-item>
+              <app-meta-card-key>Updated</app-meta-card-key>
+              <app-meta-card-value>{{ v.updatedAt | date:'medium' }}</app-meta-card-value>
+            </app-meta-card-item>
+          }
+
+          <app-meta-card-item customStyle="column">
+            <app-meta-card-key>Tags</app-meta-card-key>
             <app-meta-card-value>
-              <a [href]="v.dashboardUrl" target="_blank" rel="noopener" class="text-accent">
-                <span class="material-icons align-middle">launch</span>
-              </a>
+              <app-chips [chips]="v.tags"></app-chips>
             </app-meta-card-value>
           </app-meta-card-item>
-        }
-      } @else {
-        @if (v.routeServiceUrl) {
-          <app-meta-card-item customStyle="long-text">
-            <app-meta-card-key>Route Service URL</app-meta-card-key>
-            <app-meta-card-value>{{ v.routeServiceUrl }}</app-meta-card-value>
-          </app-meta-card-item>
-        }
-        @if (v.syslogDrainUrl) {
-          <app-meta-card-item customStyle="long-text">
-            <app-meta-card-key>Syslog Drain URL</app-meta-card-key>
-            <app-meta-card-value>{{ v.syslogDrainUrl }}</app-meta-card-value>
-          </app-meta-card-item>
-        }
-      }
+        </app-meta-card>
+      </div>
 
-      @if (v.space) {
-        <app-meta-card-item>
-          <app-meta-card-key>Space</app-meta-card-key>
-          <app-meta-card-value>{{ v.space }}@if (v.org) { ({{ v.org }}) }</app-meta-card-value>
-        </app-meta-card-item>
-      }
-
-      <app-meta-card-item>
-        <app-meta-card-key>Created</app-meta-card-key>
-        <app-meta-card-value>{{ v.createdAt | date:'medium' }}</app-meta-card-value>
-      </app-meta-card-item>
-
-      @if (v.updatedAt) {
-        <app-meta-card-item>
-          <app-meta-card-key>Updated</app-meta-card-key>
-          <app-meta-card-value>{{ v.updatedAt | date:'medium' }}</app-meta-card-value>
-        </app-meta-card-item>
-      }
-
-      <app-meta-card-item customStyle="column">
-        <app-meta-card-key>Tags</app-meta-card-key>
-        <app-meta-card-value>
-          <app-chips [chips]="v.tags"></app-chips>
-        </app-meta-card-value>
-      </app-meta-card-item>
-    </app-meta-card>
-
-    <section class="mt-6">
-      <h2 class="text-lg font-semibold text-content-text mb-2">Bound Applications</h2>
-      @if (bindingsLoading()) {
-        <p class="text-content-muted">Loading bindings…</p>
-      } @else if (bindings().length === 0) {
-        <p class="text-content-muted">No applications are bound to this service instance.</p>
-      } @else {
-        <table class="w-full text-left">
-          <thead>
-            <tr class="border-b border-content-border text-sm uppercase tracking-wide text-content-muted">
-              <th class="py-2">Application</th>
-              <th class="py-2 w-24 text-right">Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (b of bindings(); track b.guid) {
-              <tr class="border-b border-content-border">
-                <td class="py-2 text-content-text">{{ b.appName }}</td>
-                <td class="py-2 text-right">
-                  <button type="button" class="btn btn-secondary btn-sm" (click)="unbind(b)">Unbind</button>
-                </td>
+      <section class="flex-1 min-w-[20rem]">
+        <h2 class="text-lg font-semibold text-content-text mb-2">Bound Applications</h2>
+        @if (bindingsLoading()) {
+          <p class="text-content-muted">Loading bindings…</p>
+        } @else if (bindings().length === 0) {
+          <p class="text-content-muted">No applications are bound to this service instance.</p>
+        } @else {
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b border-content-border text-sm uppercase tracking-wide text-content-muted">
+                <th class="py-2">Application</th>
+                <th class="py-2 w-24 text-right">Action</th>
               </tr>
-            }
-          </tbody>
-        </table>
-      }
-    </section>
+            </thead>
+            <tbody>
+              @for (b of bindings(); track b.guid) {
+                <tr class="border-b border-content-border">
+                  <td class="py-2 text-content-text">{{ b.appName }}</td>
+                  <td class="py-2 text-right">
+                    <button type="button" class="btn btn-secondary btn-sm" (click)="unbind(b)">Unbind</button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        }
+      </section>
+    </div>
 
     @if (v.isManaged) {
       <!-- Parameters — managed only (CF's /parameters queries the broker, which

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
@@ -1,5 +1,16 @@
 <app-page-header [breadcrumbs]="breadcrumbs">
   {{ title() }}
+  @if (actions().length) {
+    <div class="page-header-right flex gap-2">
+      @for (a of actions(); track a.label) {
+        <button type="button" (click)="runAction(a)"
+          [class]="a.danger ? 'btn btn-secondary btn-sm text-danger' : 'btn btn-secondary btn-sm'">
+          <span class="material-icons text-base align-middle">{{ a.icon }}</span>
+          {{ a.label }}
+        </button>
+      }
+    </div>
+  }
 </app-page-header>
 
 <div class="p-4">

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
@@ -136,5 +136,70 @@
         </table>
       }
     </section>
+
+    @if (v.isManaged) {
+      <!-- Parameters — managed only (CF's /parameters queries the broker, which
+           a UPS has none of). Lazy, click-to-expand; fetched on first expand so
+           a broker that doesn't support parameter retrieval errors only here. -->
+      <section class="mt-6">
+        <button type="button"
+          class="flex items-center gap-2 text-left hover:opacity-80"
+          [attr.aria-expanded]="isParamsOpen()" (click)="toggleParams()">
+          <svg class="w-5 h-5 shrink-0 text-content-muted transition-transform duration-200"
+            [class.rotate-90]="isParamsOpen()" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z" />
+          </svg>
+          <h2 class="text-lg font-semibold text-content-text">Parameters</h2>
+        </button>
+        @if (isParamsOpen()) {
+          <div class="mt-2">
+            @if (paramsLoading()) {
+              <p class="flex items-center gap-2 text-content-muted">
+                <span class="animate-spin inline-block h-4 w-4 rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"></span>
+                Loading parameters…
+              </p>
+            } @else if (paramsUnavailable()) {
+              <p class="text-content-muted">Parameters are not available for this service.</p>
+            } @else if (paramsEmpty()) {
+              <p class="text-content-muted">No configured parameters.</p>
+            } @else if (params(); as p) {
+              <app-json-viewer [json]="p" root="parameters"></app-json-viewer>
+            }
+          </div>
+        }
+      </section>
+    } @else {
+      <!-- Credentials — UPS only. Lazy + masked: nothing is fetched from CF
+           until the user expands, and values stay masked until revealed. -->
+      <section class="mt-6">
+        <button type="button"
+          class="flex items-center gap-2 text-left hover:opacity-80"
+          [attr.aria-expanded]="isCredsOpen()" (click)="toggleCreds()">
+          <svg class="w-5 h-5 shrink-0 text-content-muted transition-transform duration-200"
+            [class.rotate-90]="isCredsOpen()" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z" />
+          </svg>
+          <h2 class="text-lg font-semibold text-content-text">Credentials</h2>
+        </button>
+        @if (isCredsOpen()) {
+          <div class="mt-2">
+            @if (credsLoading()) {
+              <p class="flex items-center gap-2 text-content-muted">
+                <span class="animate-spin inline-block h-4 w-4 rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"></span>
+                Loading credentials…
+              </p>
+            } @else if (credsError()) {
+              <p class="text-danger">Could not load credentials for this service instance.</p>
+            } @else if (credentialFields().length === 0) {
+              <p class="text-content-muted">No credentials are set on this service instance.</p>
+            } @else {
+              <app-masked-credentials [fields]="credentialFields()"></app-masked-credentials>
+            }
+          </div>
+        }
+      </section>
+    }
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.spec.ts
@@ -1,0 +1,115 @@
+import { provideZonelessChangeDetection, signal, Signal, WritableSignal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { ServiceInstanceSummaryComponent } from './service-instance-summary.component';
+import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import {
+  CfServiceInstancesSignalConfigService,
+} from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
+import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+import { ConfirmationDialogService, TailwindSnackBarService } from '@stratosui/core';
+
+function source<T>(value: T, error: unknown = null): SignalSource<T> {
+  return {
+    value: signal(value).asReadonly(),
+    isLoading: signal(false).asReadonly(),
+    error: signal(error).asReadonly() as Signal<never>,
+  };
+}
+
+const managed = { guid: 'si-1', name: 'db', type: 'managed' } as unknown as StServiceInstance;
+
+describe('ServiceInstanceSummaryComponent — Parameters / Credentials sections', () => {
+  let catalog: {
+    serviceInstance: ReturnType<typeof vi.fn>;
+    serviceBindingsForInstance: ReturnType<typeof vi.fn>;
+    serviceInstanceParameters: ReturnType<typeof vi.fn>;
+    userProvidedCredentials: ReturnType<typeof vi.fn>;
+  };
+
+  function build(instance: StServiceInstance = managed) {
+    catalog = {
+      serviceInstance: vi.fn(() => source<StServiceInstance | null>(instance)),
+      serviceBindingsForInstance: vi.fn(() => source([])),
+      serviceInstanceParameters: vi.fn(() => source<Record<string, unknown> | null>({ a: 1 })),
+      userProvidedCredentials: vi.fn(() => source<Record<string, unknown> | null>({ password: 's3cr3t' })),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ServiceInstanceSummaryComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: ServiceCatalogDataService, useValue: catalog },
+        { provide: EndpointDataRegistry, useValue: { acquire: vi.fn(), release: vi.fn() } },
+        { provide: EntityDeleteController, useValue: {} },
+        { provide: CfServiceInstancesSignalConfigService, useValue: {} },
+        { provide: ConfirmationDialogService, useValue: {} },
+        { provide: TailwindSnackBarService, useValue: {} },
+      ],
+    });
+    return TestBed.createComponent(ServiceInstanceSummaryComponent).componentInstance;
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('does not fetch parameters until the section is expanded', () => {
+    const c = build();
+    expect(catalog.serviceInstanceParameters).not.toHaveBeenCalled();
+
+    c.toggleParams();
+    expect(catalog.serviceInstanceParameters).toHaveBeenCalledTimes(1);
+    expect(c.isParamsOpen()).toBe(true);
+
+    // Collapsing then re-expanding must not refetch.
+    c.toggleParams();
+    c.toggleParams();
+    expect(catalog.serviceInstanceParameters).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch credentials until the section is expanded', () => {
+    const c = build();
+    expect(catalog.userProvidedCredentials).not.toHaveBeenCalled();
+
+    c.toggleCreds();
+    expect(catalog.userProvidedCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it('distinguishes an empty params object from a broker error', () => {
+    const c = build();
+    // Empty object → "no parameters", not "unavailable".
+    catalog.serviceInstanceParameters.mockReturnValueOnce(source<Record<string, unknown> | null>({}));
+    c.toggleParams();
+    expect(c.paramsEmpty()).toBe(true);
+    expect(c.paramsUnavailable()).toBe(false);
+  });
+
+  it('flags a broker error as unavailable', () => {
+    const c = build();
+    catalog.serviceInstanceParameters.mockReturnValueOnce(
+      source<Record<string, unknown> | null>(null, { status: 502 }),
+    );
+    c.toggleParams();
+    expect(c.paramsUnavailable()).toBe(true);
+    expect(c.paramsEmpty()).toBe(false);
+  });
+
+  it('derives masked credential fields from the fetched credentials', () => {
+    const c = build();
+    c.toggleCreds();
+    const fields = c.credentialFields();
+    const pw = fields.find(f => f.key === 'password')!;
+    expect(pw.sensitive).toBe(true);
+    expect(pw.displayMasked).toBe('••••••••');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
@@ -10,7 +10,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import {
   AppChip,
@@ -24,6 +24,7 @@ import {
   MetaCardValueComponent,
   AppChipsComponent,
   PageHeaderComponent,
+  SignalListRowAction,
   TailwindSnackBarService,
 } from '@stratosui/core';
 import { of } from 'rxjs';
@@ -33,6 +34,12 @@ import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-d
 import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
 import { runCfDelete } from '../../../services/deletes/run-cf-delete';
 import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import {
+  CfServiceInstancesSignalConfigService,
+} from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
+import {
+  buildServiceInstanceRowActions,
+} from '../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import { StServiceCredentialBinding, StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 
 interface BindingRow {
@@ -98,6 +105,8 @@ export class ServiceInstanceSummaryComponent implements OnDestroy {
   private readonly registry = inject(EndpointDataRegistry);
   private readonly confirmDialog = inject(ConfirmationDialogService);
   private readonly snackBar = inject(TailwindSnackBarService);
+  private readonly router = inject(Router);
+  private readonly instancesConfig = inject(CfServiceInstancesSignalConfigService);
 
   private readonly cfGuid: string;
   private readonly siGuid: string;
@@ -117,6 +126,7 @@ export class ServiceInstanceSummaryComponent implements OnDestroy {
   readonly title: Signal<string>;
   readonly bindingsLoading: Signal<boolean>;
   readonly bindings: Signal<BindingRow[]>;
+  readonly actions: Signal<SignalListRowAction<StServiceInstance>[]>;
 
   constructor() {
     this.cfGuid = this.route.snapshot.params.endpointId;
@@ -143,10 +153,37 @@ export class ServiceInstanceSummaryComponent implements OnDestroy {
         .filter(b => b.type === 'app')
         .map(b => ({ guid: b.guid, appName: b.app?.name ?? b.app?.guid ?? '' })),
     );
+
+    // Header action bar. Reuse the shared builder (Edit / Service Keys /
+    // Delete) so the route conventions and keys gating match the lists.
+    // Detach is dropped — the inline per-app Unbind above covers it. Delete
+    // here also navigates back to the wall, since the page's instance is gone.
+    this.actions = computed(() => {
+      const si = this.source.value();
+      if (!si) { return []; }
+      return buildServiceInstanceRowActions(si, {
+        router: this.router,
+        confirmDialog: this.confirmDialog,
+        snackBar: this.snackBar,
+        deleteServiceInstance: async (cnsiGuid, guid) => {
+          await this.instancesConfig.deleteServiceInstance(cnsiGuid, guid, si.name);
+          void this.router.navigate(['/services']);
+        },
+        // Offering-bindability cache isn't warmed on this page; fail open so
+        // Service Keys shows for managed instances (the builder's convention).
+        isOfferingBindable: () => undefined,
+      }).filter(a => a.label !== 'Detach');
+    });
   }
 
   ngOnDestroy(): void {
     this.registry.release(this.cfGuid);
+  }
+
+  /** Invoke a header action (the builder's invokes close over the instance). */
+  runAction(action: SignalListRowAction<StServiceInstance>): void {
+    const si = this.source.value();
+    if (si) { void action.invoke(si); }
   }
 
   /** Unbind one app from this instance (confirm → v3 DELETE → re-fetch list). */

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
@@ -1,9 +1,21 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Signal, computed, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  Signal,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import {
   AppChip,
+  ConfirmationDialogConfig,
+  ConfirmationDialogService,
   IHeaderBreadcrumb,
   MetaCardComponent,
   MetaCardItemComponent,
@@ -12,11 +24,21 @@ import {
   MetaCardValueComponent,
   AppChipsComponent,
   PageHeaderComponent,
+  TailwindSnackBarService,
 } from '@stratosui/core';
 import { of } from 'rxjs';
 
+import { serviceCredentialBindingEntityType } from '../../../entity-relations/signal/cf-relation-registrations';
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { runCfDelete } from '../../../services/deletes/run-cf-delete';
 import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
-import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+import { StServiceCredentialBinding, StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+
+interface BindingRow {
+  guid: string;
+  appName: string;
+}
 
 interface InstanceView {
   name: string;
@@ -68,11 +90,22 @@ interface InstanceView {
     AppChipsComponent,
   ],
 })
-export class ServiceInstanceSummaryComponent {
+export class ServiceInstanceSummaryComponent implements OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly serviceCatalog = inject(ServiceCatalogDataService);
+  private readonly http = inject(HttpClient);
+  private readonly deleteController = inject(EntityDeleteController);
+  private readonly registry = inject(EndpointDataRegistry);
+  private readonly confirmDialog = inject(ConfirmationDialogService);
+  private readonly snackBar = inject(TailwindSnackBarService);
 
+  private readonly cfGuid: string;
+  private readonly siGuid: string;
   private readonly source: SignalSource<StServiceInstance | null>;
+
+  // One-shot bindings fetch; re-issued after an unbind so the list refreshes
+  // (the thin data service doesn't auto-update like the EDS rollups).
+  private readonly bindingsSource: WritableSignal<SignalSource<StServiceCredentialBinding[]>>;
 
   readonly breadcrumbs: IHeaderBreadcrumb[] = [
     { breadcrumbs: [{ value: 'Services', routerLink: '/services' }] },
@@ -82,11 +115,19 @@ export class ServiceInstanceSummaryComponent {
   readonly error: Signal<boolean>;
   readonly view: Signal<InstanceView | null>;
   readonly title: Signal<string>;
+  readonly bindingsLoading: Signal<boolean>;
+  readonly bindings: Signal<BindingRow[]>;
 
   constructor() {
-    const cfGuid = this.route.snapshot.params.endpointId;
-    const siGuid = this.route.snapshot.params.serviceInstanceId;
-    this.source = this.serviceCatalog.serviceInstance(cfGuid, siGuid);
+    this.cfGuid = this.route.snapshot.params.endpointId;
+    this.siGuid = this.route.snapshot.params.serviceInstanceId;
+    this.source = this.serviceCatalog.serviceInstance(this.cfGuid, this.siGuid);
+    this.bindingsSource = signal(this.serviceCatalog.serviceBindingsForInstance(this.cfGuid, this.siGuid));
+
+    // Hold a refcount on the endpoint's data service so the delete chokepoint
+    // can peek it to invalidate binding rollups (the wall's "Attached Apps",
+    // app pages) after an unbind.
+    this.registry.acquire(this.cfGuid);
 
     this.loading = this.source.isLoading;
     this.error = computed(() => this.source.error() != null);
@@ -95,6 +136,41 @@ export class ServiceInstanceSummaryComponent {
       return si ? this.toView(si) : null;
     });
     this.title = computed(() => this.view()?.name ?? '');
+
+    this.bindingsLoading = computed(() => this.bindingsSource().isLoading());
+    this.bindings = computed(() =>
+      (this.bindingsSource().value() ?? [])
+        .filter(b => b.type === 'app')
+        .map(b => ({ guid: b.guid, appName: b.app?.name ?? b.app?.guid ?? '' })),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.registry.release(this.cfGuid);
+  }
+
+  /** Unbind one app from this instance (confirm → v3 DELETE → re-fetch list). */
+  unbind(row: BindingRow): void {
+    const confirm = new ConfirmationDialogConfig(
+      'Unbind Application',
+      `Unbind "${row.appName}" from this service instance?`,
+      'Unbind',
+      true,
+    );
+    this.confirmDialog.open(confirm, async () => {
+      try {
+        await runCfDelete(this.deleteController, this.http, {
+          cnsiGuid: this.cfGuid,
+          entityKind: serviceCredentialBindingEntityType,
+          deleteGuid: row.guid,
+          path: `/pp/v1/cf/service_bindings/${this.cfGuid}/${row.guid}`,
+        });
+        // Re-issue the one-shot fetch so the unbound app drops out.
+        this.bindingsSource.set(this.serviceCatalog.serviceBindingsForInstance(this.cfGuid, this.siGuid));
+      } catch (err: unknown) {
+        this.snackBar.error(`Unbind failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
   }
 
   private toView(si: StServiceInstance): InstanceView {

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
@@ -29,11 +29,17 @@ import {
 } from '@stratosui/core';
 import { of } from 'rxjs';
 
+import { JsonViewerComponent } from '../../../../../core/src/shared/components/json-viewer/json-viewer.component';
 import { serviceCredentialBindingEntityType } from '../../../entity-relations/signal/cf-relation-registrations';
 import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
 import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
 import { runCfDelete } from '../../../services/deletes/run-cf-delete';
 import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import {
+  CredentialField,
+  MaskedCredentialsComponent,
+  toCredentialFields,
+} from '../../../shared/components/masked-credentials/masked-credentials.component';
 import {
   CfServiceInstancesSignalConfigService,
 } from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
@@ -75,11 +81,13 @@ interface InstanceView {
  * type: managed shows plan/offering/broker/dashboard, UPS shows the route-
  * service and syslog-drain URLs.
  *
- * Phase 1+2 (this commit): route shell + metadata card. Still to come:
- * bindings list + unbind (Phase 3), action bar (Phase 4), uniform card
- * linking (Phase 5), read-only parameters (Phase 6, needs a backend fetch).
- * UPS credentials metadata is an open question and is deliberately omitted
- * for now.
+ * Sections: metadata card, bound-applications list with unbind, a header
+ * action bar, and two lazily-fetched expandable sections — Parameters
+ * (managed + UPS, read-only json-viewer) and Credentials (UPS only, masked
+ * with per-field reveal). Both expandable sections fetch only on expand: a
+ * deliberate choice so credentials never hit CF until the user explicitly
+ * asks, and so a broker that doesn't support parameter retrieval errors only
+ * the section, not the page.
  */
 @Component({
   selector: 'app-service-instance-summary',
@@ -95,6 +103,8 @@ interface InstanceView {
     MetaCardKeyComponent,
     MetaCardValueComponent,
     AppChipsComponent,
+    JsonViewerComponent,
+    MaskedCredentialsComponent,
   ],
 })
 export class ServiceInstanceSummaryComponent implements OnDestroy {
@@ -174,6 +184,54 @@ export class ServiceInstanceSummaryComponent implements OnDestroy {
         isOfferingBindable: () => undefined,
       }).filter(a => a.label !== 'Detach');
     });
+  }
+
+  // Parameters section — lazy, click-to-expand. Managed and UPS both expose
+  // CF's GET .../parameters; the source is created on first expand so the page
+  // load stays light and a broker that errors only fails this section.
+  private readonly paramsOpen = signal(false);
+  private readonly paramsSource = signal<SignalSource<Record<string, unknown> | null> | null>(null);
+  readonly isParamsOpen = computed(() => this.paramsOpen());
+  readonly paramsLoading = computed(() => this.paramsSource()?.isLoading() ?? false);
+  // An error here means the broker doesn't support parameter retrieval — a
+  // normal condition for many services, shown as "not available" rather than
+  // an error, and kept distinct from an empty object ("no parameters").
+  readonly paramsUnavailable = computed(() => this.paramsSource()?.error() != null);
+  readonly params = computed(() => this.paramsSource()?.value() ?? null);
+  readonly paramsEmpty = computed(() => {
+    const p = this.params();
+    return p != null && Object.keys(p).length === 0;
+  });
+
+  // Credentials section — UPS only, lazy, click-to-expand. Sensitive, so the
+  // fetch is deferred until the user opens the section; values are masked by
+  // default in the rendered MaskedCredentialsComponent.
+  private readonly credsOpen = signal(false);
+  private readonly credsSource = signal<SignalSource<Record<string, unknown> | null> | null>(null);
+  readonly isCredsOpen = computed(() => this.credsOpen());
+  readonly credsLoading = computed(() => this.credsSource()?.isLoading() ?? false);
+  readonly credsError = computed(() => this.credsSource()?.error() != null);
+  readonly credentialFields = computed<CredentialField[]>(() => {
+    const c = this.credsSource()?.value();
+    return c ? toCredentialFields(c) : [];
+  });
+
+  /** Expand/collapse the Parameters section; fetch lazily on first expand. */
+  toggleParams(): void {
+    const opening = !this.paramsOpen();
+    this.paramsOpen.set(opening);
+    if (opening && this.paramsSource() == null) {
+      this.paramsSource.set(this.serviceCatalog.serviceInstanceParameters(this.cfGuid, this.siGuid));
+    }
+  }
+
+  /** Expand/collapse the Credentials section; fetch lazily on first expand. */
+  toggleCreds(): void {
+    const opening = !this.credsOpen();
+    this.credsOpen.set(opening);
+    if (opening && this.credsSource() == null) {
+      this.credsSource.set(this.serviceCatalog.userProvidedCredentials(this.cfGuid, this.siGuid));
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
@@ -1,0 +1,121 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Signal, computed, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+import {
+  AppChip,
+  IHeaderBreadcrumb,
+  MetaCardComponent,
+  MetaCardItemComponent,
+  MetaCardKeyComponent,
+  MetaCardTitleComponent,
+  MetaCardValueComponent,
+  AppChipsComponent,
+  PageHeaderComponent,
+} from '@stratosui/core';
+import { of } from 'rxjs';
+
+import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+
+interface InstanceView {
+  name: string;
+  isManaged: boolean;
+  typeLabel: string;
+  status: string;
+  statusDetail: string;
+  plan: string;
+  offering: string;
+  broker: string;
+  dashboardUrl: string;
+  routeServiceUrl: string;
+  syslogDrainUrl: string;
+  space: string;
+  org: string;
+  tags: AppChip<string>[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * ServiceInstanceSummaryComponent — per-instance read view (#5370).
+ *
+ * The single read surface for one service instance, managed or
+ * user-provided, at `/services/:type/:cnsi/:siGuid` (the parent of the
+ * existing `.../edit` write stepper). Branches its metadata on instance
+ * type: managed shows plan/offering/broker/dashboard, UPS shows the route-
+ * service and syslog-drain URLs.
+ *
+ * Phase 1+2 (this commit): route shell + metadata card. Still to come:
+ * bindings list + unbind (Phase 3), action bar (Phase 4), uniform card
+ * linking (Phase 5), read-only parameters (Phase 6, needs a backend fetch).
+ * UPS credentials metadata is an open question and is deliberately omitted
+ * for now.
+ */
+@Component({
+  selector: 'app-service-instance-summary',
+  templateUrl: './service-instance-summary.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    PageHeaderComponent,
+    MetaCardComponent,
+    MetaCardTitleComponent,
+    MetaCardItemComponent,
+    MetaCardKeyComponent,
+    MetaCardValueComponent,
+    AppChipsComponent,
+  ],
+})
+export class ServiceInstanceSummaryComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly serviceCatalog = inject(ServiceCatalogDataService);
+
+  private readonly source: SignalSource<StServiceInstance | null>;
+
+  readonly breadcrumbs: IHeaderBreadcrumb[] = [
+    { breadcrumbs: [{ value: 'Services', routerLink: '/services' }] },
+  ];
+
+  readonly loading: Signal<boolean>;
+  readonly error: Signal<boolean>;
+  readonly view: Signal<InstanceView | null>;
+  readonly title: Signal<string>;
+
+  constructor() {
+    const cfGuid = this.route.snapshot.params.endpointId;
+    const siGuid = this.route.snapshot.params.serviceInstanceId;
+    this.source = this.serviceCatalog.serviceInstance(cfGuid, siGuid);
+
+    this.loading = this.source.isLoading;
+    this.error = computed(() => this.source.error() != null);
+    this.view = computed(() => {
+      const si = this.source.value();
+      return si ? this.toView(si) : null;
+    });
+    this.title = computed(() => this.view()?.name ?? '');
+  }
+
+  private toView(si: StServiceInstance): InstanceView {
+    const isManaged = si.type !== 'user-provided';
+    return {
+      name: si.name,
+      isManaged,
+      typeLabel: isManaged ? 'Managed' : 'User-provided',
+      status: si.lastOperation?.state ?? '',
+      statusDetail: si.lastOperation?.description ?? '',
+      plan: si.servicePlan?.name ?? '',
+      offering: si.servicePlan?.serviceOffering?.name ?? '',
+      broker: si.servicePlan?.serviceOffering?.broker?.name ?? '',
+      dashboardUrl: si.dashboardUrl ?? '',
+      routeServiceUrl: si.routeServiceUrl ?? '',
+      syslogDrainUrl: si.syslogDrainUrl ?? '',
+      space: si.space?.name ?? '',
+      org: si.space?.organization?.name ?? '',
+      tags: (si.tags ?? []).map(t => ({ value: t, hideClearButton$: of(true) })),
+      createdAt: si.createdAt ?? '',
+      updatedAt: si.updatedAt ?? '',
+    };
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -97,35 +97,7 @@
               } @else if (credentialFields(key.guid).length === 0) {
                 <p class="text-content-muted">No credentials returned for this key.</p>
               } @else {
-                <!-- Not w-full: columns size to content so the key/value/actions
-                     align in tidy columns packed to the left, with the copy
-                     controls in one aligned column right after the values. -->
-                <table class="text-left text-sm">
-                  <tbody>
-                    @for (field of credentialFields(key.guid); track field.key) {
-                      <tr class="border-b border-content-border last:border-0">
-                        <td class="py-1 pr-8 align-top font-medium text-content-muted whitespace-nowrap">{{ field.key }}</td>
-                        <td class="py-1 pr-4 align-top break-all font-mono">{{ displayValue(key.guid, field) }}</td>
-                        <td class="py-1 align-top whitespace-nowrap text-right">
-                          @if (field.sensitive) {
-                            <button type="button" class="text-link hover:underline text-xs"
-                              (click)="toggleField(key.guid, field.key)">
-                              {{ fieldShown(key.guid, field.key) ? 'Hide' : 'Show' }}
-                            </button>
-                          }
-                        </td>
-                        <!-- pl-8: the copy component renders its icon absolute-left of
-                             its own (0-width) box, so reserve space here so it doesn't
-                             overlap the Show column. -->
-                        <td class="py-1 pl-10 align-top">
-                          <app-copy-to-clipboard class="inline-block w-5" [text]="field.value"
-                            [tooltip]="'Copy ' + field.key"
-                            [showSuccessText]="false" [compact]="true"></app-copy-to-clipboard>
-                        </td>
-                      </tr>
-                    }
-                  </tbody>
-                </table>
+                <app-masked-credentials [fields]="credentialFields(key.guid)"></app-masked-credentials>
               }
             </div>
           }

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
@@ -6,7 +6,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
-import { ServiceKeysComponent, toCredentialFields } from './service-keys.component';
+import { ServiceKeysComponent } from './service-keys.component';
 import { ServiceCatalogDataService, ServiceKeyView } from '../../../services/endpoint-data/service-catalog-data.service';
 import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
 import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
@@ -176,63 +176,5 @@ describe('ServiceKeysComponent — context-aware breadcrumbs', () => {
   it('omits the space-services trail until the instance (with its space/org) has loaded', () => {
     const c = setup(null, [{ guid: 'cf-1', name: 'prod-cf' }]);
     expect(c.breadcrumbs().find(b => b.key === 'space-services')).toBeUndefined();
-  });
-});
-
-describe('toCredentialFields — credential masking', () => {
-  const fieldFor = (key: string, value: unknown) =>
-    toCredentialFields({ [key]: value }).find(f => f.key === key)!;
-
-  it('redacts only the password in an embedded-credential URL, keeping the rest visible', () => {
-    const f = fieldFor('uri', 'postgres://user:s3cr3t@host:5432/db');
-    expect(f.sensitive).toBe(true);
-    expect(f.displayMasked).toBe('postgres://user:<redacted>@host:5432/db');
-    // The real value is preserved for copy / reveal.
-    expect(f.value).toBe('postgres://user:s3cr3t@host:5432/db');
-  });
-
-  it('fully masks a key-sensitive non-URL secret', () => {
-    const f = fieldFor('password', 's3cr3t');
-    expect(f.sensitive).toBe(true);
-    expect(f.displayMasked).toBe('••••••••');
-  });
-
-  it('leaves a plain non-sensitive value unmasked', () => {
-    const f = fieldFor('host', 'db.example.com');
-    expect(f.sensitive).toBe(false);
-  });
-
-  it('does not mask a URL that carries no embedded credentials', () => {
-    const f = fieldFor('dashboard_url', 'https://dashboard.example.com/db');
-    expect(f.sensitive).toBe(false);
-  });
-});
-
-describe('ServiceKeysComponent — displayValue masking toggle', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ServiceKeysComponent],
-      providers: [
-        provideZonelessChangeDetection(),
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        provideRouter([]),
-        provideNoopAnimations(),
-        {
-          provide: ServiceCatalogDataService,
-          useValue: { serviceInstance: () => source(null), serviceKeysForInstance: () => source([] as ServiceKeyView[]) },
-        },
-      ],
-    }).compileComponents();
-  });
-
-  it('shows the partial mask when hidden and the real value once revealed', () => {
-    const c = TestBed.createComponent(ServiceKeysComponent).componentInstance;
-    const field = { key: 'uri', value: 'postgres://user:s3cr3t@host/db', sensitive: true, displayMasked: 'postgres://user:<redacted>@host/db' };
-
-    expect(c.displayValue('k1', field)).toBe('postgres://user:<redacted>@host/db');
-
-    c.toggleField('k1', 'uri');
-    expect(c.displayValue('k1', field)).toBe('postgres://user:s3cr3t@host/db');
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -4,12 +4,13 @@ import { ChangeDetectionStrategy, Component, Signal, computed, effect, inject, s
 import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 
-import { CopyToClipboardComponent, IHeaderBreadcrumb, ListSubNavAddAction, ListSubNavComponent, PageHeaderComponent } from '@stratosui/core';
+import { IHeaderBreadcrumb, ListSubNavAddAction, ListSubNavComponent, PageHeaderComponent } from '@stratosui/core';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
 import { ServiceCatalogDataService, ServiceKeyView, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
 import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
+import { CredentialField, MaskedCredentialsComponent, toCredentialFields } from '../../../shared/components/masked-credentials/masked-credentials.component';
 
 type RowStatus = 'idle' | 'busy' | 'error';
 
@@ -19,50 +20,6 @@ interface KeyDetailsResponse {
 
 interface OfferingBindableResponse {
   bindable?: boolean;
-}
-
-// One displayable credential entry. `sensitive` drives on-screen masking;
-// `value` always holds the real value so copy works even while masked;
-// `displayMasked` is what to show while hidden — a full bullet mask for plain
-// secrets, or a URL with only its password redacted so the host/port/db stay
-// readable.
-export interface CredentialField {
-  key: string;
-  value: string;
-  sensitive: boolean;
-  displayMasked: string;
-}
-
-// Mask credential keys that look like secrets. We iterate every field (rather
-// than hardcoding username/password/url) so the list survives broker key-name
-// changes; only the display is masked, never the copied value.
-const SENSITIVE_KEY = /pass|secret|token|private|key|cred/i;
-// Connection strings frequently embed the password as scheme://user:pass@host
-// (e.g. a postgres `uri`). Mask by VALUE too so these don't leak even though
-// the key ("uri"/"read_uri") looks innocuous; a plain URL without credentials
-// stays visible.
-const EMBEDDED_CREDENTIAL = /:\/\/[^/\s:@]+:[^/\s@]+@/;
-const FULL_MASK = '••••••••';
-
-// Redact only the password run in a scheme://user:pass@host URL, leaving the
-// scheme, user, host, port and path readable. Non-URL values (or URLs without
-// embedded credentials) pass through unchanged.
-function redactEmbeddedCredential(value: string): string {
-  return value.replace(/(:\/\/[^/\s:@]+:)[^/\s@]+(@)/, '$1<redacted>$2');
-}
-
-export function toCredentialFields(creds: Record<string, unknown>): CredentialField[] {
-  return Object.entries(creds).map(([key, raw]) => {
-    const value = typeof raw === 'string' ? raw : JSON.stringify(raw);
-    const embedsCredential = EMBEDDED_CREDENTIAL.test(value);
-    const sensitive = SENSITIVE_KEY.test(key) || embedsCredential;
-    return {
-      key,
-      value,
-      sensitive,
-      displayMasked: embedsCredential ? redactEmbeddedCredential(value) : FULL_MASK,
-    };
-  });
 }
 
 // ServiceKeysComponent — per-instance Service Keys page, reached via the
@@ -77,7 +34,7 @@ export function toCredentialFields(creds: Record<string, unknown>): CredentialFi
   templateUrl: './service-keys.component.html',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe, PageHeaderComponent, CopyToClipboardComponent, ListSubNavComponent],
+  imports: [DatePipe, PageHeaderComponent, ListSubNavComponent, MaskedCredentialsComponent],
 })
 export class ServiceKeysComponent {
   private http = inject(HttpClient);
@@ -169,8 +126,6 @@ export class ServiceKeysComponent {
   private credsByGuid = signal<Record<string, Record<string, unknown>>>({});
   private credsLoadingByGuid = signal<Record<string, boolean>>({});
   private credsErrorByGuid = signal<Record<string, string>>({});
-  // Revealed sensitive fields, keyed `${guid}::${fieldKey}`.
-  private shownFields = signal<ReadonlySet<string>>(new Set<string>());
   // Per-key delete status.
   private statusByGuid = signal<Record<string, RowStatus>>({});
   // Transient "Copied" feedback for the header Copy-all button, by key guid.
@@ -184,9 +139,6 @@ export class ServiceKeysComponent {
     const creds = this.credsByGuid()[guid];
     return creds ? toCredentialFields(creds) : [];
   };
-  fieldShown = (guid: string, key: string): boolean => this.shownFields().has(`${guid}::${key}`);
-  displayValue = (guid: string, field: CredentialField): string =>
-    field.sensitive && !this.fieldShown(guid, field.key) ? field.displayMasked : field.value;
 
   constructor() {
     const route = inject(ActivatedRoute);
@@ -217,15 +169,6 @@ export class ServiceKeysComponent {
     if (opening && this.credsByGuid()[guid] === undefined && !this.credsLoading(guid)) {
       void this.loadCredentials(guid);
     }
-  }
-
-  toggleField(guid: string, key: string): void {
-    const id = `${guid}::${key}`;
-    this.shownFields.update(prev => {
-      const next = new Set(prev);
-      if (next.has(id)) { next.delete(id); } else { next.add(id); }
-      return next;
-    });
   }
 
   // Header "Copy all (JSON)" — works without expanding the panel: loads the

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.ts
@@ -224,13 +224,11 @@ export class ServicesWallComponent implements OnInit {
         {
           header: 'Name', key: 'name', sortField: 'name',
           kind: 'link',
-          // Land on the marketplace offering summary for managed instances;
-          // user-provided instances have no offering so the name stays
-          // plain text (signal-list renders `null` as non-link).
+          // Land on the per-instance detail page (#5370), uniformly for both
+          // managed and user-provided — the latter previously had no link.
           link: (si: StServiceInstance) => {
-            const offeringGuid = si.servicePlan?.serviceOffering?.guid;
-            if (!offeringGuid) return null;
-            return ['/marketplace', si.cnsiGuid, offeringGuid, 'summary'];
+            const siType = si.type === 'user-provided' ? 'user-service' : 'service';
+            return ['/services', siType, si.cnsiGuid, si.guid];
           },
           render: (si: StServiceInstance) => si.name,
           widthHint: '14rem',

--- a/src/frontend/packages/cloud-foundry/src/features/services/services.routes.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services.routes.ts
@@ -8,6 +8,7 @@ import {
 } from '../../shared/components/add-service-instance/add-service-instance/add-service-instance.component';
 import { DetachServiceInstanceComponent } from './detach-service-instance/detach-service-instance.component';
 import { RouteServiceComponent } from './route-service/route-service.component';
+import { ServiceInstanceSummaryComponent } from './service-instance-summary/service-instance-summary.component';
 import { ServiceKeysComponent } from './service-keys/service-keys.component';
 import { ServicesWallComponent } from './services-wall/services-wall.component';
 
@@ -39,5 +40,11 @@ export const SERVICES_ROUTES: Routes = [
   {
     path: 'route-service/:endpointId/:routeGuid',
     component: RouteServiceComponent
+  },
+  // Bare per-instance detail/summary (read view, #5370). Listed AFTER the
+  // literal `route-service/...` route so its `:type` segment cannot shadow it.
+  {
+    path: ':type/:endpointId/:serviceInstanceId',
+    component: ServiceInstanceSummaryComponent
   }
 ];

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
@@ -213,6 +213,35 @@ export class ServiceCatalogDataService {
     );
   }
 
+  // Managed-instance parameters — CF v3 GET .../parameters, proxied by the
+  // native handler, returning the bare params object the broker was
+  // provisioned with. No catchAs404Null: brokers that don't enable
+  // instances_retrievable make CF error here, and the section needs to tell
+  // "not available" (error) apart from "no parameters" (an empty object), so
+  // the failure must surface on `.error` rather than collapse to null. Lazy —
+  // the detail page calls this only when the Parameters section is expanded.
+  serviceInstanceParameters(cnsiGuid: string, instanceGuid: string): SignalSource<Record<string, unknown> | null> {
+    return this.signalize(
+      this.http.get<Record<string, unknown>>(
+        `/pp/v1/cf/service_instances/${cnsiGuid}/${instanceGuid}/parameters`,
+      ),
+      null,
+    );
+  }
+
+  // User-provided instance credentials — CF v3 GET .../credentials, proxied by
+  // the native handler. Sensitive: the caller fetches this only on an explicit
+  // reveal action (never on page load) and the UI masks the values by default.
+  // UPS-only — CF errors for a managed instance, surfaced via `.error`.
+  userProvidedCredentials(cnsiGuid: string, instanceGuid: string): SignalSource<Record<string, unknown> | null> {
+    return this.signalize(
+      this.http.get<Record<string, unknown>>(
+        `/pp/v1/cf/service_instances/${cnsiGuid}/${instanceGuid}/credentials`,
+      ),
+      null,
+    );
+  }
+
   // Service keys for a single instance — credential bindings with type=key
   // (filtered server-side by GH#4301's native handler). Maps the raw v3
   // binding resources to a small view model the keys page renders. The keys

--- a/src/frontend/packages/cloud-foundry/src/shared/components/masked-credentials/masked-credentials.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/masked-credentials/masked-credentials.component.spec.ts
@@ -1,0 +1,64 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect } from 'vitest';
+
+import { MaskedCredentialsComponent, toCredentialFields } from './masked-credentials.component';
+
+describe('toCredentialFields — credential masking', () => {
+  const fieldFor = (key: string, value: unknown) =>
+    toCredentialFields({ [key]: value }).find(f => f.key === key)!;
+
+  it('redacts only the password in an embedded-credential URL, keeping the rest visible', () => {
+    const f = fieldFor('uri', 'postgres://user:s3cr3t@host:5432/db');
+    expect(f.sensitive).toBe(true);
+    expect(f.displayMasked).toBe('postgres://user:<redacted>@host:5432/db');
+    // The real value is preserved for copy / reveal.
+    expect(f.value).toBe('postgres://user:s3cr3t@host:5432/db');
+  });
+
+  it('fully masks a key-sensitive non-URL secret', () => {
+    const f = fieldFor('password', 's3cr3t');
+    expect(f.sensitive).toBe(true);
+    expect(f.displayMasked).toBe('••••••••');
+  });
+
+  it('leaves a plain non-sensitive value unmasked', () => {
+    const f = fieldFor('host', 'db.example.com');
+    expect(f.sensitive).toBe(false);
+  });
+
+  it('does not mask a URL that carries no embedded credentials', () => {
+    const f = fieldFor('dashboard_url', 'https://dashboard.example.com/db');
+    expect(f.sensitive).toBe(false);
+  });
+
+  it('serialises a non-string value before masking', () => {
+    const f = fieldFor('config', { nested: true });
+    expect(f.value).toBe('{"nested":true}');
+  });
+});
+
+describe('MaskedCredentialsComponent — reveal toggle', () => {
+  it('shows the partial mask when hidden and the real value once revealed', () => {
+    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+    const c = TestBed.createComponent(MaskedCredentialsComponent).componentInstance;
+    const field = { key: 'uri', value: 'postgres://user:s3cr3t@host/db', sensitive: true, displayMasked: 'postgres://user:<redacted>@host/db' };
+
+    // Hidden by default.
+    expect(c.displayValue(field)).toBe('postgres://user:<redacted>@host/db');
+
+    c.toggleField('uri');
+    expect(c.displayValue(field)).toBe('postgres://user:s3cr3t@host/db');
+
+    // Toggling back re-masks.
+    c.toggleField('uri');
+    expect(c.displayValue(field)).toBe('postgres://user:<redacted>@host/db');
+  });
+
+  it('never masks a non-sensitive field regardless of reveal state', () => {
+    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+    const c = TestBed.createComponent(MaskedCredentialsComponent).componentInstance;
+    const field = { key: 'host', value: 'db.example.com', sensitive: false, displayMasked: '••••••••' };
+    expect(c.displayValue(field)).toBe('db.example.com');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/masked-credentials/masked-credentials.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/masked-credentials/masked-credentials.component.ts
@@ -1,0 +1,108 @@
+import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core';
+
+import { CopyToClipboardComponent } from '@stratosui/core';
+
+// One displayable credential entry. `sensitive` drives on-screen masking;
+// `value` always holds the real value so copy works even while masked;
+// `displayMasked` is what to show while hidden — a full bullet mask for plain
+// secrets, or a URL with only its password redacted so the host/port/db stay
+// readable.
+export interface CredentialField {
+  key: string;
+  value: string;
+  sensitive: boolean;
+  displayMasked: string;
+}
+
+// Mask credential keys that look like secrets. We iterate every field (rather
+// than hardcoding username/password/url) so the list survives broker key-name
+// changes; only the display is masked, never the copied value.
+const SENSITIVE_KEY = /pass|secret|token|private|key|cred/i;
+// Connection strings frequently embed the password as scheme://user:pass@host
+// (e.g. a postgres `uri`). Mask by VALUE too so these don't leak even though
+// the key ("uri"/"read_uri") looks innocuous; a plain URL without credentials
+// stays visible.
+const EMBEDDED_CREDENTIAL = /:\/\/[^/\s:@]+:[^/\s@]+@/;
+const FULL_MASK = '••••••••';
+
+// Redact only the password run in a scheme://user:pass@host URL, leaving the
+// scheme, user, host, port and path readable. Non-URL values (or URLs without
+// embedded credentials) pass through unchanged.
+function redactEmbeddedCredential(value: string): string {
+  return value.replace(/(:\/\/[^/\s:@]+:)[^/\s@]+(@)/, '$1<redacted>$2');
+}
+
+export function toCredentialFields(creds: Record<string, unknown>): CredentialField[] {
+  return Object.entries(creds).map(([key, raw]) => {
+    const value = typeof raw === 'string' ? raw : JSON.stringify(raw);
+    const embedsCredential = EMBEDDED_CREDENTIAL.test(value);
+    const sensitive = SENSITIVE_KEY.test(key) || embedsCredential;
+    return {
+      key,
+      value,
+      sensitive,
+      displayMasked: embedsCredential ? redactEmbeddedCredential(value) : FULL_MASK,
+    };
+  });
+}
+
+// MaskedCredentialsComponent — a read-only key/value table of credential
+// fields, sensitive ones masked by default with a per-field Show/Hide toggle
+// and a copy-to-clipboard control that always copies the real value. One
+// component instance renders one credential set (a service key's credentials,
+// or a user-provided instance's), so reveal state is keyed by field key alone.
+@Component({
+  selector: 'app-masked-credentials',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CopyToClipboardComponent],
+  template: `
+    <!-- Not w-full: columns size to content so the key/value/actions align in
+         tidy columns packed to the left, with the copy controls in one aligned
+         column right after the values. -->
+    <table class="text-left text-sm">
+      <tbody>
+        @for (field of fields(); track field.key) {
+          <tr class="border-b border-content-border last:border-0">
+            <td class="py-1 pr-8 align-top font-medium text-content-muted whitespace-nowrap">{{ field.key }}</td>
+            <td class="py-1 pr-4 align-top break-all font-mono">{{ displayValue(field) }}</td>
+            <td class="py-1 align-top whitespace-nowrap text-right">
+              @if (field.sensitive) {
+                <button type="button" class="text-link hover:underline text-xs"
+                  (click)="toggleField(field.key)">
+                  {{ fieldShown(field.key) ? 'Hide' : 'Show' }}
+                </button>
+              }
+            </td>
+            <!-- pl-10: the copy component renders its icon absolute-left of its
+                 own (0-width) box, so reserve space here so it doesn't overlap
+                 the Show column. -->
+            <td class="py-1 pl-10 align-top">
+              <app-copy-to-clipboard class="inline-block w-5" [text]="field.value"
+                [tooltip]="'Copy ' + field.key"
+                [showSuccessText]="false" [compact]="true"></app-copy-to-clipboard>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  `,
+})
+export class MaskedCredentialsComponent {
+  readonly fields = input.required<CredentialField[]>();
+
+  // Revealed sensitive field keys for this set.
+  private shown = signal<ReadonlySet<string>>(new Set<string>());
+
+  fieldShown = (key: string): boolean => this.shown().has(key);
+  displayValue = (field: CredentialField): string =>
+    field.sensitive && !this.fieldShown(field.key) ? field.displayMasked : field.value;
+
+  toggleField(key: string): void {
+    this.shown.update(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) { next.delete(key); } else { next.add(key); }
+      return next;
+    });
+  }
+}

--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -22,6 +22,14 @@ replace (
 	github.com/vito/go-interact => github.com/vito/go-interact v1.0.0
 )
 
+// Fork-staging replace for #5370 Phase 6: ServiceInstances.GetCredentials +
+// the parameters wire-format fix. Points at the fw-capi fork pre-release until
+// the change lands upstream. The /v3-suffix trick: the path carries /v3 (the
+// fork's go.mod declares module .../capi/v3) and the tag is a v3 semver
+// pre-release, satisfying Go's path-major + version checks. Drop this and bump
+// the require line once Wayne tags the upstream release.
+replace github.com/fivetwenty-io/capi/v3 => github.com/norman-abramovitz/fw-capi/v3 v3.222.3-svc-creds.1
+
 require (
 	code.cloudfoundry.org/go-log-cache/v2 v2.0.7
 	code.cloudfoundry.org/go-loggregator/v9 v9.2.1

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -156,8 +156,6 @@ github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fivetwenty-io/capi/v3 v3.222.3 h1:HdifNtsdgoEUcoNrf+A517gb4YAp/glQQk227AmYzjs=
-github.com/fivetwenty-io/capi/v3 v3.222.3/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/foxcpp/go-mockdns v1.2.0 h1:omK3OrHRD1IWJz1FuFBCFquhXslXoF17OvBS6JPzZF0=
 github.com/foxcpp/go-mockdns v1.2.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -368,6 +366,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/norman-abramovitz/fw-capi/v3 v3.222.3-svc-creds.1 h1:mim3gLGeTQEhYH9vse7aJXN6DAMjq11aYqj8G6w3FqY=
+github.com/norman-abramovitz/fw-capi/v3 v3.222.3-svc-creds.1/go.mod h1:bm8z6scaTZH6h6cECafBYds/b2NiwhnNF/qvXTLXf8I=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=

--- a/src/jetstream/plugins/cloudfoundry/native_routes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_routes.go
@@ -60,6 +60,8 @@ func (c *CloudFoundrySpecification) addNativeRoutes(echoGroup *echo.Group) {
 	nativeGroup.GET("/cf/service_instances/:cnsiGuid", c.getNativeServiceInstances)
 	nativeGroup.GET("/cf/service_instances/:cnsiGuid/:instanceGuid", c.getNativeServiceInstanceDetail)
 	nativeGroup.GET("/cf/service_instances/:cnsiGuid/:instanceGuid/service_bindings", c.getServiceInstanceServiceBindings)
+	nativeGroup.GET("/cf/service_instances/:cnsiGuid/:instanceGuid/parameters", c.getNativeServiceInstanceParameters)
+	nativeGroup.GET("/cf/service_instances/:cnsiGuid/:instanceGuid/credentials", c.getNativeUserProvidedCredentials)
 	nativeGroup.DELETE("/cf/service_instances/:cnsiGuid/:siGuid", c.deleteServiceInstance)
 	nativeGroup.GET("/cf/users/:cnsiGuid", c.getNativeUsers)
 	nativeGroup.GET("/cf/users/:cnsiGuid/:userGuid", c.getNativeUserDetail)

--- a/src/jetstream/plugins/cloudfoundry/native_service_instances_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instances_reads.go
@@ -676,3 +676,73 @@ func mapLastOperation(lo *capi.ServiceInstanceLastOperation) *StLastOperation {
 	}
 	return out
 }
+
+// getNativeServiceInstanceParameters handles
+// GET /pp/v1/cf/service_instances/{cnsiGuid}/{instanceGuid}/parameters.
+//
+// Proxies CF's v3 GET .../parameters for a managed instance and returns the
+// bare parameters object the broker was provisioned with. Read-only.
+//
+// Many brokers don't enable instances_retrievable, so CF returns an error here
+// for a perfectly healthy instance — that propagates via handleCapiError and
+// the UI distinguishes "not available" from "no parameters" (an empty object).
+func (c *CloudFoundrySpecification) getNativeServiceInstanceParameters(ctx echo.Context) error {
+	cnsiGUID := ctx.Param("cnsiGuid")
+	instanceGUID := ctx.Param("instanceGuid")
+	if cnsiGUID == "" || instanceGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and instanceGuid are required")
+	}
+
+	userGUID, err := c.getUserGUID(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := ctx.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	params, paramErr := cfClient.ServiceInstances().GetParameters(reqCtx, instanceGUID)
+	if paramErr != nil {
+		return handleCapiError(ctx, paramErr)
+	}
+
+	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return ctx.JSON(http.StatusOK, params.Parameters)
+}
+
+// getNativeUserProvidedCredentials handles
+// GET /pp/v1/cf/service_instances/{cnsiGuid}/{instanceGuid}/credentials.
+//
+// Proxies CF's v3 GET .../credentials, which returns the credentials a
+// user-provided instance was created with. UPS-only — CF rejects it for a
+// managed instance, surfaced via handleCapiError. The values are sensitive;
+// the UI masks them by default and reveals per-field on explicit request.
+func (c *CloudFoundrySpecification) getNativeUserProvidedCredentials(ctx echo.Context) error {
+	cnsiGUID := ctx.Param("cnsiGuid")
+	instanceGUID := ctx.Param("instanceGuid")
+	if cnsiGUID == "" || instanceGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and instanceGuid are required")
+	}
+
+	userGUID, err := c.getUserGUID(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := ctx.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	creds, credErr := cfClient.ServiceInstances().GetCredentials(reqCtx, instanceGUID)
+	if credErr != nil {
+		return handleCapiError(ctx, credErr)
+	}
+
+	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return ctx.JSON(http.StatusOK, creds.Credentials)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_instances_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instances_reads_test.go
@@ -805,3 +805,95 @@ func TestGetNativeServiceInstancesForSpace_TypeFilterLayered_List(t *testing.T) 
 	assert.Equal(t, []string{"space-A"}, capture.InstancesSpaceGUIDs)
 	assert.Equal(t, "user-provided", capture.InstancesType)
 }
+
+// CF returns parameters as a bare object ({"key":"val"}), not wrapped — the
+// handler passes that object straight through.
+func TestGetNativeServiceInstanceParameters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_instances/si-1/parameters" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"max_connections":100,"enable_ssl":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/service_instances/cnsi-1/si-1/parameters", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid", "instanceGuid")
+	ctx.SetParamValues("cnsi-1", "si-1")
+
+	require.NoError(t, newServiceInstancesPlugin(srv.URL).getNativeServiceInstanceParameters(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.InDelta(t, float64(100), resp["max_connections"], 0)
+	assert.Equal(t, true, resp["enable_ssl"])
+}
+
+// A broker that doesn't support parameter retrieval makes CF error; the handler
+// surfaces it (handleCapiError) rather than returning 200 with empty params, so
+// the UI can show "not available" instead of "no parameters".
+func TestGetNativeServiceInstanceParameters_BrokerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_instances/si-1/parameters" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"errors":[{"detail":"This service does not support fetching parameters."}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/service_instances/cnsi-1/si-1/parameters", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid", "instanceGuid")
+	ctx.SetParamValues("cnsi-1", "si-1")
+
+	err := newServiceInstancesPlugin(srv.URL).getNativeServiceInstanceParameters(ctx)
+	// Either an echo error or a non-2xx recorded status — never a 200 with an
+	// empty body that the UI would misread as "no parameters".
+	if err == nil {
+		assert.NotEqual(t, http.StatusOK, rec.Code)
+	}
+}
+
+// CF returns UPS credentials as a bare object ({"username":..., ...}); the
+// handler passes that object straight through for the UI to mask.
+func TestGetNativeUserProvidedCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case r.URL.Path == "/v3/service_instances/si-1/credentials" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"username":"my-username","password":"super-secret"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/service_instances/cnsi-1/si-1/credentials", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid", "instanceGuid")
+	ctx.SetParamValues("cnsi-1", "si-1")
+
+	require.NoError(t, newServiceInstancesPlugin(srv.URL).getNativeUserProvidedCredentials(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "my-username", resp["username"])
+	assert.Equal(t, "super-secret", resp["password"])
+}


### PR DESCRIPTION
The service-instance detail page from #5370, completing the feature: a dedicated read view for one managed or user-provided instance at `/services/:type/:cnsi/:siGuid` (the parent of the existing edit stepper).

Sections:
- Metadata card — name, status, plan/offering/broker (managed) or route/syslog URLs (user-provided), space, timestamps, tags, dashboard link.
- Bound applications — list with per-app unbind.
- Header action bar — Edit / Service Keys / Delete, reusing the shared row-action builder.
- Parameters (managed only) — read-only json-viewer of the broker parameters, fetched on expand. A broker that doesn't support parameter retrieval shows "not available" rather than an error.
- Credentials (user-provided only) — the credential values, masked by default with per-field reveal and copy; fetched only on expand, so nothing reaches CF until asked for.

Uniform name linking: the services wall, marketplace instances, and all three Cloud-Foundry-section instance lists (space managed, space user-provided, CF Services tab) now link names to this page, including user-provided instances — which previously had no link, or a dead one to a non-existent offering page.

The credential-reveal table (masking, per-field show/hide, copy) is extracted into a shared `MaskedCredentialsComponent` reused by both the new credentials section and the existing service-keys page.

Backend: two Jetstream proxies for the CF v3 `.../parameters` and `.../credentials` endpoints.

Depends on the fw-capi fork for `ServiceInstances.GetCredentials` and a fix to `GetParameters` — CF returns the parameters/credentials as a bare top-level object, not wrapped in `{parameters}`/`{credentials}`. Staged via the `go.mod` fork-tag `replace` until fivetwenty-io/capi#12 lands; drop the replace and bump the require once that's tagged upstream.

Live-verified against managed and user-provided instances: metadata, bindings, unbind, the parameters fallback, credential masking/reveal, and the refactored service-keys credential table.

Toward #5370 — kept open until the capi dependency is upstream; functionally complete.
