### PR TITLE
ci: gate required checks with job-level conditionals (Closes #5528)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,21 +1,22 @@
 name: Pull Request Tests
 
+# tools/stb is a standalone project with its own gate (stb_tests.yml). We must
+# NOT skip this workflow for stb-only changes via a trigger-level `paths`
+# filter: these jobs are REQUIRED status checks, and a required check that is
+# path-filtered at the trigger never reports — leaving stb-only PRs stuck on
+# "Expected — waiting for status". Instead we always trigger and skip each job
+# with a `changes`-gated `if:`; a job skipped by `if:` reports success and so
+# satisfies the required check without running the Stratos build. See #5528.
 on:
   pull_request:
     branches:
       - master
       - develop
       - 'angular**'
-    # tools/stb is a standalone project with its own gate (stb_tests.yml);
-    # don't run the full frontend/backend suite for stb-only changes.
-    paths-ignore:
-      - 'tools/stb/**'
   push:
     branches:
       - develop
       - master
-    paths-ignore:
-      - 'tools/stb/**'
 
 env:
   NODE_OPTIONS: --max-old-space-size=5500
@@ -24,9 +25,29 @@ env:
   BUN_VERSION: 'latest'
 
 jobs:
+  # Decide whether this PR touches anything outside tools/stb. All the real
+  # jobs below gate on `non_stb` so stb-only PRs skip them (→ success) while
+  # every other PR runs the full suite. Always runs; cheap.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_stb: ${{ steps.filter.outputs.non_stb }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            non_stb:
+              - '**'
+              - '!tools/stb/**'
+
   lint:
     name: Lint Check
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_stb == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -63,6 +84,8 @@ jobs:
   test-frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_stb == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +130,8 @@ jobs:
   test-backend:
     name: Backend Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_stb == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -151,7 +176,8 @@ jobs:
   build-check:
     name: Build Check
     runs-on: ubuntu-latest
-    needs: [lint, test-frontend, test-backend]
+    needs: [changes, lint, test-frontend, test-backend]
+    if: needs.changes.outputs.non_stb == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -230,12 +256,17 @@ jobs:
     if: always()
     steps:
       - name: Check all jobs
+        # A stb-only PR skips every job above; "skipped" is an acceptable
+        # outcome here (the Stratos suite is genuinely N/A), only "failure"
+        # or "cancelled" should fail the gate.
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || \
-             [ "${{ needs.test-frontend.result }}" != "success" ] || \
-             [ "${{ needs.test-backend.result }}" != "success" ] || \
-             [ "${{ needs.build-check.result }}" != "success" ]; then
-            echo "❌ One or more required checks failed"
-            exit 1
-          fi
+          for res in "${{ needs.lint.result }}" \
+                     "${{ needs.test-frontend.result }}" \
+                     "${{ needs.test-backend.result }}" \
+                     "${{ needs.build-check.result }}"; do
+            if [ "$res" != "success" ] && [ "$res" != "skipped" ]; then
+              echo "❌ One or more required checks failed (result: $res)"
+              exit 1
+            fi
+          done
           echo "✅ All PR checks passed!"

--- a/.github/workflows/stb_tests.yml
+++ b/.github/workflows/stb_tests.yml
@@ -2,7 +2,7 @@ name: STB Tests
 
 # Gate for the Stratos Theme Builder (tools/stb). It is a standalone npm
 # project outside the Angular workspace, so the frontend/backend workflows
-# never exercise it. The real work runs only when stb itself changes, or when
+# never exercise it. The real gate runs only when stb itself changes, or when
 # one of the Stratos templates stb is instrumented against changes — a template
 # edit can break the snapshot-id <-> routing correspondence the harvest lint
 # checks.
@@ -10,10 +10,9 @@ name: STB Tests
 # STB Tests is a REQUIRED status check on develop/main. A required check that is
 # `paths`-filtered at the trigger level never reports on PRs that don't touch
 # its paths, leaving those PRs stuck forever on "Expected — Waiting for status
-# to be reported". So this workflow triggers on every PR to the protected
-# branches and decides internally (via the paths-filter step) whether to run
-# the gate — the job still completes green when stb is untouched, satisfying
-# the required check without doing needless work.
+# to be reported". So we always trigger and gate the real work with a job-level
+# `if:`: a job skipped by `if:` reports success and satisfies the required
+# check, without spinning a runner. See #5528.
 on:
   pull_request:
     branches:
@@ -31,20 +30,17 @@ env:
   NODE_VERSION: '24'
 
 jobs:
-  test:
-    name: STB Tests
+  # Does this PR touch stb or an instrumented template? The gate job gates on
+  # this output. Add new instrumented templates here as more scenes convert.
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: tools/stb
+    outputs:
+      stb: ${{ steps.filter.outputs.stb }}
     steps:
       - uses: actions/checkout@v4
-
-      # Does this PR touch stb or an instrumented template? Every real step
-      # below is gated on this so the job still reports green on unrelated PRs.
-      # Add new instrumented templates here as more scenes are converted.
       - uses: dorny/paths-filter@v3
-        id: changes
+        id: filter
         with:
           filters: |
             stb:
@@ -54,47 +50,46 @@ jobs:
               - 'src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html'
               - 'src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.html'
 
+  test:
+    name: STB Tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.stb == 'true'
+    defaults:
+      run:
+        working-directory: tools/stb
+    steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
-        if: steps.changes.outputs.stb == 'true'
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       # No package-lock.json in tools/stb, so install (not ci).
-      - if: steps.changes.outputs.stb == 'true'
-        run: npm install
+      - run: npm install
 
       # The integration suite runs in real browsers (vite.config.ts defines
       # integration-chromium/firefox/webkit projects); CI has no browser
       # binaries by default. NOTE: installs all three to keep CI == local
       # `npm test`; narrow to chromium if the gate gets slow.
       - name: Install Playwright browsers
-        if: steps.changes.outputs.stb == 'true'
         run: npx playwright install --with-deps
 
       - name: Typecheck
-        if: steps.changes.outputs.stb == 'true'
         run: npm run typecheck
 
       - name: Lint
-        if: steps.changes.outputs.stb == 'true'
         run: npm run lint
 
       - name: Unit + integration tests
-        if: steps.changes.outputs.stb == 'true'
         run: npm test
 
       # Drift check: login live template ids vs the snapshot routing map.
       - name: Harvest lint (login template <-> routing drift)
-        if: steps.changes.outputs.stb == 'true'
         run: npm run lint:harvest
 
       # Drift check: the shared scene's live template ids (stepper +
       # dialog-confirm) must exist in its captured snapshot. (login is covered
       # by lint:harvest above; app-list is a mock with no static correspondence.)
       - name: Template lint (shared live templates <-> snapshot drift)
-        if: steps.changes.outputs.stb == 'true'
         run: npm run lint:templates
-
-      - name: No stb changes — gate not needed
-        if: steps.changes.outputs.stb != 'true'
-        run: echo "No tools/stb or instrumented-template changes; STB gate satisfied."


### PR DESCRIPTION
## Summary
Required status checks were skipped via **trigger-level** `paths`/`paths-ignore` filters. A required check filtered at the trigger never reports a status, so PRs that don't touch its paths stick on **"Expected — waiting for status to be reported"** and can't merge. This bit both directions:

- **`pr.yml`** (`Lint Check`, `Frontend Tests`, `Backend Tests`, `Build Check`) was `paths-ignore: tools/stb/**` → **stb-only PRs blocked** (e.g. the in-flight composite-facet work).
- **`stb_tests.yml`** (`STB Tests`) was `paths`-filtered → non-stb PRs blocked. #5527 already unblocked this direction with an always-run workflow + step-level gating; this PR finishes the job by moving to job-level gating (no runner spins when stb is untouched).

## Fix
Convert both workflows from trigger path-filters to **job-level `if:` conditionals**, per GitHub's own [required-checks troubleshooting guidance](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks): a job **skipped by `if:` reports success** and satisfies the required check.

- Add a small always-run `changes` job (`dorny/paths-filter`) to each workflow.
- `pr.yml`: drop `paths-ignore`; gate `lint`/`test-frontend`/`test-backend`/`build-check` on `needs.changes.outputs.non_stb == 'true'`. `pr-success` now treats `skipped` as acceptable.
- `stb_tests.yml`: replace #5527's per-step gating with a single job-level `if: needs.changes.outputs.stb == 'true'` (STB runner no longer spins on stratos PRs).

## Behavior
| PR shape | Stratos jobs | STB Tests |
|---|---|---|
| pure-stb | skip → success | run |
| stratos-only | run | skip → success |
| mixed | run | run |

`Build Check`'s `needs: [lint, test-frontend, test-backend]` cascades correctly — skipped needs → skipped → success. No stub workflow to keep in sync with the frontend matrix; no green stub masking a real failure on mixed PRs; no branch-protection/admin change.

## Validation
This PR touches `.github/**` (non-stb) → the `changes` job outputs `non_stb=true` → the full Stratos suite runs for real on this PR, exercising the stratos path directly. The pure-stb **skip** path reports success once this lands on develop (naturally validated by the next stb-only PR). No regression risk: pure-stb PRs are already blocked today.

Closes #5528. Follows #5527.