### PR TITLE
stb: per-element scoped CSS facet (R1 escape hatch) — model → edit → live preview → export

### DIFF
--- a/tools/stb/docs/architecture.md
+++ b/tools/stb/docs/architecture.md
@@ -51,10 +51,16 @@ is settled. The destination is DOM-only:
 by prefix so accessibility and theming stay separate concerns even where one
 semantic feeds both:
 
-- **`stba-*`** — mimics ARIA and is intended to **become genuine ARIA**.
-  Authoring `stba-*` is an a11y on-ramp: the same instrumentation pass that
-  drives theming also gives Stratos a real accessibility footing, and `stba-*`
-  promotes to real `aria-*`/`role` as an element matures.
+- **`stba-*`** — a strict **1-1 ARIA mirror**: every `stba-X` corresponds to a
+  real ARIA attribute (`stba-role`↔`role`, `stba-label`↔`aria-label`,
+  `stba-roledescription`↔`aria-roledescription`) and **must adhere to ARIA
+  conventions** (valid role vocabulary; identity in the ARIA-correct slot). The
+  tool reads **either** namespace — real `aria-*`/`role` *or* `stba-*` — and
+  **`stba-*` takes precedence** when both are present (`stba-X ?? aria-X`). So
+  `stba-*` is stb's curated override and real ARIA is the fallback the tool
+  consumes when no `stba-*` is supplied. Because it mirrors ARIA, the same
+  instrumentation is also an a11y on-ramp: `stba-*` can later **promote** to
+  real `aria-*`/`role` (the phased outbound direction, below).
 - **`stb-*`** — pure theming, zero ARIA meaning (`stb-snapshot-id` is just
   type-agnostic identity; future colour/asset/visibility carriers live here).
 - **`stbx-*`** — a genuinely shared *semantic* concept that projects to **both**
@@ -62,26 +68,33 @@ semantic feeds both:
   One upstream truth, two independent projections — not mixing. *(Not in use
   yet; reserved by the scheme.)*
 
-**ARIA projection (the a11y on-ramp) — deferred (futurism).** The `stba-*`
-attributes are *shaped* to mirror ARIA so they can later be mechanically
-converted (`stba-role`→`role`, `stba-roledescription`→`aria-roledescription`).
-But the actual projection is **deliberately deferred**, not the next build —
-designing it before we have real instrumentation data (especially how many
-`stbx-*` shared-semantic cases exist) would be speculative over-build.
+**ARIA projection — two directions.** The `stba-*` correspondence runs both
+ways, and the two directions have different status:
 
-This is **safe to defer**: `stba-*`/`stb-*` are a **private namespace, not live
-ARIA**, so a wrong annotation only produces a theming mistake — never an
-accessibility regression (a screen reader never sees these attributes). The
-careful a11y-correctness work all lives in the future projection. So instrument
-freely now; the worst case is a branding bug fixed in the tool.
+- **Inbound (read) — in use now.** Model-generation ingests an element's
+  semantic identity from **either** real `aria-*`/`role` **or** `stba-*`, with
+  `stba-*` winning. This is a present tool requirement, not deferred. A useful
+  consequence: elements that already carry real ARIA (the login message
+  `role="note"`, the error `role="alert"`) need **no duplicate `stba-role`** —
+  the tool reads the real one — so the old `role`-dedup worry dissolves into the
+  precedence rule. You author `stba-*` only to override or to fill a gap.
+- **Outbound (emit) — phased.** Mechanically *writing* `stba-*` back out as real
+  `aria-*`/`role` into the **shipped Stratos DOM** (the actual accessibility
+  improvement) is deliberately later, not the next build. Designing it before we
+  have real instrumentation data — especially how many `stbx-*` shared-semantic
+  cases exist — would be speculative, and this is the direction where a wrong
+  annotation *would* be an a11y regression, so it wants real care.
 
-When the projector is eventually built, two things get decided there: how to
-**dedup** `role` where an element already carries real ARIA (the login message
-is already `role="note"`, the error already `role="alert"`), and exactly which
-descriptions become real `aria-*`. The **`aria-roledescription` unlock** is why
-the container "kind" rides on `roledescription`: ARIA's `role` vocabulary is a
-fixed closed set (no `role="stepper"`), so a stepper stays a valid
-`role="group"` *named* "stepper" via `aria-roledescription`.
+While `stba-*` stays inbound-only it is a **private namespace, not live ARIA**:
+a wrong annotation produces a theming mistake, never an accessibility regression
+(a screen reader never sees it). So instrument freely now; the a11y-correctness
+discipline attaches when the outbound emission is built. Because `stba-*` is held
+to ARIA conventions today, that later emission stays mechanical.
+
+The **`aria-roledescription` unlock** is why the container "kind" rides on
+`roledescription`: ARIA's `role` vocabulary is a fixed closed set (no
+`role="stepper"`), so a stepper stays a valid `role="group"` *named* "stepper"
+via `aria-roledescription`.
 
 **Descriptions — the composite shape (resolved authoring direction).** The
 opaque, theming-worded `stba-description` ("background color for the login page")

--- a/tools/stb/docs/architecture.md
+++ b/tools/stb/docs/architecture.md
@@ -62,38 +62,49 @@ semantic feeds both:
   One upstream truth, two independent projections — not mixing. *(Not in use
   yet; reserved by the scheme.)*
 
-**ARIA projection (the a11y on-ramp) — designed, not yet wired.** The `stba-*`
-attributes mirror ARIA 1:1 so they can be mechanically converted:
+**ARIA projection (the a11y on-ramp) — deferred (futurism).** The `stba-*`
+attributes are *shaped* to mirror ARIA so they can later be mechanically
+converted (`stba-role`→`role`, `stba-roledescription`→`aria-roledescription`).
+But the actual projection is **deliberately deferred**, not the next build —
+designing it before we have real instrumentation data (especially how many
+`stbx-*` shared-semantic cases exist) would be speculative over-build.
 
-| authoring attr (DOM) | projects to | model field |
-|----------------------|-------------|-------------|
-| `stb-snapshot-id` | — (identity only) | `snapshotId` |
-| `stba-role` | `role` | `role` |
-| `stba-roledescription` | `aria-roledescription` | `roledescription` |
-| `stba-description` | `aria-description` | `description` |
+This is **safe to defer**: `stba-*`/`stb-*` are a **private namespace, not live
+ARIA**, so a wrong annotation only produces a theming mistake — never an
+accessibility regression (a screen reader never sees these attributes). The
+careful a11y-correctness work all lives in the future projection. So instrument
+freely now; the worst case is a branding bug fixed in the tool.
 
-Two non-obvious points:
-- Projection is **not a pure strip**: `stba-role` drops the prefix to `role`, but
-  the other two *gain* the `aria-` prefix. A 3-entry projector table.
-- **`aria-roledescription` is the unlock.** ARIA's `role` vocabulary is a fixed
-  closed set — there is no `role="stepper"` or `role="page"`. So a stepper stays
-  a valid `role="group"` and is *named* "stepper" via `aria-roledescription`.
-  That is why the container "kind" rides on `roledescription`.
-
-The projector itself isn't built yet. When it is, two things get decided there:
-which descriptions become real `aria-description` (theming-note wording like
-"background color for the login page" is poor screen-reader text), and how to
+When the projector is eventually built, two things get decided there: how to
 **dedup** `role` where an element already carries real ARIA (the login message
-is already `role="note"`, the error already `role="alert"`).
+is already `role="note"`, the error already `role="alert"`), and exactly which
+descriptions become real `aria-*`. The **`aria-roledescription` unlock** is why
+the container "kind" rides on `roledescription`: ARIA's `role` vocabulary is a
+fixed closed set (no `role="stepper"`), so a stepper stays a valid
+`role="group"` *named* "stepper" via `aria-roledescription`.
+
+**Descriptions — the composite shape (resolved authoring direction).** The
+opaque, theming-worded `stba-description` ("background color for the login page")
+is being replaced by two explicit pieces the tool composes:
+- **Identity (the subject)** lives in `stba-*` as *ARIA-correct* terms. Its slot
+  **varies per element** — `roledescription` for a custom-named container
+  ("login" group, "stepper"), the accessible **name** for a field (a `textbox`
+  is identified by its name "Username", *not* `roledescription`, which would
+  wrongly override the spoken role), text for a heading.
+- **Theming aspect** lives in **`stb-facet`** (e.g. `stb-facet="background
+  color"`) — the brandable property, which has no ARIA equivalent, so it is pure
+  `stb-`. ("facet" is a coined term; design-token taxonomy has no single word for
+  this bundle, and `stb-property` would collide with its loaded meaning.)
+- The tool **composes** the description, default `"{facet} for {subject}"` →
+  "background color for login". An `stb-composite-order` attribute overrides the
+  order, added only when a real case breaks "x for y".
 
 **This is experimental.** Repurposing ARIA-shaped attributes as a theming
 vocabulary is a research direction — no existing standard covers the
-element-semantic layer stb occupies, and nobody has driven branding off ARIA
-this way. The stance is ARIA-first (reach for real ARIA where it fits) with a
-private `stb-*` fallback where ARIA doesn't fit or would pollute the
-accessibility tree (colour and brand-visibility have no ARIA equivalent — the
-clearest proof stb must *extend* ARIA, not just reuse it). Treat the vocabulary
-as provisional and validated by use, not a closed design.
+element-semantic layer stb occupies. The stance is ARIA-first (reach for real
+ARIA where it fits) with a private `stb-*` supplement where ARIA doesn't fit
+(colour and brand-visibility have no ARIA equivalent). Treat the vocabulary as
+provisional and validated by use, not a closed design.
 
 ## The pipeline (end to end)
 

--- a/tools/stb/public/preview-shim.js
+++ b/tools/stb/public/preview-shim.js
@@ -87,6 +87,18 @@
     }
   }
 
+  function applyScopedBlocks(cssText) {
+    // upsert ONE late <style> at the end of <head> so the element-scoped rules
+    // sit after the snapshot stylesheet and win the source-order tie (R1 facet)
+    var styleEl = document.getElementById('stb-scoped-blocks');
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = 'stb-scoped-blocks';
+      document.head.appendChild(styleEl);
+    }
+    styleEl.textContent = cssText || '';
+  }
+
   function markLevers(ids) {
     document.querySelectorAll('[data-stb-lever]').forEach((el) => el.removeAttribute('data-stb-lever'));
     for (const id of ids || []) {
@@ -146,6 +158,9 @@
         break;
       case 'STB_APPLY_LEVERS':
         applyLeversInShim(msg.levers);
+        break;
+      case 'STB_APPLY_BLOCKS':
+        applyScopedBlocks(msg.css);
         break;
       case 'STB_SET_LEVERS':
         markLevers(msg.ids);

--- a/tools/stb/scripts/generate-model.ts
+++ b/tools/stb/scripts/generate-model.ts
@@ -1,13 +1,13 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { harvestElements } from './harvest-login';
-import type { BrandingModel, ElementNode, LeverValue } from '../src/metadata/types';
+import type { BrandingModel, ElementNode, LeverValue, ScopedBlock } from '../src/metadata/types';
 
 // The branding model is GENERATED from the snapshot DOM: identity, role,
 // roledescription (the "kind") and description are harvested off the stba-*
 // attributes; the only still-authored bits — the editable value, friendly name,
 // and default visibility — come from a values.json sidecar keyed by snapshotId.
 // (Next steps move name onto the DOM via aria-label and value via capture.)
-export interface ValueEntry { name: string | null; value: LeverValue; visibility?: boolean }
+export interface ValueEntry { name: string | null; value: LeverValue; visibility?: boolean; scopedBlock?: ScopedBlock }
 export type ValuesSidecar = Record<string, ValueEntry>;
 
 export function buildModel(scene: string, html: string, values: ValuesSidecar): BrandingModel {
@@ -24,6 +24,7 @@ export function buildModel(scene: string, html: string, values: ValuesSidecar): 
     };
     if (el.roledescription) node.roledescription = el.roledescription;
     if (v.visibility !== undefined) node.visibility = v.visibility;
+    if (v.scopedBlock) node.scopedBlock = v.scopedBlock;
     nodes.push(node);
   }
   return { scene, nodes };

--- a/tools/stb/src/export/bundle-builder.ts
+++ b/tools/stb/src/export/bundle-builder.ts
@@ -13,6 +13,7 @@ export interface BuildBundleInput {
   dark: Map<string, string>;
   assets: AssetInput[];
   companyConfig?: Record<string, unknown>;
+  scopedCss?: string; // element-scoped facet rules, appended after :root (load order)
 }
 
 export interface Bundle {
@@ -32,7 +33,7 @@ export function buildBundle(input: BuildBundleInput): Bundle {
     null,
     2,
   );
-  files['theme.css'] = emitCss(input.root, input.dark);
+  files['theme.css'] = [emitCss(input.root, input.dark), input.scopedCss].filter(Boolean).join('\n\n');
   if (input.companyConfig && Object.keys(input.companyConfig).length > 0) {
     files['company-config.json'] = JSON.stringify(input.companyConfig, null, 2);
   }

--- a/tools/stb/src/iframe-bridge/messages.ts
+++ b/tools/stb/src/iframe-bridge/messages.ts
@@ -9,6 +9,7 @@ export type ParentToPreview =
   | { type: 'STB_HIGHLIGHT_TOKEN'; token: string | null }
   | { type: 'STB_HIGHLIGHT_ELEMENT'; snapshotId: string | null }
   | { type: 'STB_APPLY_LEVERS'; levers: LeverPatch[] }
+  | { type: 'STB_APPLY_BLOCKS'; css: string }
   | { type: 'STB_SET_LEVERS'; ids: string[] }
   | { type: 'STB_SET_LEVER_OUTLINE'; on: boolean };
 

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -12,7 +12,7 @@ import { mountStatusBar } from '@/ui/status-bar';
 import { mountAssetManager } from '@/ui/asset-manager';
 import { setRootValue, setDarkValue, effectiveValue } from '@/state/tokens';
 import { previewDark, activeSceneId } from '@/state/scene';
-import { nodeFor, loadBrandingModel } from '@/state/branding';
+import { nodeFor, loadBrandingModel, setNodeScopedBlock } from '@/state/branding';
 import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion } from '@/ui/element-edit';
@@ -116,6 +116,8 @@ async function main() {
       snapshotId,
       value: node.value,
       onChange: (next) => applyEdit(snapshotId, next, routing),
+      scopedBlock: node.scopedBlock,
+      onScopedBlockChange: (css) => setNodeScopedBlock(snapshotId, css),
       ...companion,
     });
   }

--- a/tools/stb/src/metadata/types.ts
+++ b/tools/stb/src/metadata/types.ts
@@ -7,6 +7,10 @@ export type LeverValue =
   | { kind: 'content'; text: string }
   | { kind: 'asset'; ref: string };
 
+// Raw element-scoped CSS declaration body — the R1 facet escape hatch.
+// Emitted as `[stb-snapshot-id="…"] { <ScopedBlock> }`.
+export type ScopedBlock = string;
+
 export interface ElementNode {
   snapshotId: string;
   role: string;            // ARIA role (DOM stba-role) — projects to `role`
@@ -15,6 +19,7 @@ export interface ElementNode {
   description: string;     // DOM stba-description → ARIA aria-description
   value: LeverValue;
   visibility?: boolean;    // optional show/hide on THIS element; undefined = shown
+  scopedBlock?: ScopedBlock; // optional raw element-scoped CSS (R1 facet escape hatch)
 }
 
 export interface BrandingModel {

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -1,8 +1,24 @@
+import type { ElementNode } from '@/metadata/types';
+
 export function emitCss(root: Map<string, string>, dark: Map<string, string>): string {
   const parts: string[] = [];
   if (root.size > 0) parts.push(block(':root', root));
   if (dark.size > 0) parts.push(block('.dark-theme', dark));
   return parts.join('\n\n');
+}
+
+// R1 facet escape hatch: one `[stb-snapshot-id="…"] { … }` rule per element
+// carrying a scoped block, ordered by snapshotId so output is deterministic.
+// These do NOT round-trip through parseCss (it reads only :root/.dark-theme).
+export function emitScopedBlocks(nodes: ElementNode[]): string {
+  return nodes
+    .filter((n) => n.scopedBlock && n.scopedBlock.trim())
+    .sort((a, b) => a.snapshotId.localeCompare(b.snapshotId))
+    .map((n) => {
+      const body = n.scopedBlock!.trim().split('\n').map((l) => `  ${l.trim()}`).join('\n');
+      return `[stb-snapshot-id="${n.snapshotId}"] {\n${body}\n}`;
+    })
+    .join('\n\n');
 }
 
 function block(selector: string, values: Map<string, string>): string {

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -15,8 +15,20 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
     .filter((n) => n.scopedBlock && n.scopedBlock.trim())
     .sort((a, b) => a.snapshotId.localeCompare(b.snapshotId))
     .map((n) => {
-      const body = n.scopedBlock!.trim().split('\n').map((l) => `  ${l.trim()}`).join('\n');
-      return `[stb-snapshot-id="${n.snapshotId}"] {\n${body}\n}`;
+      // Terminate each declaration line so a user who types one declaration per
+      // line (no trailing ';') still produces valid CSS instead of one invalid
+      // run-on declaration. Forgiving, not validating — nothing is rejected.
+      const body = n.scopedBlock!.trim().split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0)
+        .map((l) => `  ${/[;{},]$/.test(l) ? l : l + ';'}`)
+        .join('\n');
+      // Repeat the attribute selector to reach specificity (0,3,0) so the block
+      // beats the snapshot's compound rules (e.g. `.login-card h1` (0,1,1),
+      // `.dark-theme .login-card h1` (0,2,1)) without `!important` — keeping
+      // company-config inline styles (the higher, runtime-faithful path) winning.
+      const selector = `[stb-snapshot-id="${n.snapshotId}"]`.repeat(3);
+      return `${selector} {\n${body}\n}`;
     })
     .join('\n\n');
 }

--- a/tools/stb/src/state/branding.ts
+++ b/tools/stb/src/state/branding.ts
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals-core';
-import type { BrandingModel, ElementNode, LeverValue } from '@/metadata/types';
+import type { BrandingModel, ElementNode, LeverValue, ScopedBlock } from '@/metadata/types';
 
 export const brandingModel = signal<BrandingModel | null>(null);
 
@@ -39,5 +39,14 @@ export function setNodeVisibility(snapshotId: string, shown: boolean): void {
   brandingModel.value = {
     ...m,
     nodes: m.nodes.map((n) => (n.snapshotId === snapshotId ? { ...n, visibility: shown } : n)),
+  };
+}
+
+export function setNodeScopedBlock(snapshotId: string, scopedBlock: ScopedBlock): void {
+  const m = brandingModel.value;
+  if (!m) return;
+  brandingModel.value = {
+    ...m,
+    nodes: m.nodes.map((n) => (n.snapshotId === snapshotId ? { ...n, scopedBlock } : n)),
   };
 }

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -95,7 +95,18 @@ body {
   z-index: 1000; min-width: 240px; max-width: 90vw; max-height: 80vh;
   resize: both; overflow: auto;
 }
-.stb-lever-text { display: block; width: 100%; min-height: 5rem; resize: vertical; box-sizing: border-box; font: inherit; }
+/* drag handle: a grab bar spanning the popover top, overrides auto-placement */
+.stb-lever-drag {
+  cursor: move; user-select: none; text-align: center; line-height: 1;
+  color: var(--text-muted, #94a3b8); padding: 2px 0 4px;
+  margin: -0.6rem -0.6rem 0.4rem; border-bottom: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px 8px 0 0;
+}
+.stb-lever-text { display: block; width: 100%; min-height: 5rem; resize: both; box-sizing: border-box; font: inherit; }
+/* the scoped-CSS editor fills the popover width and grows with it (resize: both) */
+.stb-lever-scoped-block { width: 100%; }
+.stb-lever-scoped-block-label { font-size: 0.8rem; color: var(--text-muted, #64748b); margin: 0.3rem 0 0.2rem; }
+.stb-lever-scoped-block .cm-editor { width: 100%; max-height: 12rem; border: 1px solid var(--border, #cbd5e1); border-radius: 4px; }
 .stb-color-picker__row { display: flex; gap: 0.5rem; align-items: center; margin: 0.25rem 0; }
 .stb-color-native { width: 3rem; height: 2rem; padding: 0; border: 1px solid var(--border, #ccc); }
 .stb-color-text { flex: 1; padding: 0.25rem; font-family: var(--font-mono, monospace); }

--- a/tools/stb/src/ui/css-editor.ts
+++ b/tools/stb/src/ui/css-editor.ts
@@ -1,0 +1,26 @@
+import { EditorView, basicSetup } from 'codemirror';
+import { EditorState } from '@codemirror/state';
+import { css } from '@codemirror/lang-css';
+
+// A CodeMirror CSS editor. Shared by the token editor (editor-pane) and the
+// per-element scoped-block editor (lever popover). Returns the EditorView so
+// callers can push external changes (editor-pane) or destroy it on close.
+export function mountCssEditor(
+  host: HTMLElement,
+  initial: string,
+  onChange: (doc: string) => void,
+): EditorView {
+  return new EditorView({
+    parent: host,
+    state: EditorState.create({
+      doc: initial,
+      extensions: [
+        basicSetup,
+        css(),
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) onChange(u.state.doc.toString());
+        }),
+      ],
+    }),
+  });
+}

--- a/tools/stb/src/ui/editor-pane.ts
+++ b/tools/stb/src/ui/editor-pane.ts
@@ -1,9 +1,8 @@
-import { EditorView, basicSetup } from 'codemirror';
-import { EditorState } from '@codemirror/state';
-import { css } from '@codemirror/lang-css';
+import type { EditorView } from 'codemirror';
 import { effect } from '@preact/signals-core';
 import { parseCss } from '@/parse/css-parser';
 import { emitCss } from '@/parse/css-emitter';
+import { mountCssEditor } from '@/ui/css-editor';
 import { rootValues, darkValues } from '@/state/tokens';
 
 const DEBOUNCE_MS = 150;
@@ -27,19 +26,7 @@ export function mountEditorPane(host: HTMLElement): EditorView {
 
   const initial = emitCss(rootValues.value, darkValues.value);
 
-  const view = new EditorView({
-    parent: host,
-    state: EditorState.create({
-      doc: initial,
-      extensions: [
-        basicSetup,
-        css(),
-        EditorView.updateListener.of((u) => {
-          if (u.docChanged) onDocChange(u.state.doc.toString());
-        }),
-      ],
-    }),
-  });
+  const view = mountCssEditor(host, initial, onDocChange);
 
   effect(() => {
     const desired = emitCss(rootValues.value, darkValues.value);

--- a/tools/stb/src/ui/export-dialog.ts
+++ b/tools/stb/src/ui/export-dialog.ts
@@ -5,6 +5,7 @@ import { bundleToZip, triggerDownload } from '@/export/zip';
 import { assets } from '@/state/assets';
 import { brandingAssets, brandingAssetInputs } from '@/state/branding-assets';
 import { project, type RoutingMap } from '@/projection/projector';
+import { emitScopedBlocks } from '@/parse/css-emitter';
 import type { BrandingModel } from '@/metadata/types';
 import { brandingModel } from '@/state/branding';
 import { activeSceneId } from '@/state/scene';
@@ -18,14 +19,20 @@ export function exportInputs(
 ): Omit<BuildBundleInput, 'name' | 'id' | 'description'> {
   const merged = new Map(root);
   let companyConfig: Record<string, unknown> | undefined;
+  let scopedCss: string | undefined;
   if (model) {
     const r = project(model, routing);
     for (const [k, v] of r.tokens) merged.set(k, v);
     companyConfig = r.companyConfig;
+    scopedCss = emitScopedBlocks(model.nodes) || undefined;
   }
-  return companyConfig !== undefined
-    ? { root: merged, dark, assets, companyConfig }
-    : { root: merged, dark, assets };
+  return {
+    root: merged,
+    dark,
+    assets,
+    ...(companyConfig !== undefined ? { companyConfig } : {}),
+    ...(scopedCss ? { scopedCss } : {}),
+  };
 }
 
 export function openExportDialog(): void {

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -1,6 +1,8 @@
 import type { LeverValue } from '@/metadata/types';
+import type { EditorView } from 'codemirror';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
+import { mountCssEditor } from '@/ui/css-editor';
 import { positionInPreviewGutter } from '@/ui/popover';
 
 export interface OpenLeverEditorOptions {
@@ -10,6 +12,8 @@ export interface OpenLeverEditorOptions {
   onChange: (next: LeverValue) => void;
   onClose?: () => void;
   visibilityCompanion?: { shown: boolean; onChange: (shown: boolean) => void };
+  scopedBlock?: string | undefined;
+  onScopedBlockChange?: (css: string) => void;
 }
 
 export function colorValueFromHex(hex: string): LeverValue {
@@ -26,7 +30,9 @@ export function initialColorHex(v: LeverValue): string {
 }
 
 let openPanel: HTMLElement | null = null;
+let openScopedEditor: EditorView | null = null;
 function closeOpen(): void {
+  if (openScopedEditor) { openScopedEditor.destroy(); openScopedEditor = null; }
   if (openPanel) { openPanel.remove(); openPanel = null; }
 }
 
@@ -70,6 +76,19 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
     label.appendChild(cb);
     label.append(' show');
     panel.appendChild(label);
+  }
+
+  if (opts.onScopedBlockChange) {
+    const section = document.createElement('div');
+    section.className = 'stb-lever-scoped-block';
+    const label = document.createElement('div');
+    label.className = 'stb-lever-scoped-block-label';
+    label.textContent = 'Scoped CSS';
+    section.appendChild(label);
+    const editorHost = document.createElement('div');
+    section.appendChild(editorHost);
+    panel.appendChild(section);
+    openScopedEditor = mountCssEditor(editorHost, opts.scopedBlock ?? '', opts.onScopedBlockChange);
   }
 
   const close = document.createElement('button');

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -3,7 +3,7 @@ import type { EditorView } from 'codemirror';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 import { mountCssEditor } from '@/ui/css-editor';
-import { positionInPreviewGutter } from '@/ui/popover';
+import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
 
 export interface OpenLeverEditorOptions {
   previewHost: HTMLElement;
@@ -97,7 +97,14 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   close.addEventListener('click', () => { closeOpen(); opts.onClose?.(); });
   panel.appendChild(close);
 
+  const drag = document.createElement('div');
+  drag.className = 'stb-lever-drag';
+  drag.textContent = '⠿';
+  drag.title = 'Drag to move';
+  panel.prepend(drag);
+
   document.body.appendChild(panel);
   positionInPreviewGutter(panel, opts.previewHost);
+  makeDraggable(panel, drag);
   openPanel = panel;
 }

--- a/tools/stb/src/ui/popover.ts
+++ b/tools/stb/src/ui/popover.ts
@@ -20,3 +20,26 @@ export function positionInPreviewGutter(panel: HTMLElement, previewHost: HTMLEle
   panel.style.left = `${Math.max(8, left) + window.scrollX}px`;
   panel.style.top = `${Math.max(8, top) + window.scrollY}px`;
 }
+
+// Let the user drag the popover by a handle, overriding the auto-placement.
+// Position stays clamped to the viewport so it can't be dragged off-screen.
+export function makeDraggable(panel: HTMLElement, handle: HTMLElement): void {
+  handle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    const rect = panel.getBoundingClientRect();
+    const dx = e.clientX - rect.left;
+    const dy = e.clientY - rect.top;
+    const onMove = (ev: MouseEvent) => {
+      const left = Math.min(Math.max(0, ev.clientX - dx), window.innerWidth - panel.offsetWidth);
+      const top = Math.min(Math.max(0, ev.clientY - dy), window.innerHeight - panel.offsetHeight);
+      panel.style.left = `${left + window.scrollX}px`;
+      panel.style.top = `${top + window.scrollY}px`;
+    };
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  });
+}

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -6,6 +6,7 @@ import type { ParentToPreview, PreviewToParent } from '@/iframe-bridge/messages'
 import type { BrandingModel } from '@/metadata/types';
 import type { LeverPatch } from '@/iframe-bridge/apply-levers';
 import { attachAssetBlobs, brandingAssets } from '@/state/branding-assets';
+import { emitScopedBlocks } from '@/parse/css-emitter';
 
 export function leverPatchesFor(model: BrandingModel): LeverPatch[] {
   const out: LeverPatch[] = [];
@@ -55,6 +56,12 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
     send({ type: 'STB_SET_LEVERS', ids: m.nodes.map((n) => n.snapshotId) });
   }
 
+  function applyScopedBlocksToPreview(): void {
+    const m = brandingModel.value;
+    // send even when empty so clearing a block removes the rule from the iframe
+    send({ type: 'STB_APPLY_BLOCKS', css: m ? emitScopedBlocks(m.nodes) : '' });
+  }
+
   function onMessage(event: MessageEvent): void {
     const msg = event.data as PreviewToParent | undefined;
     if (!msg || typeof msg !== 'object') return;
@@ -63,6 +70,7 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
       applyTokens();
       applyDark();
       applyLeversToPreview();
+      applyScopedBlocksToPreview();
     } else if (msg.type === 'STB_ELEMENT_SELECTED') {
       opts.onElementSelected?.(msg.selector, msg.tokens, msg.snapshotId);
     }
@@ -105,7 +113,7 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
 
       effect(() => {
         void brandingModel.value;
-        if (ready) applyLeversToPreview();
+        if (ready) { applyLeversToPreview(); applyScopedBlocksToPreview(); }
       });
     },
 

--- a/tools/stb/tests/export/bundle-builder.test.ts
+++ b/tools/stb/tests/export/bundle-builder.test.ts
@@ -46,4 +46,23 @@ describe('buildBundle', () => {
     });
     expect(bundle.files['company-config.json']).toBeUndefined();
   });
+
+  it('appends scopedCss after the :root block in theme.css', () => {
+    const bundle = buildBundle({
+      name: 'b', id: 'b', description: '',
+      root: new Map([['--color-brand-500', '#aaa']]), dark: new Map(), assets: [],
+      scopedCss: '[stb-snapshot-id="auth.login.page.card.title"] {\n  font-size: 18px\n}',
+    });
+    const css = bundle.files['theme.css']!;
+    expect(css).toContain('[stb-snapshot-id="auth.login.page.card.title"]');
+    expect(css.indexOf(':root')).toBeLessThan(css.indexOf('[stb-snapshot-id'));
+  });
+
+  it('omits scoped rules when scopedCss is absent', () => {
+    const bundle = buildBundle({
+      name: 'b', id: 'b', description: '',
+      root: new Map([['--color-brand-500', '#aaa']]), dark: new Map(), assets: [],
+    });
+    expect(bundle.files['theme.css']).not.toContain('[stb-snapshot-id');
+  });
 });

--- a/tools/stb/tests/export/export-projection.test.ts
+++ b/tools/stb/tests/export/export-projection.test.ts
@@ -23,4 +23,15 @@ describe('exportInputs', () => {
     expect(out.root.get('--x')).toBe('#000');        // preserved
     expect('companyConfig' in out).toBe(false);      // key absent, no empty company-config.json
   });
+
+  it('keeps token-first for a color node that also carries a scopedBlock, and exports the block', () => {
+    const m: BrandingModel = { scene: 'login', nodes: [
+      { snapshotId: 'auth.login.sign-in', role: 'button', name: 'S', description: 'btn',
+        value: { kind: 'color', oklch: { l: 0.55, c: 0.15, h: 250 } },
+        scopedBlock: 'font-size: 18px' },
+    ] };
+    const out = exportInputs(m, routing, new Map(), new Map(), []);
+    expect(out.root.get('--color-brand-500')).toMatch(/^#[0-9a-f]{6}$/); // token-first still wins
+    expect(out.scopedCss).toContain('[stb-snapshot-id="auth.login.sign-in"]'); // block also exported
+  });
 });

--- a/tools/stb/tests/integration/css-editor.test.ts
+++ b/tools/stb/tests/integration/css-editor.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { mountCssEditor } from '@/ui/css-editor';
+
+describe('mountCssEditor', () => {
+  it('seeds the editor with the initial CSS', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const view = mountCssEditor(host, 'font-size: 18px', () => {});
+    expect(view.state.doc.toString()).toBe('font-size: 18px');
+    view.destroy();
+    host.remove();
+  });
+
+  it('fires onChange with the new document when it changes', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    let captured = '';
+    const view = mountCssEditor(host, 'a: 1', (css) => { captured = css; });
+    view.dispatch({ changes: { from: view.state.doc.length, insert: '; b: 2' } });
+    expect(captured).toBe('a: 1; b: 2');
+    view.destroy();
+    host.remove();
+  });
+});

--- a/tools/stb/tests/integration/live-apply.test.ts
+++ b/tools/stb/tests/integration/live-apply.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { setRootValue, resetTokens } from '@/state/tokens';
 import { activeSceneId } from '@/state/scene';
+import { brandingModel } from '@/state/branding';
 import { createPreviewPane } from '@/ui/preview-pane';
+import type { BrandingModel } from '@/metadata/types';
+
+function signInModel(scopedBlock: string): BrandingModel {
+  return { scene: 'login', nodes: [
+    { snapshotId: 'auth.login.page.card.sign-in', role: 'button', name: 'S', description: 'btn',
+      value: { kind: 'color', oklch: { l: 0.55, c: 0.15, h: 250 } }, scopedBlock },
+  ] };
+}
 
 describe('live-apply pipeline', () => {
   beforeEach(() => {
     resetTokens();
     activeSceneId.value = 'login';
+    brandingModel.value = null;
     document.body.innerHTML = '<div id="host" style="width:600px;height:400px"></div>';
   });
 
@@ -33,5 +43,34 @@ describe('live-apply pipeline', () => {
     const innerDoc = iframe.contentDocument!;
     const root = innerDoc.documentElement;
     expect(root.style.getPropertyValue('--color-brand-500')).toBe('#ff0000');
+  });
+
+  it('injects a late scoped-block style that applies, upserting on change', async () => {
+    const host = document.getElementById('host')!;
+    const pane = createPreviewPane();
+    pane.mount(host);
+    const iframe = host.querySelector('iframe')!;
+    await new Promise<void>((resolve) => {
+      function listen(e: MessageEvent) {
+        if (e.data?.type === 'STB_PREVIEW_READY') { window.removeEventListener('message', listen); resolve(); }
+      }
+      window.addEventListener('message', listen);
+    });
+
+    brandingModel.value = signInModel('color: rgb(0, 255, 0)');
+    await new Promise((r) => setTimeout(r, 100));
+
+    const innerDoc = iframe.contentDocument!;
+    const styles = innerDoc.querySelectorAll('#stb-scoped-blocks');
+    expect(styles.length).toBe(1);
+    expect(styles[0]!.textContent).toContain('[stb-snapshot-id="auth.login.page.card.sign-in"]');
+    const el = innerDoc.querySelector('[stb-snapshot-id="auth.login.page.card.sign-in"]')!;
+    expect(getComputedStyle(el).color).toBe('rgb(0, 255, 0)');
+
+    // a second change upserts the SAME style element (no duplicate) and re-applies
+    brandingModel.value = signInModel('color: rgb(0, 0, 255)');
+    await new Promise((r) => setTimeout(r, 100));
+    expect(innerDoc.querySelectorAll('#stb-scoped-blocks').length).toBe(1);
+    expect(getComputedStyle(el).color).toBe('rgb(0, 0, 255)');
   });
 });

--- a/tools/stb/tests/metadata/model.test.ts
+++ b/tools/stb/tests/metadata/model.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { BrandingModel } from '@/metadata/types';
 import { isColorNode } from '@/metadata/types';
+import { buildModel, type ValuesSidecar } from '../../scripts/generate-model';
 
 describe('branding model types', () => {
   it('isColorNode narrows by lever kind', () => {
@@ -16,5 +17,33 @@ describe('branding model types', () => {
       ],
     };
     expect(model.nodes.filter(isColorNode)).toHaveLength(1);
+  });
+});
+
+describe('buildModel carries the scoped block', () => {
+  const html =
+    '<button stb-snapshot-id="auth.login.sign-in" stba-role="button" stba-description="sign-in button">Sign in</button>';
+
+  it('copies scopedBlock from the values sidecar onto the node', () => {
+    const values: ValuesSidecar = {
+      'auth.login.sign-in': {
+        name: 'Sign in',
+        value: { kind: 'color', oklch: { l: 0.55, c: 0.15, h: 250 } },
+        scopedBlock: 'font-size: 18px;',
+      },
+    };
+    const model = buildModel('login', html, values);
+    expect(model.nodes[0]!.scopedBlock).toBe('font-size: 18px;');
+  });
+
+  it('omits scopedBlock when the sidecar entry has none', () => {
+    const values: ValuesSidecar = {
+      'auth.login.sign-in': {
+        name: 'Sign in',
+        value: { kind: 'color', oklch: { l: 0.55, c: 0.15, h: 250 } },
+      },
+    };
+    const model = buildModel('login', html, values);
+    expect(model.nodes[0]!).not.toHaveProperty('scopedBlock');
   });
 });

--- a/tools/stb/tests/parse/css-emitter.test.ts
+++ b/tools/stb/tests/parse/css-emitter.test.ts
@@ -14,6 +14,12 @@ function node(snapshotId: string, scopedBlock?: string): ElementNode {
   };
 }
 
+// The scoped rule repeats the attribute selector to reach specificity (0,3,0),
+// so it beats the snapshot's compound selectors (e.g. `.login-card h1` (0,1,1),
+// `.dark-theme .login-card h1` (0,2,1)) without `!important` — company-config
+// inline still wins. Empirically verified against the login snapshot.
+const sel = (id: string) => `[stb-snapshot-id="${id}"]`.repeat(3);
+
 describe('emitCss', () => {
   it('emits :root block when only root values present', () => {
     const root = new Map([['--color-brand-500', '#1e88e5']]);
@@ -64,7 +70,23 @@ describe('emitCss', () => {
 describe('emitScopedBlocks', () => {
   it('emits a snapshot-id-scoped rule for a node with a scoped block', () => {
     const out = emitScopedBlocks([node('auth.login.page.card.title', 'font-size: 18px')]);
-    expect(out).toBe('[stb-snapshot-id="auth.login.page.card.title"] {\n  font-size: 18px\n}');
+    expect(out).toBe(`${sel('auth.login.page.card.title')} {\n  font-size: 18px;\n}`);
+  });
+
+  it('repeats the attribute selector to out-specify compound stylesheet rules', () => {
+    const out = emitScopedBlocks([node('a.b', 'color: red')]);
+    expect(out.match(/\[stb-snapshot-id="a\.b"\]/g)).toHaveLength(3); // (0,3,0)
+  });
+
+  it('terminates each declaration line so newline-separated declarations stay valid', () => {
+    // a user naturally types one declaration per line without trailing semicolons
+    const out = emitScopedBlocks([node('a.b', 'color: crimson\nfont-size: 60px')]);
+    expect(out).toBe(`${sel('a.b')} {\n  color: crimson;\n  font-size: 60px;\n}`);
+  });
+
+  it('does not double-terminate lines that already end in a semicolon', () => {
+    const out = emitScopedBlocks([node('a.b', 'color: red;\nfont-size: 12px;')]);
+    expect(out).toBe(`${sel('a.b')} {\n  color: red;\n  font-size: 12px;\n}`);
   });
 
   it('skips nodes with no or blank scoped block', () => {
@@ -83,7 +105,7 @@ describe('emitScopedBlocks', () => {
   it('joins multiple rules with a blank line', () => {
     const out = emitScopedBlocks([node('a.one', 'color: red'), node('a.two', 'color: blue')]);
     expect(out).toBe(
-      '[stb-snapshot-id="a.one"] {\n  color: red\n}\n\n[stb-snapshot-id="a.two"] {\n  color: blue\n}',
+      `${sel('a.one')} {\n  color: red;\n}\n\n${sel('a.two')} {\n  color: blue;\n}`,
     );
   });
 });

--- a/tools/stb/tests/parse/css-emitter.test.ts
+++ b/tools/stb/tests/parse/css-emitter.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { emitCss } from '@/parse/css-emitter';
+import { emitCss, emitScopedBlocks } from '@/parse/css-emitter';
 import { parseCss } from '@/parse/css-parser';
+import type { ElementNode } from '@/metadata/types';
+
+function node(snapshotId: string, scopedBlock?: string): ElementNode {
+  return {
+    snapshotId,
+    role: '',
+    name: null,
+    description: '',
+    value: { kind: 'content', text: '' },
+    ...(scopedBlock !== undefined ? { scopedBlock } : {}),
+  };
+}
 
 describe('emitCss', () => {
   it('emits :root block when only root values present', () => {
@@ -46,5 +58,32 @@ describe('emitCss', () => {
     const reparsed = parseCss(emitted);
     expect(reparsed.root.get('--color-brand-500')).toBe('#1e88e5');
     expect(reparsed.dark.get('--color-brand-500')).toBe('#42a5f5');
+  });
+});
+
+describe('emitScopedBlocks', () => {
+  it('emits a snapshot-id-scoped rule for a node with a scoped block', () => {
+    const out = emitScopedBlocks([node('auth.login.page.card.title', 'font-size: 18px')]);
+    expect(out).toBe('[stb-snapshot-id="auth.login.page.card.title"] {\n  font-size: 18px\n}');
+  });
+
+  it('skips nodes with no or blank scoped block', () => {
+    expect(emitScopedBlocks([node('a.b'), node('a.c', '   ')])).toBe('');
+  });
+
+  it('returns empty string for no nodes', () => {
+    expect(emitScopedBlocks([])).toBe('');
+  });
+
+  it('orders rules deterministically by snapshotId', () => {
+    const out = emitScopedBlocks([node('z.last', 'color: red'), node('a.first', 'color: blue')]);
+    expect(out.indexOf('a.first')).toBeLessThan(out.indexOf('z.last'));
+  });
+
+  it('joins multiple rules with a blank line', () => {
+    const out = emitScopedBlocks([node('a.one', 'color: red'), node('a.two', 'color: blue')]);
+    expect(out).toBe(
+      '[stb-snapshot-id="a.one"] {\n  color: red\n}\n\n[stb-snapshot-id="a.two"] {\n  color: blue\n}',
+    );
   });
 });

--- a/tools/stb/tests/state/branding.test.ts
+++ b/tools/stb/tests/state/branding.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { brandingModel, nodeFor, setNodeValue, setNodeVisibility, loadBrandingModel } from '@/state/branding';
+import { brandingModel, nodeFor, setNodeValue, setNodeVisibility, setNodeScopedBlock, loadBrandingModel } from '@/state/branding';
 import type { BrandingModel } from '@/metadata/types';
 
 const model: BrandingModel = {
@@ -39,6 +39,14 @@ describe('branding state', () => {
     setNodeVisibility('auth.login.logo', false);
     expect(nodeFor('auth.login.logo')?.visibility).toBe(false);
     expect(brandingModel.value).not.toBe(before); // new reference → reactivity
+  });
+
+  it('setNodeScopedBlock sets the scoped block on one node immutably', () => {
+    const before = brandingModel.value;
+    setNodeScopedBlock('auth.login.title', 'font-size: 18px');
+    expect(nodeFor('auth.login.title')?.scopedBlock).toBe('font-size: 18px');
+    expect(brandingModel.value).not.toBe(before); // new reference → reactivity
+    expect(nodeFor('auth.login.sign-in')?.scopedBlock).toBeUndefined(); // others untouched
   });
 });
 

--- a/tools/stb/vite.config.ts
+++ b/tools/stb/vite.config.ts
@@ -22,6 +22,22 @@ export default defineConfig({
       '@': resolve(__dirname, 'src'),
     },
   },
+  // Pre-bundle runtime deps the browser tests import. Without this, Vite
+  // discovers and optimizes them mid-run (e.g. "new dependencies optimized:
+  // jszip"), forces a reload, and in-flight test files fail to import
+  // ("runner is undefined" / "Importing a module script failed") — a flake
+  // that hits different browsers on different runs. Listing them here bundles
+  // them before the run starts. See vitest browser-mode reload warning.
+  optimizeDeps: {
+    include: [
+      'jszip',
+      'codemirror',
+      '@codemirror/state',
+      '@codemirror/view',
+      '@codemirror/commands',
+      '@codemirror/lang-css',
+    ],
+  },
   test: {
     projects: [
       {


### PR DESCRIPTION
## Summary

Adds the **R1 facet "scoped block"** to stb: an element can carry a raw, element-scoped CSS block that brands many CSS properties (including typography) without a 1‑1 `stb-*`→CSS attribute explosion. End to end: authored in `values.json` or edited in the lever popover → emitted as `[stb-snapshot-id]` rules → applied live in the preview iframe → exported into `theme.css`. **Token-first is preserved** — a colour with a routing token still routes to the token, not a scoped rule.

Built in two logical phases. They ship as one PR because **Phase B's code depends on Phase A's** (it imports `emitScopedBlocks`, `ScopedBlock`, etc.), so they can't be independent PRs — review in two passes via the commit boundary below.

### Phase A — scoped-block foundation (no UI)
- `ScopedBlock` type + optional `ElementNode.scopedBlock`; `buildModel` carries it from the `values.json` sidecar (additive — regen guard stays green with no regen).
- `emitScopedBlocks(nodes)` — deterministic `[stb-snapshot-id]` rules, blank blocks skipped.
- Export: `theme.css = tokens + scoped blocks` (scoped appended after `:root` for load order). Projector untouched; token-first locked by test.

### Phase B — edit + live preview
- Per-element CSS editor in the lever popover (CodeMirror extracted to a shared `mountCssEditor`; `setNodeScopedBlock` mutates the model).
- `STB_APPLY_BLOCKS` message → the preview shim upserts one late `<style>` so the block applies live (the in-tool analog of the deferred runtime loader).
- Popover is now **movable** (drag handle) and **fully resizable**.

### Robustness (from live testing)
- Declaration lines are auto-terminated with `;`, so typing one declaration per line (no trailing `;`) stays valid instead of silently no-op'ing.
- The rule's attribute selector is repeated to specificity **(0,3,0)** so a scoped block beats the snapshot's compound rules (`.login-card h1` etc.) in light **and** dark — **without `!important`**, so company-config inline styles (the runtime-faithful path) still win.

## Notes
- Architecture doc corrected: the `stba-*`↔ARIA projection is split — **inbound dual-read is now**, outbound emit-to-real-ARIA stays phased.
- A scoped-block edit is **session + export only** (whole-model reload persistence is deferred, matching how content/asset edits already behave).

## Testing
- **160 tests** (unit + chromium/firefox/webkit) green; `typecheck` + `lint` clean.
- **Live-verified** in the running app (Playwright): edits apply live including typography; `color`/`font-size` work on the title in light and dark; popover drag + both-axis resize; 0 console errors.

## Review boundary
- **Phase A:** `Add optional scopedBlock…` → `Export stb scoped blocks…`
- **Phase B:** `Edit an element's scoped CSS block…` → `Make the stb lever popover movable…`
