### PR TITLE
Read real ARIA as a fallback in stb harvest

### DIFF
--- a/tools/stb/scripts/harvest-login.ts
+++ b/tools/stb/scripts/harvest-login.ts
@@ -5,9 +5,9 @@ export interface HarvestedElement {
   snapshotId: string;
   tag: string;
   line: number;
-  role?: string;            // stba-role  → projects to ARIA `role`
-  roledescription?: string; // stba-roledescription → ARIA `aria-roledescription`; the navigator "kind"
-  description?: string;     // stba-description → ARIA `aria-description`
+  role?: string;            // stba-role or real `role` (stba wins)
+  roledescription?: string; // stba-roledescription or real `aria-roledescription`; the navigator "kind"
+  description?: string;     // stba-description or real `aria-description`
 }
 export interface DriftReport { phantoms: string[]; orphans: string[] }
 
@@ -17,6 +17,12 @@ const SID_RE = /stb-snapshot-id\s*=\s*"([^"]*)"/;
 const ROLE_RE = /stba-role\s*=\s*"([^"]*)"/;
 const ROLEDESC_RE = /stba-roledescription\s*=\s*"([^"]*)"/;
 const DESC_RE = /stba-description\s*=\s*"([^"]*)"/;
+// Real-ARIA fallbacks. stba-* is a strict 1-1 mirror of ARIA; the tool reads
+// either, with stba winning (stba-X ?? aria-X). The leading (?:^|\s) on role
+// is load-bearing: it stops `role=` matching inside `stba-role=`.
+const ARIA_ROLE_RE = /(?:^|\s)role\s*=\s*"([^"]*)"/;
+const ARIA_ROLEDESC_RE = /aria-roledescription\s*=\s*"([^"]*)"/;
+const ARIA_DESC_RE = /aria-description\s*=\s*"([^"]*)"/;
 
 const unescape = (s: string) => s.replace(/&quot;/g, '"').replace(/&amp;/g, '&');
 
@@ -27,9 +33,9 @@ export function harvestElements(html: string): HarvestedElement[] {
     const attrs = m[2]!;
     const sid = SID_RE.exec(attrs);
     if (!sid) continue;
-    const role = ROLE_RE.exec(attrs);
-    const roledesc = ROLEDESC_RE.exec(attrs);
-    const desc = DESC_RE.exec(attrs);
+    const role = ROLE_RE.exec(attrs) ?? ARIA_ROLE_RE.exec(attrs);
+    const roledesc = ROLEDESC_RE.exec(attrs) ?? ARIA_ROLEDESC_RE.exec(attrs);
+    const desc = DESC_RE.exec(attrs) ?? ARIA_DESC_RE.exec(attrs);
     out.push({
       snapshotId: sid[1]!,
       tag: m[1]!.toLowerCase(),

--- a/tools/stb/tests/scripts/harvest-login.test.ts
+++ b/tools/stb/tests/scripts/harvest-login.test.ts
@@ -29,6 +29,29 @@ describe('harvestElements', () => {
     });
     expect(els[1]).toEqual({ snapshotId: 'shared.confirm-dialog.title', tag: 'span', line: 3, role: 'heading' });
   });
+
+  it('falls back to real ARIA (role/aria-roledescription/aria-description) when no stba-*', () => {
+    const html = `
+<div stb-snapshot-id="shared.confirm-dialog" role="dialog" aria-roledescription="dialog" aria-description="the confirm dialog"></div>`;
+    expect(harvestElements(html)[0]).toEqual({
+      snapshotId: 'shared.confirm-dialog', tag: 'div', line: 2,
+      role: 'dialog', roledescription: 'dialog', description: 'the confirm dialog',
+    });
+  });
+
+  it('prefers stba-* over the real ARIA attribute when both are present', () => {
+    const html = `
+<div stb-snapshot-id="x" stba-role="dialog" role="alertdialog" stba-description="from stba" aria-description="from aria"></div>`;
+    const el = harvestElements(html)[0]!;
+    expect(el.role).toBe('dialog');
+    expect(el.description).toBe('from stba');
+  });
+
+  it('does not let the role regex match inside stba-role', () => {
+    // a tag with ONLY stba-role must not also surface a phantom real `role`
+    const html = `<div stb-snapshot-id="x" stba-role="dialog"></div>`;
+    expect(harvestElements(html)[0]).toEqual({ snapshotId: 'x', tag: 'div', line: 1, role: 'dialog' });
+  });
 });
 
 describe('lintRouting', () => {


### PR DESCRIPTION
## What

`harvestElements()` (tools/stb/scripts/harvest-login.ts) only read the `stba-*` mirror attributes when building the element model. This adds real-ARIA fallbacks so the harvester consumes **either** namespace:

- `stba-role` → falls back to real `role`
- `stba-roledescription` → falls back to `aria-roledescription`
- `stba-description` → falls back to `aria-description`

`stba-*` wins when both are present (`stba-X ?? aria-X`), so an element already carrying real ARIA needs no duplicate `stba-*`.

## Why

The architecture (docs/architecture.md, "ARIA projection — two directions") already specified inbound dual-read as a present tool requirement with `stba` winning; the code lagged the spec. This lands the inbound half. Outbound emit (`stba-*` → real `aria-*` in shipped DOM) stays phased, unchanged.

## Test

TDD, 3 new cases in tests/scripts/harvest-login.test.ts: real-ARIA fallback, stba-over-aria precedence, and that the `role` fallback regex (leading-whitespace boundary) does **not** match inside `stba-role`. Full gate green — typecheck + 163 tests + lint.