### PR TITLE
fix(cf): show real CF error when starting an unstaged app (#5520)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -342,6 +343,27 @@ describe('AppApplicationActionsService', () => {
     expect(failEntry).toBeDefined();
     expect(failEntry?.error?.code).toBe('CF-AppStaged');
     expect(failEntry?.error?.message).toBe('staging failed');
+  });
+
+  // #5520: starting an unstaged app throws a synchronous CF 422 with no job
+  // envelope. The fail log (and thus the snackbar's outcomeError) must show
+  // the real CF detail, not a generic "Operation failed".
+  it('surfaces the real CF detail on a synchronous 422 (no job envelope)', async () => {
+    appsStub.startApp.mockImplementationOnce(async () => {
+      throw new HttpErrorResponse({
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        error: { errors: [{ code: 10008, title: 'CF-UnprocessableEntity', detail: 'Assign a droplet before starting this app.' }] },
+      });
+    });
+
+    void svc.start();
+    await tick(8);
+
+    const failEntry = svc.log().find(e => e.event === 'fail');
+    expect(failEntry).toBeDefined();
+    expect(failEntry?.error?.message).toBe('Assign a droplet before starting this app.');
+    expect(svc.outcomeError()).toBe('Assign a droplet before starting this app.');
   });
 
   it('log() includes target info on each entry', async () => {

--- a/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/application-actions.service.ts
@@ -9,6 +9,7 @@ import { AppDetailDataService } from '../../features/applications/app-detail-dat
 import { AppLifecycleStateService } from '../../features/applications/app-lifecycle-state.service';
 import { CloudFoundryEndpointService } from '../../features/cf/services/cloud-foundry-endpoint.service';
 import { AppStatsDataRegistry } from '../../services/endpoint-data/app-stats-data.registry';
+import { extractHttpErrorMessage } from '../../services/extract-error-message';
 import { CfAppsSignalConfigService } from '../signal-list-configs/app/cf-apps-signal-config.service';
 import type { JobStage, StratosJob } from '../../services/async-jobs/async-job.types';
 
@@ -255,9 +256,17 @@ export class AppApplicationActionsService {
       })
       .catch((err: any) => {
         const firstError = err?.job?.errors?.[0];
+        // A synchronous CF 4xx (e.g. 422 "Assign a droplet before starting
+        // this app.") throws a raw HttpErrorResponse with no `.job`, so the
+        // job-shaped extraction misses and the snackbar shows a generic
+        // "Operation failed". Fall back to the CF error-envelope extractor
+        // so the operator sees the real reason. (#5520)
+        const error = firstError
+          ? { code: String(firstError.code), message: String(firstError.message) }
+          : { code: '', message: extractHttpErrorMessage(err) };
         this.appendLog({
           at: new Date(), verb: lifecycleVerb, target: parsedTarget, event: 'fail',
-          error: firstError ? { code: String(firstError.code), message: String(firstError.message) } : undefined,
+          error,
         });
         this.refreshAppStats();
         // Failure path may have left CF in a partial state — refresh to


### PR DESCRIPTION
Closes #5520

## Problem
Starting an app that has no assigned droplet (e.g. pushed with `--no-start`) fails with an ambiguous **"Operation failed"** popup. CF actually returns a clear 422:
```
code 10008 CF-UnprocessableEntity: Assign a droplet before starting this app.
```

## Root cause
That synchronous 4xx throws a raw `HttpErrorResponse` with no async-job envelope, so the lifecycle catch handler's `err.job.errors[0]` lookup missed and `outcomeError` fell back to the literal `"Operation failed"`. The real message reached the frontend but was never surfaced.

## Fix
Fall back to the existing `extractHttpErrorMessage()` helper (already used by several components), which unpacks the CF error envelope, so the operator sees the real reason. Adds a regression test asserting the 422 `detail` reaches `outcomeError`.

## Follow-up (not in this PR)
A fuller UX — detecting the no-droplet case and offering to stage the app (the backend `restageApp` orchestrator is already wired) — is a separate enhancement worth its own issue. This PR is the minimal, safe fix: stop hiding the real error.