### PR TITLE
feat(stepper): consistently offer Cancel across setup wizards

### DIFF
--- a/src/frontend/packages/core/src/features/setup/local-account-wizard/local-account-wizard.component.html
+++ b/src/frontend/packages/core/src/features/setup/local-account-wizard/local-account-wizard.component.html
@@ -4,7 +4,7 @@
   </app-page-header>
   <app-show-page-header></app-show-page-header>
   <div class="p-6">
-    <app-steppers class="flex flex-1 my-6">
+    <app-steppers class="flex flex-1 my-6" [cancel]="'/setup'">
       <app-step title="Local Account Information" [signalHandle]="signalHandle">
         <app-loading-page [isLoading]="applyingSetup()" alert="Saving configuration"
           text="Please wait - this will take a few moments">

--- a/src/frontend/packages/core/src/features/setup/setup-welcome/setup-welcome.component.html
+++ b/src/frontend/packages/core/src/features/setup/setup-welcome/setup-welcome.component.html
@@ -4,7 +4,7 @@
   </app-page-header>
   <app-show-page-header></app-show-page-header>
   <div class="p-6">
-    <app-steppers>
+    <app-steppers [cancel]="'/setup'" [cancelReload]="true">
       <app-step [hideNextButton]="true" [signalHandle]="signalHandle">
         <div class="text-center space-y-8">
           <app-stratos-title></app-stratos-title>

--- a/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.html
+++ b/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.html
@@ -4,7 +4,7 @@
   </app-page-header>
   <app-show-page-header></app-show-page-header>
   <div class="p-6">
-    <app-steppers class="flex flex-1 my-6">
+    <app-steppers class="flex flex-1 my-6" [cancel]="'/setup'">
       <app-step title="UAA Endpoint" [signalHandle]="uaaFormStepHandle">
         <div class="space-y-6">
           <p class="text-content-text">Please enter the following information to allow <app-product-name></app-product-name> to authenticate

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html
@@ -95,10 +95,10 @@
             @if (!steps[currentIndex()].hideCloseButton && cancel) {
               <button id="stepper_cancel"
                 class="btn btn-secondary"
-                [routerLink]="cancel$ | async"
-                [queryParams]="cancelQueryParams$ | async"
+                [routerLink]="cancelReload ? null : (cancel$ | async)"
+                [queryParams]="cancelReload ? null : (cancelQueryParams$ | async)"
                 [disabled]="!canCancel(currentIndex())"
-                (click)="steps[currentIndex()].onLeave(false)">
+                (click)="onCancel(currentIndex())">
                 {{ this.getCancelButtonText(currentIndex()) }}
               </button>
             }

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -45,6 +45,10 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
   @ContentChildren(StepComponent) stepComponents!: QueryList<StepComponent>;
 
   @Input() cancel?: string;
+  // When true the Cancel button does a full-page load to `cancel` instead of a
+  // router navigation. Needed by first-run setup, which has no in-app
+  // destination and wants Cancel to hard-refresh back to the flow's start.
+  @Input() cancelReload = false;
   @Input() nextButtonProgress = true;
   @Input() basePreviousRedirect: StepperRedirectPayload | null = this.route.snapshot.queryParams[BASE_REDIRECT_QUERY] ? {
     path: this.route.snapshot.queryParams[BASE_REDIRECT_QUERY]
@@ -400,6 +404,15 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
 
   getCancelButtonText(currentIndex: number): string {
     return this.steps[currentIndex].cancelButtonText;
+  }
+
+  onCancel(index: number) {
+    this.steps[index].onLeave(false);
+    if (this.cancelReload && this.cancel) {
+      // Full page load restarts the wizard from a clean state; the template
+      // drops routerLink when cancelReload so this is the only navigation.
+      window.location.assign(this.cancel);
+    }
   }
   private unsubscribeNext() {
     if (this.nextSub) {


### PR DESCRIPTION
## Summary

Brings the first-run **setup wizards** into line with every other Stratos stepper so a Cancel button is consistently offered.

The shared stepper only renders Cancel when a `cancel` route is supplied (`!hideCloseButton && cancel` in `steppers.component.html`). An audit of all 36 `<app-steppers>` consumers found **33 already pass a `cancel` route** (they render Cancel today); the only ones missing it were the three pre-login setup wizards.

## Changes

- **`console-uaa-wizard`, `local-account-wizard`** — `[cancel]="'/setup'"`: the generic themed Cancel now returns to the welcome / auth-method choice, restarting the flow.
- **`setup-welcome`** — it's the flow's start with no in-app destination, so a router nav would be a no-op. Added an optional `cancelReload` input to the shared stepper: the *same* Cancel button does a full-page `window.location.assign(cancel)`, matching the setup flow's existing hard-reload-on-success idiom. Opted in via `[cancel]="'/setup'" [cancelReload]="true"`.

`cancelReload` **defaults off**, so all existing steppers are behavior-identical (routerLink still resolves to `cancel$`, `onCancel` just calls `onLeave(false)`).

## Verification

- `vitest --project=core --project=cloud-foundry` over the shared stepper suite + consumers (`steppers.component`, `steppers-destructive-flow` `canClose` gating, `step.component`, `stepper-form`, `add-route-stepper`, all three setup specs): **21 files / 65 tests pass**.
- ESLint clean on all touched files.

## Out of scope (follow-up)

Modal **dialogs** (`connect-endpoint`, `add-api-key`, `add-user`, `variable-edit`, `rollback`, …) hand-roll their own Cancel with inconsistent classes (`btn-warn`/`btn-danger`/`btn-secondary`). Not `<app-steppers>` consumers — a separate normalization worth its own issue.

Closes #5521.