### PR TITLE
ci(stb): make the required STB Tests check report on all PRs

### DIFF
--- a/.github/workflows/stb_tests.yml
+++ b/.github/workflows/stb_tests.yml
@@ -2,23 +2,24 @@ name: STB Tests
 
 # Gate for the Stratos Theme Builder (tools/stb). It is a standalone npm
 # project outside the Angular workspace, so the frontend/backend workflows
-# never exercise it. Runs only when stb itself changes, or when one of the
-# Stratos templates stb is instrumented against changes — a template edit can
-# break the snapshot-id <-> routing correspondence the harvest lint checks.
+# never exercise it. The real work runs only when stb itself changes, or when
+# one of the Stratos templates stb is instrumented against changes — a template
+# edit can break the snapshot-id <-> routing correspondence the harvest lint
+# checks.
+#
+# STB Tests is a REQUIRED status check on develop/main. A required check that is
+# `paths`-filtered at the trigger level never reports on PRs that don't touch
+# its paths, leaving those PRs stuck forever on "Expected — Waiting for status
+# to be reported". So this workflow triggers on every PR to the protected
+# branches and decides internally (via the paths-filter step) whether to run
+# the gate — the job still completes green when stb is untouched, satisfying
+# the required check without doing needless work.
 on:
   pull_request:
     branches:
       - master
       - develop
       - 'angular**'
-    paths:
-      - 'tools/stb/**'
-      # Instrumented templates (stb-snapshot-id / stba-*). Add new ones here
-      # as more scenes are converted; the harvest lint currently covers login.
-      - 'src/frontend/packages/core/src/features/login/login-page/login-page.component.html'
-      - 'src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html'
-      - 'src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html'
-      - 'src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.html'
   push:
     branches:
       - develop
@@ -39,35 +40,61 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Does this PR touch stb or an instrumented template? Every real step
+      # below is gated on this so the job still reports green on unrelated PRs.
+      # Add new instrumented templates here as more scenes are converted.
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            stb:
+              - 'tools/stb/**'
+              - 'src/frontend/packages/core/src/features/login/login-page/login-page.component.html'
+              - 'src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html'
+              - 'src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html'
+              - 'src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.html'
+
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.stb == 'true'
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       # No package-lock.json in tools/stb, so install (not ci).
-      - run: npm install
+      - if: steps.changes.outputs.stb == 'true'
+        run: npm install
 
       # The integration suite runs in real browsers (vite.config.ts defines
       # integration-chromium/firefox/webkit projects); CI has no browser
       # binaries by default. NOTE: installs all three to keep CI == local
       # `npm test`; narrow to chromium if the gate gets slow.
       - name: Install Playwright browsers
+        if: steps.changes.outputs.stb == 'true'
         run: npx playwright install --with-deps
 
       - name: Typecheck
+        if: steps.changes.outputs.stb == 'true'
         run: npm run typecheck
 
       - name: Lint
+        if: steps.changes.outputs.stb == 'true'
         run: npm run lint
 
       - name: Unit + integration tests
+        if: steps.changes.outputs.stb == 'true'
         run: npm test
 
       # Drift check: login live template ids vs the snapshot routing map.
       - name: Harvest lint (login template <-> routing drift)
+        if: steps.changes.outputs.stb == 'true'
         run: npm run lint:harvest
 
       # Drift check: the shared scene's live template ids (stepper +
       # dialog-confirm) must exist in its captured snapshot. (login is covered
       # by lint:harvest above; app-list is a mock with no static correspondence.)
       - name: Template lint (shared live templates <-> snapshot drift)
+        if: steps.changes.outputs.stb == 'true'
         run: npm run lint:templates
+
+      - name: No stb changes — gate not needed
+        if: steps.changes.outputs.stb != 'true'
+        run: echo "No tools/stb or instrumented-template changes; STB gate satisfied."


### PR DESCRIPTION
## Problem
`STB Tests` is a **required** status check on `develop`/`main`, but the workflow is `paths`-filtered (`tools/stb/**` + a few instrumented templates). GitHub never reports a required check that a PR's paths don't trigger, so **every PR that doesn't touch stb** (backend-only, most frontend) gets stuck indefinitely on:

> STB Tests — Expected — Waiting for status to be reported

…and cannot be merged. (Live example: several open bug-fix PRs are blocked on this alone, with all 12 real checks green.)

## Fix
Trigger the workflow on **every** PR to the protected branches, and decide *internally* whether to run the gate:
- a `dorny/paths-filter` step sets an `stb` output from the same path list;
- every real step (`npm install`, Playwright, typecheck, lint, tests, both drift lints) is gated on `steps.changes.outputs.stb == 'true'`;
- an else-branch step reports green when stb is untouched.

The **job always runs**, so the required check is always satisfied; real stb changes still run the full gate exactly as before.

## Self-unblocking
`pull_request` runs the workflow as it exists in the PR's merge ref, so this PR's own modified workflow runs on it — STB Tests executes and passes here too.

## Note
`dorny/paths-filter@v3` is a third-party action (widely used across CNCF projects). If the org prefers to avoid non-GitHub actions, this can be swapped for a native `git diff --name-only` step — happy to change it.