### PR TITLE
fix(cf): keep shared domains in Add Route domain dropdown (#5523)

### DIFF
--- a/src/jetstream/plugins/cloudfoundry/native_domains_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_domains_reads.go
@@ -3,6 +3,7 @@ package cloudfoundry
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/fivetwenty-io/capi/v3/pkg/capi"
 	"github.com/labstack/echo/v4"
@@ -68,9 +69,20 @@ func (c *CloudFoundrySpecification) getNativeDomains(ctx echo.Context) error {
 }
 
 // getNativeOrgDomains handles GET /pp/v1/cf/org/{cnsiGuid}/{orgGuid}/private_domains.
-// Returns only private domains (owned by the org) — V3 collapses
-// `/v2/organizations/:guid/private_domains` into `/v3/domains?organization_guids=:guid`,
-// which mixes owned + shared. Server-side filter to OwningOrgGUID==orgGuid.
+// V3 collapses `/v2/organizations/:guid/private_domains` into
+// `/v3/domains?organization_guids=:guid`, which returns every domain
+// visible to the org: its own private domains, domains explicitly
+// shared with it, AND global shared domains (no owning org at all).
+// Despite the route's legacy "private_domains" name, all of those are
+// valid Add-Route candidates for the org, so we only exclude domains
+// privately owned by a *different* org (defensive — CF shouldn't
+// return those for this filter, but we don't rely on that).
+//
+// Regression note: an earlier version of this handler discarded
+// everything except OwningOrgGUID==orgGuid, which dropped every
+// shared/global domain. Most orgs have no private domains of their
+// own and rely entirely on the foundation's shared domain, so the
+// Add Route domain dropdown ended up empty (#5523).
 func (c *CloudFoundrySpecification) getNativeOrgDomains(ctx echo.Context) error {
 	cnsiGUID := ctx.Param("cnsiGuid")
 	orgGUID := ctx.Param("orgGuid")
@@ -104,7 +116,9 @@ func (c *CloudFoundrySpecification) getNativeOrgDomains(ctx echo.Context) error 
 	resources := make([]StDomain, 0, len(raw.Resources))
 	for _, d := range raw.Resources {
 		st := toStDomain(d, cnsiGUID)
-		if st.OwningOrgGUID == orgGUID {
+		ownedByOtherOrg := st.OwningOrgGUID != "" && st.OwningOrgGUID != orgGUID
+		sharedWithOrg := slices.Contains(st.SharedOrgGUIDs, orgGUID)
+		if !ownedByOtherOrg || sharedWithOrg {
 			resources = append(resources, st)
 		}
 	}

--- a/src/jetstream/plugins/cloudfoundry/native_domains_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_domains_reads_test.go
@@ -104,6 +104,45 @@ func newDomainsContext(e *echo.Echo, target string) (echo.Context, *httptest.Res
 	return ctx, rec
 }
 
+func newOrgDomainsContext(e *echo.Echo, target, orgGUID string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid", "orgGuid")
+	ctx.SetParamValues("test-cnsi", orgGUID)
+	return ctx, rec
+}
+
+// orgDomainsTestServer mimics what CF v3 actually returns for
+// `/v3/domains?organization_guids=:orgGuid` — a mix of the org's own
+// private domain, a domain explicitly shared with the org (owned by a
+// different org), and a global shared domain (no owning org at all).
+// It also includes a domain privately owned by a different org, which
+// CF would not normally return for this filter, to prove the handler
+// still excludes it defensively.
+func orgDomainsTestServer(t *testing.T, orgGUID string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case "/v3/domains":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 4, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					domainResource("dom-global-shared", "apps.example.com", false, "", nil),
+					domainResource("dom-owned", "owned.example.com", false, orgGUID, nil),
+					domainResource("dom-shared-with-org", "shared-in.example.com", false, "org-other", []string{orgGUID}),
+					domainResource("dom-owned-other", "other-owner.example.com", false, "org-other", nil),
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
 func newDomainsPlugin(serverURL string) *CloudFoundrySpecification {
 	return &CloudFoundrySpecification{
 		testProxy: &mockNativeCFProxy{
@@ -254,4 +293,43 @@ func TestGetNativeDomains_OmitsPagingWhenAbsent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.False(t, q.PerPagePresent)
 	assert.False(t, q.PagePresent)
+}
+
+// TestGetNativeOrgDomains_KeepsSharedAndGlobalDomains is a regression
+// test for #5523: the Add Route domain dropdown was always empty
+// because CF v3's `organization_guids` filter mixes owned + shared
+// domains, and the handler used to discard everything except domains
+// privately owned by the requested org. Most orgs have zero private
+// domains and rely entirely on a shared/global domain, so the
+// dropdown had nothing to show.
+func TestGetNativeOrgDomains_KeepsSharedAndGlobalDomains(t *testing.T) {
+	const orgGUID = "org-1"
+	ts := orgDomainsTestServer(t, orgGUID)
+	defer ts.Close()
+
+	e := echo.New()
+	ctx, rec := newOrgDomainsContext(e, "/pp/v1/cf/org/test-cnsi/"+orgGUID+"/private_domains", orgGUID)
+	plugin := newDomainsPlugin(ts.URL)
+
+	require.NoError(t, plugin.getNativeOrgDomains(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp StratosPagedResponse[StDomain]
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	guids := make([]string, 0, len(resp.Resources))
+	for _, d := range resp.Resources {
+		guids = append(guids, d.GUID)
+	}
+
+	// The global shared domain and the org's own private domain must
+	// survive — this is the #5523 bug.
+	assert.Contains(t, guids, "dom-global-shared", "global shared domain (no owning org) must be kept")
+	assert.Contains(t, guids, "dom-owned", "domain owned by the requested org must be kept")
+	assert.Contains(t, guids, "dom-shared-with-org", "domain explicitly shared with the requested org must be kept")
+
+	// A domain privately owned by a *different* org must still be excluded.
+	assert.NotContains(t, guids, "dom-owned-other", "domain owned by a different org must be excluded")
+
+	assert.Len(t, resp.Resources, 3)
 }


### PR DESCRIPTION
Closes #5523

## Problem
On Applications → an app → Routes → **Add Route**, the domain dropdown is always empty, so a route can't be created. The delay before it (fails to) populate grows with the number of routes in the environment.

## Root cause
`getNativeOrgDomains` (`native_domains_reads.go`) queried CF v3's `/v3/domains?organization_guids=:guid` — which returns the org's private domains **plus** domains shared with it **plus** global shared domains — then filtered the result down to `OwningOrgGUID == orgGuid`, discarding every shared and global domain. Most orgs have no private domains of their own and rely entirely on the foundation's shared domain, so the list came back empty. Regression from the V2→V3 frontend cutover (PR #5308); the handler had no test coverage.

(The latency-scales-with-route-count symptom is a *separate*, legitimate O(routes) route-picker fetch on the same screen — not addressed here.)

## Fix
Only exclude domains privately owned by a *different* org; keep global shared domains (no owner) and domains explicitly shared with this org via `SharedOrgGUIDs`. Adds `TestGetNativeOrgDomains_KeepsSharedAndGlobalDomains`, the first coverage for this handler.

Full `cloudfoundry` package test suite + `go vet`/`gofmt` clean; no frontend change needed (the dropdown consumes this endpoint directly).