### PR TITLE
stb: facet light/dark axis + dark-mode preview fix

### DIFF
--- a/tools/stb/public/preview-shim.js
+++ b/tools/stb/public/preview-shim.js
@@ -4,17 +4,18 @@
   let metadata = null;
 
   function applyVars(rootVars, darkVars) {
-    const root = document.documentElement;
-    for (const [k, v] of Object.entries(rootVars || {})) root.style.setProperty(k, v);
-    // dark vars are scoped — emulate stratos by toggling .dark-theme + setting overrides as needed
-    // For MVP we apply both sets and rely on the .dark-theme selector chain in the snapshot's stylesheet
+    // Apply :root vars via a <style> block (NOT inline on documentElement): inline
+    // custom props beat any selector, which would shadow the .dark-theme overrides
+    // below and silently break dark mode. A :root rule sits at the same cascade
+    // level as .dark-theme, so dark overrides win when the class is present.
+    let rootEl = document.getElementById('stb-root-vars');
+    if (!rootEl) { rootEl = document.createElement('style'); rootEl.id = 'stb-root-vars'; document.head.appendChild(rootEl); }
+    const rootDecls = Object.entries(rootVars || {}).map(([k, v]) => `${k}: ${v};`).join(' ');
+    rootEl.textContent = `:root { ${rootDecls} }`;
+
     if (darkVars && Object.keys(darkVars).length > 0) {
       let styleEl = document.getElementById('stb-dark-overrides');
-      if (!styleEl) {
-        styleEl = document.createElement('style');
-        styleEl.id = 'stb-dark-overrides';
-        document.head.appendChild(styleEl);
-      }
+      if (!styleEl) { styleEl = document.createElement('style'); styleEl.id = 'stb-dark-overrides'; document.head.appendChild(styleEl); }
       const decls = Object.entries(darkVars).map(([k, v]) => `${k}: ${v};`).join(' ');
       styleEl.textContent = `.dark-theme { ${decls} }`;
     }

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -13,7 +13,7 @@ import { mountStatusBar } from '@/ui/status-bar';
 import { mountAssetManager } from '@/ui/asset-manager';
 import { setRootValue, setDarkValue, effectiveValue } from '@/state/tokens';
 import { previewDark, activeSceneId } from '@/state/scene';
-import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets } from '@/state/branding';
+import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets, setNodeFacetsDark } from '@/state/branding';
 import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens } from '@/ui/element-edit';
@@ -128,6 +128,12 @@ async function main() {
           setNodeFacets(snapshotId, facets);
           reprojectNodeTokens(snapshotId, facets, routing);
         }
+      },
+      facetsDark: node.facetsDark ?? {},
+      onFacetEditDark: (key, value) => {
+        const n = nodeFor(snapshotId);
+        if (n) setNodeFacetsDark(snapshotId, setFacetProp(n.facetsDark ?? {}, key, value));
+        // No reproject: dark facet values are scoped literals, not token-projected.
       },
       onAddGroup: (g) => {
         const n = nodeFor(snapshotId);

--- a/tools/stb/src/metadata/types.ts
+++ b/tools/stb/src/metadata/types.ts
@@ -18,6 +18,7 @@ export interface ElementNode {
   name: string | null;
   description: string;     // DOM stba-description → ARIA aria-description
   facets: Facets;
+  facetsDark?: Facets;     // optional parallel dark-mode overrides (emitter writes a .dark-theme block)
   visibility?: boolean;    // optional show/hide on THIS element; undefined = shown
   scopedBlock?: ScopedBlock; // optional raw element-scoped CSS (R1 facet escape hatch)
 }

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -16,36 +16,41 @@ export function emitCss(root: Map<string, string>, dark: Map<string, string>): s
 export function emitScopedBlocks(nodes: ElementNode[]): string {
   return nodes
     .sort((a, b) => a.snapshotId.localeCompare(b.snapshotId))
-    .map((n) => {
-      // Collect literal facet declarations first (token values are skipped).
-      const facetLines: string[] = [];
-      if (n.facets) {
-        for (const d of facetDeclarations(n.facets)) {
-          const css = facetLiteralCss(d.spec, d.value);
-          if (css !== null) facetLines.push(`  ${d.spec.cssProp}: ${css};`);
-        }
-      }
+    .map((node) => {
+      // Repeat the attribute selector to reach specificity (0,3,0) so the block
+      // beats the snapshot's compound rules (e.g. `.login-card h1` (0,1,1)) without
+      // `!important` — keeping company-config inline styles winning.
+      const selector = `[stb-snapshot-id="${node.snapshotId}"]`.repeat(3);
+      const rules: string[] = [];
 
-      // Terminate each scopedBlock declaration line so a user who types one
-      // declaration per line (no trailing ';') still produces valid CSS instead
-      // of one invalid run-on declaration. Forgiving, not validating.
-      const scopedLines: string[] = n.scopedBlock
-        ? n.scopedBlock.trim().split('\n')
+      // Light block: literal facet declarations first, then the free-form scopedBlock.
+      const facetLines: string[] = [];
+      for (const d of facetDeclarations(node.facets)) {
+        const css = facetLiteralCss(d.spec, d.value);
+        if (css !== null) facetLines.push(`  ${d.spec.cssProp}: ${css};`);
+      }
+      const scopedLines: string[] = node.scopedBlock
+        ? node.scopedBlock.trim().split('\n')
           .map((l) => l.trim())
           .filter((l) => l.length > 0)
           .map((l) => `  ${/[;{},]$/.test(l) ? l : l + ';'}`)
         : [];
+      const lightBody = [...facetLines, ...scopedLines].join('\n');
+      if (lightBody) rules.push(`${selector} {\n${lightBody}\n}`);
 
-      // Emit the rule only when the combined body is non-empty.
-      const body = [...facetLines, ...scopedLines].join('\n');
-      if (!body) return null;
+      // Dark block: literal facetsDark declarations, gated by .dark-theme. Combined
+      // selector is (0,4,0) — beats the light block (0,3,0) AND the snapshot's own
+      // `.dark-theme .x` (0,2,0). {token} dark values are skipped (projector territory).
+      if (node.facetsDark) {
+        const darkLines: string[] = [];
+        for (const d of facetDeclarations(node.facetsDark)) {
+          const css = facetLiteralCss(d.spec, d.value);
+          if (css !== null) darkLines.push(`  ${d.spec.cssProp}: ${css};`);
+        }
+        if (darkLines.length) rules.push(`.dark-theme ${selector} {\n${darkLines.join('\n')}\n}`);
+      }
 
-      // Repeat the attribute selector to reach specificity (0,3,0) so the block
-      // beats the snapshot's compound rules (e.g. `.login-card h1` (0,1,1),
-      // `.dark-theme .login-card h1` (0,2,1)) without `!important` — keeping
-      // company-config inline styles (the higher, runtime-faithful path) winning.
-      const selector = `[stb-snapshot-id="${n.snapshotId}"]`.repeat(3);
-      return `${selector} {\n${body}\n}`;
+      return rules.length ? rules.join('\n\n') : null;
     })
     .filter((r): r is string => r !== null)
     .join('\n\n');

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -24,6 +24,8 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       const rules: string[] = [];
 
       // Light block: literal facet declarations first, then the free-form scopedBlock.
+      // Gated to :not(.dark-theme) so an element with no dark facet value falls through
+      // to the snapshot's built-in dark rule rather than being pinned to its light value.
       const facetLines: string[] = [];
       for (const d of facetDeclarations(node.facets)) {
         const css = facetLiteralCss(d.spec, d.value);
@@ -36,7 +38,7 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
           .map((l) => `  ${/[;{},]$/.test(l) ? l : l + ';'}`)
         : [];
       const lightBody = [...facetLines, ...scopedLines].join('\n');
-      if (lightBody) rules.push(`${selector} {\n${lightBody}\n}`);
+      if (lightBody) rules.push(`html:not(.dark-theme) ${selector} {\n${lightBody}\n}`);
 
       // Dark block: literal facetsDark declarations, gated by .dark-theme. Combined
       // selector is (0,4,0) — beats the light block (0,3,0) AND the snapshot's own

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -17,9 +17,10 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
   return nodes
     .sort((a, b) => a.snapshotId.localeCompare(b.snapshotId))
     .map((node) => {
-      // Repeat the attribute selector to reach specificity (0,3,0) so the block
-      // beats the snapshot's compound rules (e.g. `.login-card h1` (0,1,1)) without
-      // `!important` — keeping company-config inline styles winning.
+      // Repeat the attribute selector 3× so each block beats the snapshot's compound
+      // rules (e.g. `.login-card h1` (0,1,1)) without `!important` — keeping
+      // company-config inline styles winning. The light/dark mode prefixes below add
+      // to this base: light `html:not(.dark-theme)` → (0,4,1); dark `.dark-theme` → (0,4,0).
       const selector = `[stb-snapshot-id="${node.snapshotId}"]`.repeat(3);
       const rules: string[] = [];
 
@@ -40,9 +41,10 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       const lightBody = [...facetLines, ...scopedLines].join('\n');
       if (lightBody) rules.push(`html:not(.dark-theme) ${selector} {\n${lightBody}\n}`);
 
-      // Dark block: literal facetsDark declarations, gated by .dark-theme. Combined
-      // selector is (0,4,0) — beats the light block (0,3,0) AND the snapshot's own
-      // `.dark-theme .x` (0,2,0). {token} dark values are skipped (projector territory).
+      // Dark block: literal facetsDark declarations, gated by .dark-theme — (0,4,0).
+      // Light (`:not(.dark-theme)`) and dark (`.dark-theme`) are mutually exclusive by
+      // mode, so they never compete; each just beats the snapshot's rules in its mode
+      // (dark beats `.dark-theme .x` (0,2,0)). {token} dark values are skipped (projector territory).
       if (node.facetsDark) {
         const darkLines: string[] = [];
         for (const d of facetDeclarations(node.facetsDark)) {

--- a/tools/stb/src/state/branding.ts
+++ b/tools/stb/src/state/branding.ts
@@ -34,6 +34,16 @@ export function setNodeFacets(snapshotId: string, facets: Facets): void {
   };
 }
 
+/** Update node.facetsDark (parallel dark bundle) in a single signal write. */
+export function setNodeFacetsDark(snapshotId: string, facetsDark: Facets): void {
+  const m = brandingModel.value;
+  if (!m) return;
+  brandingModel.value = {
+    ...m,
+    nodes: m.nodes.map((n) => (n.snapshotId === snapshotId ? { ...n, facetsDark } : n)),
+  };
+}
+
 export function setNodeVisibility(snapshotId: string, shown: boolean): void {
   const m = brandingModel.value;
   if (!m) return;

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -4,6 +4,19 @@ type Group = 'text' | 'surface' | 'spacing';
 const groupOf = (key: string) => key.split('.')[0] as Group;
 const propOf  = (key: string) => key.split('.')[1]!;
 
+const STYLE_GROUPS = ['text', 'surface', 'spacing'] as const;
+
+/** Dark editing view: same style-group keys as the light bundle (so the same
+ *  property leaves render in the tree), values taken from the dark bundle.
+ *  content/asset are mode-invariant and excluded. */
+export function darkView(light: Facets, dark: Facets): Facets {
+  const out: Facets = {};
+  for (const g of STYLE_GROUPS) {
+    if (light[g]) out[g] = dark[g] ?? {};
+  }
+  return out;
+}
+
 export function setFacetProp(f: Facets, key: string, value: FacetValue): Facets {
   const g = groupOf(key);
   return { ...f, [g]: { ...(f[g] ?? {}), [propOf(key)]: value } };

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -1,6 +1,8 @@
 import type { LeverValue, Facets, FacetValue } from '@/metadata/types';
 import type { EditorView } from 'codemirror';
+import { effect } from '@preact/signals-core';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
+import { brandingModel, nodeFor } from '@/state/branding';
 import { mountCssEditor } from '@/ui/css-editor';
 import { mountFacetTree } from '@/ui/facet-tree';
 import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
@@ -34,7 +36,9 @@ export function assetValue(filename: string): LeverValue {
 let openPanel: HTMLElement | null = null;
 let openScopedEditor: EditorView | null = null;
 let openFacetTree: { destroy(): void } | null = null;
+let openTreeEffect: (() => void) | null = null;
 function closeOpen(): void {
+  if (openTreeEffect) { openTreeEffect(); openTreeEffect = null; }
   if (openFacetTree) { openFacetTree.destroy(); openFacetTree = null; }
   if (openScopedEditor) { openScopedEditor.destroy(); openScopedEditor = null; }
   if (openPanel) { openPanel.remove(); openPanel = null; }
@@ -94,9 +98,12 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
 
   function renderTree(): void {
     if (openFacetTree) { openFacetTree.destroy(); openFacetTree = null; }
+    const node = nodeFor(opts.snapshotId);
+    const liveFacets = node?.facets ?? opts.facets;
+    const liveFacetsDark = node?.facetsDark ?? opts.facetsDark ?? {};
     const dark = editTarget === 'dark';
     openFacetTree = mountFacetTree(treeHost, {
-      facets: dark ? darkView(opts.facets, opts.facetsDark ?? {}) : opts.facets,
+      facets: dark ? darkView(liveFacets, liveFacetsDark) : liveFacets,
       previewHost: opts.previewHost,
       onEdit: dark ? (opts.onFacetEditDark ?? (() => {})) : (opts.onFacetEdit ?? (() => {})),
       // Structural edits + token promote/detach + content/asset live on the light bundle only.
@@ -108,7 +115,11 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(!dark ? { onAssetEdit: (file: File) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); } } : {}),
     });
   }
-  renderTree();
+  openTreeEffect = effect(() => {
+    void brandingModel.value;                         // subscribe to model changes
+    if (treeHost.contains(document.activeElement)) return; // don't yank focus from an in-flight edit
+    renderTree();
+  });
 
   const close = document.createElement('button');
   close.className = 'stb-lever-close';

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -4,6 +4,7 @@ import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 import { mountCssEditor } from '@/ui/css-editor';
 import { mountFacetTree } from '@/ui/facet-tree';
 import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
+import { darkView } from '@/state/facets-edit';
 
 export interface OpenLeverEditorOptions {
   previewHost: HTMLElement;
@@ -14,7 +15,9 @@ export interface OpenLeverEditorOptions {
   scopedBlock?: string | undefined;
   onScopedBlockChange?: (css: string) => void;
   facets: Facets;
+  facetsDark?: Facets;
   onFacetEdit?: (key: string, value: FacetValue) => void;
+  onFacetEditDark?: (key: string, value: FacetValue) => void;
   onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   tokenForKey?: (key: string) => string | null;
@@ -71,17 +74,41 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
 
   const treeHost = document.createElement('div');
   panel.appendChild(treeHost);
-  openFacetTree = mountFacetTree(treeHost, {
-    facets: opts.facets,
-    previewHost: opts.previewHost,
-    onEdit: opts.onFacetEdit ?? (() => {}),
-    ...(opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
-    ...(opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
-    ...(opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
-    ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
-    onContentEdit: (text) => opts.onChange(contentValue(text)),
-    onAssetEdit: (file) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
-  });
+
+  let editTarget: 'light' | 'dark' = 'light';
+
+  const targetBar = document.createElement('div');
+  targetBar.className = 'stb-lever-target';
+  for (const mode of ['light', 'dark'] as const) {
+    const label = document.createElement('label');
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'stb-edit-target';
+    radio.value = mode;
+    radio.checked = mode === editTarget;
+    radio.addEventListener('change', () => { if (radio.checked) { editTarget = mode; renderTree(); } });
+    label.append(radio, ` ${mode}`);
+    targetBar.appendChild(label);
+  }
+  panel.appendChild(targetBar);
+
+  function renderTree(): void {
+    if (openFacetTree) { openFacetTree.destroy(); openFacetTree = null; }
+    const dark = editTarget === 'dark';
+    openFacetTree = mountFacetTree(treeHost, {
+      facets: dark ? darkView(opts.facets, opts.facetsDark ?? {}) : opts.facets,
+      previewHost: opts.previewHost,
+      onEdit: dark ? (opts.onFacetEditDark ?? (() => {})) : (opts.onFacetEdit ?? (() => {})),
+      // Structural edits + token promote/detach + content/asset live on the light bundle only.
+      ...(!dark && opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
+      ...(!dark && opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
+      ...(!dark && opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
+      ...(!dark && opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
+      ...(!dark ? { onContentEdit: (text: string) => opts.onChange(contentValue(text)) } : {}),
+      ...(!dark ? { onAssetEdit: (file: File) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); } } : {}),
+    });
+  }
+  renderTree();
 
   const close = document.createElement('button');
   close.className = 'stb-lever-close';

--- a/tools/stb/tests/integration/live-apply.test.ts
+++ b/tools/stb/tests/integration/live-apply.test.ts
@@ -42,7 +42,7 @@ describe('live-apply pipeline', () => {
 
     const innerDoc = iframe.contentDocument!;
     const root = innerDoc.documentElement;
-    expect(root.style.getPropertyValue('--color-brand-500')).toBe('#ff0000');
+    expect(getComputedStyle(root).getPropertyValue('--color-brand-500').trim()).toBe('#ff0000');
   });
 
   it('injects a late scoped-block style that applies, upserting on change', async () => {

--- a/tools/stb/tests/parse/css-emitter.test.ts
+++ b/tools/stb/tests/parse/css-emitter.test.ts
@@ -14,8 +14,9 @@ function node(snapshotId: string, scopedBlock?: string): ElementNode {
   };
 }
 
-// The scoped rule repeats the attribute selector to reach specificity (0,3,0),
-// so it beats the snapshot's compound selectors (e.g. `.login-card h1` (0,1,1),
+// The scoped rule repeats the attribute selector 3× and adds a mode prefix:
+// light `html:not(.dark-theme) [attr]×3` (0,4,1), dark `.dark-theme [attr]×3` (0,4,0).
+// Either beats the snapshot's compound selectors (e.g. `.login-card h1` (0,1,1),
 // `.dark-theme .login-card h1` (0,2,1)) without `!important` — company-config
 // inline still wins. Empirically verified against the login snapshot.
 const sel = (id: string) => `[stb-snapshot-id="${id}"]`.repeat(3);

--- a/tools/stb/tests/parse/css-emitter.test.ts
+++ b/tools/stb/tests/parse/css-emitter.test.ts
@@ -19,6 +19,8 @@ function node(snapshotId: string, scopedBlock?: string): ElementNode {
 // `.dark-theme .login-card h1` (0,2,1)) without `!important` — company-config
 // inline still wins. Empirically verified against the login snapshot.
 const sel = (id: string) => `[stb-snapshot-id="${id}"]`.repeat(3);
+// Light blocks are gated to :not(.dark-theme) so dark mode falls through to the snapshot's built-in rules.
+const lightSel = (id: string) => `html:not(.dark-theme) ${sel(id)}`;
 
 describe('emitCss', () => {
   it('emits :root block when only root values present', () => {
@@ -70,7 +72,7 @@ describe('emitCss', () => {
 describe('emitScopedBlocks', () => {
   it('emits a snapshot-id-scoped rule for a node with a scoped block', () => {
     const out = emitScopedBlocks([node('auth.login.page.card.title', 'font-size: 18px')]);
-    expect(out).toBe(`${sel('auth.login.page.card.title')} {\n  font-size: 18px;\n}`);
+    expect(out).toBe(`${lightSel('auth.login.page.card.title')} {\n  font-size: 18px;\n}`);
   });
 
   it('repeats the attribute selector to out-specify compound stylesheet rules', () => {
@@ -81,12 +83,12 @@ describe('emitScopedBlocks', () => {
   it('terminates each declaration line so newline-separated declarations stay valid', () => {
     // a user naturally types one declaration per line without trailing semicolons
     const out = emitScopedBlocks([node('a.b', 'color: crimson\nfont-size: 60px')]);
-    expect(out).toBe(`${sel('a.b')} {\n  color: crimson;\n  font-size: 60px;\n}`);
+    expect(out).toBe(`${lightSel('a.b')} {\n  color: crimson;\n  font-size: 60px;\n}`);
   });
 
   it('does not double-terminate lines that already end in a semicolon', () => {
     const out = emitScopedBlocks([node('a.b', 'color: red;\nfont-size: 12px;')]);
-    expect(out).toBe(`${sel('a.b')} {\n  color: red;\n  font-size: 12px;\n}`);
+    expect(out).toBe(`${lightSel('a.b')} {\n  color: red;\n  font-size: 12px;\n}`);
   });
 
   it('skips nodes with no or blank scoped block', () => {
@@ -105,7 +107,7 @@ describe('emitScopedBlocks', () => {
   it('joins multiple rules with a blank line', () => {
     const out = emitScopedBlocks([node('a.one', 'color: red'), node('a.two', 'color: blue')]);
     expect(out).toBe(
-      `${sel('a.one')} {\n  color: red;\n}\n\n${sel('a.two')} {\n  color: blue;\n}`,
+      `${lightSel('a.one')} {\n  color: red;\n}\n\n${lightSel('a.two')} {\n  color: blue;\n}`,
     );
   });
 });

--- a/tools/stb/tests/parse/facet-emit.test.ts
+++ b/tools/stb/tests/parse/facet-emit.test.ts
@@ -30,18 +30,23 @@ it('emits a .dark-theme scoped block from facetsDark, after the light block', ()
       { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
       { surface: { background: { literal: { l: 0.2, c: 0.02, h: 250 } } } }),
   ]);
-  const light = '[stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"]';
-  const dark = '.dark-theme ' + light;
+  const attrSel = '[stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"]';
+  const light = `html:not(.dark-theme) ${attrSel}`;
+  const dark = `.dark-theme ${attrSel}`;
   expect(css).toContain(`${light} {`);
   expect(css).toContain(`${dark} {`);
   expect(css.indexOf(`${light} {`)).toBeLessThan(css.indexOf(`${dark} {`)); // light before dark
+  // light block must not bleed into dark mode; dark block must not carry html:not
+  expect(css.match(/html:not/g)?.length).toBe(1); // only in the light block prefix
+  expect(css.match(/\.dark-theme \[stb/g)?.length).toBe(1); // only the dark override block
 });
 
 it('skips a node with no facetsDark (no dark block)', () => {
   const css = emitScopedBlocks([
     n('auth.login.page', { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } }),
   ]);
-  expect(css).not.toContain('.dark-theme');
+  // The light selector contains :not(.dark-theme) but no standalone dark override block should appear.
+  expect(css).not.toContain('.dark-theme [stb-snapshot-id');
 });
 
 it('skips a dark {token} value (literals only in this slice)', () => {
@@ -50,5 +55,6 @@ it('skips a dark {token} value (literals only in this slice)', () => {
       { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
       { surface: { background: { token: '--color-brand-900' } } }),
   ]);
-  expect(css).not.toContain('.dark-theme'); // token-dark routing is out of scope; nothing literal to emit
+  // token-dark routing is out of scope; nothing literal to emit — no standalone dark block.
+  expect(css).not.toContain('.dark-theme [stb-snapshot-id');
 });

--- a/tools/stb/tests/parse/facet-emit.test.ts
+++ b/tools/stb/tests/parse/facet-emit.test.ts
@@ -1,5 +1,10 @@
 import { it, expect } from 'vitest';
 import { emitScopedBlocks } from '@/parse/css-emitter';
+import type { ElementNode } from '@/metadata/types';
+
+function n(snapshotId: string, facets: ElementNode['facets'], facetsDark?: ElementNode['facets']): ElementNode {
+  return { snapshotId, role: '', name: null, description: '', facets, ...(facetsDark ? { facetsDark } : {}) };
+}
 
 it('emits literal facet props into the scoped rule and skips token values', () => {
   const nodes = [{
@@ -17,4 +22,33 @@ it('merges facet declarations with a free-form scopedBlock', () => {
   const css = emitScopedBlocks(nodes as any);
   expect(css).toContain('padding: 8px;');
   expect(css).toContain('opacity: 0.9;');
+});
+
+it('emits a .dark-theme scoped block from facetsDark, after the light block', () => {
+  const css = emitScopedBlocks([
+    n('auth.login.page',
+      { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
+      { surface: { background: { literal: { l: 0.2, c: 0.02, h: 250 } } } }),
+  ]);
+  const light = '[stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"]';
+  const dark = '.dark-theme ' + light;
+  expect(css).toContain(`${light} {`);
+  expect(css).toContain(`${dark} {`);
+  expect(css.indexOf(`${light} {`)).toBeLessThan(css.indexOf(`${dark} {`)); // light before dark
+});
+
+it('skips a node with no facetsDark (no dark block)', () => {
+  const css = emitScopedBlocks([
+    n('auth.login.page', { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } }),
+  ]);
+  expect(css).not.toContain('.dark-theme');
+});
+
+it('skips a dark {token} value (literals only in this slice)', () => {
+  const css = emitScopedBlocks([
+    n('auth.login.page',
+      { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
+      { surface: { background: { token: '--color-brand-900' } } }),
+  ]);
+  expect(css).not.toContain('.dark-theme'); // token-dark routing is out of scope; nothing literal to emit
 });

--- a/tools/stb/tests/state/branding.test.ts
+++ b/tools/stb/tests/state/branding.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { brandingModel, nodeFor, setNodeFacets, setNodeVisibility, setNodeScopedBlock, loadBrandingModel } from '@/state/branding';
+import { brandingModel, nodeFor, setNodeFacets, setNodeFacetsDark, setNodeVisibility, setNodeScopedBlock, loadBrandingModel } from '@/state/branding';
 import type { BrandingModel } from '@/metadata/types';
 
 const model: BrandingModel = {
@@ -40,6 +40,20 @@ describe('branding state', () => {
     setNodeVisibility('auth.login.logo', false);
     expect(nodeFor('auth.login.logo')?.visibility).toBe(false);
     expect(brandingModel.value).not.toBe(before); // new reference → reactivity
+  });
+
+  it('setNodeFacetsDark stores a parallel dark bundle without touching facets', () => {
+    brandingModel.value = {
+      scene: 'login',
+      nodes: [
+        { snapshotId: 'auth.login.page', role: 'region', name: 'P', description: 'page',
+          facets: { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } } },
+      ],
+    };
+    setNodeFacetsDark('auth.login.page', { surface: { background: { literal: { l: 0.2, c: 0.02, h: 250 } } } });
+    const n = nodeFor('auth.login.page')!;
+    expect(n.facetsDark?.surface?.background).toEqual({ literal: { l: 0.2, c: 0.02, h: 250 } });
+    expect(n.facets.surface?.background).toEqual({ literal: { l: 0.95, c: 0.02, h: 250 } }); // light untouched
   });
 
   it('setNodeScopedBlock sets the scoped block on one node immutably', () => {

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
+import { setFacetProp, addGroup, removeGroup, darkView } from '@/state/facets-edit';
 
 describe('facets-edit', () => {
   it('sets a nested property immutably', () => {
@@ -10,4 +10,12 @@ describe('facets-edit', () => {
     expect(addGroup({}, 'surface').surface).toEqual({});
     expect(removeGroup({ surface: { background: { literal: '#fff' } } }, 'surface').surface).toBeUndefined();
   });
+});
+
+it('darkView mirrors the light group skeleton with dark values, drops content/asset', () => {
+  const light = { text: { color: { literal: { l: 0.1, c: 0, h: 0 } }, fontSize: { literal: '14px' } }, content: { text: 'hi' } } as const;
+  const dark = { text: { fontSize: { literal: '20px' } } } as const;
+  const view = darkView(light, dark);
+  expect(Object.keys(view)).toEqual(['text']);            // same style group present; content excluded
+  expect(view.text).toEqual({ fontSize: { literal: '20px' } }); // dark values only
 });

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -1,9 +1,35 @@
-import { describe, it, expect } from 'vitest';
-import { contentValue, assetValue } from '@/ui/lever-editor';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { contentValue, assetValue, openLeverEditor } from '@/ui/lever-editor';
 
 describe('lever-editor value helpers', () => {
   it('contentValue / assetValue shape the union', () => {
     expect(contentValue('Hi')).toEqual({ kind: 'content', text: 'Hi' });
     expect(assetValue('logo.png')).toEqual({ kind: 'asset', ref: 'logo.png' });
+  });
+});
+
+describe('lever-editor light/dark target', () => {
+  beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
+
+  it('switches the tree to the dark bundle when dark is selected', () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openLeverEditor({
+      previewHost,
+      snapshotId: 'x',
+      onChange: () => {},
+      facets: { text: { fontSize: { literal: '14px' } } },
+      facetsDark: { text: { fontSize: { literal: '20px' } } },
+      onFacetEdit: () => {},
+      onFacetEditDark: () => {},
+    });
+    const fontSizeInput = () =>
+      [...document.querySelectorAll('.stb-facet-leaf')]
+        .find((l) => (l as HTMLElement).dataset.key === 'text.fontSize')!
+        .querySelector('input[type="text"]') as HTMLInputElement;
+    expect(fontSizeInput().value).toBe('14px');               // light first
+    const darkRadio = document.querySelector('input[value="dark"]') as HTMLInputElement;
+    darkRadio.checked = true;
+    darkRadio.dispatchEvent(new Event('change'));
+    expect(fontSizeInput().value).toBe('20px');               // re-rendered from dark bundle
   });
 });

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { contentValue, assetValue, openLeverEditor } from '@/ui/lever-editor';
+import { brandingModel, setNodeFacetsDark } from '@/state/branding';
+import type { BrandingModel } from '@/metadata/types';
 
 describe('lever-editor value helpers', () => {
   it('contentValue / assetValue shape the union', () => {
@@ -10,6 +12,7 @@ describe('lever-editor value helpers', () => {
 
 describe('lever-editor light/dark target', () => {
   beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
+  afterEach(() => { brandingModel.value = null; });
 
   it('switches the tree to the dark bundle when dark is selected', () => {
     const previewHost = document.querySelector('.host') as HTMLElement;
@@ -31,5 +34,29 @@ describe('lever-editor light/dark target', () => {
     darkRadio.checked = true;
     darkRadio.dispatchEvent(new Event('change'));
     expect(fontSizeInput().value).toBe('20px');               // re-rendered from dark bundle
+  });
+
+  it('re-renders the tree from the live model when facetsDark changes (no toggle)', () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    brandingModel.value = { scene: 's', nodes: [
+      { snapshotId: 'x', role: '', name: null, description: '', facets: { text: { fontSize: { literal: '14px' } } } },
+    ] } as BrandingModel;
+    openLeverEditor({
+      previewHost, snapshotId: 'x', onChange: () => {},
+      facets: { text: { fontSize: { literal: '14px' } } },
+      facetsDark: {},
+      onFacetEdit: () => {}, onFacetEditDark: () => {},
+    });
+    // switch to dark target (dark bundle is empty → input blank)
+    const darkRadio = document.querySelector('input[value="dark"]') as HTMLInputElement;
+    darkRadio.checked = true; darkRadio.dispatchEvent(new Event('change'));
+    const fontSizeInput = () =>
+      [...document.querySelectorAll('.stb-facet-leaf')]
+        .find((l) => (l as HTMLElement).dataset.key === 'text.fontSize')!
+        .querySelector('input[type="text"]') as HTMLInputElement;
+    expect(fontSizeInput().value).toBe('');               // dark empty before the edit
+    // model edit arrives from outside the focused control
+    setNodeFacetsDark('x', { text: { fontSize: { literal: '20px' } } });
+    expect(fontSizeInput().value).toBe('20px');           // editor re-rendered from the live model
   });
 });


### PR DESCRIPTION
## Summary

Restores the light/dark axis for the stb facet model and fixes preview dark-mode rendering. A facet property can now carry a distinct dark value, the element editor lets you set it, and the exported `theme.css` ships it. Toggling dark preview now flips the scene as expected.

## Background

The facet model projects each branded element as a `[stb-snapshot-id]`-scoped CSS block. Two gaps surfaced when exercising dark mode:

- Facet values had no light/dark axis — one value per property — so a branded element was pinned to its light value in both modes, which suppressed the snapshot's built-in dark theme everywhere.
- The preview shim applied `:root` custom properties as inline styles on `<html>`. Inline styles outrank any selector, so the injected `.dark-theme { … }` overrides could never win, and token-based dark mode never took effect in the preview.

## Changes

- **Preview shim:** apply `:root` vars via a `<style id="stb-root-vars">` block instead of inline, so `.dark-theme` overrides cascade normally.
- **Model:** add `ElementNode.facetsDark` (a parallel dark bundle) and `setNodeFacetsDark`.
- **Emitter:** `emitScopedBlocks` emits a `.dark-theme [stb-snapshot-id]…` block from dark facet literals; the light block is gated to `html:not(.dark-theme) …` so an element with no dark value falls through to the snapshot's built-in dark rule instead of being pinned to its light value. The two blocks are mutually exclusive by mode and each beats the snapshot's own rules in its mode without `!important` (company-config inline still wins).
- **Editor:** a light/dark edit target lets you set the dark value per property; the editor re-renders from the live model so its controls stay in sync with the preview.

## Testing

- 246 unit tests pass; typecheck and lint clean.
- Verified in the browser: dark preview flips the scene out of the box (e.g. the login card goes from white to the dark surface color and back); per-element dark overrides apply and persist across the light/dark toggle; the editor controls reflect the live model.

Scoped entirely to `tools/stb/`.
