### PR TITLE
feat(stb): peer dark value + per-row dual-field facet editor

### DIFF
--- a/tools/stb/public/preview-shim.js
+++ b/tools/stb/public/preview-shim.js
@@ -57,6 +57,29 @@
     ensureHighlightStyles();
   }
 
+  function revealElement(snapshotId) {
+    document.querySelectorAll('[data-stb-reveal]').forEach((el) => el.removeAttribute('data-stb-reveal'));
+    if (!snapshotId) return;
+    const el = document.querySelector('[stb-snapshot-id="' + snapshotId + '"]');
+    if (el) el.setAttribute('data-stb-reveal', '');
+    ensureRevealStyles();
+  }
+
+  function ensureRevealStyles() {
+    if (document.getElementById('stb-reveal-style')) return;
+    const el = document.createElement('style');
+    el.id = 'stb-reveal-style';
+    // Give a hidden/empty themable element enough presence that its colour renders:
+    // min-* is a no-op on already-sized elements; the ::before glyph only lands on
+    // empty ones and inherits the element's text colour, so text-colour levers show.
+    // Two triggers: [data-stb-reveal] = the selected element; [data-stb-show-levers]
+    // = every editable region at once ("Show editable regions").
+    el.textContent =
+      '[data-stb-reveal], [data-stb-show-levers] [data-stb-lever] { min-width: 1.5rem !important; min-height: 1.25rem !important; }' +
+      '[data-stb-reveal]:empty::before, [data-stb-show-levers] [data-stb-lever]:empty::before { content: "Abc"; opacity: 0.7; }';
+    document.head.appendChild(el);
+  }
+
   function ensureHighlightStyles() {
     if (document.getElementById('stb-highlight-style')) return;
     const el = document.createElement('style');
@@ -112,6 +135,7 @@
   function setLeverOutline(on) {
     document.documentElement.toggleAttribute('data-stb-show-levers', !!on);
     ensureLeverStyles();
+    ensureRevealStyles();
   }
 
   function ensureLeverStyles() {
@@ -156,6 +180,9 @@
         break;
       case 'STB_HIGHLIGHT_ELEMENT':
         highlightElement(msg.snapshotId);
+        break;
+      case 'STB_REVEAL':
+        revealElement(msg.snapshotId);
         break;
       case 'STB_APPLY_LEVERS':
         applyLeversInShim(msg.levers);

--- a/tools/stb/public/preview-shim.js
+++ b/tools/stb/public/preview-shim.js
@@ -76,7 +76,7 @@
     // = every editable region at once ("Show editable regions").
     el.textContent =
       '[data-stb-reveal], [data-stb-show-levers] [data-stb-lever] { min-width: 1.5rem !important; min-height: 1.25rem !important; }' +
-      '[data-stb-reveal]:empty::before, [data-stb-show-levers] [data-stb-lever]:empty::before { content: "Abc"; opacity: 0.7; }';
+      '[data-stb-reveal]:empty::before, [data-stb-show-levers] [data-stb-lever]:empty::before { content: attr(data-stb-reveal-label); opacity: 0.7; }';
     document.head.appendChild(el);
   }
 
@@ -123,11 +123,17 @@
     styleEl.textContent = cssText || '';
   }
 
-  function markLevers(ids) {
-    document.querySelectorAll('[data-stb-lever]').forEach((el) => el.removeAttribute('data-stb-lever'));
-    for (const id of ids || []) {
-      const el = document.querySelector('[stb-snapshot-id="' + id + '"]');
-      if (el) el.setAttribute('data-stb-lever', '');
+  function markLevers(levers) {
+    document.querySelectorAll('[data-stb-lever]').forEach((el) => {
+      el.removeAttribute('data-stb-lever');
+      el.removeAttribute('data-stb-reveal-label');
+    });
+    for (const lever of levers || []) {
+      const el = document.querySelector('[stb-snapshot-id="' + lever.id + '"]');
+      if (!el) continue;
+      el.setAttribute('data-stb-lever', '');
+      // stamp the element's real name so a revealed empty element labels itself
+      if (lever.name) el.setAttribute('data-stb-reveal-label', lever.name);
     }
     ensureLeverStyles();
   }
@@ -191,7 +197,7 @@
         applyScopedBlocks(msg.css);
         break;
       case 'STB_SET_LEVERS':
-        markLevers(msg.ids);
+        markLevers(msg.levers);
         break;
       case 'STB_SET_LEVER_OUTLINE':
         setLeverOutline(msg.on);

--- a/tools/stb/public/snapshots/v1/shared/branding-model.json
+++ b/tools/stb/public/snapshots/v1/shared/branding-model.json
@@ -31,6 +31,23 @@
       }
     },
     {
+      "snapshotId": "shared.confirm-dialog.cancel",
+      "role": "button",
+      "name": "Cancel button",
+      "description": "cancel button colour for the shared confirmation dialog",
+      "facets": {
+        "text": {
+          "color": {
+            "literal": {
+              "l": 0.86,
+              "c": 0.01,
+              "h": 250
+            }
+          }
+        }
+      }
+    },
+    {
       "snapshotId": "shared.confirm-dialog.confirm",
       "role": "button",
       "name": "Confirm button",
@@ -64,6 +81,23 @@
         }
       },
       "roledescription": "stepper"
+    },
+    {
+      "snapshotId": "shared.stepper.cancel",
+      "role": "button",
+      "name": "Cancel button",
+      "description": "cancel button colour for the shared stepper",
+      "facets": {
+        "text": {
+          "color": {
+            "literal": {
+              "l": 0.86,
+              "c": 0.01,
+              "h": 250
+            }
+          }
+        }
+      }
     },
     {
       "snapshotId": "shared.stepper.previous",

--- a/tools/stb/public/snapshots/v1/shared/index.html
+++ b/tools/stb/public/snapshots/v1/shared/index.html
@@ -11,7 +11,7 @@
         <h1 stb-snapshot-id="shared.confirm-dialog.title" stba-role="heading" stba-description="title text for the shared confirmation dialog">Are you sure?</h1>
         <p>This action cannot be undone.</p>
         <div class="actions">
-          <button class="btn-secondary">Cancel</button>
+          <button class="btn-secondary" stb-snapshot-id="shared.confirm-dialog.cancel" stba-role="button" stba-description="cancel button colour for the shared confirmation dialog">Cancel</button>
           <button class="btn-primary" stb-snapshot-id="shared.confirm-dialog.confirm" stba-role="button" stba-description="confirm button colour for the shared confirmation dialog">Confirm</button>
         </div>
       </section>
@@ -19,6 +19,7 @@
         <div class="steps"><span>1 Details</span><span>2 Review</span><span>3 Done</span></div>
         <div class="step-body">Step content…</div>
         <div class="actions">
+          <button class="btn-secondary" stb-snapshot-id="shared.stepper.cancel" stba-role="button" stba-description="cancel button colour for the shared stepper">Cancel</button>
           <button class="btn-secondary" stb-snapshot-id="shared.stepper.previous" stba-role="button" stba-description="previous button colour for the shared stepper">Previous</button>
           <button class="btn-primary" stb-snapshot-id="shared.stepper.next" stba-role="button" stba-description="next/submit button colour for the shared stepper">Next</button>
         </div>

--- a/tools/stb/public/snapshots/v1/shared/values.json
+++ b/tools/stb/public/snapshots/v1/shared/values.json
@@ -7,6 +7,10 @@
     "name": "Dialog title",
     "facets": { "content": { "text": "Are you sure?" } }
   },
+  "shared.confirm-dialog.cancel": {
+    "name": "Cancel button",
+    "facets": { "text": { "color": { "literal": { "l": 0.86, "c": 0.01, "h": 250 } } } }
+  },
   "shared.confirm-dialog.confirm": {
     "name": "Confirm button",
     "facets": { "text": { "color": { "literal": { "l": 0.55, "c": 0.15, "h": 250 } } } }
@@ -14,6 +18,10 @@
   "shared.stepper": {
     "name": "Stepper",
     "facets": { "surface": { "background": { "literal": { "l": 0.98, "c": 0.005, "h": 250 } } } }
+  },
+  "shared.stepper.cancel": {
+    "name": "Cancel button",
+    "facets": { "text": { "color": { "literal": { "l": 0.86, "c": 0.01, "h": 250 } } } }
   },
   "shared.stepper.previous": {
     "name": "Previous button",

--- a/tools/stb/src/color/derive-dark.ts
+++ b/tools/stb/src/color/derive-dark.ts
@@ -1,15 +1,50 @@
 import type { Oklch } from '@/color/oklch';
+import { oklchToHex } from '@/color/oklch';
+import { contrastRatio } from '@/color/contrast';
 
-function mod(n: number, m: number): number {
-  return ((n % m) + m) % m;
+const clamp01 = (n: number): number => Math.max(0, Math.min(1, n));
+
+export interface DeriveDarkContext {
+  /** The effective dark-mode surface behind this color. A foreground color is
+   *  pushed to the lightness that contrasts with it. Omit to assume a dark surface. */
+  background?: Oklch;
+  /** 'background' (a surface fill) inverts lightness so a light surface becomes a
+   *  dark one; 'foreground' (default: text, borders) keeps hue + chroma and moves
+   *  lightness toward the end that stays legible against the background. */
+  role?: 'foreground' | 'background';
 }
 
-// Standard perceptual light->dark recipe: invert lightness, halve chroma,
-// shift hue slightly so dark variants don't read as a flat negative.
-export function deriveDarkOklch(light: Oklch): Oklch {
-  return {
-    l: 1 - light.l,
-    c: light.c * 0.5,
-    h: mod(light.h + 15, 360),
-  };
+// Assumed surface when the caller can't resolve the element's real dark
+// background (the snapshot-id hierarchy doesn't always match DOM nesting).
+// A dark surface is the right default in dark mode.
+const ASSUMED_DARK: Oklch = { l: 0.2, c: 0, h: 0 };
+const TARGET_RATIO = 4.5; // WCAG AA body text
+
+// Derive a dark-mode value from a light one. The key fix over a naive
+// lightness-inversion: keep the chroma (halving it is what turned a red into a
+// muddy brown) and derive against the background so the result stays legible.
+export function deriveDarkOklch(light: Oklch, ctx: DeriveDarkContext = {}): Oklch {
+  if ((ctx.role ?? 'foreground') === 'background') {
+    // A surface fill: flip lightness (light surface → dark surface), keep hue + chroma.
+    return { l: clamp01(1 - light.l), c: light.c, h: light.h };
+  }
+
+  // Foreground: hold hue + chroma; search lightness toward the contrasting end
+  // of the background until it meets the contrast target.
+  const bg = ctx.background ?? ASSUMED_DARK;
+  const bgHex = oklchToHex(bg);
+  const goLighter = bg.l < 0.5;
+  const step = goLighter ? 0.02 : -0.02;
+
+  // Start past the midpoint on the contrasting side so a dark-mode foreground is a
+  // visibly softer/lighter tint (the #ef4444 → #f87171 convention), not the same
+  // colour it was in light mode; then keep stepping until the contrast target holds.
+  let l = clamp01(goLighter ? Math.max(light.l, 0.7) : Math.min(light.l, 0.35));
+  const at = (ll: number): Oklch => ({ l: ll, c: light.c, h: light.h });
+  let ratio = contrastRatio(oklchToHex(at(l)), bgHex);
+  for (let i = 0; i < 60 && ratio < TARGET_RATIO && l > 0 && l < 1; i++) {
+    l = clamp01(l + step);
+    ratio = contrastRatio(oklchToHex(at(l)), bgHex);
+  }
+  return at(l);
 }

--- a/tools/stb/src/color/derive-dark.ts
+++ b/tools/stb/src/color/derive-dark.ts
@@ -1,0 +1,15 @@
+import type { Oklch } from '@/color/oklch';
+
+function mod(n: number, m: number): number {
+  return ((n % m) + m) % m;
+}
+
+// Standard perceptual light->dark recipe: invert lightness, halve chroma,
+// shift hue slightly so dark variants don't read as a flat negative.
+export function deriveDarkOklch(light: Oklch): Oklch {
+  return {
+    l: 1 - light.l,
+    c: light.c * 0.5,
+    h: mod(light.h + 15, 360),
+  };
+}

--- a/tools/stb/src/iframe-bridge/messages.ts
+++ b/tools/stb/src/iframe-bridge/messages.ts
@@ -11,7 +11,7 @@ export type ParentToPreview =
   | { type: 'STB_REVEAL'; snapshotId: string | null }
   | { type: 'STB_APPLY_LEVERS'; levers: LeverPatch[] }
   | { type: 'STB_APPLY_BLOCKS'; css: string }
-  | { type: 'STB_SET_LEVERS'; ids: string[] }
+  | { type: 'STB_SET_LEVERS'; levers: { id: string; name: string | null }[] }
   | { type: 'STB_SET_LEVER_OUTLINE'; on: boolean };
 
 export type PreviewToParent =

--- a/tools/stb/src/iframe-bridge/messages.ts
+++ b/tools/stb/src/iframe-bridge/messages.ts
@@ -8,6 +8,7 @@ export type ParentToPreview =
   | { type: 'STB_SET_DARK'; dark: boolean }
   | { type: 'STB_HIGHLIGHT_TOKEN'; token: string | null }
   | { type: 'STB_HIGHLIGHT_ELEMENT'; snapshotId: string | null }
+  | { type: 'STB_REVEAL'; snapshotId: string | null }
   | { type: 'STB_APPLY_LEVERS'; levers: LeverPatch[] }
   | { type: 'STB_APPLY_BLOCKS'; css: string }
   | { type: 'STB_SET_LEVERS'; ids: string[] }

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -168,6 +168,7 @@ async function main() {
         setNodeFacets(snapshotId, removeGroup(n.facets, g));
         selectElement(snapshotId);
       },
+      colorFormat: () => colorFormat.value,
       tokenForKey: (key) => routing.elements[snapshotId]?.properties?.[key]?.token ?? null,
       resolveLiteral: (key, token) => {
         const spec = FACET_PROPS[key];

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -150,7 +150,9 @@ async function main() {
         const v = decl?.value;
         const lit = v && 'literal' in v && typeof v.literal === 'object' ? v.literal as Oklch : null;
         if (!lit) return;
-        const facetsDark = setFacetProp(n.facetsDark ?? {}, key, { literal: deriveDarkOklch(lit) });
+        // A surface fill darkens; text/borders keep their colour and lift for contrast.
+        const role = key === 'surface.background' ? 'background' : 'foreground';
+        const facetsDark = setFacetProp(n.facetsDark ?? {}, key, { literal: deriveDarkOklch(lit, { role }) });
         setNodeFacetsDark(snapshotId, facetsDark);
         reprojectNodeTokensDark(snapshotId, facetsDark, routing);
       },

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -115,6 +115,9 @@ async function main() {
   function selectElement(snapshotId: string): void {
     const node = nodeFor(snapshotId);
     if (!node) return;
+    // reveal the selected element so a hidden/empty target (e.g. an empty error
+    // alert) shows its color in the preview while you theme it
+    preview.revealElement(snapshotId);
     const companion = buildVisibilityCompanion(snapshotId, node.visibility);
     openLeverEditor({
       previewHost,

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -16,9 +16,11 @@ import { previewDark, activeSceneId } from '@/state/scene';
 import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets, setNodeFacetsDark } from '@/state/branding';
 import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
-import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens } from '@/ui/element-edit';
-import { FACET_PROPS } from '@/metadata/facets';
+import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens, reprojectNodeTokensDark } from '@/ui/element-edit';
+import { FACET_PROPS, facetDeclarations } from '@/metadata/facets';
 import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
+import { deriveDarkOklch } from '@/color/derive-dark';
+import type { Oklch } from '@/color/oklch';
 import { effect } from '@preact/signals-core';
 import { loadBuiltInPreset } from '@/state/presets';
 import { restoreSession, startAutoSave } from '@/state/persistence';
@@ -132,8 +134,22 @@ async function main() {
       facetsDark: node.facetsDark ?? {},
       onFacetEditDark: (key, value) => {
         const n = nodeFor(snapshotId);
-        if (n) setNodeFacetsDark(snapshotId, setFacetProp(n.facetsDark ?? {}, key, value));
-        // No reproject: dark facet values are scoped literals, not token-projected.
+        if (n) {
+          const facetsDark = setFacetProp(n.facetsDark ?? {}, key, value);
+          setNodeFacetsDark(snapshotId, facetsDark);
+          reprojectNodeTokensDark(snapshotId, facetsDark, routing);
+        }
+      },
+      deriveDark: (key) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        const decl = [...facetDeclarations(n.facets)].find((d) => d.key === key);
+        const v = decl?.value;
+        const lit = v && 'literal' in v && typeof v.literal === 'object' ? v.literal as Oklch : null;
+        if (!lit) return;
+        const facetsDark = setFacetProp(n.facetsDark ?? {}, key, { literal: deriveDarkOklch(lit) });
+        setNodeFacetsDark(snapshotId, facetsDark);
+        reprojectNodeTokensDark(snapshotId, facetsDark, routing);
       },
       onAddGroup: (g) => {
         const n = nodeFor(snapshotId);

--- a/tools/stb/src/projection/projector.ts
+++ b/tools/stb/src/projection/projector.ts
@@ -61,6 +61,31 @@ function setPath(obj: Record<string, unknown>, path: string, value: unknown): vo
   cur[parts[parts.length - 1]!] = value;
 }
 
+/** Project per-property `{token}`-routed color facets into the token map.
+ *  Shared by project() (light, node.facets) and projectDark() (dark, node.facetsDark) —
+ *  same routing rules, different facet source. */
+function projectColorTokens(
+  facets: Facets,
+  properties: Record<string, PropertyRoute>,
+  tokens: Map<string, string>,
+): void {
+  for (const d of facetDeclarations(facets)) {
+    const pr = properties[d.key];
+    if (!pr) continue;
+    if (pr.token && d.spec.isColor && 'literal' in d.value && typeof d.value.literal === 'object') {
+      const color = d.value.literal as Oklch;
+      if (pr.oklchRole === 'scale') {
+        const scale = scaleFromOklch(color);
+        for (const [step, hex] of Object.entries(scale)) {
+          tokens.set(pr.token.replace(/\d+$/, step), hex);
+        }
+      } else {
+        tokens.set(pr.token, oklchToHex(color));
+      }
+    }
+  }
+}
+
 export function project(model: BrandingModel, routing: RoutingMap): ProjectionResult {
   const tokens = new Map<string, string>();
   const companyConfig: Record<string, unknown> = {};
@@ -97,20 +122,10 @@ export function project(model: BrandingModel, routing: RoutingMap): ProjectionRe
 
     // Property-level routing via nested properties map (back-compat: legacy path above still runs first)
     if (entry.properties) {
+      projectColorTokens(node.facets, entry.properties, tokens);
       for (const d of facetDeclarations(node.facets)) {
         const pr = entry.properties[d.key];
         if (!pr) continue;
-        if (pr.token && d.spec.isColor && 'literal' in d.value && typeof d.value.literal === 'object') {
-          const color = d.value.literal as Oklch;
-          if (pr.oklchRole === 'scale') {
-            const scale = scaleFromOklch(color);
-            for (const [step, hex] of Object.entries(scale)) {
-              tokens.set(pr.token.replace(/\d+$/, step), hex);
-            }
-          } else {
-            tokens.set(pr.token, oklchToHex(color));
-          }
-        }
         const cssVal = facetLiteralCss(d.spec, d.value);
         if (pr.config && cssVal !== null) {
           const ns = pr.config.includes('.') ? null : namespaceFor(node.snapshotId, containers);
@@ -128,4 +143,17 @@ export function project(model: BrandingModel, routing: RoutingMap): ProjectionRe
     }
   }
   return { tokens, companyConfig, unmapped };
+}
+
+/** Project dark-mode facet overrides (node.facetsDark) into a dark token map only —
+ *  same per-property {token} color routing as project(), no companyConfig/unmapped
+ *  (dark is values-only). A node with no facetsDark contributes nothing. */
+export function projectDark(model: BrandingModel, routing: RoutingMap): Map<string, string> {
+  const tokens = new Map<string, string>();
+  for (const node of model.nodes) {
+    const entry = routing.elements[node.snapshotId];
+    if (!entry?.properties || !node.facetsDark) continue;
+    projectColorTokens(node.facetsDark, entry.properties, tokens);
+  }
+  return tokens;
 }

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -4,19 +4,6 @@ type Group = 'text' | 'surface' | 'spacing';
 const groupOf = (key: string) => key.split('.')[0] as Group;
 const propOf  = (key: string) => key.split('.')[1]!;
 
-const STYLE_GROUPS = ['text', 'surface', 'spacing'] as const;
-
-/** Dark editing view: same style-group keys as the light bundle (so the same
- *  property leaves render in the tree), values taken from the dark bundle.
- *  content/asset are mode-invariant and excluded. */
-export function darkView(light: Facets, dark: Facets): Facets {
-  const out: Facets = {};
-  for (const g of STYLE_GROUPS) {
-    if (light[g]) out[g] = dark[g] ?? {};
-  }
-  return out;
-}
-
 export function setFacetProp(f: Facets, key: string, value: FacetValue): Facets {
   const g = groupOf(key);
   return { ...f, [g]: { ...(f[g] ?? {}), [propOf(key)]: value } };

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -112,6 +112,39 @@ body {
 .stb-color-text { flex: 1; padding: 0.25rem; font-family: var(--font-mono, monospace); }
 .stb-close { padding: 0.25rem 0.5rem; margin-left: auto; }
 
+/* Facet tree (element lever editor): label column + value control(s) per row.
+   Fixed-width label so the light/dark swatch columns line up across rows and
+   under the dual header. */
+.stb-facet-bar { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-bottom: 0.4rem; }
+.stb-facet-bar button, .stb-facet-add { font-size: 0.72rem; padding: 0.15rem 0.4rem; }
+.stb-facet-group { display: flex; align-items: center; gap: 0.3rem; font-weight: 600; font-size: 0.78rem; padding: 0.35rem 0 0.15rem; cursor: pointer; color: var(--foreground, #1e293b); }
+.stb-facet-group::before { content: '▾'; font-size: 0.65rem; color: var(--text-muted, #94a3b8); }
+.stb-facet-group.stb-facet-collapsed::before { content: '▸'; }
+.stb-facet-remove { margin-left: auto; border: none; background: none; cursor: pointer; color: var(--text-muted, #94a3b8); font-size: 0.9rem; line-height: 1; padding: 0 0.2rem; }
+.stb-facet-leaves { display: flex; flex-direction: column; gap: 0.15rem; }
+.stb-facet-leaf { display: flex; align-items: center; gap: 0.35rem; padding: 0.05rem 0; }
+.stb-facet-leaf-label { flex: 0 0 5.5rem; color: var(--text-muted, #64748b); font-size: 0.74rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.stb-facet-leaf select, .stb-facet-leaf input[type="text"] { flex: 1; min-width: 0; font: inherit; font-size: 0.75rem; padding: 0.1rem 0.25rem; }
+.stb-facet-leaf textarea { flex: 1; min-width: 0; min-height: 2.5rem; font: inherit; font-size: 0.75rem; }
+.stb-facet-leaf input[type="file"] { flex: 1; min-width: 0; font-size: 0.7rem; }
+/* light + dark color swatches, side by side, followed by the derive button */
+.stb-facet-swatch, .stb-facet-swatch-dark, .stb-facet-derive-dark { flex: 0 0 auto; width: 1.4rem; height: 1.4rem; padding: 0; border: 1px solid var(--border, #cbd5e1); border-radius: 3px; cursor: pointer; }
+.stb-facet-derive-dark { display: inline-flex; align-items: center; justify-content: center; line-height: 1; background: var(--content-secondary, #f8fafc); color: var(--text-muted, #64748b); font-size: 0.8rem; }
+.stb-facet-derive-dark:disabled { opacity: 0.35; cursor: default; }
+/* empty dark swatch = "inherits the snapshot's built-in dark" — a neutral hatch, not a color */
+.stb-facet-swatch-empty { background: repeating-linear-gradient(45deg, var(--card, #fff), var(--card, #fff) 3px, var(--border, #e2e8f0) 3px, var(--border, #e2e8f0) 6px); }
+/* column header aligned over the two swatches (label width + row gap) */
+.stb-facet-dual-header { display: flex; gap: 0.35rem; padding-left: 5.85rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted, #94a3b8); margin-bottom: 0.1rem; }
+.stb-facet-dual-header-light, .stb-facet-dual-header-dark { flex: 0 0 1.4rem; text-align: center; }
+.stb-facet-shared { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--warning, #d97706); }
+.stb-facet-detach, .stb-facet-promote { font-size: 0.68rem; padding: 0.05rem 0.3rem; cursor: pointer; }
+/* When the preview is in light mode the dark column is inactive (dark values
+   only render under Dark preview) — mute it so editing it doesn't read as
+   "no change". The panel gains .stb-preview-dark while Dark preview is on. */
+.stb-lever-editor:not(.stb-preview-dark) .stb-facet-swatch-dark,
+.stb-lever-editor:not(.stb-preview-dark) .stb-facet-derive-dark,
+.stb-lever-editor:not(.stb-preview-dark) .stb-facet-dual-header-dark { opacity: 0.4; }
+
 .stb-flash { background-color: var(--warning, #ffeaa7); transition: background-color 0.3s; }
 
 .stb-status-bar { display: flex; padding: 0.4rem 0.75rem; border-top: 1px solid var(--border, #ddd); border-bottom: 1px solid var(--border, #ddd); background: var(--card, white); font-size: 0.85rem; gap: 1rem; align-items: center; }

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -102,6 +102,7 @@ body {
   margin: -0.6rem -0.6rem 0.4rem; border-bottom: 1px solid var(--border, #e5e7eb);
   border-radius: 8px 8px 0 0;
 }
+.stb-lever-title { font-weight: 600; font-size: 0.9rem; margin: 0 0 0.4rem; color: var(--text, #0f172a); }
 .stb-lever-text { display: block; width: 100%; min-height: 5rem; resize: both; box-sizing: border-box; font: inherit; }
 /* the scoped-CSS editor fills the popover width and grows with it (resize: both) */
 .stb-lever-scoped-block { width: 100%; }

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -123,6 +123,9 @@ body {
 .stb-facet-group.stb-facet-collapsed::before { content: '▸'; }
 .stb-facet-remove { margin-left: auto; border: none; background: none; cursor: pointer; color: var(--text-muted, #94a3b8); font-size: 0.9rem; line-height: 1; padding: 0 0.2rem; }
 .stb-facet-leaves { display: flex; flex-direction: column; gap: 0.15rem; }
+/* the flex rule above outranks [hidden]'s UA display:none, so collapse never hid
+   the leaves — this 2-selector rule wins back (same trap as .stb-view[hidden]) */
+.stb-facet-leaves[hidden] { display: none; }
 .stb-facet-leaf { display: flex; align-items: center; gap: 0.35rem; padding: 0.05rem 0; }
 .stb-facet-leaf-label { flex: 0 0 5.5rem; color: var(--text-muted, #64748b); font-size: 0.74rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .stb-facet-leaf select, .stb-facet-leaf input[type="text"] { flex: 1; min-width: 0; font: inherit; font-size: 0.75rem; padding: 0.1rem 0.25rem; }

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -151,7 +151,9 @@ body {
 .stb-col-caret { color: var(--text-muted, #94a3b8); flex: 0 0 auto; }
 .stb-col-kind { flex: 0 0 auto; margin-left: auto; padding-left: 0.4rem; color: var(--text-muted, #94a3b8); font-size: 0.85em; }
 /* collapsed rail: thin vertical strip = breadcrumb; click to re-expand */
-.stb-col-rail { flex: 0 0 1.6rem; border-right: 1px solid var(--border, #e5e7eb); writing-mode: vertical-rl; text-orientation: mixed; padding: 0.4rem 0.1rem; cursor: pointer; font-size: 0.72rem; color: var(--text-muted, #64748b); background: var(--content-secondary, #f8fafc); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* vertical-rl + rotate(180deg) so the label reads bottom-to-top; text-align:end
+   (under the 180° rotation) anchors the text block at the TOP of the rail. */
+.stb-col-rail { flex: 0 0 1.6rem; border-right: 1px solid var(--border, #e5e7eb); writing-mode: vertical-rl; text-orientation: mixed; transform: rotate(180deg); text-align: end; padding: 0.4rem 0.1rem; cursor: pointer; font-size: 0.72rem; color: var(--text-muted, #64748b); background: var(--content-secondary, #f8fafc); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .stb-col-rail:hover { color: var(--color-primary, #2196f3); }
 .stb-col-crumb { position: sticky; bottom: 0; flex: 0 0 100%; align-self: flex-end; padding: 0.2rem 0.5rem; font-size: 0.68rem; color: var(--text-muted, #94a3b8); background: var(--card, #fff); border-top: 1px solid var(--border, #eee); }
 

--- a/tools/stb/src/ui/color-picker.ts
+++ b/tools/stb/src/ui/color-picker.ts
@@ -18,11 +18,13 @@ export function openColorPicker(opts: OpenColorPickerOptions): void {
 
   const initialParsed = parseColor(opts.initial);
   const initialHex = initialParsed ? formatColor(initialParsed, 'hex') : '#000000';
+  // Show the text value in the user's chosen format (hex/rgb/oklch), not always hex.
+  const initialText = initialParsed ? formatColor(initialParsed, opts.format) : opts.initial;
 
   panel.innerHTML = `
     <div class="stb-color-picker__row">
       <input type="color" class="stb-color-native" value="${initialHex}" />
-      <input type="text" class="stb-color-text" value="${opts.initial}" />
+      <input type="text" class="stb-color-text" value="${initialText}" />
     </div>
     <div class="stb-color-picker__row">
       <button class="stb-close">Close</button>

--- a/tools/stb/src/ui/element-edit.ts
+++ b/tools/stb/src/ui/element-edit.ts
@@ -1,8 +1,8 @@
 import type { Facets, FacetValue, LeverValue } from '@/metadata/types';
 import type { RoutingMap } from '@/projection/projector';
-import { project } from '@/projection/projector';
+import { project, projectDark } from '@/projection/projector';
 import { brandingModel, setNodeFacets, setNodeVisibility } from '@/state/branding';
-import { setRootValue } from '@/state/tokens';
+import { setRootValue, setDarkValue } from '@/state/tokens';
 
 export function buildVisibilityCompanion(
   snapshotId: string,
@@ -36,6 +36,21 @@ export function reprojectNodeTokens(snapshotId: string, facets: Facets, routing:
   if (!node) return;
   const { tokens } = project({ scene: m.scene, nodes: [{ ...node, facets }] }, routing);
   for (const [k, v] of tokens) setRootValue(k, v);
+}
+
+/** Dark-mode mirror of reprojectNodeTokens: routes node.facetsDark through projectDark
+ *  and writes the resulting tokens into the .dark-theme block via setDarkValue. */
+export function reprojectNodeTokensDark(
+  snapshotId: string,
+  facetsDark: Facets,
+  routing: RoutingMap,
+): void {
+  const m = brandingModel.value;
+  if (!m) return;
+  const node = m.nodes.find((n) => n.snapshotId === snapshotId);
+  if (!node) return;
+  const tokens = projectDark({ scene: m.scene, nodes: [{ ...node, facetsDark }] }, routing);
+  for (const [k, v] of tokens) setDarkValue(k, v);
 }
 
 export function applyEdit(snapshotId: string, value: LeverValue, routing: RoutingMap): void {

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -2,6 +2,7 @@
 import type { Facets, FacetValue } from '@/metadata/types';
 import type { Oklch } from '@/color/oklch';
 import { toOklch, oklchToHex } from '@/color/oklch';
+import type { ColorFormat } from '@/color/format';
 import { FACET_PROPS } from '@/metadata/facets';
 import { openColorPicker } from '@/ui/color-picker';
 
@@ -27,6 +28,9 @@ export interface FacetTreeOptions {
   resolveLiteral?: (key: string, token: string) => FacetValue;
   onContentEdit?: (text: string) => void;
   onAssetEdit?: (file: File) => void;
+  /** Live color-format accessor (hex/rgb/oklch), read when a color picker opens so the
+   *  picker's text field matches the format chosen in the top bar. */
+  colorFormat?: () => ColorFormat;
 }
 
 const FONT_FAMILIES = [
@@ -212,9 +216,9 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         btn.addEventListener('click', () => openColorPicker({
           previewHost: opts.previewHost,
           initial: lit ? oklchToHex(lit) : '#000000',
-          // NOTE: hex is deliberate — value is stored as Oklch regardless of picker display format,
-          // so threading the live color-format signal buys nothing here.
-          format: 'hex',
+          // Value is stored as Oklch, but the picker's text field shows the format
+          // chosen in the top bar (hex/rgb/oklch) so the editor tracks that setting.
+          format: opts.colorFormat?.() ?? 'hex',
           onChange: (value) => opts.onEdit(key, { literal: toOklch(value) }),
         }));
         leaf.appendChild(btn);
@@ -237,7 +241,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         darkBtn.addEventListener('click', () => openColorPicker({
           previewHost: opts.previewHost,
           initial: litDark ? oklchToHex(litDark) : '#000000',
-          format: 'hex',
+          format: opts.colorFormat?.() ?? 'hex',
           onChange: (value) => opts.onDarkEdit?.(key, { literal: toOklch(value) }),
         }));
         leaf.appendChild(darkBtn);

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -309,6 +309,16 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     }
   }
 
+  // Expand/Collapse all act on the style groups (text/surface/spacing) only.
+  // The content/asset "default group" is a standalone always-on field (the
+  // element's payload), so it's deliberately excluded — it has no group header
+  // to fold into and is usually the thing you came to edit.
+  // TO INCLUDE IT: wrap the content/asset field (rendered via onContentEdit/
+  // onAssetEdit) in a collapsible GroupEntry — give it a branch header + a
+  // `leaves` container and push it into `groupEntries` — then these two loops
+  // (and Isolate) will fold it like any other group. This behaviour could also
+  // be exposed as a user preference (include default group: on/off) rather than
+  // hardcoded.
   btnExpandAll.addEventListener('click', () => {
     for (const entry of groupEntries) setCollapsed(entry, false);
   });

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -10,8 +10,15 @@ const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.sta
 
 export interface FacetTreeOptions {
   facets: Facets;
+  /** Parallel dark-mode overrides, rendered as a second value column beside each color row. */
+  darkFacets?: Facets;
   previewHost: HTMLElement;
   onEdit: (key: string, value: FacetValue) => void;
+  /** Dark-mode counterpart of onEdit; fired when the dark swatch is edited directly. */
+  onDarkEdit?: (key: string, value: FacetValue) => void;
+  /** Fired when the per-row "derive dark from light" button is clicked. Caller computes
+   *  deriveDarkOklch and routes the result through its own dark-edit path. */
+  deriveDark?: (key: string) => void;
   onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   /** Returns the token name mapped to this element's property, or null if none. */
@@ -168,7 +175,21 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       setCollapsed(entry, !entry.collapsed);
     });
 
-    for (const [key, spec] of propsOf(g)) {
+    const props = propsOf(g);
+    if (props.some(([, s]) => s.isColor)) {
+      const header = document.createElement('div');
+      header.className = 'stb-facet-dual-header';
+      const lightLab = document.createElement('span');
+      lightLab.className = 'stb-facet-dual-header-light';
+      lightLab.textContent = 'light';
+      const darkLab = document.createElement('span');
+      darkLab.className = 'stb-facet-dual-header-dark';
+      darkLab.textContent = 'dark';
+      header.append(lightLab, darkLab);
+      leavesEl.appendChild(header);
+    }
+
+    for (const [key, spec] of props) {
       const leaf = document.createElement('div');
       leaf.className = 'stb-facet-leaf';
       leaf.dataset.key = key;
@@ -197,6 +218,39 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           onChange: (value) => opts.onEdit(key, { literal: toOklch(value) }),
         }));
         leaf.appendChild(btn);
+
+        // Dark counterpart, always rendered beside the light swatch (locked layout: light, dark, derive).
+        const currentDark = (opts.darkFacets?.[g] as Record<string, FacetValue | undefined>)?.[propName];
+        const litDark = currentDark && 'literal' in currentDark && typeof currentDark.literal === 'object'
+          ? currentDark.literal as Oklch
+          : null;
+        const darkBtn = document.createElement('button');
+        darkBtn.type = 'button';
+        darkBtn.className = 'stb-facet-swatch-dark';
+        if (litDark) {
+          darkBtn.style.backgroundColor = oklchToHex(litDark);
+        } else {
+          // No dark literal set — neutral empty state, NOT a computed color: means
+          // "inherits the snapshot's built-in dark", not "dark equals black/transparent".
+          darkBtn.classList.add('stb-facet-swatch-empty');
+        }
+        darkBtn.addEventListener('click', () => openColorPicker({
+          previewHost: opts.previewHost,
+          initial: litDark ? oklchToHex(litDark) : '#000000',
+          format: 'hex',
+          onChange: (value) => opts.onDarkEdit?.(key, { literal: toOklch(value) }),
+        }));
+        leaf.appendChild(darkBtn);
+
+        const deriveBtn = document.createElement('button');
+        deriveBtn.type = 'button';
+        deriveBtn.className = 'stb-facet-derive-dark';
+        deriveBtn.textContent = '↓';
+        deriveBtn.title = 'Derive dark from light';
+        // No literal Oklch on the light side (e.g. a bare token reference) — nothing to derive from.
+        deriveBtn.disabled = !lit;
+        deriveBtn.addEventListener('click', () => { if (lit) opts.deriveDark?.(key); });
+        leaf.appendChild(deriveBtn);
       } else if (key === 'text.fontFamily' || key === 'text.fontWeight') {
         const sel = document.createElement('select');
         const options = key === 'text.fontWeight' ? FONT_WEIGHTS : FONT_FAMILIES;

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -26,6 +26,8 @@ export interface OpenLeverEditorOptions {
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   tokenForKey?: (key: string) => string | null;
   resolveLiteral?: (key: string, token: string) => FacetValue;
+  /** Live color-format accessor, forwarded to the facet tree's color pickers. */
+  colorFormat?: () => import('@/color/format').ColorFormat;
 }
 
 export function contentValue(text: string): LeverValue {
@@ -100,6 +102,7 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
       ...(opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
       ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
+      ...(opts.colorFormat ? { colorFormat: opts.colorFormat } : {}),
       onContentEdit: (text: string) => opts.onChange(contentValue(text)),
       onAssetEdit: (file: File) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
     });

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -106,7 +106,11 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   }
   openTreeEffect = effect(() => {
     void brandingModel.value;                         // subscribe to model changes
-    if (treeHost.contains(document.activeElement)) return; // don't yank focus from an in-flight edit
+    // Don't yank focus from an in-flight TYPED edit (text input / textarea).
+    // A focused button (e.g. the derive-dark ↓) must NOT suppress the re-render,
+    // or its own swatch would keep the stale value it just changed.
+    const ae = document.activeElement;
+    if (ae && treeHost.contains(ae) && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) return;
     renderTree();
   });
 

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -6,6 +6,7 @@ import { brandingModel, nodeFor } from '@/state/branding';
 import { mountCssEditor } from '@/ui/css-editor';
 import { mountFacetTree } from '@/ui/facet-tree';
 import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
+import { previewDark } from '@/state/scene';
 
 export interface OpenLeverEditorOptions {
   previewHost: HTMLElement;
@@ -38,7 +39,9 @@ let openPanel: HTMLElement | null = null;
 let openScopedEditor: EditorView | null = null;
 let openFacetTree: { destroy(): void } | null = null;
 let openTreeEffect: (() => void) | null = null;
+let openDarkEffect: (() => void) | null = null;
 function closeOpen(): void {
+  if (openDarkEffect) { openDarkEffect(); openDarkEffect = null; }
   if (openTreeEffect) { openTreeEffect(); openTreeEffect = null; }
   if (openFacetTree) { openFacetTree.destroy(); openFacetTree = null; }
   if (openScopedEditor) { openScopedEditor.destroy(); openScopedEditor = null; }
@@ -123,4 +126,9 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   positionInPreviewGutter(panel, opts.previewHost);
   makeDraggable(panel, drag);
   openPanel = panel;
+
+  // Flag the active preview mode on the panel so CSS can mute the inactive
+  // (dark) column — editing a dark value while the preview is in light mode
+  // otherwise reads as "no change".
+  openDarkEffect = effect(() => { panel.classList.toggle('stb-preview-dark', previewDark.value); });
 }

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -6,7 +6,6 @@ import { brandingModel, nodeFor } from '@/state/branding';
 import { mountCssEditor } from '@/ui/css-editor';
 import { mountFacetTree } from '@/ui/facet-tree';
 import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
-import { darkView } from '@/state/facets-edit';
 
 export interface OpenLeverEditorOptions {
   previewHost: HTMLElement;
@@ -20,6 +19,8 @@ export interface OpenLeverEditorOptions {
   facetsDark?: Facets;
   onFacetEdit?: (key: string, value: FacetValue) => void;
   onFacetEditDark?: (key: string, value: FacetValue) => void;
+  /** Per-row "derive dark from light" — caller computes deriveDarkOklch and routes it through its own dark-edit path. */
+  deriveDark?: (key: string) => void;
   onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   tokenForKey?: (key: string) => string | null;
@@ -79,40 +80,25 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   const treeHost = document.createElement('div');
   panel.appendChild(treeHost);
 
-  let editTarget: 'light' | 'dark' = 'light';
-
-  const targetBar = document.createElement('div');
-  targetBar.className = 'stb-lever-target';
-  for (const mode of ['light', 'dark'] as const) {
-    const label = document.createElement('label');
-    const radio = document.createElement('input');
-    radio.type = 'radio';
-    radio.name = 'stb-edit-target';
-    radio.value = mode;
-    radio.checked = mode === editTarget;
-    radio.addEventListener('change', () => { if (radio.checked) { editTarget = mode; renderTree(); } });
-    label.append(radio, ` ${mode}`);
-    targetBar.appendChild(label);
-  }
-  panel.appendChild(targetBar);
-
   function renderTree(): void {
     if (openFacetTree) { openFacetTree.destroy(); openFacetTree = null; }
     const node = nodeFor(opts.snapshotId);
     const liveFacets = node?.facets ?? opts.facets;
     const liveFacetsDark = node?.facetsDark ?? opts.facetsDark ?? {};
-    const dark = editTarget === 'dark';
     openFacetTree = mountFacetTree(treeHost, {
-      facets: dark ? darkView(liveFacets, liveFacetsDark) : liveFacets,
+      facets: liveFacets,
+      darkFacets: liveFacetsDark,
       previewHost: opts.previewHost,
-      onEdit: dark ? (opts.onFacetEditDark ?? (() => {})) : (opts.onFacetEdit ?? (() => {})),
+      onEdit: opts.onFacetEdit ?? (() => {}),
+      onDarkEdit: opts.onFacetEditDark ?? (() => {}),
       // Structural edits + token promote/detach + content/asset live on the light bundle only.
-      ...(!dark && opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
-      ...(!dark && opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
-      ...(!dark && opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
-      ...(!dark && opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
-      ...(!dark ? { onContentEdit: (text: string) => opts.onChange(contentValue(text)) } : {}),
-      ...(!dark ? { onAssetEdit: (file: File) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); } } : {}),
+      ...(opts.deriveDark ? { deriveDark: opts.deriveDark } : {}),
+      ...(opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
+      ...(opts.onRemoveGroup ? { onRemoveGroup: opts.onRemoveGroup } : {}),
+      ...(opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
+      ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
+      onContentEdit: (text: string) => opts.onChange(contentValue(text)),
+      onAssetEdit: (file: File) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
     });
   }
   openTreeEffect = effect(() => {

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -55,6 +55,15 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   const panel = document.createElement('div');
   panel.className = 'stb-lever-editor';
 
+  // Title bar: name what's being edited (the popover is decoupled from the
+  // tree selection, so without this you can't tell which element it targets).
+  const titledNode = nodeFor(opts.snapshotId);
+  const title = document.createElement('div');
+  title.className = 'stb-lever-title';
+  title.textContent = titledNode?.name ?? opts.snapshotId;
+  if (titledNode?.description) title.title = titledNode.description;
+  panel.appendChild(title);
+
   if (opts.visibilityCompanion) {
     const c = opts.visibilityCompanion;
     const label = document.createElement('label');

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -53,8 +53,9 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
     const m = brandingModel.value;
     if (!m) return;
     send({ type: 'STB_APPLY_LEVERS', levers: attachAssetBlobs(leverPatchesFor(m), brandingAssets.value) });
-    // tell the shim which elements are editable so it can show a click affordance
-    send({ type: 'STB_SET_LEVERS', ids: m.nodes.map((n) => n.snapshotId) });
+    // tell the shim which elements are editable (name rides along so a revealed
+    // empty element can label itself with its real name, not invented text)
+    send({ type: 'STB_SET_LEVERS', levers: m.nodes.map((n) => ({ id: n.snapshotId, name: n.name })) });
   }
 
   function applyScopedBlocksToPreview(): void {

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -26,6 +26,7 @@ export interface PreviewPane {
   mount(host: HTMLElement): void;
   highlightToken(token: string | null): void;
   highlightElement(snapshotId: string | null): void;
+  revealElement(snapshotId: string | null): void;
   showLevers(on: boolean): void;
 }
 
@@ -123,6 +124,10 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
 
     highlightElement(snapshotId) {
       send({ type: 'STB_HIGHLIGHT_ELEMENT', snapshotId });
+    },
+
+    revealElement(snapshotId) {
+      send({ type: 'STB_REVEAL', snapshotId });
     },
 
     showLevers(on) {

--- a/tools/stb/tests/color/derive-dark.test.ts
+++ b/tools/stb/tests/color/derive-dark.test.ts
@@ -1,22 +1,46 @@
 import { describe, it, expect } from 'vitest';
 import { deriveDarkOklch } from '@/color/derive-dark';
+import { oklchToHex } from '@/color/oklch';
+import { contrastRatio } from '@/color/contrast';
 
-describe('deriveDarkOklch', () => {
-  it('inverts lightness, halves chroma, shifts hue by 15deg', () => {
-    const dark = deriveDarkOklch({ l: 0.9, c: 0.2, h: 250 });
-    expect(dark.l).toBeCloseTo(0.1, 10);
-    expect(dark.c).toBeCloseTo(0.1, 10);
-    expect(dark.h).toBeCloseTo(265, 10);
+// The assumed dark surface a foreground color is derived against when no
+// explicit background is supplied (mirrors the value in derive-dark.ts).
+const ASSUMED_DARK = { l: 0.2, c: 0, h: 0 };
+
+describe('deriveDarkOklch — foreground (default)', () => {
+  it('preserves hue and chroma (no muddy chroma-halving)', () => {
+    const light = { l: 0.62, c: 0.22, h: 27 };
+    const dark = deriveDarkOklch(light);
+    expect(dark.h).toBeCloseTo(27, 5);
+    expect(dark.c).toBeCloseTo(0.22, 5);
   });
 
-  it('double-application returns lightness to ~original (self-inverting axis)', () => {
-    const original = { l: 0.3, c: 0.15, h: 100 };
-    const roundTrip = deriveDarkOklch(deriveDarkOklch(original));
-    expect(roundTrip.l).toBeCloseTo(original.l, 10);
+  it('lifts lightness so the color stays legible on a dark surface', () => {
+    const light = { l: 0.62, c: 0.22, h: 27 }; // a mid red — old recipe made a muddy dark brown
+    const dark = deriveDarkOklch(light);
+    expect(dark.l).toBeGreaterThan(light.l);
+    expect(contrastRatio(oklchToHex(dark), oklchToHex(ASSUMED_DARK))).toBeGreaterThanOrEqual(4.5);
   });
 
-  it('wraps hue past 360', () => {
-    const dark = deriveDarkOklch({ l: 0.5, c: 0.1, h: 350 });
-    expect(dark.h).toBeCloseTo(5, 10);
+  it('contrasts against an explicitly supplied background', () => {
+    const light = { l: 0.5, c: 0.15, h: 250 };
+    const lightBg = { l: 0.95, c: 0.02, h: 250 };
+    const dark = deriveDarkOklch(light, { background: lightBg });
+    // a light background pushes the derived color darker to keep contrast
+    expect(contrastRatio(oklchToHex(dark), oklchToHex(lightBg))).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('deriveDarkOklch — background (surface)', () => {
+  it('inverts lightness but keeps chroma and hue', () => {
+    const dark = deriveDarkOklch({ l: 0.9, c: 0.1, h: 250 }, { role: 'background' });
+    expect(dark.l).toBeCloseTo(0.1, 5);
+    expect(dark.c).toBeCloseTo(0.1, 5); // NOT halved
+    expect(dark.h).toBeCloseTo(250, 5);
+  });
+
+  it('turns a white surface dark', () => {
+    const dark = deriveDarkOklch({ l: 1, c: 0, h: 0 }, { role: 'background' });
+    expect(dark.l).toBeCloseTo(0, 5);
   });
 });

--- a/tools/stb/tests/color/derive-dark.test.ts
+++ b/tools/stb/tests/color/derive-dark.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { deriveDarkOklch } from '@/color/derive-dark';
+
+describe('deriveDarkOklch', () => {
+  it('inverts lightness, halves chroma, shifts hue by 15deg', () => {
+    const dark = deriveDarkOklch({ l: 0.9, c: 0.2, h: 250 });
+    expect(dark.l).toBeCloseTo(0.1, 10);
+    expect(dark.c).toBeCloseTo(0.1, 10);
+    expect(dark.h).toBeCloseTo(265, 10);
+  });
+
+  it('double-application returns lightness to ~original (self-inverting axis)', () => {
+    const original = { l: 0.3, c: 0.15, h: 100 };
+    const roundTrip = deriveDarkOklch(deriveDarkOklch(original));
+    expect(roundTrip.l).toBeCloseTo(original.l, 10);
+  });
+
+  it('wraps hue past 360', () => {
+    const dark = deriveDarkOklch({ l: 0.5, c: 0.1, h: 350 });
+    expect(dark.h).toBeCloseTo(5, 10);
+  });
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -1,6 +1,7 @@
 // tests/integration/facet-tree.test.ts
 import { it, expect } from 'vitest';
 import { mountFacetTree } from '@/ui/facet-tree';
+import { deriveDarkOklch } from '@/color/derive-dark';
 
 it('renders a branch per present group and a leaf per property', () => {
   const host = document.createElement('div');
@@ -177,6 +178,160 @@ it('renders an asset leaf with a file input', () => {
   });
   const fileInput = host.querySelector('.stb-facet-leaf[data-key="asset"] input[type="file"]');
   expect(fileInput).not.toBeNull();
+});
+
+it('renders a light swatch, a dark swatch and a derive button for a color leaf', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  expect(leaf.querySelectorAll('.stb-facet-swatch').length).toBe(1);
+  expect(leaf.querySelector('.stb-facet-swatch-dark')).not.toBeNull();
+  expect(leaf.querySelector('.stb-facet-derive-dark')).not.toBeNull();
+});
+
+it('renders a non-color leaf once, with no dark field or derive button', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { text: { fontSize: { literal: '18px' } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.fontSize"]')!;
+  expect(leaf.querySelectorAll('input').length).toBe(1);
+  expect(leaf.querySelector('.stb-facet-swatch-dark')).toBeNull();
+  expect(leaf.querySelector('.stb-facet-derive-dark')).toBeNull();
+});
+
+it('shows the light/dark header once per group that has a color leaf', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } }, fontSize: { literal: '12px' } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  expect(host.querySelectorAll('.stb-facet-dual-header').length).toBe(1);
+});
+
+it('omits the light/dark header for a group with no color leaves', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { spacing: { padding: { literal: '4px' } } },
+    onEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  expect(host.querySelector('.stb-facet-dual-header')).toBeNull();
+});
+
+it('dark swatch is neutral/empty when no dark value is set (inherits built-in dark)', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  const darkBtn = leaf.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  expect(darkBtn.classList.contains('stb-facet-swatch-empty')).toBe(true);
+  expect(darkBtn.style.backgroundColor).toBe('');
+});
+
+it('dark swatch reflects an existing dark literal', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+    darkFacets: { text: { color: { literal: { l: 0.2, c: 0.05, h: 100 } } } },
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  const darkBtn = leaf.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  expect(darkBtn.classList.contains('stb-facet-swatch-empty')).toBe(false);
+  expect(darkBtn.style.backgroundColor).not.toBe('');
+});
+
+it('editing the dark swatch invokes onDarkEdit with the picked color', () => {
+  const host = document.createElement('div');
+  const darkEdits: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: (k, v) => darkEdits.push([k, v]),
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  (leaf.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement).click();
+  const textInput = document.querySelector('.stb-color-text') as HTMLInputElement;
+  expect(textInput).toBeTruthy();
+  textInput.value = '#112233';
+  textInput.dispatchEvent(new Event('input'));
+  expect(darkEdits.length).toBe(1);
+  expect(darkEdits[0]![0]).toBe('text.color');
+  expect(darkEdits[0]![1]).toHaveProperty('literal');
+});
+
+it('clicking the derive button calls deriveDark with the leaf key', () => {
+  const host = document.createElement('div');
+  const derived: string[] = [];
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    deriveDark: (k) => derived.push(k),
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  (leaf.querySelector('.stb-facet-derive-dark') as HTMLButtonElement).click();
+  expect(derived).toEqual(['text.color']);
+});
+
+it('derive button is disabled (no-op) when the light value has no literal Oklch', () => {
+  const host = document.createElement('div');
+  const derived: string[] = [];
+  mountFacetTree(host, {
+    facets: { text: { color: { token: 'fg' } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    deriveDark: (k) => derived.push(k),
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  const deriveBtn = leaf.querySelector('.stb-facet-derive-dark') as HTMLButtonElement;
+  expect(deriveBtn.disabled).toBe(true);
+  deriveBtn.click();
+  expect(derived).toEqual([]);
+});
+
+it('an integration-style wiring of deriveDark routes deriveDarkOklch(light) into onDarkEdit', () => {
+  const host = document.createElement('div');
+  const lightOklch = { l: 0.5, c: 0.1, h: 250 };
+  const darkEdits: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { text: { color: { literal: lightOklch } } },
+    darkFacets: {},
+    onEdit: () => {},
+    onDarkEdit: (k, v) => darkEdits.push([k, v]),
+    deriveDark: (k) => darkEdits.push([k, { literal: deriveDarkOklch(lightOklch) }]),
+    previewHost: document.createElement('div'),
+  });
+  const leaf = host.querySelector('.stb-facet-leaf[data-key="text.color"]')!;
+  (leaf.querySelector('.stb-facet-derive-dark') as HTMLButtonElement).click();
+  expect(darkEdits).toEqual([['text.color', { literal: deriveDarkOklch(lightOklch) }]]);
 });
 
 it('shows promote for a literal property with a token mapping, none without', () => {

--- a/tools/stb/tests/projection/projector.test.ts
+++ b/tools/stb/tests/projection/projector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { project } from '@/projection/projector';
+import { project, projectDark } from '@/projection/projector';
+import { oklchToHex } from '@/color/oklch';
 import type { BrandingModel } from '@/metadata/types';
 
 const model: BrandingModel = {
@@ -113,5 +114,46 @@ describe('project', () => {
     expect(r.tokens.get('--color-brand-50')).toMatch(/^#[0-9a-f]{6}$/);
     expect(r.tokens.get('--color-brand-900')).toMatch(/^#[0-9a-f]{6}$/);
     expect(r.tokens.size).toBe(10);
+  });
+});
+
+describe('projectDark', () => {
+  const oklch = { l: 0.55, c: 0.15, h: 250 };
+
+  it('routes a facetsDark color node to the dark token map', () => {
+    const m: BrandingModel = {
+      scene: 'login',
+      nodes: [
+        { snapshotId: 'auth.login.sign-in', role: 'button', name: 'Sign in',
+          description: 'sign-in button for the login page',
+          facets: { text: { color: { literal: { l: 0.2, c: 0.05, h: 250 } } } },
+          facetsDark: { text: { color: { literal: oklch } } } },
+      ],
+    };
+    const routing = {
+      elements: {
+        'auth.login.sign-in': { properties: { 'text.color': { token: '--color-x' } } },
+      },
+    };
+    const r = projectDark(m, routing as any);
+    expect(r.get('--color-x')).toBe(oklchToHex(oklch));
+  });
+
+  it('contributes nothing for a node with no facetsDark', () => {
+    const m: BrandingModel = {
+      scene: 'login',
+      nodes: [
+        { snapshotId: 'auth.login.sign-in', role: 'button', name: 'Sign in',
+          description: 'sign-in button for the login page',
+          facets: { text: { color: { literal: oklch } } } },
+      ],
+    };
+    const routing = {
+      elements: {
+        'auth.login.sign-in': { properties: { 'text.color': { token: '--color-x' } } },
+      },
+    };
+    const r = projectDark(m, routing as any);
+    expect(r.size).toBe(0);
   });
 });

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { setFacetProp, addGroup, removeGroup, darkView } from '@/state/facets-edit';
+import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
 
 describe('facets-edit', () => {
   it('sets a nested property immutably', () => {
@@ -10,12 +10,4 @@ describe('facets-edit', () => {
     expect(addGroup({}, 'surface').surface).toEqual({});
     expect(removeGroup({ surface: { background: { literal: '#fff' } } }, 'surface').surface).toBeUndefined();
   });
-});
-
-it('darkView mirrors the light group skeleton with dark values, drops content/asset', () => {
-  const light = { text: { color: { literal: { l: 0.1, c: 0, h: 0 } }, fontSize: { literal: '14px' } }, content: { text: 'hi' } } as const;
-  const dark = { text: { fontSize: { literal: '20px' } } } as const;
-  const view = darkView(light, dark);
-  expect(Object.keys(view)).toEqual(['text']);            // same style group present; content excluded
-  expect(view.text).toEqual({ fontSize: { literal: '20px' } }); // dark values only
 });

--- a/tools/stb/tests/ui/element-edit.test.ts
+++ b/tools/stb/tests/ui/element-edit.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { brandingModel } from '@/state/branding';
+import { rootValues, darkValues, effectiveValue } from '@/state/tokens';
+import { reprojectNodeTokensDark } from '@/ui/element-edit';
+import type { BrandingModel } from '@/metadata/types';
+
+const routing = { containers: { 'auth.login': 'login' }, elements: {
+  'auth.login.sign-in': { properties: { 'surface.background': { token: '--color-x' } } },
+} };
+const model: BrandingModel = { scene: 'login', nodes: [
+  { snapshotId: 'auth.login.sign-in', role: 'button', name: 'S', description: 'btn',
+    facets: { surface: { background: { literal: { l: 0.4, c: 0.1, h: 30 } } } } },
+] };
+
+describe('reprojectNodeTokensDark', () => {
+  beforeEach(() => {
+    brandingModel.value = JSON.parse(JSON.stringify(model));
+    rootValues.value = new Map([['--color-x', '#112233']]);
+    darkValues.value = new Map();
+  });
+
+  it('re-projects a dark facet color edit to the bound token via setDarkValue', () => {
+    reprojectNodeTokensDark(
+      'auth.login.sign-in',
+      { surface: { background: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
+      routing,
+    );
+    expect(effectiveValue('--color-x', true)).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it('leaves the light value (rootValues) untouched', () => {
+    reprojectNodeTokensDark(
+      'auth.login.sign-in',
+      { surface: { background: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
+      routing,
+    );
+    expect(effectiveValue('--color-x', false)).toBe('#112233');
+    expect(rootValues.value.get('--color-x')).toBe('#112233');
+  });
+});

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -10,11 +10,32 @@ describe('lever-editor value helpers', () => {
   });
 });
 
-describe('lever-editor light/dark target', () => {
+describe('lever-editor light+dark per-row editing (no toggle)', () => {
   beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
   afterEach(() => { brandingModel.value = null; });
 
-  it('switches the tree to the dark bundle when dark is selected', () => {
+  it('renders light and dark swatches for a color row simultaneously, with no radio', () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openLeverEditor({
+      previewHost,
+      snapshotId: 'x',
+      onChange: () => {},
+      facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+      facetsDark: { text: { color: { literal: { l: 0.2, c: 0.05, h: 100 } } } },
+      onFacetEdit: () => {},
+      onFacetEditDark: () => {},
+    });
+    expect(document.querySelector('input[name="stb-edit-target"]')).toBeNull(); // radio fully removed
+    const leaf = [...document.querySelectorAll('.stb-facet-leaf')]
+      .find((l) => (l as HTMLElement).dataset.key === 'text.color')!;
+    const lightBtn = leaf.querySelector('.stb-facet-swatch') as HTMLButtonElement;
+    const darkBtn = leaf.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+    expect(lightBtn).toBeTruthy();
+    expect(darkBtn).toBeTruthy();
+    expect(darkBtn.classList.contains('stb-facet-swatch-empty')).toBe(false); // dark literal is set
+  });
+
+  it('non-color rows render once and are unaffected by facetsDark', () => {
     const previewHost = document.querySelector('.host') as HTMLElement;
     openLeverEditor({
       previewHost,
@@ -25,38 +46,30 @@ describe('lever-editor light/dark target', () => {
       onFacetEdit: () => {},
       onFacetEditDark: () => {},
     });
-    const fontSizeInput = () =>
-      [...document.querySelectorAll('.stb-facet-leaf')]
-        .find((l) => (l as HTMLElement).dataset.key === 'text.fontSize')!
-        .querySelector('input[type="text"]') as HTMLInputElement;
-    expect(fontSizeInput().value).toBe('14px');               // light first
-    const darkRadio = document.querySelector('input[value="dark"]') as HTMLInputElement;
-    darkRadio.checked = true;
-    darkRadio.dispatchEvent(new Event('change'));
-    expect(fontSizeInput().value).toBe('20px');               // re-rendered from dark bundle
+    const fontSizeLeaf = [...document.querySelectorAll('.stb-facet-leaf')]
+      .find((l) => (l as HTMLElement).dataset.key === 'text.fontSize')!;
+    const inputs = fontSizeLeaf.querySelectorAll('input[type="text"]');
+    expect(inputs.length).toBe(1);
+    expect((inputs[0] as HTMLInputElement).value).toBe('14px'); // light only, dark bundle ignored
   });
 
-  it('re-renders the tree from the live model when facetsDark changes (no toggle)', () => {
+  it('re-renders the dark field from the live model when facetsDark changes (no toggle)', () => {
     const previewHost = document.querySelector('.host') as HTMLElement;
     brandingModel.value = { scene: 's', nodes: [
-      { snapshotId: 'x', role: '', name: null, description: '', facets: { text: { fontSize: { literal: '14px' } } } },
+      { snapshotId: 'x', role: '', name: null, description: '', facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } } },
     ] } as BrandingModel;
     openLeverEditor({
       previewHost, snapshotId: 'x', onChange: () => {},
-      facets: { text: { fontSize: { literal: '14px' } } },
+      facets: { text: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
       facetsDark: {},
       onFacetEdit: () => {}, onFacetEditDark: () => {},
     });
-    // switch to dark target (dark bundle is empty → input blank)
-    const darkRadio = document.querySelector('input[value="dark"]') as HTMLInputElement;
-    darkRadio.checked = true; darkRadio.dispatchEvent(new Event('change'));
-    const fontSizeInput = () =>
-      [...document.querySelectorAll('.stb-facet-leaf')]
-        .find((l) => (l as HTMLElement).dataset.key === 'text.fontSize')!
-        .querySelector('input[type="text"]') as HTMLInputElement;
-    expect(fontSizeInput().value).toBe('');               // dark empty before the edit
+    const darkBtn = () => [...document.querySelectorAll('.stb-facet-leaf')]
+      .find((l) => (l as HTMLElement).dataset.key === 'text.color')!
+      .querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+    expect(darkBtn().classList.contains('stb-facet-swatch-empty')).toBe(true); // dark empty before the edit
     // model edit arrives from outside the focused control
-    setNodeFacetsDark('x', { text: { fontSize: { literal: '20px' } } });
-    expect(fontSizeInput().value).toBe('20px');           // editor re-rendered from the live model
+    setNodeFacetsDark('x', { text: { color: { literal: { l: 0.2, c: 0.05, h: 100 } } } });
+    expect(darkBtn().classList.contains('stb-facet-swatch-empty')).toBe(false); // editor re-rendered from the live model
   });
 });


### PR DESCRIPTION
## What

Adds a **peer dark value** to the stb facet model plus a **per-row dual-field editor**, so each element facet can carry a distinct light and dark value, editable side by side — then a round of editor/preview UX fixes found while testing it live. Builds on the facet dark-axis work merged in #5514.

## Dual light/dark facet editing

- **`projectDark()`** — dark `{token}` colors project to a dedicated dark token map; light output unchanged.
- **`reprojectNodeTokensDark()`** — writes dark values only, leaving `:root` untouched.
- **`deriveDarkOklch(light, ctx)`** — derive a dark value from the light one.
- **Dual-field editor** — color rows render a light swatch + dark swatch + "↓" derive button under a `light`/`dark` header; non-color rows stay single-field.
- **Reactive dark-column dimming** — the dark column mutes to 0.4 opacity in light preview, full in dark, tracking the Dark-preview toggle.

## Editor / preview UX fixes (from live testing)

- **Reveal hidden elements** — an empty/zero-size themable element (e.g. the login error alert) rendered invisibly, so its swatch had no on-screen counterpart. It's now revealed — the selected element always shows (min-size + a glyph that inherits its own text color), and "Show editable regions" reveals every editable region at once. The label is the element's **real name**, never invented text.
- **Background-aware derive** — the old derive halved chroma and inverted lightness blindly, turning a red into a muddy dark brown on a dark surface. It now keeps hue/chroma and lifts a foreground to a legible, contrast-checked tint (`#f52f39` → `#ff4d4f`); a surface fill inverts lightness but keeps chroma. (Assumes a dark surface where the element's exact background can't be resolved.)
- **Color-format selector drives the facet picker** — the hex/rgb/oklch selector was ignored by the facet color picker (hardcoded hex); it now threads through for both light and dark swatches.
- **Editor title bar** — the popover is decoupled from the tree selection, so nothing told you which element it targeted; it now shows the element's name (description on hover).
- **Expand/Collapse all** — `.stb-facet-leaves { display:flex }` outranked the `hidden` attribute, so collapsing only flipped the arrow; fixed with a 2-selector `[hidden]` rule (same trap already fixed for `.stb-view`). Also fixes per-group collapse.
- **Cancel button modeled** — the shared stepper had only Previous/Next and the dialog's Cancel was uninstrumented, so the secondary "cancel" action wasn't themable anywhere; added a Cancel to the stepper and gave the dialog's Cancel a snapshot id.

## Testing

- `npm run typecheck && npm test && npm run lint` — **285 tests pass**, typecheck + lint clean.
- Live-verified each change on the dev server (Playwright): dual light/dark editing drives the preview; derive fills a legible dark swatch; reveal shows a hidden element in its own color, labeled with its name; color-format reformats the picker; expand/collapse hides/shows groups; both Cancel buttons render and are editable.

All changes under `tools/stb/`.
