### PR TITLE
Brand the login page from company-config (error, inputs, notice, show-toggles)

### DIFF
--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
@@ -14,6 +14,7 @@
       'background-position': 'center',
       'background-repeat': 'no-repeat'
     }"
+    data-stratos-snapshot-id="auth.login.background"
   ></div>
   <!-- Login Form Card -->
   <div
@@ -36,7 +37,7 @@
           {{ themeDisplayName() || themeTitle() || 'Stratos' }}
         </h1>
         @if (themeSubtitle()) {
-          <p class="login-subtitle text-sm text-content-muted">
+          <p class="login-subtitle text-sm text-content-muted" data-stratos-snapshot-id="auth.login.subtitle">
             {{ themeSubtitle() }}
           </p>
         }

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
@@ -26,16 +26,20 @@
     >
     <!-- Logo and Display Name Header -->
     <div class="login-header flex items-center space-x-4 mb-6">
-      <img
-        class="login-logo h-12 w-12 shrink-0"
-        [src]="themeLogo()"
-        [alt]="themeDisplayName() || 'Logo'"
-        data-stratos-snapshot-id="auth.login.logo"
-        />
+      @if (showLogo()) {
+        <img
+          class="login-logo h-12 w-12 shrink-0"
+          [src]="themeLogo()"
+          [alt]="themeDisplayName() || 'Logo'"
+          data-stratos-snapshot-id="auth.login.logo"
+          />
+      }
       <div class="login-title-section flex-1">
-        <h1 class="login-title text-xl font-bold text-content-text mb-1" data-stratos-snapshot-id="auth.login.title">
-          {{ themeDisplayName() || themeTitle() || 'Stratos' }}
-        </h1>
+        @if (showTitle()) {
+          <h1 class="login-title text-xl font-bold text-content-text mb-1" data-stratos-snapshot-id="auth.login.title">
+            {{ themeDisplayName() || themeTitle() || 'Stratos' }}
+          </h1>
+        }
         @if (themeSubtitle()) {
           <p class="login-subtitle text-sm text-content-muted" data-stratos-snapshot-id="auth.login.subtitle">
             {{ themeSubtitle() }}

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
@@ -18,9 +18,9 @@
   <!-- Login Form Card -->
   <div
     class="login-card card w-full max-w-md mx-4 p-8 rounded-lg shadow-lg relative z-10"
-    [ngStyle]="{
-      'background-color': loginCardBackground()
-    }"
+    [ngStyle]="{ 'background-color': loginCardBackground() }"
+    [style.--input-bg]="inputBackground()"
+    [style.--input-border]="inputBorder()"
     data-stratos-snapshot-id="auth.login.card"
     >
     <!-- Logo and Display Name Header -->

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
@@ -109,8 +109,7 @@
       id="login-error-message"
       class="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 transition-all duration-300
              flex items-center gap-2 px-4 py-3 rounded-lg shadow-lg
-             bg-danger-50 dark:bg-danger-900/30 border border-danger-300 dark:border-danger-700
-             text-danger-900 dark:text-danger-100 text-sm max-w-md"
+             border alert-danger text-sm max-w-md"
       [ngClass]="{
         'translate-y-0 opacity-100': !!displayMessage,
         '-translate-y-full opacity-0': !displayMessage

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.html
@@ -49,6 +49,13 @@
     </div>
 
     <div class="login-body">
+      @if (customMessage()) {
+        <p class="login-message text-sm text-content-muted mb-4"
+           role="note"
+           data-stratos-snapshot-id="auth.login.message">
+          {{ customMessage() }}
+        </p>
+      }
       <div class="login-form-outer" [ngClass]="{'login-sso': (ssoLogin$ | async)}">
         <form class="login-form space-y-6" name="loginForm" (ngSubmit)="login()" #loginForm="ngForm">
           @if ((ssoLogin$ | async) === false) {

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
@@ -244,3 +244,76 @@ describe('LoginPageComponent — snapshot-id instrumentation', () => {
     expect(el.querySelector('[data-stratos-snapshot-id="auth.login.subtitle"]')).not.toBeNull();
   });
 });
+
+describe('LoginPageComponent — before-login notice', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+
+  beforeEach(async () => {
+    const themeState = signal<StratosTheme>({
+      ...defaultTheme,
+      login: {
+        ...defaultTheme.login,
+        customMessage: 'Authorized users only',
+      },
+    });
+
+    const brandingStub = {
+      theme: themeState.asReadonly(),
+    } as unknown as StratosBrandingService;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        NoopAnimationsModule,
+        createBasicStoreModule(),
+        LoginPageComponent,
+      ],
+      providers: [
+        ...STORE_TEST_PROVIDERS,
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: StratosBrandingService, useValue: brandingStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+  });
+
+  it('renders the before-login notice when a custom message is set', () => {
+    fixture.detectChanges();
+    const el = fixture.nativeElement.querySelector('[data-stratos-snapshot-id="auth.login.message"]');
+    expect(el).not.toBeNull();
+    expect(el.textContent).toContain('Authorized users only');
+  });
+});
+
+describe('LoginPageComponent — before-login notice hidden when empty', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+
+  beforeEach(async () => {
+    const themeState = signal<StratosTheme>({
+      ...defaultTheme,
+      login: { ...defaultTheme.login, customMessage: '' },
+    });
+    const brandingStub = { theme: themeState.asReadonly() } as unknown as StratosBrandingService;
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, NoopAnimationsModule, createBasicStoreModule(), LoginPageComponent],
+      providers: [
+        ...STORE_TEST_PROVIDERS,
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: StratosBrandingService, useValue: brandingStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+  });
+
+  it('hides the before-login notice when customMessage is empty', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-stratos-snapshot-id="auth.login.message"]')).toBeNull();
+  });
+});

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
@@ -154,3 +154,46 @@ describe('LoginPageComponent — login-scoped input branding', () => {
     expect(card.style.getPropertyValue('--input-border')).toBe('#ff0000');
   });
 });
+
+describe('LoginPageComponent — snapshot-id instrumentation', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+
+  beforeEach(async () => {
+    const themeState = signal<StratosTheme>({
+      ...defaultTheme,
+      branding: {
+        ...defaultTheme.branding,
+        loginSubtitle: 'Multi-cloud management',
+      },
+    });
+
+    const brandingStub = {
+      theme: themeState.asReadonly(),
+    } as unknown as StratosBrandingService;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        NoopAnimationsModule,
+        createBasicStoreModule(),
+        LoginPageComponent,
+      ],
+      providers: [
+        ...STORE_TEST_PROVIDERS,
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: StratosBrandingService, useValue: brandingStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+  });
+
+  it('instruments the login background and subtitle for harvest', () => {
+    fixture.detectChanges();
+    const el = fixture.nativeElement;
+    expect(el.querySelector('[data-stratos-snapshot-id="auth.login.background"]')).not.toBeNull();
+    expect(el.querySelector('[data-stratos-snapshot-id="auth.login.subtitle"]')).not.toBeNull();
+  });
+});

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
@@ -1,13 +1,19 @@
+import { ApplicationRef, provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { createBasicStoreModule, STORE_TEST_PROVIDERS } from '@test-framework';
+import { AuthDataService } from '@stratosui/store';
+import type { AuthState } from '@stratosui/store';
 
 import { LoginPageComponent } from './login-page.component';
+
+function flushEffects() {
+  TestBed.inject(ApplicationRef).tick();
+}
 
 describe('LoginPageComponent', () => {
   let component: LoginPageComponent;
@@ -38,5 +44,67 @@ describe('LoginPageComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+describe('LoginPageComponent — error banner branding', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+
+  beforeEach(async () => {
+    const errorAuthState: AuthState = {
+      loggedIn: false,
+      loggingIn: false,
+      user: null,
+      error: true,
+      errorResponse: { status: 401, error: null },
+      sessionData: null,
+      verifying: false,
+    };
+
+    const stubAuthData = {
+      auth: signal<AuthState | undefined>(errorAuthState),
+      loggedIn: signal(false),
+      loggingIn: signal(false),
+      verifying: signal(false),
+      error: signal(true),
+      errorResponse: signal({ status: 401, error: null }),
+      sessionData: signal(null),
+      sessionValid: signal(false),
+      redirect: signal(undefined),
+      loginCompletedAt: signal(0),
+      login: vi.fn(),
+      logout: vi.fn(),
+      verifySession: vi.fn(),
+      navigateAndRememberRedirect: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        NoopAnimationsModule,
+        createBasicStoreModule(),
+        LoginPageComponent,
+      ],
+      providers: [
+        ...STORE_TEST_PROVIDERS,
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthDataService, useValue: stubAuthData },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+  });
+
+  it('brands the login error banner via the semantic alert-danger surface', () => {
+    flushEffects();
+    fixture.detectChanges();
+    flushEffects();
+    fixture.detectChanges();
+    const banner = fixture.nativeElement.querySelector('[data-stratos-snapshot-id="auth.login.error"]');
+    expect(banner).not.toBeNull();
+    expect(banner.classList).toContain('alert-danger');
+    expect(banner.className).not.toContain('bg-danger-50');
   });
 });

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
@@ -155,6 +155,53 @@ describe('LoginPageComponent — login-scoped input branding', () => {
   });
 });
 
+describe('LoginPageComponent — logo and title visibility', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+
+  beforeEach(async () => {
+    const themeState = signal<StratosTheme>({
+      ...defaultTheme,
+      login: {
+        ...defaultTheme.login,
+        showLogo: false,
+        showTitle: false,
+      }
+    });
+
+    const brandingStub = {
+      theme: themeState.asReadonly(),
+    } as unknown as StratosBrandingService;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        NoopAnimationsModule,
+        createBasicStoreModule(),
+        LoginPageComponent,
+      ],
+      providers: [
+        ...STORE_TEST_PROVIDERS,
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: StratosBrandingService, useValue: brandingStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+  });
+
+  it('hides the login logo when showLogo is false', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-stratos-snapshot-id="auth.login.logo"]')).toBeNull();
+  });
+
+  it('hides the login title when showTitle is false', () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-stratos-snapshot-id="auth.login.title"]')).toBeNull();
+  });
+});
+
 describe('LoginPageComponent — snapshot-id instrumentation', () => {
   let fixture: ComponentFixture<LoginPageComponent>;
 

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
@@ -8,6 +8,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { createBasicStoreModule, STORE_TEST_PROVIDERS } from '@test-framework';
 import { AuthDataService } from '@stratosui/store';
 import type { AuthState } from '@stratosui/store';
+import { StratosBrandingService } from '../../../../../theme/stratos-branding.service';
+import { StratosTheme, defaultTheme } from '../../../../../theme/theme.config';
 
 import { LoginPageComponent } from './login-page.component';
 
@@ -106,5 +108,49 @@ describe('LoginPageComponent — error banner branding', () => {
     expect(banner).not.toBeNull();
     expect(banner.classList).toContain('alert-danger');
     expect(banner.className).not.toContain('bg-danger-50');
+  });
+});
+
+describe('LoginPageComponent — login-scoped input branding', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+
+  beforeEach(async () => {
+    const themeState = signal<StratosTheme>({
+      ...defaultTheme,
+      login: {
+        ...defaultTheme.login,
+        inputBackground: '#222222',
+        inputBorder: '#ff0000',
+      }
+    });
+
+    const brandingStub = {
+      theme: themeState.asReadonly(),
+    } as unknown as StratosBrandingService;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        NoopAnimationsModule,
+        createBasicStoreModule(),
+        LoginPageComponent,
+      ],
+      providers: [
+        ...STORE_TEST_PROVIDERS,
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: StratosBrandingService, useValue: brandingStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+  });
+
+  it('applies login input branding scoped to the login card', () => {
+    fixture.detectChanges();
+    const card = fixture.nativeElement.querySelector('[data-stratos-snapshot-id="auth.login.card"]');
+    expect(card.style.getPropertyValue('--input-bg')).toBe('#222222');
+    expect(card.style.getPropertyValue('--input-border')).toBe('#ff0000');
   });
 });

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
@@ -69,6 +69,9 @@ export class LoginPageComponent implements OnInit {
     this.branding.theme()?.branding?.loginSubtitle || ''
   );
 
+  public showLogo = computed(() => this.branding.theme()?.login?.showLogo ?? true);
+  public showTitle = computed(() => this.branding.theme()?.login?.showTitle ?? true);
+
   // Form state
   loginForm!: NgForm;
   username = '';

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
@@ -50,6 +50,9 @@ export class LoginPageComponent implements OnInit {
     this.branding.theme()?.login?.cardBackground || '#ffffff'
   );
 
+  public inputBackground = computed(() => this.branding.theme()?.login?.inputBackground || null);
+  public inputBorder = computed(() => this.branding.theme()?.login?.inputBorder || null);
+
   public themeLogo = computed(() =>
     this.branding.theme()?.branding?.logo || '/core/assets/logo.png'
   );

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
@@ -71,6 +71,7 @@ export class LoginPageComponent implements OnInit {
 
   public showLogo = computed(() => this.branding.theme()?.login?.showLogo ?? true);
   public showTitle = computed(() => this.branding.theme()?.login?.showTitle ?? true);
+  public customMessage = computed(() => this.branding.theme()?.login?.customMessage || '');
 
   // Form state
   loginForm!: NgForm;

--- a/src/frontend/packages/theme/company-config.interface.ts
+++ b/src/frontend/packages/theme/company-config.interface.ts
@@ -52,6 +52,8 @@ export interface CompanyConfig {
     backgroundColor?: string; // Login page background color
     cardBackground?: string;  // Login card background color
     customMessage?: string;   // Custom message on login page
+    inputBackground?: string; // Login input background (scoped to login card)
+    inputBorder?: string;     // Login input border color (scoped to login card)
   };
 
   // Footer/copyright

--- a/src/frontend/packages/theme/stratos-branding.service.ts
+++ b/src/frontend/packages/theme/stratos-branding.service.ts
@@ -269,6 +269,8 @@ export class StratosBrandingService {
     if (config.login.backgroundColor) loginCustom.backgroundColor = config.login.backgroundColor;
     if (config.login.cardBackground) loginCustom.cardBackground = config.login.cardBackground;
     if (config.login.customMessage) loginCustom.customMessage = config.login.customMessage;
+    if (config.login.inputBackground) loginCustom.inputBackground = config.login.inputBackground;
+    if (config.login.inputBorder) loginCustom.inputBorder = config.login.inputBorder;
     if (config.logos.loginBackground) loginCustom.backgroundImage = config.logos.loginBackground;
     this.setLoginCustomization(loginCustom);
   }

--- a/src/frontend/packages/theme/styles/main.scss
+++ b/src/frontend/packages/theme/styles/main.scss
@@ -395,6 +395,15 @@ router-outlet + * {
     }
   }
 
+  /* Alert / failure surface — derives the entire surface from one semantic state
+     token so a single brand color re-skins every failure surface that adopts it.
+     Mirror for warning/success/info when those surfaces need branding. */
+  .alert-danger {
+    background-color: color-mix(in srgb, var(--color-danger) 12%, var(--card-bg));
+    border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
+    color: color-mix(in srgb, var(--color-danger) 75%, var(--content-text));
+  }
+
   /* Info Button */
   .btn-info {
     @apply text-white shadow-sm;

--- a/src/frontend/packages/theme/theme.config.ts
+++ b/src/frontend/packages/theme/theme.config.ts
@@ -56,6 +56,8 @@ export interface StratosTheme {
     backgroundColor?: string;
     cardBackground?: string;
     customMessage?: string;
+    inputBackground?: string;
+    inputBorder?: string;
   };
 }
 


### PR DESCRIPTION
Extends the login page to honor more `company-config.json` branding:

- Reusable `.alert-danger` failure surface for the error banner
- Login-scoped input branding (`login.inputBackground` / `inputBorder`, optional, backward-compatible)
- Optional before-login notice from `login.customMessage`
- Honors `showLogo` / `showTitle`
- `data-stratos-snapshot-id` instrumentation on the login background/subtitle

**Scope:** `src/frontend/packages/core/.../login` + `src/frontend/packages/theme` (5 commits).
