### PR TITLE
ci: disambiguate the two paths-filter job names

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
   # jobs below gate on `non_stb` so stb-only PRs skip them (→ success) while
   # every other PR runs the full suite. Always runs; cheap.
   changes:
-    name: Detect changes
+    name: Detect non-stb changes
     runs-on: ubuntu-latest
     outputs:
       non_stb: ${{ steps.filter.outputs.non_stb }}

--- a/.github/workflows/stb_tests.yml
+++ b/.github/workflows/stb_tests.yml
@@ -33,7 +33,7 @@ jobs:
   # Does this PR touch stb or an instrumented template? The gate job gates on
   # this output. Add new instrumented templates here as more scenes convert.
   changes:
-    name: Detect changes
+    name: Detect stb changes
     runs-on: ubuntu-latest
     outputs:
       stb: ${{ steps.filter.outputs.stb }}


### PR DESCRIPTION
## Summary
After #5529, `pr.yml` and `stb_tests.yml` each carry their own always-run `dorny/paths-filter` job that gates the real jobs (a job's `if:` can only read `needs` within its own workflow, so the two gates can't be merged without merging the workflows). Both were named **"Detect changes"**, so the PR checks list showed the context twice with no way to tell them apart.

## Change
Name each for what it detects — no behavior change:

| Workflow | Old | New |
|---|---|---|
| `pr.yml` | Detect changes | **Detect non-stb changes** |
| `stb_tests.yml` | Detect changes | **Detect stb changes** |

Neither is a required check; this is purely readability. All required contexts (`Lint Check`, `Frontend Tests …`, `Backend Tests`, `Build Check`, `STB Tests`) are unchanged.

Follows #5529.