### PR TITLE
fix(cf): stop app-detail remount + env-var refetch on every tab (#5519)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/applications.routes.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/applications.routes.ts
@@ -78,6 +78,16 @@ export const APPLICATIONS_ROUTES: Routes = [
       {
         path: ':endpointId/:id',
         component: ApplicationBaseComponent,
+        // Keep the app-detail shell alive while the user switches side tabs
+        // (Summary/Logs/Variables/...). Without this the CustomReuseStrategy
+        // tears down ApplicationBaseComponent on every tab click, re-running
+        // its eager data load — including the env-vars fetch that emits an
+        // audit.app.environment.show event each time. The strategy only
+        // reuses when the route params (:endpointId/:id) also match, so
+        // navigating to a different app still rebuilds. (#5519)
+        data: {
+          reuseRoute: ApplicationBaseComponent
+        },
         children: [
           {
             path: 'delete',
@@ -110,7 +120,12 @@ export const APPLICATIONS_ROUTES: Routes = [
             path: '',
             component: ApplicationTabsBaseComponent,
             data: {
-              extensionsActionsKey: StratosActionType.Application
+              extensionsActionsKey: StratosActionType.Application,
+              // Persist the tabs shell across tab switches too (see the
+              // parent route's reuseRoute note). Its path is empty so its
+              // params never change; it rebuilds only when the parent does
+              // (i.e. on navigation to a different app). (#5519)
+              reuseRoute: ApplicationTabsBaseComponent
             },
             children: [
               // Function-form redirect so the ?breadcrumbs= query param

--- a/src/frontend/packages/core/src/route-reuse-stragegy.spec.ts
+++ b/src/frontend/packages/core/src/route-reuse-stragegy.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ActivatedRouteSnapshot } from '@angular/router';
+
+// The strategy imports AppComponent + DashboardBaseComponent purely for
+// identity comparison. Stub them so the spec doesn't pull the whole app
+// template tree — we only need stable class references.
+vi.mock('./app.component', () => ({ AppComponent: class AppComponent {} }));
+vi.mock('./features/dashboard/dashboard-base/dashboard-base.component', () => ({
+  DashboardBaseComponent: class DashboardBaseComponent {},
+}));
+
+import { CustomReuseStrategy } from './route-reuse-stragegy';
+
+// Stand-in for a detail shell keyed by route params (like ApplicationBaseComponent).
+class FakeShell {}
+
+function snap(opts: { component?: unknown; data?: Record<string, unknown>; params?: Record<string, string> }): ActivatedRouteSnapshot {
+  return {
+    component: opts.component ?? null,
+    data: opts.data ?? {},
+    params: opts.params ?? {},
+  } as unknown as ActivatedRouteSnapshot;
+}
+
+describe('CustomReuseStrategy', () => {
+  const strat = new CustomReuseStrategy();
+
+  it('reuses a component-keyed shell across tab switches (params unchanged)', () => {
+    const curr = snap({ component: FakeShell, data: { reuseRoute: FakeShell }, params: { endpointId: 'cf1', id: 'app1' } });
+    const future = snap({ component: FakeShell, data: { reuseRoute: FakeShell }, params: { endpointId: 'cf1', id: 'app1' } });
+    expect(strat.shouldReuseRoute(future, curr)).toBe(true);
+  });
+
+  it('does NOT reuse a component-keyed shell across different resources (params differ) — #5519', () => {
+    const curr = snap({ component: FakeShell, data: { reuseRoute: FakeShell }, params: { endpointId: 'cf1', id: 'app1' } });
+    const future = snap({ component: FakeShell, data: { reuseRoute: FakeShell }, params: { endpointId: 'cf1', id: 'app2' } });
+    expect(strat.shouldReuseRoute(future, curr)).toBe(false);
+  });
+
+  it('does not reuse a component route with no reuseRoute marker', () => {
+    const curr = snap({ component: FakeShell, data: {}, params: { id: 'app1' } });
+    const future = snap({ component: FakeShell, data: {}, params: { id: 'app1' } });
+    expect(strat.shouldReuseRoute(future, curr)).toBe(false);
+  });
+
+  it('still reuses a data-only (component-less) reuseRoute:true route', () => {
+    const curr = snap({ component: null, data: { reuseRoute: true }, params: {} });
+    const future = snap({ component: null, data: { reuseRoute: true }, params: {} });
+    expect(strat.shouldReuseRoute(future, curr)).toBe(true);
+  });
+});

--- a/src/frontend/packages/core/src/route-reuse-stragegy.ts
+++ b/src/frontend/packages/core/src/route-reuse-stragegy.ts
@@ -1,8 +1,15 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy } from '@angular/router';
+import { ActivatedRouteSnapshot, DetachedRouteHandle, Params, RouteReuseStrategy } from '@angular/router';
 
 import { AppComponent } from './app.component';
 import { DashboardBaseComponent } from './features/dashboard/dashboard-base/dashboard-base.component';
+
+// Shallow equality of a route node's own params (e.g. { endpointId, id }).
+function paramsEqual(a: Params, b: Params): boolean {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  return ak.length === bk.length && ak.every((k) => a[k] === b[k]);
+}
 
 @Injectable()
 export class CustomReuseStrategy extends RouteReuseStrategy {
@@ -19,8 +26,17 @@ export class CustomReuseStrategy extends RouteReuseStrategy {
     if (curr.data.reuseRoute === true) {
       reuse = curr.data.reuseRoute && future.data.reuseRoute && !curr.component && !future.component;
     } else {
-      // Expect it to be a component
-      reuse = curr.component === curr.data.reuseRoute && future.component === future.data.reuseRoute;
+      // A component-keyed reuseRoute keeps a detail shell alive while the
+      // user moves between its child tabs (route params unchanged). It must
+      // NOT reuse across two different resources of the same component
+      // (e.g. app A -> app B): such shells derive their identity — CF/app
+      // GUIDs — from route params at construction time, so reusing the
+      // instance would leave them pinned to the previous resource and show
+      // stale data. Require the node's own params to match too. (#5519)
+      reuse =
+        curr.component === curr.data.reuseRoute &&
+        future.component === future.data.reuseRoute &&
+        paramsEqual(curr.params, future.params);
     }
     return isDashboard || isAppComp || reuse;
   }


### PR DESCRIPTION
Closes #5519

## Problem
Clicking between an application's side tabs (Summary, Log Stream, Revisions, Routes, Variables, Services, Events) triggers a fetch of `/v3/apps/:guid/environment_variables` **every time**, each emitting an `audit.app.environment.show` event and polluting the app's event feed. Env vars should only be fetched for the Variables tab.

## Root cause
`CustomReuseStrategy` reuses a route only when a `reuseRoute` marker matches; the app-detail routes carried none, so **every** tab navigation tore down and rebuilt `ApplicationBaseComponent`. Its `ngOnInit` re-runs the eager data load (`refresh('all')`), which includes the env-vars fetch → an audit event per tab click.

A plain `reuseRoute` marker can't be used directly here: `ApplicationBaseComponent` derives its CF/app GUIDs from route params via **construction-time DI factories**, so reusing the instance across two different apps (A → B) would leave it pinned to app A's data.

## Fix
Teach the component-keyed branch of `shouldReuseRoute` to also require the route node's own **params** to match:
- same params (tab switch) → shell is reused, no remount, no env-vars refetch;
- different params (different app) → shell rebuilds, GUIDs correct.

Then mark the app-detail shell (`ApplicationBaseComponent`) and tabs-base (`ApplicationTabsBaseComponent`) routes. Also fixes the same latent cross-resource staleness for the k8s helm-release shell, which uses the identical construction-time-guid pattern (verified). Adds `route-reuse-stragegy.spec.ts` covering param-aware reuse.

## Verification
Strategy unit tests (4/4) cover reuse-on-same-params and rebuild-on-different-params. **End-to-end live verification (clicking tabs, confirming the env-vars call no longer fires and the event feed stays clean) is pending an available CF endpoint** and should be done before merge.