### PR TITLE
chore: retarget master branch refs to main

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - main
     # tools/stb has its own gate (stb_tests.yml); skip the backend suite
     # for stb-only changes.
     paths-ignore:

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - develop
-      - master
+      - main
     # tools/stb has its own gate (stb_tests.yml); skip the frontend suite
     # for stb-only changes.
     paths-ignore:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,13 +10,13 @@ name: Pull Request Tests
 on:
   pull_request:
     branches:
-      - master
+      - main
       - develop
       - 'angular**'
   push:
     branches:
       - develop
-      - master
+      - main
 
 env:
   NODE_OPTIONS: --max-old-space-size=5500

--- a/.github/workflows/stb_tests.yml
+++ b/.github/workflows/stb_tests.yml
@@ -16,13 +16,13 @@ name: STB Tests
 on:
   pull_request:
     branches:
-      - master
+      - main
       - develop
       - 'angular**'
   push:
     branches:
       - develop
-      - master
+      - main
     paths:
       - 'tools/stb/**'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 filter_secrets: false
 branches:
   only:
-    - master
+    - main
     - v2-master
     - e2e-tests
 cache:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To send your code change, use GitHub pull requests. The workflow is as follows:
 
   1. Fork the project.
 
-  1. Create a branch based on `master`.
+  1. Create a branch based on `develop`.
 
   1. Implement your change, including tests and documentation.
 
@@ -66,8 +66,8 @@ pointing to the number of the issue (e.g. "Fixes #123").
 
 ### Pull requests and branches
 
-All work happens in branches. The master branch is only used as the target for pull
-requests.
+All work happens in branches. The develop branch is the target for pull
+requests; releases are cut from main.
 
 During code review you often need to update pull requests. Usually you do that
 by pushing additional commits.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <a href="https://goreportcard.com/report/github.com/cloudfoundry/stratos"><img src="https://goreportcard.com/badge/github.com/cloudfoundry-incubator/stratos"/></a>
 <a href="https://codecov.io/gh/cloudfoundry-community/stratos/branch/master"><img src="https://codecov.io/gh/cloudfoundry-community/stratos/branch/master/graph/badge.svg"/></a>
 [![GitHub release](https://img.shields.io/github/release/cloudfoundry-community/stratos.svg)](https://github.com/cloudfoundry/stratos/releases/latest)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/cloudfoundry/stratos/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/cloudfoundry/stratos/blob/main/LICENSE)
 [![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/messages/C80EP4Y57/)
 
 # Roadmap

--- a/deploy/ci/console-sync-release.yml
+++ b/deploy/ci/console-sync-release.yml
@@ -8,7 +8,7 @@ resources:
 - name: helm-charts-repository
   type: git
   source:
-    branch: master
+    branch: main
     private_key: {{github-private-key}}
     uri: {{release-helm-repo}}
 jobs:

--- a/deploy/ci/secrets.yml-sample
+++ b/deploy/ci/secrets.yml-sample
@@ -1,6 +1,6 @@
 # Branches
-stratos-deploy-branch: master
-stratos-ui-branch: master
+stratos-deploy-branch: main
+stratos-ui-branch: main
 ui-pr-label: my-pr-label
 
 # Images

--- a/deploy/kubernetes/console/Chart.yaml
+++ b/deploy/kubernetes/console/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 appVersion: 0.1.0
 sources:
   - https://github.com/cloudfoundry/stratos
-icon: https://raw.githubusercontent.com/cloudfoundry/stratos/master/deploy/kubernetes/console/icon.png
+icon: https://raw.githubusercontent.com/cloudfoundry/stratos/main/deploy/kubernetes/console/icon.png
 home: https://stratos.app
 maintainers:
   - name: Stratos Maintainers

--- a/docs/cf-api-v2-usage.md
+++ b/docs/cf-api-v2-usage.md
@@ -772,7 +772,7 @@ Endpoint | Inline Relations | Notes
 
 #### Others
 The include-relations property is populated by walking our relationship tree, so for a complete and exhaustive list of all possible
-relations please see the [`entity-factory.ts`](https://github.com/cloudfoundry/stratos/blob/master/src/frontend/app/store/helpers/entity-factory.ts).
+relations please see the [`entity-factory.ts`](https://github.com/cloudfoundry/stratos/blob/main/src/frontend/app/store/helpers/entity-factory.ts).
 
 In terms of api requests we also make use of...
 

--- a/docs/contributing_guide.md
+++ b/docs/contributing_guide.md
@@ -96,7 +96,7 @@ Browse [open issues](https://github.com/cloudfoundry/stratos/issues):
 ### 2. Create a Feature Branch
 
 All changes go to feature branches off `develop`. Never push directly to
-`develop` or `master`.
+`develop` or `main`.
 
 ```bash
 git checkout develop

--- a/docs/developer-environment.md
+++ b/docs/developer-environment.md
@@ -185,8 +185,8 @@ GitHub Actions workflows:
 
 | Workflow | File | Trigger |
 |----------|------|---------|
-| Frontend tests | `.github/workflows/frontend_tests.yml` | Push/PR to develop/master |
-| Backend tests | `.github/workflows/backend_tests.yml` | Push/PR to develop/master |
+| Frontend tests | `.github/workflows/frontend_tests.yml` | Push/PR to develop/main |
+| Backend tests | `.github/workflows/backend_tests.yml` | Push/PR to develop/main |
 | Docker builds | `.github/workflows/docker.yml` | Release + manual dispatch |
 
 ### Known CI Drift

--- a/docs/developer/developers-guide-e2e-tests.md
+++ b/docs/developer/developers-guide-e2e-tests.md
@@ -30,7 +30,7 @@ The tests require an instance of Cloud Foundry with the following:
 To meet the above requirements we recommend running the Stratos CF E2E set up script which is kept up to date with the latest test requirements.
 More information can be found [below](#running-the-e2e-set-up-script).
 
-Before running the E2E tests, you need to create a file named `secrets.yaml` in the root of the Stratos folder. An example template is included in [e2e/secrets.yaml.example](https://github.com/cloudfoundry/stratos/blob/master/e2e/secrets.yaml.example) - copy this to `secrets.yaml` and edit accordingly.
+Before running the E2E tests, you need to create a file named `secrets.yaml` in the root of the Stratos folder. An example template is included in [e2e/secrets.yaml.example](https://github.com/cloudfoundry/stratos/blob/main/e2e/secrets.yaml.example) - copy this to `secrets.yaml` and edit accordingly.
 
 If you want to run the tests in headless Chrome, add the following to the secrets file:
 
@@ -39,7 +39,7 @@ headless: true
 ```
 
 ## Running the E2E Set up Script
-The script can be found in [deploy/tools/init-cf-for-e2e.sh](https://github.com/cloudfoundry/stratos/blob/master/deploy/tools/init-cf-for-e2e.sh)
+The script can be found in [deploy/tools/init-cf-for-e2e.sh](https://github.com/cloudfoundry/stratos/blob/main/deploy/tools/init-cf-for-e2e.sh)
 
 ### Minimum Requirements
 - CF CLI
@@ -111,7 +111,7 @@ Given the output of the script, the following template can be used to update the
 
 ### Tidying up test generated CF entities
 If tests are stopped before completing or fail to clean old test artifacts will exist in the CF. To clean some of these please see the script
-at [deploy/ci/automation/e2e-clean-remnants.sh](https://github.com/cloudfoundry/stratos/blob/master/deploy/ci/automation/e2e-clean-remnants.sh)
+at [deploy/ci/automation/e2e-clean-remnants.sh](https://github.com/cloudfoundry/stratos/blob/main/deploy/ci/automation/e2e-clean-remnants.sh)
 
 ## Running the tests
 

--- a/docs/devops_guide.md
+++ b/docs/devops_guide.md
@@ -882,7 +882,7 @@ kubectl -n stratos run -it --rm debug --image=curlimages/curl --restart=Never --
 
 ### Documentation
 - [Official Docs](https://stratos.app/docs)
-- [Helm Chart](https://github.com/cloudfoundry/stratos/tree/master/deploy/kubernetes)
+- [Helm Chart](https://github.com/cloudfoundry/stratos/tree/main/deploy/kubernetes)
 - [Troubleshooting Guide](deploy/troubleshooting.md)
 
 ### Community

--- a/docs/extensions/disable-packages.md
+++ b/docs/extensions/disable-packages.md
@@ -9,10 +9,10 @@ Frontend packages and their associated backend plugins can be removed at build t
 ## Frontend Package to Backend Plugin Dependencies
 
 Stratos NPM packages define a list of backend plugins that they require in order to function. These are found in the package's `package.json` in
-the `stratos` section `backend` property. For instance the [Stratos Cloud Foundry](https://github.com/cloudfoundry/stratos/blob/master/src/frontend/packages/cloud-foundry/package.json)
+the `stratos` section `backend` property. For instance the [Stratos Cloud Foundry](https://github.com/cloudfoundry/stratos/blob/main/src/frontend/packages/cloud-foundry/package.json)
  package depends on multiple backend plugins.
 
-If a backend package is not referenced by a package that is built and is not in the 'default' plugins [list](https://github.com/cloudfoundry/stratos/blob/master/src/jetstream/default_plugins.go)
+If a backend package is not referenced by a package that is built and is not in the 'default' plugins [list](https://github.com/cloudfoundry/stratos/blob/main/src/jetstream/default_plugins.go)
  then it will not be included in the backend build. Therefore omitting a frontend package will also most likely remove it's dependent plugins.
 
 > [!IMPORTANT]

--- a/docs/extensions/introduction.md
+++ b/docs/extensions/introduction.md
@@ -29,7 +29,7 @@ More information can be found in the [custom plugins page](./backend.md).
 ## Examples
 
 ### ACME
-The ACME example contains a number of [theming](https://github.com/cloudfoundry/stratos/tree/master/src/frontend/packages/example-theme) and [functionality](https://github.com/cloudfoundry/stratos/tree/master/src/frontend/packages/example-extensions) customization.
+The ACME example contains a number of [theming](https://github.com/cloudfoundry/stratos/tree/main/src/frontend/packages/example-theme) and [functionality](https://github.com/cloudfoundry/stratos/tree/main/src/frontend/packages/example-extensions) customization.
 
 To run Stratos with these customizations
 

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -48,7 +48,7 @@ That's it! GitHub Actions handles everything else.
 
 ### Code Quality
 
-- [ ] All tests passing on develop/master branch
+- [ ] All tests passing on develop/main branch
 - [ ] No open critical bugs or blockers
 - [ ] All planned features merged
 - [ ] Code freeze announced (if applicable)
@@ -57,8 +57,8 @@ That's it! GitHub Actions handles everything else.
 **Verify:**
 ```bash
 # Check branch status
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 git status
 
 # Run the full quality gate (lint + unit tests)
@@ -113,7 +113,7 @@ make release cf FINAL=strip
 # Commit version bump (both files are updated automatically)
 git add package.json src/jetstream/VERSION
 git commit -m "chore: bump version to v5.0.0"
-git push origin master
+git push origin main
 ```
 
 Every `make bump` automatically appends `+build.YYYYMMDD.SHORT-SHA` build
@@ -252,9 +252,9 @@ git push origin v5.0.0-rc.2
 
 **Process:**
 ```bash
-# 1. Create hotfix branch from master
-git checkout master
-git pull origin master
+# 1. Create hotfix branch from main
+git checkout main
+git pull origin main
 git checkout -b hotfix/5.0.1
 
 # 2. Apply fix
@@ -262,8 +262,8 @@ git checkout -b hotfix/5.0.1
 make test
 git commit -am "fix: critical security issue"
 
-# 3. Merge to master
-git checkout master
+# 3. Merge to main
+git checkout main
 git merge hotfix/5.0.1
 
 # 4. Bump patch version
@@ -276,7 +276,7 @@ Critical security fix for authentication bypass.
 All users should upgrade immediately."
 
 # 6. Push
-git push origin master v5.0.1
+git push origin main v5.0.1
 ```
 
 **Timeline:** ~15 minutes
@@ -738,7 +738,7 @@ All users should upgrade immediately.
 Details: https://github.com/cloudfoundry/stratos/security/advisories/GHSA-XXXX"
 
 # 3. Push at coordinated time
-git push origin master v5.0.1
+git push origin main v5.0.1
 
 # 4. Publish security advisory
 gh advisory create

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "e2e:screenshot:v4": "E2E_BASE_URL=https://console481.run.adepttech.ca E2E_PROFILE=adepttech STRATOS_SCREENSHOT_LABEL=v4 playwright test e2e/tests/core/screenshots.spec.ts",
     "e2e:screenshot:v5": "E2E_BASE_URL=https://console.run.adepttech.ca E2E_PROFILE=adepttech STRATOS_SCREENSHOT_LABEL=v5 playwright test e2e/tests/core/screenshots.spec.ts",
     "e2e:screenshot:compare": "bunx tsx e2e/scripts/compare-screenshots.ts v4 v5",
-    "climate": "codeclimate analyze $(git diff --name-only master)",
+    "climate": "codeclimate analyze $(git diff --name-only main)",
     "gate-check": "bun run lint && bun run test && bun run build",
     "store-git-metadata": "sh -c 'mv build/store-git-metadata.js build/store-git-metadata.cjs 2>/dev/null || true && node build/store-git-metadata.cjs && mv build/store-git-metadata.cjs build/store-git-metadata.js 2>/dev/null || true'",
     "build-devkit": "cd src/frontend/packages/devkit && bun run build",


### PR DESCRIPTION
## ⚠ Merge after the rename

**Draft until the `master` → `main` rename executes** (requested from org admins in cloudfoundry/community#1544; protection pre-staged in cloudfoundry/community#1537). Merging early would point the chart icon raw URL at a branch that doesn't exist yet. Once the rename lands, this should merge promptly — develop's `master` refs (icon raw URL, workflow triggers) break at rename time until it does.

Closes #5507

## What

Swaps every in-repo reference to stratos's own `master` branch over to `main`:

- **Workflow triggers**: `pr.yml`, `stb_tests.yml`, `backend_tests.yml`, `frontend_tests.yml`, `documentation.yml`
- **Release CI**: `deploy/ci/console-sync-release.yml` (`branch: master`) + `deploy/ci/secrets.yml-sample` branch defaults
- **`deploy/kubernetes/console/Chart.yaml`** icon raw URL — the one mandatory link fix (raw.githubusercontent URLs do **not** redirect on branch rename; blob/tree web URLs do)
- **`package.json`** `climate` script diff base
- **`.travis.yml`** branch allowlist (`v2-master` left as-is — that branch still exists)
- **Docs**: `release_guide.md` (release flow now cuts from `main`), `contributing_guide.md`, `developer-environment.md`, `devops_guide.md`, `cf-api-v2-usage.md`, README license badge
- **`CONTRIBUTING.md`**: also fixes the stale claim that PRs target `master` — `develop` is the PR target; `main` is the release line

## Deliberately untouched

Other projects' `master` URLs (helm, gimme, mo, mariadb, angular-cli, monocular, golang/dep), historical CHANGELOG entries, "master/detail" UI-pattern comments, the e2e branch-name matcher (already accepts both), and the codecov badge (points at the cloudfoundry-community fork).

All edited YAML validated. 17 files, 34 substitutions.