### PR TITLE
stb facet model Phase 2 — editor (collapsible facet tree)

### DIFF
--- a/tools/stb/scripts/generate-model.ts
+++ b/tools/stb/scripts/generate-model.ts
@@ -9,8 +9,6 @@ import type { BrandingModel, ElementNode, ScopedBlock, Facets } from '../src/met
 export interface ValueEntry { name: string | null; facets: Facets; visibility?: boolean; scopedBlock?: ScopedBlock }
 export type ValuesSidecar = Record<string, ValueEntry>;
 
-export { primaryValue } from '../src/metadata/facets';
-
 export function buildModel(scene: string, html: string, values: ValuesSidecar): BrandingModel {
   const nodes: ElementNode[] = [];
   for (const el of harvestElements(html)) {

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -1,3 +1,4 @@
+import { toOklch } from '@/color/oklch';
 import { mountEditorPane } from '@/ui/editor-pane';
 import { mountTokenSidebar } from '@/ui/token-sidebar';
 import { mountElementTree } from '@/ui/element-tree';
@@ -16,7 +17,7 @@ import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets } from '@
 import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion } from '@/ui/element-edit';
-import { primaryValue } from '@/metadata/facets';
+import { primaryValue, FACET_PROPS } from '@/metadata/facets';
 import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
 import { effect } from '@preact/signals-core';
 import { loadBuiltInPreset } from '@/state/presets';
@@ -139,6 +140,12 @@ async function main() {
         if (!n) return;
         setNodeFacets(snapshotId, removeGroup(n.facets, g));
         selectElement(snapshotId);
+      },
+      tokenForKey: (key) => routing.elements[snapshotId]?.properties?.[key]?.token ?? null,
+      resolveLiteral: (key, token) => {
+        const spec = FACET_PROPS[key];
+        const v = effectiveValue(token, previewDark.value);
+        return spec?.isColor ? { literal: toOklch(v) } : { literal: v };
       },
       ...companion,
     });

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -12,11 +12,12 @@ import { mountStatusBar } from '@/ui/status-bar';
 import { mountAssetManager } from '@/ui/asset-manager';
 import { setRootValue, setDarkValue, effectiveValue } from '@/state/tokens';
 import { previewDark, activeSceneId } from '@/state/scene';
-import { nodeFor, loadBrandingModel, setNodeScopedBlock } from '@/state/branding';
+import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets } from '@/state/branding';
 import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion } from '@/ui/element-edit';
 import { primaryValue } from '@/metadata/facets';
+import { setFacetProp } from '@/state/facets-edit';
 import { effect } from '@preact/signals-core';
 import { loadBuiltInPreset } from '@/state/presets';
 import { restoreSession, startAutoSave } from '@/state/persistence';
@@ -123,6 +124,10 @@ async function main() {
       scopedBlock: node.scopedBlock,
       onScopedBlockChange: (css) => setNodeScopedBlock(snapshotId, css),
       facets: node.facets,
+      onFacetEdit: (key, value) => {
+        const n = nodeFor(snapshotId);
+        if (n) setNodeFacets(snapshotId, setFacetProp(n.facets, key, value));
+      },
       ...companion,
     });
   }

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -16,8 +16,8 @@ import { previewDark, activeSceneId } from '@/state/scene';
 import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets } from '@/state/branding';
 import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
-import { applyEdit, buildVisibilityCompanion } from '@/ui/element-edit';
-import { primaryValue, FACET_PROPS } from '@/metadata/facets';
+import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens } from '@/ui/element-edit';
+import { FACET_PROPS } from '@/metadata/facets';
 import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
 import { effect } from '@preact/signals-core';
 import { loadBuiltInPreset } from '@/state/presets';
@@ -113,21 +113,21 @@ async function main() {
   function selectElement(snapshotId: string): void {
     const node = nodeFor(snapshotId);
     if (!node) return;
-    const lever = primaryValue(node.facets);
-    // NOTE: color-less node has no single-lever primary; the facet tree edits it.
-    if (!lever) return;
     const companion = buildVisibilityCompanion(snapshotId, node.visibility);
     openLeverEditor({
       previewHost,
       snapshotId,
-      value: lever,
       onChange: (next) => applyEdit(snapshotId, next, routing),
       scopedBlock: node.scopedBlock,
       onScopedBlockChange: (css) => setNodeScopedBlock(snapshotId, css),
       facets: node.facets,
       onFacetEdit: (key, value) => {
         const n = nodeFor(snapshotId);
-        if (n) setNodeFacets(snapshotId, setFacetProp(n.facets, key, value));
+        if (n) {
+          const facets = setFacetProp(n.facets, key, value);
+          setNodeFacets(snapshotId, facets);
+          reprojectNodeTokens(snapshotId, facets, routing);
+        }
       },
       onAddGroup: (g) => {
         const n = nodeFor(snapshotId);

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -17,7 +17,7 @@ import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion } from '@/ui/element-edit';
 import { primaryValue } from '@/metadata/facets';
-import { setFacetProp } from '@/state/facets-edit';
+import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
 import { effect } from '@preact/signals-core';
 import { loadBuiltInPreset } from '@/state/presets';
 import { restoreSession, startAutoSave } from '@/state/persistence';
@@ -127,6 +127,18 @@ async function main() {
       onFacetEdit: (key, value) => {
         const n = nodeFor(snapshotId);
         if (n) setNodeFacets(snapshotId, setFacetProp(n.facets, key, value));
+      },
+      onAddGroup: (g) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, addGroup(n.facets, g));
+        selectElement(snapshotId);
+      },
+      onRemoveGroup: (g) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, removeGroup(n.facets, g));
+        selectElement(snapshotId);
       },
       ...companion,
     });

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -122,6 +122,7 @@ async function main() {
       onChange: (next) => applyEdit(snapshotId, next, routing),
       scopedBlock: node.scopedBlock,
       onScopedBlockChange: (css) => setNodeScopedBlock(snapshotId, css),
+      facets: node.facets,
       ...companion,
     });
   }

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -111,11 +111,14 @@ async function main() {
   function selectElement(snapshotId: string): void {
     const node = nodeFor(snapshotId);
     if (!node) return;
+    const lever = primaryValue(node.facets);
+    // NOTE: color-less node has no single-lever primary; the facet tree edits it.
+    if (!lever) return;
     const companion = buildVisibilityCompanion(snapshotId, node.visibility);
     openLeverEditor({
       previewHost,
       snapshotId,
-      value: primaryValue(node.facets),
+      value: lever,
       onChange: (next) => applyEdit(snapshotId, next, routing),
       scopedBlock: node.scopedBlock,
       onScopedBlockChange: (css) => setNodeScopedBlock(snapshotId, css),

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -1,4 +1,4 @@
-import type { Facets, FacetValue, LeverValue } from '@/metadata/types';
+import type { Facets, FacetValue } from '@/metadata/types';
 import { oklchToHex, type Oklch } from '@/color/oklch';
 
 export interface FacetPropSpec { cssProp: string; isColor: boolean; }
@@ -52,17 +52,4 @@ export function* contentAssetDeclarations(
 ): Generator<ContentAssetDeclaration> {
   if (facets.content) yield { key: 'content', value: facets.content.text };
   if (facets.asset) yield { key: 'asset', value: facets.asset.ref };
-}
-
-/** Derive the Phase-1 single LeverValue from a Facets bundle.
- *  Priority: content > asset > text.color > surface.background > null.
- *  Returns null for color-less nodes (typography/spacing only); callers must guard. */
-export function primaryValue(f: Facets): LeverValue | null {
-  if (f.content) return { kind: 'content', text: f.content.text };
-  if (f.asset) return { kind: 'asset', ref: f.asset.ref };
-  const color = f.text?.color ?? f.surface?.background;
-  if (color && 'literal' in color && typeof color.literal === 'object') {
-    return { kind: 'color', oklch: color.literal as Oklch };
-  }
-  return null;
 }

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -55,13 +55,14 @@ export function* contentAssetDeclarations(
 }
 
 /** Derive the Phase-1 single LeverValue from a Facets bundle.
- *  Priority: content > asset > text.color > surface.background > fallback black. */
-export function primaryValue(f: Facets): LeverValue {
+ *  Priority: content > asset > text.color > surface.background > null.
+ *  Returns null for color-less nodes (typography/spacing only); callers must guard. */
+export function primaryValue(f: Facets): LeverValue | null {
   if (f.content) return { kind: 'content', text: f.content.text };
   if (f.asset) return { kind: 'asset', ref: f.asset.ref };
   const color = f.text?.color ?? f.surface?.background;
   if (color && 'literal' in color && typeof color.literal === 'object') {
     return { kind: 'color', oklch: color.literal as Oklch };
   }
-  return { kind: 'color', oklch: { l: 0, c: 0, h: 0 } };
+  return null;
 }

--- a/tools/stb/src/metadata/types.ts
+++ b/tools/stb/src/metadata/types.ts
@@ -27,13 +27,6 @@ export interface BrandingModel {
   nodes: ElementNode[];
 }
 
-/** True when the node's primary lever is a color (text.color or surface.background literal). */
-export function isColorNode(n: ElementNode): boolean {
-  if (n.facets.content || n.facets.asset) return false;
-  const c = n.facets.text?.color ?? n.facets.surface?.background;
-  return !!(c && 'literal' in c && typeof c.literal === 'object');
-}
-
 export type FacetValue = { token: string } | { literal: Oklch | string };
 
 export interface TextFacet { color?: FacetValue; fontFamily?: FacetValue; fontSize?: FacetValue; fontWeight?: FacetValue; lineHeight?: FacetValue; }

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -1,0 +1,33 @@
+import type { Facets, FacetValue } from '@/metadata/types';
+import type { Oklch } from '@/color/oklch';
+
+type Group = 'text' | 'surface' | 'spacing';
+const groupOf = (key: string) => key.split('.')[0] as Group;
+const propOf  = (key: string) => key.split('.')[1]!;
+
+export function setFacetProp(f: Facets, key: string, value: FacetValue): Facets {
+  const g = groupOf(key);
+  return { ...f, [g]: { ...(f[g] ?? {}), [propOf(key)]: value } };
+}
+export function clearFacetProp(f: Facets, key: string): Facets {
+  const g = groupOf(key);
+  if (!f[g]) return f;
+  const next = { ...(f[g] as Record<string, unknown>) };
+  delete next[propOf(key)];
+  return { ...f, [g]: next };
+}
+export function addGroup(f: Facets, group: Group): Facets {
+  return f[group] ? f : { ...f, [group]: {} };
+}
+export function removeGroup(f: Facets, group: Group): Facets {
+  if (!f[group]) return f;
+  const next = { ...f };
+  delete next[group];
+  return next;
+}
+export function promoteToToken(f: Facets, key: string, token: string): Facets {
+  return setFacetProp(f, key, { token });
+}
+export function detachToLiteral(f: Facets, key: string, literal: Oklch | string): Facets {
+  return setFacetProp(f, key, { literal });
+}

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -1,5 +1,4 @@
 import type { Facets, FacetValue } from '@/metadata/types';
-import type { Oklch } from '@/color/oklch';
 
 type Group = 'text' | 'surface' | 'spacing';
 const groupOf = (key: string) => key.split('.')[0] as Group;
@@ -9,13 +8,6 @@ export function setFacetProp(f: Facets, key: string, value: FacetValue): Facets 
   const g = groupOf(key);
   return { ...f, [g]: { ...(f[g] ?? {}), [propOf(key)]: value } };
 }
-export function clearFacetProp(f: Facets, key: string): Facets {
-  const g = groupOf(key);
-  if (!f[g]) return f;
-  const next = { ...(f[g] as Record<string, unknown>) };
-  delete next[propOf(key)];
-  return { ...f, [g]: next };
-}
 export function addGroup(f: Facets, group: Group): Facets {
   return f[group] ? f : { ...f, [group]: {} };
 }
@@ -24,10 +16,4 @@ export function removeGroup(f: Facets, group: Group): Facets {
   const next = { ...f };
   delete next[group];
   return next;
-}
-export function promoteToToken(f: Facets, key: string, token: string): Facets {
-  return setFacetProp(f, key, { token });
-}
-export function detachToLiteral(f: Facets, key: string, literal: Oklch | string): Facets {
-  return setFacetProp(f, key, { literal });
 }

--- a/tools/stb/src/ui/element-edit.ts
+++ b/tools/stb/src/ui/element-edit.ts
@@ -21,7 +21,7 @@ export function buildVisibilityCompanion(
 function leverValueToFacets(value: LeverValue, existing: Facets): Facets {
   if (value.kind === 'content') return { ...existing, content: { text: value.text } };
   if (value.kind === 'asset') return { ...existing, asset: { ref: value.ref } };
-  // color: write into the same slot primaryValue read from (text.color > surface.background)
+  // color: write into text.color if present, else surface.background
   const colorFacet: FacetValue = { literal: value.oklch };
   if (existing.text?.color !== undefined) {
     return { ...existing, text: { ...existing.text, color: colorFacet } };

--- a/tools/stb/src/ui/element-edit.ts
+++ b/tools/stb/src/ui/element-edit.ts
@@ -29,6 +29,15 @@ function leverValueToFacets(value: LeverValue, existing: Facets): Facets {
   return { ...existing, surface: { ...existing.surface, background: colorFacet } };
 }
 
+export function reprojectNodeTokens(snapshotId: string, facets: Facets, routing: RoutingMap): void {
+  const m = brandingModel.value;
+  if (!m) return;
+  const node = m.nodes.find((n) => n.snapshotId === snapshotId);
+  if (!node) return;
+  const { tokens } = project({ scene: m.scene, nodes: [{ ...node, facets }] }, routing);
+  for (const [k, v] of tokens) setRootValue(k, v);
+}
+
 export function applyEdit(snapshotId: string, value: LeverValue, routing: RoutingMap): void {
   const m = brandingModel.value;
   if (!m) return;
@@ -38,6 +47,5 @@ export function applyEdit(snapshotId: string, value: LeverValue, routing: Routin
   const updatedFacets = leverValueToFacets(value, node.facets);
   setNodeFacets(snapshotId, updatedFacets);
   // re-project only the edited node so color levers update their bound token
-  const { tokens } = project({ scene: m.scene, nodes: [{ ...node, facets: updatedFacets }] }, routing);
-  for (const [k, v] of tokens) setRootValue(k, v);
+  reprojectNodeTokens(snapshotId, updatedFacets, routing);
 }

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -4,7 +4,6 @@ import type { Oklch } from '@/color/oklch';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import { FACET_PROPS } from '@/metadata/facets';
 import { openColorPicker } from '@/ui/color-picker';
-import { mountCssEditor } from '@/ui/css-editor';
 
 const GROUPS = ['text', 'surface', 'spacing'] as const;
 const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.startsWith(g + '.'));
@@ -13,8 +12,6 @@ export interface FacetTreeOptions {
   facets: Facets;
   previewHost: HTMLElement;
   onEdit: (key: string, value: FacetValue) => void;
-  scopedBlock?: string;
-  onScopedBlockChange?: (css: string) => void;
   onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   /** Returns the token name mapped to this element's property, or null if none. */
@@ -50,7 +47,6 @@ function setCollapsed(entry: GroupEntry, collapsed: boolean): void {
 export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { destroy(): void } {
   host.classList.add('stb-facet-tree');
   host.innerHTML = '';
-  let scoped: ReturnType<typeof mountCssEditor> | null = null;
   let focusedGroup: string | null = null;
 
   // Control bar — rendered first so it is the top child
@@ -230,7 +226,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         const badge = document.createElement('span');
         badge.className = 'stb-facet-shared';
         badge.textContent = 'shared';
-        badge.title = `token --${current.token} (changes everywhere)`;
+        badge.title = `token ${current.token} (changes everywhere)`;
         const detach = document.createElement('button');
         detach.type = 'button';
         detach.className = 'stb-facet-detach';
@@ -270,15 +266,5 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     }
   });
 
-  if (opts.onScopedBlockChange) {
-    const branch = document.createElement('div');
-    branch.className = 'stb-facet-group';
-    branch.textContent = 'Scoped CSS';
-    host.appendChild(branch);
-    const editorHost = document.createElement('div');
-    host.appendChild(editorHost);
-    scoped = mountCssEditor(editorHost, opts.scopedBlock ?? '', opts.onScopedBlockChange);
-  }
-
-  return { destroy() { scoped?.destroy(); host.innerHTML = ''; } };
+  return { destroy() { host.innerHTML = ''; } };
 }

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -142,8 +142,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       }
 
       // Track focused group for isolate
-      const capturedGroup = g;
-      leaf.addEventListener('focusin', () => { focusedGroup = capturedGroup; });
+      leaf.addEventListener('focusin', () => { focusedGroup = g; });
 
       leavesEl.appendChild(leaf);
     }

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -17,6 +17,10 @@ export interface FacetTreeOptions {
   onScopedBlockChange?: (css: string) => void;
   onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
+  /** Returns the token name mapped to this element's property, or null if none. */
+  tokenForKey?: (key: string) => string | null;
+  /** Resolves the literal FacetValue to detach TO (token's current value). */
+  resolveLiteral?: (key: string, token: string) => FacetValue;
 }
 
 const FONT_FAMILIES = [
@@ -179,6 +183,31 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         }
         input.addEventListener('input', () => opts.onEdit(key, { literal: input.value }));
         leaf.appendChild(input);
+      }
+
+      // Scope indicator: shared badge + detach for token values; promote for promotable literals
+      const defaultLiteralFor = (s: typeof spec): FacetValue =>
+        s.isColor ? { literal: { l: 0, c: 0, h: 0 } } : { literal: '' };
+      if (current && 'token' in current) {
+        const badge = document.createElement('span');
+        badge.className = 'stb-facet-shared';
+        badge.textContent = 'shared';
+        badge.title = `token --${current.token} (changes everywhere)`;
+        const detach = document.createElement('button');
+        detach.type = 'button';
+        detach.className = 'stb-facet-detach';
+        detach.textContent = 'detach';
+        detach.addEventListener('click', () =>
+          opts.onEdit(key, opts.resolveLiteral ? opts.resolveLiteral(key, current.token) : defaultLiteralFor(spec)),
+        );
+        leaf.append(badge, detach);
+      } else if (current && 'literal' in current && opts.tokenForKey?.(key)) {
+        const promote = document.createElement('button');
+        promote.type = 'button';
+        promote.className = 'stb-facet-promote';
+        promote.textContent = 'promote';
+        promote.addEventListener('click', () => opts.onEdit(key, { token: opts.tokenForKey!(key)! }));
+        leaf.appendChild(promote);
       }
 
       // Track focused group for isolate

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -15,6 +15,8 @@ export interface FacetTreeOptions {
   onEdit: (key: string, value: FacetValue) => void;
   scopedBlock?: string;
   onScopedBlockChange?: (css: string) => void;
+  onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
+  onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
 }
 
 const FONT_FAMILIES = [
@@ -67,6 +69,33 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
   bar.appendChild(btnExpandAll);
   bar.appendChild(btnCollapseAll);
   bar.appendChild(btnIsolate);
+
+  // "+ add group" select — lists only the GROUPS not yet present in facets
+  const addSelect = document.createElement('select');
+  addSelect.className = 'stb-facet-add';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = '+ add group';
+  placeholder.disabled = true;
+  addSelect.appendChild(placeholder);
+  for (const g of GROUPS) {
+    if (!opts.facets[g]) {
+      const opt = document.createElement('option');
+      opt.value = g;
+      opt.textContent = g;
+      addSelect.appendChild(opt);
+    }
+  }
+  addSelect.value = '';
+  addSelect.addEventListener('change', () => {
+    const g = addSelect.value as 'text' | 'surface' | 'spacing';
+    if (g) {
+      opts.onAddGroup?.(g);
+      addSelect.value = '';
+    }
+  });
+  bar.appendChild(addSelect);
+
   host.appendChild(bar);
 
   const groupEntries: GroupEntry[] = [];
@@ -77,6 +106,17 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     const branch = document.createElement('div');
     branch.className = 'stb-facet-group';
     branch.textContent = g;
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'stb-facet-remove';
+    removeBtn.textContent = '×';
+    removeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      opts.onRemoveGroup?.(g as 'text' | 'surface' | 'spacing');
+    });
+    branch.appendChild(removeBtn);
+
     host.appendChild(branch);
 
     const leavesEl = document.createElement('div');

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -1,0 +1,51 @@
+// src/ui/facet-tree.ts  (render-only; controls added in Task 3)
+import type { Facets, FacetValue } from '@/metadata/types';
+import { FACET_PROPS } from '@/metadata/facets';
+import { mountCssEditor } from '@/ui/css-editor';
+
+const GROUPS = ['text', 'surface', 'spacing'] as const;
+const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.startsWith(g + '.'));
+
+export interface FacetTreeOptions {
+  facets: Facets;
+  onEdit: (key: string, value: FacetValue) => void;
+  scopedBlock?: string;
+  onScopedBlockChange?: (css: string) => void;
+}
+
+export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { destroy(): void } {
+  host.classList.add('stb-facet-tree');
+  host.innerHTML = '';
+  let scoped: ReturnType<typeof mountCssEditor> | null = null;
+
+  for (const g of GROUPS) {
+    if (!opts.facets[g]) continue;
+    const branch = document.createElement('div');
+    branch.className = 'stb-facet-group';
+    branch.textContent = g;
+    host.appendChild(branch);
+    for (const [key, spec] of propsOf(g)) {
+      const leaf = document.createElement('div');
+      leaf.className = 'stb-facet-leaf';
+      leaf.dataset.key = key;
+      const lab = document.createElement('span');
+      lab.className = 'stb-facet-leaf-label';
+      lab.textContent = spec.cssProp;
+      leaf.appendChild(lab);
+      // Task 3 appends the control here.
+      host.appendChild(leaf);
+    }
+  }
+
+  if (opts.onScopedBlockChange) {
+    const branch = document.createElement('div');
+    branch.className = 'stb-facet-group';
+    branch.textContent = 'Scoped CSS';
+    host.appendChild(branch);
+    const editorHost = document.createElement('div');
+    host.appendChild(editorHost);
+    scoped = mountCssEditor(editorHost, opts.scopedBlock ?? '', opts.onScopedBlockChange);
+  }
+
+  return { destroy() { scoped?.destroy(); host.innerHTML = ''; } };
+}

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -1,6 +1,9 @@
-// src/ui/facet-tree.ts  (render-only; controls added in Task 3)
+// src/ui/facet-tree.ts
 import type { Facets, FacetValue } from '@/metadata/types';
+import type { Oklch } from '@/color/oklch';
+import { toOklch, oklchToHex } from '@/color/oklch';
 import { FACET_PROPS } from '@/metadata/facets';
+import { openColorPicker } from '@/ui/color-picker';
 import { mountCssEditor } from '@/ui/css-editor';
 
 const GROUPS = ['text', 'surface', 'spacing'] as const;
@@ -8,10 +11,20 @@ const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.sta
 
 export interface FacetTreeOptions {
   facets: Facets;
+  previewHost: HTMLElement;
   onEdit: (key: string, value: FacetValue) => void;
   scopedBlock?: string;
   onScopedBlockChange?: (css: string) => void;
 }
+
+const FONT_FAMILIES = [
+  'inherit',
+  'system-ui',
+  'Arial, sans-serif',
+  'Georgia, serif',
+  '"Courier New", monospace',
+];
+const FONT_WEIGHTS = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
 
 export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { destroy(): void } {
   host.classList.add('stb-facet-tree');
@@ -32,7 +45,49 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       lab.className = 'stb-facet-leaf-label';
       lab.textContent = spec.cssProp;
       leaf.appendChild(lab);
-      // Task 3 appends the control here.
+
+      const propName = key.split('.')[1]!;
+      const current = (opts.facets[g] as Record<string, FacetValue | undefined>)?.[propName];
+
+      if (spec.isColor) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'stb-facet-swatch';
+        const lit = current && 'literal' in current && typeof current.literal === 'object'
+          ? current.literal as Oklch
+          : null;
+        if (lit) btn.style.backgroundColor = oklchToHex(lit);
+        btn.addEventListener('click', () => openColorPicker({
+          previewHost: opts.previewHost,
+          initial: lit ? oklchToHex(lit) : '#000000',
+          // NOTE: hex is deliberate — value is stored as Oklch regardless of picker display format,
+          // so threading the live color-format signal buys nothing here.
+          format: 'hex',
+          onChange: (value) => opts.onEdit(key, { literal: toOklch(value) }),
+        }));
+        leaf.appendChild(btn);
+      } else if (key === 'text.fontFamily' || key === 'text.fontWeight') {
+        const sel = document.createElement('select');
+        const options = key === 'text.fontWeight' ? FONT_WEIGHTS : FONT_FAMILIES;
+        for (const o of options) {
+          const opt = document.createElement('option');
+          opt.value = o;
+          opt.textContent = o;
+          sel.appendChild(opt);
+        }
+        if (current && 'literal' in current) sel.value = String(current.literal);
+        sel.addEventListener('change', () => opts.onEdit(key, { literal: sel.value }));
+        leaf.appendChild(sel);
+      } else {
+        const input = document.createElement('input');
+        input.type = 'text';
+        if (current && 'literal' in current && typeof current.literal === 'string') {
+          input.value = current.literal;
+        }
+        input.addEventListener('input', () => opts.onEdit(key, { literal: input.value }));
+        leaf.appendChild(input);
+      }
+
       host.appendChild(leaf);
     }
   }

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -21,6 +21,8 @@ export interface FacetTreeOptions {
   tokenForKey?: (key: string) => string | null;
   /** Resolves the literal FacetValue to detach TO (token's current value). */
   resolveLiteral?: (key: string, token: string) => FacetValue;
+  onContentEdit?: (text: string) => void;
+  onAssetEdit?: (file: File) => void;
 }
 
 const FONT_FAMILIES = [
@@ -103,6 +105,42 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
   host.appendChild(bar);
 
   const groupEntries: GroupEntry[] = [];
+
+  // Standalone content leaf — not part of any style group
+  if (opts.facets.content) {
+    const leaf = document.createElement('div');
+    leaf.className = 'stb-facet-leaf';
+    leaf.dataset.key = 'content';
+    const lab = document.createElement('span');
+    lab.className = 'stb-facet-leaf-label';
+    lab.textContent = 'content';
+    leaf.appendChild(lab);
+    const ta = document.createElement('textarea');
+    ta.value = opts.facets.content.text;
+    ta.addEventListener('input', () => opts.onContentEdit?.(ta.value));
+    leaf.appendChild(ta);
+    host.appendChild(leaf);
+  }
+
+  // Standalone asset leaf — not part of any style group
+  if (opts.facets.asset) {
+    const leaf = document.createElement('div');
+    leaf.className = 'stb-facet-leaf';
+    leaf.dataset.key = 'asset';
+    const lab = document.createElement('span');
+    lab.className = 'stb-facet-leaf-label';
+    lab.textContent = 'asset';
+    leaf.appendChild(lab);
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.addEventListener('change', () => {
+      const file = input.files?.[0];
+      if (file) opts.onAssetEdit?.(file);
+    });
+    leaf.appendChild(input);
+    host.appendChild(leaf);
+  }
 
   for (const g of GROUPS) {
     if (!opts.facets[g]) continue;

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -26,17 +26,70 @@ const FONT_FAMILIES = [
 ];
 const FONT_WEIGHTS = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
 
+interface GroupEntry {
+  group: string;
+  branch: HTMLElement;
+  leaves: HTMLElement;
+  collapsed: boolean;
+}
+
+function setCollapsed(entry: GroupEntry, collapsed: boolean): void {
+  entry.collapsed = collapsed;
+  entry.branch.classList.toggle('stb-facet-collapsed', collapsed);
+  entry.leaves.hidden = collapsed;
+}
+
 export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { destroy(): void } {
   host.classList.add('stb-facet-tree');
   host.innerHTML = '';
   let scoped: ReturnType<typeof mountCssEditor> | null = null;
+  let focusedGroup: string | null = null;
+
+  // Control bar — rendered first so it is the top child
+  const bar = document.createElement('div');
+  bar.className = 'stb-facet-bar';
+
+  const btnExpandAll = document.createElement('button');
+  btnExpandAll.type = 'button';
+  btnExpandAll.className = 'stb-facet-expand-all';
+  btnExpandAll.textContent = 'Expand all';
+
+  const btnCollapseAll = document.createElement('button');
+  btnCollapseAll.type = 'button';
+  btnCollapseAll.className = 'stb-facet-collapse-all';
+  btnCollapseAll.textContent = 'Collapse all';
+
+  const btnIsolate = document.createElement('button');
+  btnIsolate.type = 'button';
+  btnIsolate.className = 'stb-facet-isolate';
+  btnIsolate.textContent = 'Isolate';
+
+  bar.appendChild(btnExpandAll);
+  bar.appendChild(btnCollapseAll);
+  bar.appendChild(btnIsolate);
+  host.appendChild(bar);
+
+  const groupEntries: GroupEntry[] = [];
 
   for (const g of GROUPS) {
     if (!opts.facets[g]) continue;
+
     const branch = document.createElement('div');
     branch.className = 'stb-facet-group';
     branch.textContent = g;
     host.appendChild(branch);
+
+    const leavesEl = document.createElement('div');
+    leavesEl.className = 'stb-facet-leaves';
+    host.appendChild(leavesEl);
+
+    const entry: GroupEntry = { group: g, branch, leaves: leavesEl, collapsed: false };
+    groupEntries.push(entry);
+
+    branch.addEventListener('click', () => {
+      setCollapsed(entry, !entry.collapsed);
+    });
+
     for (const [key, spec] of propsOf(g)) {
       const leaf = document.createElement('div');
       leaf.className = 'stb-facet-leaf';
@@ -88,9 +141,28 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         leaf.appendChild(input);
       }
 
-      host.appendChild(leaf);
+      // Track focused group for isolate
+      const capturedGroup = g;
+      leaf.addEventListener('focusin', () => { focusedGroup = capturedGroup; });
+
+      leavesEl.appendChild(leaf);
     }
   }
+
+  btnExpandAll.addEventListener('click', () => {
+    for (const entry of groupEntries) setCollapsed(entry, false);
+  });
+
+  btnCollapseAll.addEventListener('click', () => {
+    for (const entry of groupEntries) setCollapsed(entry, true);
+  });
+
+  btnIsolate.addEventListener('click', () => {
+    if (focusedGroup === null) return;
+    for (const entry of groupEntries) {
+      setCollapsed(entry, entry.group !== focusedGroup);
+    }
+  });
 
   if (opts.onScopedBlockChange) {
     const branch = document.createElement('div');

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -1,6 +1,5 @@
 import type { LeverValue, Facets, FacetValue } from '@/metadata/types';
 import type { EditorView } from 'codemirror';
-import { toOklch, oklchToHex } from '@/color/oklch';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 import { mountCssEditor } from '@/ui/css-editor';
 import { mountFacetTree } from '@/ui/facet-tree';
@@ -9,13 +8,12 @@ import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
 export interface OpenLeverEditorOptions {
   previewHost: HTMLElement;
   snapshotId: string;
-  value: LeverValue;
   onChange: (next: LeverValue) => void;
   onClose?: () => void;
   visibilityCompanion?: { shown: boolean; onChange: (shown: boolean) => void };
   scopedBlock?: string | undefined;
   onScopedBlockChange?: (css: string) => void;
-  facets?: Facets;
+  facets: Facets;
   onFacetEdit?: (key: string, value: FacetValue) => void;
   onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
@@ -23,17 +21,11 @@ export interface OpenLeverEditorOptions {
   resolveLiteral?: (key: string, token: string) => FacetValue;
 }
 
-export function colorValueFromHex(hex: string): LeverValue {
-  return { kind: 'color', oklch: toOklch(hex) };
-}
 export function contentValue(text: string): LeverValue {
   return { kind: 'content', text };
 }
 export function assetValue(filename: string): LeverValue {
   return { kind: 'asset', ref: filename };
-}
-export function initialColorHex(v: LeverValue): string {
-  return v.kind === 'color' ? oklchToHex(v.oklch) : '#000000';
 }
 
 let openPanel: HTMLElement | null = null;
@@ -49,29 +41,6 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   closeOpen();
   const panel = document.createElement('div');
   panel.className = 'stb-lever-editor';
-
-  const v = opts.value;
-  if (v.kind === 'color') {
-    panel.innerHTML = `<input type="color" class="stb-lever-color" value="${initialColorHex(v)}" />`;
-    panel.querySelector<HTMLInputElement>('.stb-lever-color')!
-      .addEventListener('input', (e) => opts.onChange(colorValueFromHex((e.target as HTMLInputElement).value)));
-  } else if (v.kind === 'content') {
-    const ta = document.createElement('textarea');
-    ta.className = 'stb-lever-text';
-    ta.rows = 5;
-    ta.value = v.text;
-    ta.addEventListener('input', (e) => opts.onChange(contentValue((e.target as HTMLTextAreaElement).value)));
-    panel.appendChild(ta);
-  } else {
-    panel.innerHTML = `<label class="stb-lever-asset-label">Upload image <input type="file" accept="image/*" class="stb-lever-asset" /></label>`;
-    panel.querySelector<HTMLInputElement>('.stb-lever-asset')!
-      .addEventListener('change', (e) => {
-        const file = (e.target as HTMLInputElement).files?.[0];
-        if (!file) return;
-        setBrandingAsset(opts.snapshotId, file, file.name);
-        opts.onChange(assetValue(assetRefFor(file.name)));
-      });
-  }
 
   if (opts.visibilityCompanion) {
     const c = opts.visibilityCompanion;
@@ -100,19 +69,19 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
     openScopedEditor = mountCssEditor(editorHost, opts.scopedBlock ?? '', opts.onScopedBlockChange);
   }
 
-  if (opts.facets) {
-    const treeHost = document.createElement('div');
-    panel.appendChild(treeHost);
-    openFacetTree = mountFacetTree(treeHost, {
-      facets: opts.facets,
-      previewHost: opts.previewHost,
-      onEdit: opts.onFacetEdit ?? (() => {}),
-      ...(opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
-      ...(opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
-      ...(opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
-      ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
-    });
-  }
+  const treeHost = document.createElement('div');
+  panel.appendChild(treeHost);
+  openFacetTree = mountFacetTree(treeHost, {
+    facets: opts.facets,
+    previewHost: opts.previewHost,
+    onEdit: opts.onFacetEdit ?? (() => {}),
+    ...(opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
+    ...(opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
+    ...(opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
+    ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
+    onContentEdit: (text) => opts.onChange(contentValue(text)),
+    onAssetEdit: (file) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
+  });
 
   const close = document.createElement('button');
   close.className = 'stb-lever-close';

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -17,6 +17,8 @@ export interface OpenLeverEditorOptions {
   onScopedBlockChange?: (css: string) => void;
   facets?: Facets;
   onFacetEdit?: (key: string, value: FacetValue) => void;
+  onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
+  onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
 }
 
 export function colorValueFromHex(hex: string): LeverValue {
@@ -103,6 +105,8 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       facets: opts.facets,
       previewHost: opts.previewHost,
       onEdit: opts.onFacetEdit ?? (() => {}),
+      ...(opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
+      ...(opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
     });
   }
 

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -1,8 +1,9 @@
-import type { LeverValue } from '@/metadata/types';
+import type { LeverValue, Facets } from '@/metadata/types';
 import type { EditorView } from 'codemirror';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 import { mountCssEditor } from '@/ui/css-editor';
+import { mountFacetTree } from '@/ui/facet-tree';
 import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
 
 export interface OpenLeverEditorOptions {
@@ -14,6 +15,7 @@ export interface OpenLeverEditorOptions {
   visibilityCompanion?: { shown: boolean; onChange: (shown: boolean) => void };
   scopedBlock?: string | undefined;
   onScopedBlockChange?: (css: string) => void;
+  facets?: Facets;
 }
 
 export function colorValueFromHex(hex: string): LeverValue {
@@ -31,7 +33,9 @@ export function initialColorHex(v: LeverValue): string {
 
 let openPanel: HTMLElement | null = null;
 let openScopedEditor: EditorView | null = null;
+let openFacetTree: { destroy(): void } | null = null;
 function closeOpen(): void {
+  if (openFacetTree) { openFacetTree.destroy(); openFacetTree = null; }
   if (openScopedEditor) { openScopedEditor.destroy(); openScopedEditor = null; }
   if (openPanel) { openPanel.remove(); openPanel = null; }
 }
@@ -89,6 +93,12 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
     section.appendChild(editorHost);
     panel.appendChild(section);
     openScopedEditor = mountCssEditor(editorHost, opts.scopedBlock ?? '', opts.onScopedBlockChange);
+  }
+
+  if (opts.facets) {
+    const treeHost = document.createElement('div');
+    panel.appendChild(treeHost);
+    openFacetTree = mountFacetTree(treeHost, { facets: opts.facets, onEdit: () => {} });
   }
 
   const close = document.createElement('button');

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -1,4 +1,4 @@
-import type { LeverValue, Facets } from '@/metadata/types';
+import type { LeverValue, Facets, FacetValue } from '@/metadata/types';
 import type { EditorView } from 'codemirror';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
@@ -16,6 +16,7 @@ export interface OpenLeverEditorOptions {
   scopedBlock?: string | undefined;
   onScopedBlockChange?: (css: string) => void;
   facets?: Facets;
+  onFacetEdit?: (key: string, value: FacetValue) => void;
 }
 
 export function colorValueFromHex(hex: string): LeverValue {
@@ -98,7 +99,11 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   if (opts.facets) {
     const treeHost = document.createElement('div');
     panel.appendChild(treeHost);
-    openFacetTree = mountFacetTree(treeHost, { facets: opts.facets, onEdit: () => {} });
+    openFacetTree = mountFacetTree(treeHost, {
+      facets: opts.facets,
+      previewHost: opts.previewHost,
+      onEdit: opts.onFacetEdit ?? (() => {}),
+    });
   }
 
   const close = document.createElement('button');

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -19,6 +19,8 @@ export interface OpenLeverEditorOptions {
   onFacetEdit?: (key: string, value: FacetValue) => void;
   onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
+  tokenForKey?: (key: string) => string | null;
+  resolveLiteral?: (key: string, token: string) => FacetValue;
 }
 
 export function colorValueFromHex(hex: string): LeverValue {
@@ -107,6 +109,8 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       onEdit: opts.onFacetEdit ?? (() => {}),
       ...(opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
       ...(opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
+      ...(opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
+      ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
     });
   }
 

--- a/tools/stb/tests/integration/element-edit.test.ts
+++ b/tools/stb/tests/integration/element-edit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { brandingModel, nodeFor } from '@/state/branding';
 import { rootValues } from '@/state/tokens';
-import { applyEdit } from '@/ui/element-edit';
+import { applyEdit, reprojectNodeTokens } from '@/ui/element-edit';
 import type { BrandingModel } from '@/metadata/types';
 
 const routing = { containers: { 'auth.login': 'login' }, elements: {
@@ -22,6 +22,19 @@ describe('applyEdit', () => {
   });
   it('color edit re-projects to the bound token', () => {
     applyEdit('auth.login.sign-in', { kind: 'color', oklch: { l: 0.6, c: 0.12, h: 200 } }, routing);
+    expect(rootValues.value.get('--color-brand-500')).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});
+
+describe('reprojectNodeTokens', () => {
+  beforeEach(() => { brandingModel.value = JSON.parse(JSON.stringify(model)); rootValues.value = new Map(); });
+
+  it('re-projects a color edit from facets to the bound CSS token', () => {
+    reprojectNodeTokens(
+      'auth.login.sign-in',
+      { surface: { background: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
+      routing,
+    );
     expect(rootValues.value.get('--color-brand-500')).toMatch(/^#[0-9a-f]{6}$/);
   });
 });

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -56,3 +56,37 @@ it('reflects an existing fontWeight literal as the select current value', () => 
   expect(sel).toBeTruthy();
   expect(sel.value).toBe('700');
 });
+
+it('collapse-all hides leaves; expand-all shows them', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  mountFacetTree(host, { facets: { text: {}, surface: {} }, previewHost, onEdit: () => {} });
+  (host.querySelector('.stb-facet-collapse-all') as HTMLButtonElement).click();
+  expect(host.querySelectorAll('.stb-facet-group.stb-facet-collapsed').length).toBe(2);
+  (host.querySelector('.stb-facet-expand-all') as HTMLButtonElement).click();
+  expect(host.querySelectorAll('.stb-facet-group.stb-facet-collapsed').length).toBe(0);
+});
+
+it('clicking a group branch toggles its own collapse state', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  mountFacetTree(host, { facets: { text: {} }, previewHost, onEdit: () => {} });
+  const branch = host.querySelector('.stb-facet-group') as HTMLElement;
+  branch.click();
+  expect(branch.classList.contains('stb-facet-collapsed')).toBe(true);
+  branch.click();
+  expect(branch.classList.contains('stb-facet-collapsed')).toBe(false);
+});
+
+it('isolate collapses all groups except the one with focused leaf', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  mountFacetTree(host, { facets: { text: {}, surface: {} }, previewHost, onEdit: () => {} });
+  // Focus a leaf control in the text group
+  const textLeafControl = host.querySelector('.stb-facet-leaf[data-key="text.fontSize"] input') as HTMLInputElement;
+  textLeafControl.dispatchEvent(new Event('focusin', { bubbles: true }));
+  (host.querySelector('.stb-facet-isolate') as HTMLButtonElement).click();
+  const collapsed = [...host.querySelectorAll('.stb-facet-group.stb-facet-collapsed')];
+  expect(collapsed.length).toBe(1);
+  expect(collapsed[0]!.textContent).toContain('surface');
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -1,0 +1,12 @@
+// tests/integration/facet-tree.test.ts
+import { it, expect } from 'vitest';
+import { mountFacetTree } from '@/ui/facet-tree';
+
+it('renders a branch per present group and a leaf per property', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, { facets: { text: { fontSize: { literal: '18px' } } }, onEdit: () => {} });
+  const groups = host.querySelectorAll('.stb-facet-group');
+  expect([...groups].some((g) => g.textContent?.includes('text'))).toBe(true);
+  const leaves = host.querySelectorAll('.stb-facet-leaf');
+  expect([...leaves].some((l) => l.textContent?.includes('font-size'))).toBe(true);
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -4,9 +4,26 @@ import { mountFacetTree } from '@/ui/facet-tree';
 
 it('renders a branch per present group and a leaf per property', () => {
   const host = document.createElement('div');
-  mountFacetTree(host, { facets: { text: { fontSize: { literal: '18px' } } }, onEdit: () => {} });
+  const previewHost = document.createElement('div');
+  mountFacetTree(host, { facets: { text: { fontSize: { literal: '18px' } } }, previewHost, onEdit: () => {} });
   const groups = host.querySelectorAll('.stb-facet-group');
   expect([...groups].some((g) => g.textContent?.includes('text'))).toBe(true);
   const leaves = host.querySelectorAll('.stb-facet-leaf');
   expect([...leaves].some((l) => l.textContent?.includes('font-size'))).toBe(true);
+});
+
+it('edits a string property through its input control', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  const edits: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { text: { fontSize: undefined } as any },
+    previewHost,
+    onEdit: (k, v) => edits.push([k, v]),
+  });
+  const input = host.querySelector('.stb-facet-leaf[data-key="text.fontSize"] input') as HTMLInputElement;
+  expect(input).toBeTruthy();
+  input.value = '20px';
+  input.dispatchEvent(new Event('input'));
+  expect(edits).toContainEqual(['text.fontSize', { literal: '20px' }]);
 });

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -151,6 +151,34 @@ it('marks a token-backed property as shared and offers detach', () => {
   expect(edits[0]![1]).toHaveProperty('literal');
 });
 
+it('renders a content leaf with a textarea initialized to the content text', () => {
+  const host = document.createElement('div');
+  const collected: string[] = [];
+  mountFacetTree(host, {
+    facets: { content: { text: 'A' } },
+    onEdit: () => {},
+    previewHost: document.createElement('div'),
+    onContentEdit: (t) => collected.push(t),
+  });
+  const ta = host.querySelector('.stb-facet-leaf[data-key="content"] textarea') as HTMLTextAreaElement;
+  expect(ta).not.toBeNull();
+  expect(ta.value).toBe('A');
+  ta.value = 'B';
+  ta.dispatchEvent(new Event('input'));
+  expect(collected).toContain('B');
+});
+
+it('renders an asset leaf with a file input', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { asset: { ref: 'logo.svg' } },
+    onEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  const fileInput = host.querySelector('.stb-facet-leaf[data-key="asset"] input[type="file"]');
+  expect(fileInput).not.toBeNull();
+});
+
 it('shows promote for a literal property with a token mapping, none without', () => {
   const host = document.createElement('div');
   const edits: [string, unknown][] = [];

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -63,7 +63,17 @@ it('collapse-all hides leaves; expand-all shows them', () => {
   mountFacetTree(host, { facets: { text: {}, surface: {} }, previewHost, onEdit: () => {} });
   (host.querySelector('.stb-facet-collapse-all') as HTMLButtonElement).click();
   expect(host.querySelectorAll('.stb-facet-group.stb-facet-collapsed').length).toBe(2);
+  expect([...host.querySelectorAll('.stb-facet-leaves')].every((el) => (el as HTMLElement).hidden)).toBe(true);
   (host.querySelector('.stb-facet-expand-all') as HTMLButtonElement).click();
+  expect(host.querySelectorAll('.stb-facet-group.stb-facet-collapsed').length).toBe(0);
+  expect([...host.querySelectorAll('.stb-facet-leaves')].every((el) => !(el as HTMLElement).hidden)).toBe(true);
+});
+
+it('isolate with no prior focus collapses nothing', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  mountFacetTree(host, { facets: { text: {}, surface: {} }, previewHost, onEdit: () => {} });
+  (host.querySelector('.stb-facet-isolate') as HTMLButtonElement).click();
   expect(host.querySelectorAll('.stb-facet-group.stb-facet-collapsed').length).toBe(0);
 });
 

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -17,7 +17,7 @@ it('edits a string property through its input control', () => {
   const previewHost = document.createElement('div');
   const edits: [string, unknown][] = [];
   mountFacetTree(host, {
-    facets: { text: { fontSize: undefined } as any },
+    facets: { text: {} },
     previewHost,
     onEdit: (k, v) => edits.push([k, v]),
   });
@@ -26,4 +26,33 @@ it('edits a string property through its input control', () => {
   input.value = '20px';
   input.dispatchEvent(new Event('input'));
   expect(edits).toContainEqual(['text.fontSize', { literal: '20px' }]);
+});
+
+it('fires onEdit with the selected value when a select control changes', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  const edits: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { text: {} },
+    previewHost,
+    onEdit: (k, v) => edits.push([k, v]),
+  });
+  const sel = host.querySelector('.stb-facet-leaf[data-key="text.fontWeight"] select') as HTMLSelectElement;
+  expect(sel).toBeTruthy();
+  sel.value = 'bold';
+  sel.dispatchEvent(new Event('change'));
+  expect(edits).toContainEqual(['text.fontWeight', { literal: 'bold' }]);
+});
+
+it('reflects an existing fontWeight literal as the select current value', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { text: { fontWeight: { literal: '700' } } },
+    previewHost,
+    onEdit: () => {},
+  });
+  const sel = host.querySelector('.stb-facet-leaf[data-key="text.fontWeight"] select') as HTMLSelectElement;
+  expect(sel).toBeTruthy();
+  expect(sel.value).toBe('700');
 });

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -100,3 +100,39 @@ it('isolate collapses all groups except the one with focused leaf', () => {
   expect(collapsed.length).toBe(1);
   expect(collapsed[0]!.textContent).toContain('surface');
 });
+
+it('offers absent groups and adds one on select', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  const added: string[] = [];
+  mountFacetTree(host, { facets: { text: {} }, previewHost, onEdit: () => {}, onAddGroup: (g) => added.push(g) });
+  const add = host.querySelector('.stb-facet-add') as HTMLSelectElement;
+  expect(add).toBeTruthy();
+  expect([...add.options].map((o) => o.value)).toEqual(expect.arrayContaining(['surface', 'spacing']));
+  add.value = 'surface';
+  add.dispatchEvent(new Event('change'));
+  expect(added).toContain('surface');
+  // select resets to placeholder after selection
+  expect(add.value).toBe('');
+});
+
+it('remove button calls onRemoveGroup and does not trigger collapse', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  const removed: string[] = [];
+  mountFacetTree(host, {
+    facets: { text: {}, surface: {} },
+    previewHost,
+    onEdit: () => {},
+    onRemoveGroup: (g) => removed.push(g),
+  });
+  // Find the remove button on the text branch
+  const branches = [...host.querySelectorAll('.stb-facet-group')] as HTMLElement[];
+  const textBranch = branches.find((b) => b.textContent?.includes('text'))!;
+  const removeBtn = textBranch.querySelector('.stb-facet-remove') as HTMLButtonElement;
+  expect(removeBtn).toBeTruthy();
+  removeBtn.click();
+  expect(removed).toContain('text');
+  // stopPropagation must have prevented the branch click from toggling collapse
+  expect(textBranch.classList.contains('stb-facet-collapsed')).toBe(false);
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -136,3 +136,35 @@ it('remove button calls onRemoveGroup and does not trigger collapse', () => {
   // stopPropagation must have prevented the branch click from toggling collapse
   expect(textBranch.classList.contains('stb-facet-collapsed')).toBe(false);
 });
+
+it('marks a token-backed property as shared and offers detach', () => {
+  const host = document.createElement('div');
+  const edits: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { text: { color: { token: 'fg' } } },
+    onEdit: (k, v) => edits.push([k, v]),
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  expect(leaf.querySelector('.stb-facet-shared')).not.toBeNull();
+  (leaf.querySelector('.stb-facet-detach') as HTMLButtonElement).click();
+  expect(edits[0]![1]).toHaveProperty('literal');
+});
+
+it('shows promote for a literal property with a token mapping, none without', () => {
+  const host = document.createElement('div');
+  const edits: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+    onEdit: (k, v) => edits.push([k, v]),
+    previewHost: document.createElement('div'),
+    tokenForKey: (k) => k === 'text.color' ? 'fg' : null,
+  });
+  const colorLeaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  expect(colorLeaf.querySelector('.stb-facet-promote')).not.toBeNull();
+  (colorLeaf.querySelector('.stb-facet-promote') as HTMLButtonElement).click();
+  expect(edits[0]).toEqual(['text.color', { token: 'fg' }]);
+  // A leaf whose key has no token mapping shows no promote button
+  const sizeLeaf = host.querySelector('.stb-facet-leaf[data-key="text.fontSize"]')!;
+  expect(sizeLeaf.querySelector('.stb-facet-promote')).toBeNull();
+});

--- a/tools/stb/tests/integration/live-apply.test.ts
+++ b/tools/stb/tests/integration/live-apply.test.ts
@@ -73,4 +73,54 @@ describe('live-apply pipeline', () => {
     expect(innerDoc.querySelectorAll('#stb-scoped-blocks').length).toBe(1);
     expect(getComputedStyle(el).color).toBe('rgb(0, 0, 255)');
   });
+
+  it('applies a facet literal edit to the preview live', async () => {
+    const host = document.getElementById('host')!;
+    const pane = createPreviewPane();
+    pane.mount(host);
+    const iframe = host.querySelector('iframe')!;
+    await new Promise<void>((resolve) => {
+      function listen(e: MessageEvent) {
+        if (e.data?.type === 'STB_PREVIEW_READY') { window.removeEventListener('message', listen); resolve(); }
+      }
+      window.addEventListener('message', listen);
+    });
+
+    // Set a model with a facet literal (no scopedBlock); emitScopedBlocks should
+    // emit the font-size rule from facetDeclarations, not scopedBlock.
+    brandingModel.value = {
+      scene: 'login',
+      nodes: [{
+        snapshotId: 'auth.login.page.card.sign-in',
+        role: 'button',
+        name: 'S',
+        description: 'btn',
+        facets: { text: { fontSize: { literal: '18px' } } },
+      }],
+    };
+    await new Promise((r) => setTimeout(r, 100));
+
+    const innerDoc = iframe.contentDocument!;
+    const styles = innerDoc.querySelectorAll('#stb-scoped-blocks');
+    expect(styles.length).toBe(1);
+    expect(styles[0]!.textContent).toContain('[stb-snapshot-id="auth.login.page.card.sign-in"]');
+    expect(styles[0]!.textContent).toContain('font-size: 18px');
+    const el = innerDoc.querySelector('[stb-snapshot-id="auth.login.page.card.sign-in"]')!;
+    expect(getComputedStyle(el).fontSize).toBe('18px');
+
+    // Upsert: change to 22px — must produce exactly ONE #stb-scoped-blocks
+    brandingModel.value = {
+      scene: 'login',
+      nodes: [{
+        snapshotId: 'auth.login.page.card.sign-in',
+        role: 'button',
+        name: 'S',
+        description: 'btn',
+        facets: { text: { fontSize: { literal: '22px' } } },
+      }],
+    };
+    await new Promise((r) => setTimeout(r, 100));
+    expect(innerDoc.querySelectorAll('#stb-scoped-blocks').length).toBe(1);
+    expect(getComputedStyle(el).fontSize).toBe('22px');
+  });
 });

--- a/tools/stb/tests/metadata/model.test.ts
+++ b/tools/stb/tests/metadata/model.test.ts
@@ -1,24 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { BrandingModel } from '@/metadata/types';
-import { isColorNode } from '@/metadata/types';
 import { buildModel, primaryValue, type ValuesSidecar } from '../../scripts/generate-model';
-
-describe('branding model types', () => {
-  it('isColorNode narrows by lever kind', () => {
-    const model: BrandingModel = {
-      scene: 'login',
-      nodes: [
-        { snapshotId: 'auth.login.sign-in', role: 'button', name: 'Sign in',
-          description: 'sign-in button for the login page',
-          facets: { text: { color: { literal: { l: 0.55, c: 0.15, h: 250 } } } } },
-        { snapshotId: 'auth.login.title', role: 'heading', name: 'Sign in to Stratos',
-          description: 'title for the login page',
-          facets: { content: { text: 'Sign in to Stratos' } } },
-      ],
-    };
-    expect(model.nodes.filter(isColorNode)).toHaveLength(1);
-  });
-});
 
 describe('buildModel carries the scoped block', () => {
   const html =
@@ -57,8 +38,13 @@ describe('facets on ElementNode', () => {
   });
 
   it('primaryValue prefers content, then asset, then a color', () => {
-    expect(primaryValue({ content: { text: 'hi' }, text: { color: { literal: { l:0,c:0,h:0 } } } }).kind).toBe('content');
-    expect(primaryValue({ asset: { ref: 'a.svg' } }).kind).toBe('asset');
-    expect(primaryValue({ surface: { background: { literal: { l:1,c:0,h:0 } } } }).kind).toBe('color');
+    expect(primaryValue({ content: { text: 'hi' }, text: { color: { literal: { l:0,c:0,h:0 } } } })!.kind).toBe('content');
+    expect(primaryValue({ asset: { ref: 'a.svg' } })!.kind).toBe('asset');
+    expect(primaryValue({ surface: { background: { literal: { l:1,c:0,h:0 } } } })!.kind).toBe('color');
+  });
+
+  it('primaryValue returns null for a color-less node (typography/spacing only)', () => {
+    expect(primaryValue({ text: { fontSize: { literal: '18px' } } })).toBeNull();
+    expect(primaryValue({})).toBeNull();
   });
 });

--- a/tools/stb/tests/metadata/model.test.ts
+++ b/tools/stb/tests/metadata/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildModel, primaryValue, type ValuesSidecar } from '../../scripts/generate-model';
+import { buildModel, type ValuesSidecar } from '../../scripts/generate-model';
 
 describe('buildModel carries the scoped block', () => {
   const html =
@@ -35,16 +35,5 @@ describe('facets on ElementNode', () => {
     const values = { x: { name: 'X', facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } } } };
     const model = buildModel('s', html, values as any);
     expect(model.nodes[0]!.facets.text!.color).toEqual({ literal: { l: 0.5, c: 0.1, h: 250 } });
-  });
-
-  it('primaryValue prefers content, then asset, then a color', () => {
-    expect(primaryValue({ content: { text: 'hi' }, text: { color: { literal: { l:0,c:0,h:0 } } } })!.kind).toBe('content');
-    expect(primaryValue({ asset: { ref: 'a.svg' } })!.kind).toBe('asset');
-    expect(primaryValue({ surface: { background: { literal: { l:1,c:0,h:0 } } } })!.kind).toBe('color');
-  });
-
-  it('primaryValue returns null for a color-less node (typography/spacing only)', () => {
-    expect(primaryValue({ text: { fontSize: { literal: '18px' } } })).toBeNull();
-    expect(primaryValue({})).toBeNull();
   });
 });

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { setFacetProp, clearFacetProp, addGroup, removeGroup, promoteToToken, detachToLiteral } from '@/state/facets-edit';
+
+describe('facets-edit', () => {
+  it('sets and clears a nested property immutably', () => {
+    const a = setFacetProp({}, 'text.fontSize', { literal: '18px' });
+    expect(a.text!.fontSize).toEqual({ literal: '18px' });
+    const b = clearFacetProp(a, 'text.fontSize');
+    expect(b.text!.fontSize).toBeUndefined();
+    expect(a.text!.fontSize).toEqual({ literal: '18px' }); // original untouched
+  });
+  it('adds and removes a group', () => {
+    expect(addGroup({}, 'surface').surface).toEqual({});
+    expect(removeGroup({ surface: { background: { literal: '#fff' } } }, 'surface').surface).toBeUndefined();
+  });
+  it('promotes a literal to a token and detaches back', () => {
+    const t = promoteToToken({ text: { color: { literal: { l:0,c:0,h:0 } } } }, 'text.color', 'fg');
+    expect(t.text!.color).toEqual({ token: 'fg' });
+    const d = detachToLiteral(t, 'text.color', { l:0,c:0,h:0 });
+    expect(d.text!.color).toEqual({ literal: { l:0,c:0,h:0 } });
+  });
+});

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -1,22 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { setFacetProp, clearFacetProp, addGroup, removeGroup, promoteToToken, detachToLiteral } from '@/state/facets-edit';
+import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
 
 describe('facets-edit', () => {
-  it('sets and clears a nested property immutably', () => {
+  it('sets a nested property immutably', () => {
     const a = setFacetProp({}, 'text.fontSize', { literal: '18px' });
     expect(a.text!.fontSize).toEqual({ literal: '18px' });
-    const b = clearFacetProp(a, 'text.fontSize');
-    expect(b.text!.fontSize).toBeUndefined();
-    expect(a.text!.fontSize).toEqual({ literal: '18px' }); // original untouched
   });
   it('adds and removes a group', () => {
     expect(addGroup({}, 'surface').surface).toEqual({});
     expect(removeGroup({ surface: { background: { literal: '#fff' } } }, 'surface').surface).toBeUndefined();
-  });
-  it('promotes a literal to a token and detaches back', () => {
-    const t = promoteToToken({ text: { color: { literal: { l:0,c:0,h:0 } } } }, 'text.color', 'fg');
-    expect(t.text!.color).toEqual({ token: 'fg' });
-    const d = detachToLiteral(t, 'text.color', { l:0,c:0,h:0 });
-    expect(d.text!.color).toEqual({ literal: { l:0,c:0,h:0 } });
   });
 });

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { colorValueFromHex, contentValue, assetValue, initialColorHex } from '@/ui/lever-editor';
+import { contentValue, assetValue } from '@/ui/lever-editor';
 
 describe('lever-editor value helpers', () => {
-  it('colorValueFromHex round-trips through OKLCH', () => {
-    const v = colorValueFromHex('#2196f3');
-    expect(v.kind).toBe('color');
-    if (v.kind === 'color') expect(initialColorHex(v)).toBe('#2196f3');
-  });
   it('contentValue / assetValue shape the union', () => {
     expect(contentValue('Hi')).toEqual({ kind: 'content', text: 'Hi' });
     expect(assetValue('logo.png')).toEqual({ kind: 'asset', ref: 'logo.png' });
-  });
-  it('initialColorHex falls back for non-color values', () => {
-    expect(initialColorHex({ kind: 'content', text: 'x' })).toBe('#000000');
   });
 });


### PR DESCRIPTION
## stb Facet Model Phase 2 — Editor

Builds on the merged facet-model foundation (#5512). Replaces the Phase‑1 single‑lever popover with a collapsible **facet tree** that edits an element's typed facets, so an element can carry many branded CSS properties (text / surface / spacing) plus content/asset, with token‑vs‑literal scope made visible and editable.

All changes are under `tools/stb/`. **239 tests pass** (unit + Playwright browser projects across chromium/firefox/webkit); `typecheck` and `lint` clean.

### What's in it
- **Collapsible facet tree** (`src/ui/facet-tree.ts`) — group → property leaves with typed controls: color swatch (via the existing `openColorPicker`), font‑family/weight `<select>`s, text inputs for size/line‑height/border/radius/spacing, plus a content textarea and asset file‑input leaf.
- **Expand‑all / collapse‑all / isolate** controls (isolate = collapse all but the focused group), per‑group collapse via a `.stb-facet-leaves` wrapper.
- **+ add group / remove group** affordances, wired to immutable facet mutators (`src/state/facets-edit.ts`).
- **Token shared‑vs‑scoped** indicator with **promote** (literal → shared token) and **detach** (token → this‑element literal); detach resolves the token's current value so the visible value is preserved.
- **Single non‑duplicating projection path** — color edits flow through the tree swatch and re‑project token‑bound colors to the live `:root` via a shared `reprojectNodeTokens` helper (extracted from `applyEdit`).
- **Retired the Phase‑1 single‑lever body** and the now‑dead `primaryValue` adapter / `isColorNode`; facets are the sole brandable field.

### Verification notes
- Typography/surface/spacing facets have no runtime company‑config consumer yet (that's a later phase) — they're verified via exported `theme.css` / model state, consistent with stb being infrastructure built ahead of its consumers. Login color behavior (the live company‑config keys) is preserved.
- Live‑preview application of facet literal edits is covered end‑to‑end (`tests/integration/live-apply.test.ts`) via computed style + upsert.

### Process
Executed task‑by‑task with an independent spec+quality review after each task and a final whole‑branch review. The final review returned **ready to merge** with no Critical/Important findings; the small dead‑code/cosmetic cleanups it surfaced were folded into the last commit.
