### PR TITLE
ci: fix bun cache key, pin bun version, freeze lockfile installs

### DIFF
--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -13,7 +13,7 @@ on:
 env:
   NODE_OPTIONS: --max-old-space-size=5500
   NODE_VERSION: '24'
-  BUN_VERSION: 'latest'
+  BUN_VERSION: '1.3.14'
 
 jobs:
   test_suite:
@@ -32,7 +32,7 @@ jobs:
         bun-version: ${{ env.BUN_VERSION }}
 
     - name: Install Dependencies
-      run: bun install
+      run: bun install --frozen-lockfile
 
     - name: Generate build info
       run: make stamp frontend

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ env:
   NODE_OPTIONS: --max-old-space-size=5500
   NODE_VERSION: '24'
   GO_VERSION: '1.26'
-  BUN_VERSION: 'latest'
+  BUN_VERSION: '1.3.14'
 
 jobs:
   # Decide whether this PR touches anything outside tools/stb. All the real
@@ -71,12 +71,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run linting
         run: bun run lint
@@ -113,12 +113,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Generate build info
         run: make stamp frontend
@@ -153,7 +153,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Create extra_plugins.go
         run: |
@@ -207,12 +207,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Create extra_plugins.go
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
   NODE_OPTIONS: --max-old-space-size=5500
   NODE_VERSION: '24'
   GO_VERSION: '1.26'
-  BUN_VERSION: 'latest'
+  BUN_VERSION: '1.3.14'
 
 jobs:
   validate-version:
@@ -78,7 +78,7 @@ jobs:
           cache-dependency-path: src/jetstream/go.sum
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build all (frontend + cross-compile backends)
         run: make build all VERSION=${{ needs.validate-version.outputs.version }}


### PR DESCRIPTION
## What

Three CI hardening fixes for the recurring install-time flakes (root-cause analysis in #5542):

1. **Cache key**: `hashFiles('**/bun.lockb')` → `hashFiles('**/bun.lock')` (3 sites in `pr.yml`). The repo has the text-format lockfile; the old glob matched nothing, so every run on every PR resolved to one constant, never-invalidated cache key — changed dependencies were re-downloaded from the registry on every job.
2. **Pin bun**: `BUN_VERSION: 'latest'` → `'1.3.14'` in `pr.yml`, `frontend_tests.yml`, `release.yml`. 1.3.14 is verified green (PR #5541 rerun). Bump deliberately from now on.
3. **Frozen installs**: `bun install` → `bun install --frozen-lockfile` (6 sites) so CI installs are reproducible and lockfile drift fails loudly.

## Why

Two install-infra failures in two days on unrelated PRs — `Integrity check failed for tarball: terser` on docs-only #5541, and an esbuild postinstall failure the day before. The stb/non-stb job split roughly doubled installs per PR, turning rare registry blips into recurring flakes. Details in #5542.

Closes #5542
