### PR TITLE
stb: composite facet framework

### DIFF
--- a/tools/stb/docs/text-contrast-and-dark-mode.md
+++ b/tools/stb/docs/text-contrast-and-dark-mode.md
@@ -1,0 +1,120 @@
+# Text contrast against arbitrary backgrounds
+
+How to pick a text color that stays readable — and doesn't turn muddy — against
+whatever background it sits on: flat colors, gradients, images, translucent
+tints, light and dark mode. Distilled from collected research notes and
+corrected after verification on 2026-07-02; every formula below was checked
+numerically.
+
+## The verified core: WCAG 2.x luminance
+
+Already implemented in `src/color/contrast.ts` (`relativeLuminance`,
+`contrastRatio`) — use those, don't re-derive. The math, for reference:
+
+1. Linearize each sRGB channel: `c ≤ 0.04045 ? c/12.92 : ((c+0.055)/1.055)^2.4`
+   (contrast.ts uses the WCAG-published `0.03928` cutoff; the difference is
+   below one 8-bit step — either is fine, don't "fix" it).
+2. Relative luminance `L = 0.2126·R + 0.7152·G + 0.0722·B`.
+3. Contrast ratio `(L_hi + 0.05) / (L_lo + 0.05)`, range 1–21.
+
+**Black-or-white text decision:** flip on the break-even luminance
+
+```
+L_break = √(1.05 × 0.05) − 0.05 = 0.1791
+```
+
+- `L > 0.179` → black text, else white.
+- Guarantee (proven): the better of black/white always achieves at least
+  `√21 ≈ 4.58:1`, so the binary choice **always passes WCAG AA** (4.5:1,
+  normal text) on a flat opaque background.
+- The threshold check and "compute both ratios, keep the larger" are
+  mathematically equivalent — use the threshold, it's one comparison.
+
+## Rules the naive version gets wrong
+
+These are the three failure modes found (with counterexamples) in the original
+notes — each one produces exactly the unreadable/muddy text this doc exists to
+prevent.
+
+1. **Re-check every derived shade.** A hover/active variant shifted in
+   lightness must get its own contrast decision. Counterexample: accent
+   `#8a8a8a` takes black text at 6.08:1, but its −10-lightness hover `#717171`
+   drops black text to 4.30:1 — an AA failure on the state the user is
+   actively pointing at. Contrast is a property of the *(text, surface)* pair,
+   never of the brand color alone.
+2. **Contrast against the surface actually painted.** Text on a ±40-lightness
+   "subtle" tint must be checked against the tint, not the accent it was
+   derived from (white text chosen for a dark accent is unreadable on that
+   accent's pastel tint).
+3. **Composite alpha first.** A translucent surface (`bg-accent/10`, overlay
+   scrims) has no luminance of its own — blend it over what's underneath
+   (`out = α·fg + (1−α)·bg`, per channel, *before* linearization is wrong;
+   composite in linear space or accept the small error consciously), then run
+   the math on the result.
+
+## Backgrounds that aren't flat colors
+
+This is stb's actual terrain — the background facet is a color backstop plus a
+stack of image/gradient layers (`src/metadata/facets.ts`, `backgroundCss`).
+
+- **Gradient:** one text color must survive the whole surface. Evaluate the
+  contrast decision at every stop (stops are where the extremes live for a
+  two-stop gradient; sample midpoints too when stops are many or the
+  interpolation is long). Choose the color that passes *all* of them; if none
+  does, the gradient itself is the problem — surface that to the user rather
+  than silently picking the least-bad text.
+- **Image:** no closed form. Either sample the region behind the text (canvas
+  readback) or — the robust designer's answer — put a scrim between image and
+  text (a translucent black/white layer or a gradient fade) and contrast
+  against the composited scrim. stb's layer stack expresses a scrim naturally:
+  it's just one more gradient layer above the image.
+- **`transparent` backstop / no paint:** the effective background is whatever
+  the cascade paints underneath — resolve through the stack (element layers →
+  parent surfaces → page background) before deciding.
+
+## Avoiding *muddy*, not just *failing*
+
+WCAG 2.x ratios are known to overrate white text on mid-tone saturated
+backgrounds (oranges, mid-blues, magentas) — text can pass 4.5:1 and still
+look washed out. Two practical mitigations, short of adopting APCA (the WCAG 3
+draft model, which fixes this but has no normative standing yet):
+
+- Treat 4.5:1 as a floor, not a target — aim ≥ 7:1 for body text when the
+  choice is free.
+- Do all lightness *manipulation* in **OKLCH**, never HSL. HSL lightness is not
+  perceptually uniform (a ±10 HSL shift is a different visual step per hue,
+  which is where muddy hover states come from). stb already standardizes on
+  OKLCH — `src/color/oklch.ts` (`toOklch`, `oklchToHex`) and
+  `src/color/derive-dark.ts` (role-aware dark derivation: surfaces darken,
+  foregrounds keep hue and lift lightness for contrast). Derive shades in
+  OKLCH, then *verify* them with WCAG luminance (rule 1 above). The two systems
+  answer different questions: OKLCH = "how do I move a color," WCAG = "can I
+  read this."
+
+## Platform notes (Stratos specifics)
+
+- **Dark mode is a class, not a media query.** Stratos toggles `.dark-theme`
+  (stb emits `html:not(.dark-theme)` / `.dark-theme` scoped rules —
+  `src/parse/css-emitter.ts`). CSS `light-dark()` and Tailwind's `dark:`
+  variant only help if their mode source is wired to that class; don't mix a
+  `prefers-color-scheme`-driven mechanism into class-driven theming.
+- **Tailwind v4, not v3.** Runtime-themable tokens are declared in CSS
+  (`theme/styles/tailwind.css`), not `tailwind.config.js`. To map a runtime
+  variable into utilities use `@theme inline` so `bg-accent` compiles to
+  `background-color: var(--user-accent)`; opacity modifiers (`bg-accent/10`)
+  work in v4 via `color-mix()`. The v3 config-object pattern in the original
+  notes does not carry over (and its `/10` modifier never worked in v3 with an
+  opaque var anyway).
+- **Dark values are a color axis only** (design rule, 2026-07-01): mode may
+  change colors, backgrounds, shadow/border paint — never spacing or
+  typography.
+
+## What to build on, in order
+
+1. `contrastRatio` / `relativeLuminance` (`src/color/contrast.ts`) — the
+   verified decision core.
+2. OKLCH derivation (`src/color/oklch.ts`, `src/color/derive-dark.ts`) — shade
+   generation.
+3. Per-stop gradient checking + alpha compositing — the missing piece if stb
+   ever auto-suggests text colors for themed surfaces; the facet model already
+   exposes every stop and layer needed to do it.

--- a/tools/stb/public/preview-shim.js
+++ b/tools/stb/public/preview-shim.js
@@ -90,6 +90,55 @@
     document.head.appendChild(el);
   }
 
+  // Plain-JS mirror of the closed-grammar subset parser — reference
+  // implementation: src/content/subset-format.ts (keep the two in lockstep).
+  // Grammar v1: **bold** → <strong>, _italic_ → <em>, newline → <br>;
+  // everything else is a text node; unterminated markers render literally.
+  // DELIBERATELY DOM-construction, NOT innerHTML: this shim accepts postMessage
+  // from any origin ('*'), so an innerHTML sink here would be an XSS primitive
+  // for any window that can message the iframe. Building only strong/em/br/text
+  // nodes bounds a hostile payload to harmless formatting.
+  function renderSubsetInto(el, text) {
+    el.textContent = '';
+    appendSubsetSpan(el, String(text));
+  }
+  function appendSubsetSpan(parent, s) {
+    var doc = parent.ownerDocument;
+    var buf = '';
+    function flush() {
+      if (buf) { parent.appendChild(doc.createTextNode(buf)); buf = ''; }
+    }
+    var i = 0;
+    while (i < s.length) {
+      var ch = s[i];
+      if (ch === '\n') { flush(); parent.appendChild(doc.createElement('br')); i++; continue; }
+      if (s.slice(i, i + 2) === '**') {
+        var endB = s.indexOf('**', i + 2);
+        if (endB !== -1) {
+          flush();
+          var strong = doc.createElement('strong');
+          appendSubsetSpan(strong, s.slice(i + 2, endB));
+          parent.appendChild(strong);
+          i = endB + 2;
+          continue;
+        }
+      } else if (ch === '_') {
+        var endI = s.indexOf('_', i + 1);
+        if (endI !== -1) {
+          flush();
+          var em = doc.createElement('em');
+          appendSubsetSpan(em, s.slice(i + 1, endI));
+          parent.appendChild(em);
+          i = endI + 1;
+          continue;
+        }
+      }
+      buf += ch;
+      i++;
+    }
+    flush();
+  }
+
   function applyLeversInShim(levers) {
     for (var i = 0; i < (levers || []).length; i++) {
       var p = levers[i];
@@ -101,7 +150,10 @@
       }
       var e = document.querySelector('[stb-snapshot-id="' + p.snapshotId + '"]');
       if (!e) continue;
-      if (p.kind === 'content' && p.text !== undefined) e.textContent = p.text;
+      if (p.kind === 'content' && p.text !== undefined) {
+        if (p.format === 'subset') renderSubsetInto(e, p.text);
+        else e.textContent = p.text;
+      }
       if (p.kind === 'asset') {
         var src = p.blob ? URL.createObjectURL(p.blob) : p.ref; // NOTE: object URL not revoked
         if (src === undefined) continue;

--- a/tools/stb/public/snapshots/v1/app-list/branding-model.json
+++ b/tools/stb/public/snapshots/v1/app-list/branding-model.json
@@ -7,8 +7,8 @@
       "name": "Applications page",
       "description": "background color for the applications list page",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 0.97,
               "c": 0.01,
@@ -24,8 +24,8 @@
       "name": "Navigation bar",
       "description": "top navigation bar background for the applications page",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 0.22,
               "c": 0.01,
@@ -52,8 +52,8 @@
       "name": "App card 1",
       "description": "card background for an application tile",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 1,
               "c": 0,
@@ -97,8 +97,8 @@
       "name": "App card 2",
       "description": "card background for an application tile",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 1,
               "c": 0,
@@ -142,8 +142,8 @@
       "name": "App card 3",
       "description": "card background for an application tile",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 1,
               "c": 0,

--- a/tools/stb/public/snapshots/v1/app-list/values.json
+++ b/tools/stb/public/snapshots/v1/app-list/values.json
@@ -1,11 +1,11 @@
 {
   "cf.applications.page": {
     "name": "Applications page",
-    "facets": { "surface": { "background": { "literal": { "l": 0.97, "c": 0.01, "h": 250 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 0.97, "c": 0.01, "h": 250 } } } }
   },
   "cf.applications.nav": {
     "name": "Navigation bar",
-    "facets": { "surface": { "background": { "literal": { "l": 0.22, "c": 0.01, "h": 250 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 0.22, "c": 0.01, "h": 250 } } } }
   },
   "cf.applications.heading": {
     "name": "Page heading",
@@ -13,7 +13,7 @@
   },
   "cf.applications.app-card-1": {
     "name": "App card 1",
-    "facets": { "surface": { "background": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
   },
   "cf.applications.app-card-1.heading": {
     "name": "App name",
@@ -25,7 +25,7 @@
   },
   "cf.applications.app-card-2": {
     "name": "App card 2",
-    "facets": { "surface": { "background": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
   },
   "cf.applications.app-card-2.heading": {
     "name": "App name",
@@ -37,7 +37,7 @@
   },
   "cf.applications.app-card-3": {
     "name": "App card 3",
-    "facets": { "surface": { "background": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
   },
   "cf.applications.app-card-3.heading": {
     "name": "App name",

--- a/tools/stb/public/snapshots/v1/login/branding-model.json
+++ b/tools/stb/public/snapshots/v1/login/branding-model.json
@@ -7,8 +7,8 @@
       "name": "Login page",
       "description": "background color for the login page",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 0.97,
               "c": 0.01,
@@ -25,8 +25,13 @@
       "name": "Background",
       "description": "background image for the login page",
       "facets": {
-        "asset": {
-          "ref": "login-bg.svg"
+        "background": {
+          "layers": [
+            {
+              "kind": "image",
+              "ref": "login-bg.svg"
+            }
+          ]
         }
       }
     },
@@ -36,8 +41,8 @@
       "name": "Login card",
       "description": "card background for the login page",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 1,
               "c": 0,

--- a/tools/stb/public/snapshots/v1/login/routing.json
+++ b/tools/stb/public/snapshots/v1/login/routing.json
@@ -1,8 +1,8 @@
 {
   "containers": { "auth.login": "login" },
   "elements": {
-    "auth.login.page":               { "properties": { "surface.background": { "config": "backgroundColor" } } },
-    "auth.login.page.card":          { "properties": { "surface.background": { "config": "cardBackground" } } },
+    "auth.login.page":               { "properties": { "background.color": { "config": "backgroundColor" } } },
+    "auth.login.page.card":          { "properties": { "background.color": { "config": "cardBackground" } } },
     "auth.login.page.card.title":    { "visibilityConfig": "showTitle", "properties": { "content": { "config": "title" } } },
     "auth.login.page.card.subtitle": { "properties": { "content": { "config": "subtitle" } } },
     "auth.login.page.card.message":  { "properties": { "content": { "config": "customMessage" } } },

--- a/tools/stb/public/snapshots/v1/login/values.json
+++ b/tools/stb/public/snapshots/v1/login/values.json
@@ -1,11 +1,11 @@
 {
   "auth.login.page": {
     "name": "Login page",
-    "facets": { "surface": { "background": { "literal": { "l": 0.97, "c": 0.01, "h": 250 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 0.97, "c": 0.01, "h": 250 } } } }
   },
   "auth.login.page.card": {
     "name": "Login card",
-    "facets": { "surface": { "background": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
   },
   "auth.login.page.card.title": {
     "name": "Welcome message",
@@ -27,7 +27,7 @@
   },
   "auth.login.page.background": {
     "name": "Background",
-    "facets": { "asset": { "ref": "login-bg.svg" } }
+    "facets": { "background": { "layers": [{ "kind": "image", "ref": "login-bg.svg" }] } }
   },
   "auth.login.page.card.sign-in": {
     "name": "Sign in",

--- a/tools/stb/public/snapshots/v1/shared/branding-model.json
+++ b/tools/stb/public/snapshots/v1/shared/branding-model.json
@@ -31,6 +31,18 @@
       }
     },
     {
+      "snapshotId": "shared.confirm-dialog.message",
+      "role": "paragraph",
+      "name": "Dialog message",
+      "description": "message text for the shared confirmation dialog",
+      "facets": {
+        "content": {
+          "text": "This action cannot be undone.",
+          "format": "subset"
+        }
+      }
+    },
+    {
       "snapshotId": "shared.confirm-dialog.cancel",
       "role": "button",
       "name": "Cancel button",

--- a/tools/stb/public/snapshots/v1/shared/branding-model.json
+++ b/tools/stb/public/snapshots/v1/shared/branding-model.json
@@ -7,8 +7,8 @@
       "name": "Confirm dialog",
       "description": "surface/background colour for the shared confirmation dialog",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 1,
               "c": 0,
@@ -70,8 +70,8 @@
       "name": "Stepper",
       "description": "surface/background colour for the shared stepper wizard",
       "facets": {
-        "surface": {
-          "background": {
+        "background": {
+          "color": {
             "literal": {
               "l": 0.98,
               "c": 0.005,

--- a/tools/stb/public/snapshots/v1/shared/index.html
+++ b/tools/stb/public/snapshots/v1/shared/index.html
@@ -9,7 +9,7 @@
     <main class="shared-grid">
       <section class="confirm-dialog" stb-snapshot-id="shared.confirm-dialog" stba-role="dialog" stba-roledescription="dialog" stba-description="surface/background colour for the shared confirmation dialog">
         <h1 stb-snapshot-id="shared.confirm-dialog.title" stba-role="heading" stba-description="title text for the shared confirmation dialog">Are you sure?</h1>
-        <p>This action cannot be undone.</p>
+        <p stb-snapshot-id="shared.confirm-dialog.message" stba-role="paragraph" stba-description="message text for the shared confirmation dialog">This action cannot be undone.</p>
         <div class="actions">
           <button class="btn-secondary" stb-snapshot-id="shared.confirm-dialog.cancel" stba-role="button" stba-description="cancel button colour for the shared confirmation dialog">Cancel</button>
           <button class="btn-primary" stb-snapshot-id="shared.confirm-dialog.confirm" stba-role="button" stba-description="confirm button colour for the shared confirmation dialog">Confirm</button>

--- a/tools/stb/public/snapshots/v1/shared/values.json
+++ b/tools/stb/public/snapshots/v1/shared/values.json
@@ -1,7 +1,7 @@
 {
   "shared.confirm-dialog": {
     "name": "Confirm dialog",
-    "facets": { "surface": { "background": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 1, "c": 0, "h": 0 } } } }
   },
   "shared.confirm-dialog.title": {
     "name": "Dialog title",
@@ -17,7 +17,7 @@
   },
   "shared.stepper": {
     "name": "Stepper",
-    "facets": { "surface": { "background": { "literal": { "l": 0.98, "c": 0.005, "h": 250 } } } }
+    "facets": { "background": { "color": { "literal": { "l": 0.98, "c": 0.005, "h": 250 } } } }
   },
   "shared.stepper.cancel": {
     "name": "Cancel button",

--- a/tools/stb/public/snapshots/v1/shared/values.json
+++ b/tools/stb/public/snapshots/v1/shared/values.json
@@ -7,6 +7,10 @@
     "name": "Dialog title",
     "facets": { "content": { "text": "Are you sure?" } }
   },
+  "shared.confirm-dialog.message": {
+    "name": "Dialog message",
+    "facets": { "content": { "text": "This action cannot be undone.", "format": "subset" } }
+  },
   "shared.confirm-dialog.cancel": {
     "name": "Cancel button",
     "facets": { "text": { "color": { "literal": { "l": 0.86, "c": 0.01, "h": 250 } } } }

--- a/tools/stb/src/content/subset-format.ts
+++ b/tools/stb/src/content/subset-format.ts
@@ -1,0 +1,92 @@
+// Closed-grammar "subset" content format — grammar v1:
+//   **bold** → <strong>, _italic_ → <em>, newline → <br>; EVERYTHING else is text.
+// The parser only ever constructs strong/em/br elements and text nodes; there is
+// deliberately NO innerHTML anywhere in this module (the DOM form is built node
+// by node, the HTML form by escaping text segments). Unterminated markers render
+// literally as text. public/preview-shim.js carries a plain-JS mirror of this
+// parser — keep the two in lockstep.
+
+export type ContentFormat = 'plain' | 'subset';
+
+type SubsetNode =
+  | { t: 'text'; v: string }
+  | { t: 'br' }
+  | { t: 'strong' | 'em'; children: SubsetNode[] };
+
+function parseSpan(s: string): SubsetNode[] {
+  const out: SubsetNode[] = [];
+  let buf = '';
+  const flush = (): void => {
+    if (buf) { out.push({ t: 'text', v: buf }); buf = ''; }
+  };
+  let i = 0;
+  while (i < s.length) {
+    const ch = s[i]!;
+    if (ch === '\n') { flush(); out.push({ t: 'br' }); i++; continue; }
+    if (s.startsWith('**', i)) {
+      const end = s.indexOf('**', i + 2);
+      if (end !== -1) {
+        flush();
+        out.push({ t: 'strong', children: parseSpan(s.slice(i + 2, end)) });
+        i = end + 2;
+        continue;
+      }
+      // unterminated ** → literal text
+    } else if (ch === '_') {
+      const end = s.indexOf('_', i + 1);
+      if (end !== -1) {
+        flush();
+        out.push({ t: 'em', children: parseSpan(s.slice(i + 1, end)) });
+        i = end + 1;
+        continue;
+      }
+      // unterminated _ → literal text
+    }
+    buf += ch;
+    i++;
+  }
+  flush();
+  return out;
+}
+
+function appendNodes(parent: Element, nodes: SubsetNode[]): void {
+  const doc = parent.ownerDocument;
+  for (const n of nodes) {
+    if (n.t === 'text') {
+      parent.appendChild(doc.createTextNode(n.v));
+    } else if (n.t === 'br') {
+      parent.appendChild(doc.createElement('br'));
+    } else {
+      const el = doc.createElement(n.t);
+      appendNodes(el, n.children);
+      parent.appendChild(el);
+    }
+  }
+}
+
+/** Render subset-formatted text into `el` by DOM construction (replaces children). */
+export function renderSubsetInto(el: Element, text: string): void {
+  el.textContent = '';
+  appendNodes(el, parseSpan(text));
+}
+
+const ESCAPES: Record<string, string> = {
+  '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+};
+const escapeText = (s: string): string => s.replace(/[&<>"']/g, (c) => ESCAPES[c]!);
+
+function serialize(nodes: SubsetNode[]): string {
+  return nodes
+    .map((n) => {
+      if (n.t === 'text') return escapeText(n.v);
+      if (n.t === 'br') return '<br>';
+      return `<${n.t}>${serialize(n.children)}</${n.t}>`;
+    })
+    .join('');
+}
+
+/** Serialize subset-formatted text to safe HTML: text segments are escaped
+ *  (&<>"'), tags come only from the closed set {strong, em, br}. */
+export function subsetToSafeHtml(text: string): string {
+  return serialize(parseSpan(text));
+}

--- a/tools/stb/src/iframe-bridge/apply-levers.ts
+++ b/tools/stb/src/iframe-bridge/apply-levers.ts
@@ -28,8 +28,12 @@ export function applyLevers(doc: Document, levers: LeverPatch[]): void {
       else el.style.backgroundImage = `url(${src})`;
     }
     if (p.kind === 'background') {
-      if (p.backgroundColor) el.style.backgroundColor = p.backgroundColor;
-      if (p.backgroundImage) el.style.backgroundImage = p.backgroundImage;
+      // A background patch owns BOTH inline props: an absent component clears the
+      // previous inline value (removing the last layer must drop the stale image).
+      // When no background patch is sent at all (e.g. dark preview with no dark
+      // override), this branch never runs — scoped blocks / dark CSS keep owning it.
+      el.style.backgroundColor = p.backgroundColor ?? '';
+      el.style.backgroundImage = p.backgroundImage ?? '';
     }
   }
 }

--- a/tools/stb/src/iframe-bridge/apply-levers.ts
+++ b/tools/stb/src/iframe-bridge/apply-levers.ts
@@ -1,10 +1,12 @@
 export interface LeverPatch {
   snapshotId: string;
-  kind: 'content' | 'asset' | 'visibility';
+  kind: 'content' | 'asset' | 'visibility' | 'background';
   text?: string;
   ref?: string;
   shown?: boolean;
   blob?: Blob;
+  backgroundColor?: string;
+  backgroundImage?: string;
 }
 
 export function applyLevers(doc: Document, levers: LeverPatch[]): void {
@@ -24,6 +26,10 @@ export function applyLevers(doc: Document, levers: LeverPatch[]): void {
       if (src === undefined) continue;
       if (el instanceof HTMLImageElement) el.setAttribute('src', src);
       else el.style.backgroundImage = `url(${src})`;
+    }
+    if (p.kind === 'background') {
+      if (p.backgroundColor) el.style.backgroundColor = p.backgroundColor;
+      if (p.backgroundImage) el.style.backgroundImage = p.backgroundImage;
     }
   }
 }

--- a/tools/stb/src/iframe-bridge/apply-levers.ts
+++ b/tools/stb/src/iframe-bridge/apply-levers.ts
@@ -1,7 +1,13 @@
+import { renderSubsetInto } from '@/content/subset-format';
+import type { ContentFormat } from '@/metadata/types';
+
 export interface LeverPatch {
   snapshotId: string;
   kind: 'content' | 'asset' | 'visibility' | 'background';
   text?: string;
+  /** Content text format; absent = plain (textContent). 'subset' renders the
+   *  closed grammar via DOM construction — see src/content/subset-format.ts. */
+  format?: ContentFormat;
   ref?: string;
   shown?: boolean;
   blob?: Blob;
@@ -20,7 +26,10 @@ export function applyLevers(doc: Document, levers: LeverPatch[]): void {
     }
     const el = doc.querySelector<HTMLElement>(`[stb-snapshot-id="${p.snapshotId}"]`);
     if (!el) continue;
-    if (p.kind === 'content' && p.text !== undefined) el.textContent = p.text;
+    if (p.kind === 'content' && p.text !== undefined) {
+      if (p.format === 'subset') renderSubsetInto(el, p.text);
+      else el.textContent = p.text;
+    }
     if (p.kind === 'asset') {
       const src = p.blob ? URL.createObjectURL(p.blob) : p.ref; // NOTE: object URL not revoked; revoke-prev if preview leaks
       if (src === undefined) continue;

--- a/tools/stb/src/iframe-bridge/apply-levers.ts
+++ b/tools/stb/src/iframe-bridge/apply-levers.ts
@@ -3,7 +3,7 @@ import type { ContentFormat } from '@/metadata/types';
 
 export interface LeverPatch {
   snapshotId: string;
-  kind: 'content' | 'asset' | 'visibility' | 'background';
+  kind: 'content' | 'asset' | 'visibility';
   text?: string;
   /** Content text format; absent = plain (textContent). 'subset' renders the
    *  closed grammar via DOM construction — see src/content/subset-format.ts. */
@@ -11,8 +11,6 @@ export interface LeverPatch {
   ref?: string;
   shown?: boolean;
   blob?: Blob;
-  backgroundColor?: string;
-  backgroundImage?: string;
 }
 
 export function applyLevers(doc: Document, levers: LeverPatch[]): void {
@@ -35,14 +33,6 @@ export function applyLevers(doc: Document, levers: LeverPatch[]): void {
       if (src === undefined) continue;
       if (el instanceof HTMLImageElement) el.setAttribute('src', src);
       else el.style.backgroundImage = `url(${src})`;
-    }
-    if (p.kind === 'background') {
-      // A background patch owns BOTH inline props: an absent component clears the
-      // previous inline value (removing the last layer must drop the stale image).
-      // When no background patch is sent at all (e.g. dark preview with no dark
-      // override), this branch never runs — scoped blocks / dark CSS keep owning it.
-      el.style.backgroundColor = p.backgroundColor ?? '';
-      el.style.backgroundImage = p.backgroundImage ?? '';
     }
   }
 }

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -18,7 +18,7 @@ import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens, reprojectNodeTokensDark } from '@/ui/element-edit';
 import { FACET_PROPS, facetDeclarations } from '@/metadata/facets';
-import { setFacetProp, addGroup, removeGroup, setBackstop, addLayer, setLayer, removeLayer, reorderLayer } from '@/state/facets-edit';
+import { setFacetProp, addGroup, removeGroup, setBackstop, addLayer, setLayer, removeLayer, reorderLayer, addFont, setFont, removeFont, reorderFont } from '@/state/facets-edit';
 import { deriveDarkOklch } from '@/color/derive-dark';
 import type { Oklch } from '@/color/oklch';
 import { effect } from '@preact/signals-core';
@@ -199,6 +199,30 @@ async function main() {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, reorderLayer(n.facets, from, to));
+        selectElement(snapshotId);
+      },
+      onAddFont: (value) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, addFont(n.facets, value));
+        selectElement(snapshotId);
+      },
+      onSetFont: (index, value) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, setFont(n.facets, index, value));
+        selectElement(snapshotId);
+      },
+      onRemoveFont: (index) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, removeFont(n.facets, index));
+        selectElement(snapshotId);
+      },
+      onReorderFont: (from, to) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, reorderFont(n.facets, from, to));
         selectElement(snapshotId);
       },
       colorFormat: () => colorFormat.value,

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -190,6 +190,19 @@ async function main() {
         if (!n) return;
         setNodeFacets(snapshotId, setLayer(n.facets, index, layer));
       },
+      onSetLayerDark: (index, layer) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        // Copy-on-first-dark-edit: seed the dark background's layer array as a
+        // structural copy of the light layers before the first dark layer edit.
+        // After this point light and dark layer structures are independent forks —
+        // editing one never touches the other.
+        const darkBg = n.facetsDark?.background;
+        const seededDarkFacets = darkBg?.layers
+          ? n.facetsDark!
+          : { ...(n.facetsDark ?? {}), background: { ...darkBg, layers: JSON.parse(JSON.stringify(n.facets.background?.layers ?? [])) } };
+        setNodeFacetsDark(snapshotId, setLayer(seededDarkFacets, index, layer));
+      },
       onRemoveLayer: (index) => {
         const n = nodeFor(snapshotId);
         if (!n) return;

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -151,7 +151,8 @@ async function main() {
         const lit = v && 'literal' in v && typeof v.literal === 'object' ? v.literal as Oklch : null;
         if (!lit) return;
         // A surface fill darkens; text/borders keep their colour and lift for contrast.
-        const role = key === 'surface.background' ? 'background' : 'foreground';
+        // (background.color replaced surface.background in the composite-facet migration.)
+        const role = key === 'background.color' ? 'background' : 'foreground';
         const facetsDark = setFacetProp(n.facetsDark ?? {}, key, { literal: deriveDarkOklch(lit, { role }) });
         setNodeFacetsDark(snapshotId, facetsDark);
         reprojectNodeTokensDark(snapshotId, facetsDark, routing);

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -3,7 +3,8 @@ import { mountEditorPane } from '@/ui/editor-pane';
 import { mountTokenSidebar } from '@/ui/token-sidebar';
 import { mountElementTree } from '@/ui/element-tree';
 import { mountElementColumns } from '@/ui/element-columns';
-import { createPreviewPane } from '@/ui/preview-pane';
+import { createPreviewPane, mountCompareToggle } from '@/ui/preview-pane';
+import type { PreviewPane } from '@/ui/preview-pane';
 import { openColorPicker } from '@/ui/color-picker';
 import { createHighlightWiring } from '@/ui/highlight';
 import { mountLightDarkActions } from '@/ui/light-dark-actions';
@@ -39,7 +40,10 @@ async function main() {
       <div class="stb-sidebar-host"></div>
       <div class="stb-editor-host"></div>
     </div>
-    <div class="stb-preview-host"></div>
+    <div class="stb-preview-host">
+      <div class="stb-preview-pane" data-stb-pane="primary"></div>
+      <div class="stb-preview-pane" data-stb-pane="dark" hidden></div>
+    </div>
   `;
 
   const restored = restoreSession();
@@ -116,8 +120,9 @@ async function main() {
     const node = nodeFor(snapshotId);
     if (!node) return;
     // reveal the selected element so a hidden/empty target (e.g. an empty error
-    // alert) shows its color in the preview while you theme it
-    preview.revealElement(snapshotId);
+    // alert) shows its color in the preview while you theme it — in compare
+    // mode both panes reveal, so light and dark stay structurally identical
+    forEachPane((p) => p.revealElement(snapshotId));
     const companion = buildVisibilityCompanion(snapshotId, node.visibility);
     openLeverEditor({
       previewHost,
@@ -270,29 +275,52 @@ async function main() {
   // forward-declared so onElementSelected can drive the columns (bidirectional select)
   let columnsApi: import('@/ui/element-columns').ElementColumnsApi | null = null;
 
-  const preview = createPreviewPane({
-    onElementSelected: (_selector, tokens, snapshotId) => {
-      if (tokens.length) { wiring.scrollSidebarToToken(sidebarHost, tokens[0]!); wiring.flashSidebarRows(sidebarHost, tokens); }
-      // jump the columns so the selection is reflected there (bidirectional), then edit
-      if (snapshotId) { columnsApi?.jumpTo(snapshotId); selectElement(snapshotId); } // render → columns (R1/§2.6)
-    },
-  });
-  preview.mount(app.querySelector('.stb-preview-host') as HTMLElement);
+  // ONE select pipeline for every pane — a click in either compare pane lands
+  // in the same editor (messages are pane-scoped, so exactly one pane fires).
+  const onPreviewElementSelected = (_selector: string, tokens: string[], snapshotId: string | null) => {
+    if (tokens.length) { wiring.scrollSidebarToToken(sidebarHost, tokens[0]!); wiring.flashSidebarRows(sidebarHost, tokens); }
+    // jump the columns so the selection is reflected there (bidirectional), then edit
+    if (snapshotId) { columnsApi?.jumpTo(snapshotId); selectElement(snapshotId); } // render → columns (R1/§2.6)
+  };
+
+  const preview = createPreviewPane({ onElementSelected: onPreviewElementSelected });
+  preview.mount(previewHost.querySelector('[data-stb-pane="primary"]') as HTMLElement);
+
+  // The pinned-dark compare pane is created lazily on first Compare enable and
+  // then kept (hidden host when compare is off) — panes have no unmount, so
+  // create-once avoids stacking effects/listeners across toggles.
+  let darkPane: PreviewPane | null = null;
+  const forEachPane = (fn: (p: PreviewPane) => void): void => { fn(preview); if (darkPane) fn(darkPane); };
+  const darkPaneHost = previewHost.querySelector('[data-stb-pane="dark"]') as HTMLElement;
 
   const leverToggle = document.createElement('label');
   leverToggle.className = 'stb-lever-toggle-action';
   leverToggle.style.marginLeft = '0.5rem';
   const leverCb = document.createElement('input');
   leverCb.type = 'checkbox';
-  leverCb.addEventListener('change', () => preview.showLevers(leverCb.checked));
+  leverCb.addEventListener('change', () => forEachPane((p) => p.showLevers(leverCb.checked)));
   leverToggle.appendChild(leverCb);
   leverToggle.append(' Show editable regions');
   actionsHost.appendChild(leverToggle);
 
+  const compareHost = document.createElement('span');
+  (actionsHost.querySelector('.stb-mode-toggle') as HTMLElement).after(compareHost);
+  mountCompareToggle(compareHost, {
+    panesHost: previewHost,
+    darkPaneHost,
+    darkToggle: actionsHost.querySelector<HTMLInputElement>('#stb-preview-dark'),
+    onFirstEnable: () => {
+      darkPane = createPreviewPane({ mode: 'dark', onElementSelected: onPreviewElementSelected });
+      darkPane.mount(darkPaneHost);
+      // parity with the primary pane's transient UI state (outline toggle)
+      darkPane.showLevers(leverCb.checked);
+    },
+  });
+
   // hover only highlights when the node belongs to the scene on screen
   const navHover = (id: string | null, scene: string | null) => {
-    if (id && scene === activeSceneId.value) preview.highlightElement(id);
-    else preview.highlightElement(null);
+    if (id && scene === activeSceneId.value) forEachPane((p) => p.highlightElement(id));
+    else forEachPane((p) => p.highlightElement(null));
   };
 
   mountElementTree(treeView, {
@@ -319,7 +347,7 @@ async function main() {
         },
       });
     },
-    onHover: (tokenName) => preview.highlightToken(tokenName),
+    onHover: (tokenName) => forEachPane((p) => p.highlightToken(tokenName)),
   });
 
   mountEditorPane(app.querySelector('.stb-editor-host') as HTMLElement);

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -14,12 +14,12 @@ import { mountStatusBar } from '@/ui/status-bar';
 import { mountAssetManager } from '@/ui/asset-manager';
 import { setRootValue, setDarkValue, effectiveValue } from '@/state/tokens';
 import { previewDark, activeSceneId } from '@/state/scene';
-import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets, setNodeFacetsDark } from '@/state/branding';
+import { nodeFor, loadBrandingModel, setNodeScopedBlock, setNodeFacets, setNodeFacetsDark, resetNode } from '@/state/branding';
 import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens, reprojectNodeTokensDark } from '@/ui/element-edit';
 import { FACET_PROPS, facetDeclarations } from '@/metadata/facets';
-import { setFacetProp, addGroup, removeGroup, setBackstop, addLayer, setLayer, removeLayer, reorderLayer, addFont, setFont, removeFont, reorderFont, setSide, setGap } from '@/state/facets-edit';
+import { setFacetProp, clearFacetProp, addGroup, removeGroup, setBackstop, addLayer, setLayer, removeLayer, reorderLayer, addFont, setFont, removeFont, reorderFont, setSide, setGap } from '@/state/facets-edit';
 import { deriveDarkOklch } from '@/color/derive-dark';
 import type { Oklch } from '@/color/oklch';
 import { effect } from '@preact/signals-core';
@@ -124,7 +124,19 @@ async function main() {
     // mode both panes reveal, so light and dark stay structurally identical
     forEachPane((p) => p.revealElement(snapshotId));
     const companion = buildVisibilityCompanion(snapshotId, node.visibility);
+    // Each page stands alone (Norm, 2026-07-02): a page's visible background
+    // may belong to a dedicated full-bleed backdrop child (harvest convention:
+    // `<id>.background`, e.g. the login scene's .login-bg overlay). Background
+    // edits on the parent are painted over by it, which reads as a broken
+    // editor — surface the backdrop with a jump link instead.
+    // ponytail: naming-convention detection; geometry-based full-bleed
+    // detection if a scene ever ships a backdrop under another name.
+    const backdrop = nodeFor(`${snapshotId}.background`);
     openLeverEditor({
+      ...(backdrop ? { backdropHint: {
+        name: backdrop.name || 'Background',
+        onJump: () => selectElement(backdrop.snapshotId),
+      } } : {}),
       previewHost,
       snapshotId,
       onChange: (next) => applyEdit(snapshotId, next, routing),
@@ -146,6 +158,29 @@ async function main() {
           const facetsDark = setFacetProp(n.facetsDark ?? {}, key, value);
           setNodeFacetsDark(snapshotId, facetsDark);
           reprojectNodeTokensDark(snapshotId, facetsDark, routing);
+        }
+      },
+      onFacetClear: (key) => {
+        const n = nodeFor(snapshotId);
+        if (n) {
+          const facets = clearFacetProp(n.facets, key);
+          setNodeFacets(snapshotId, facets);
+          reprojectNodeTokens(snapshotId, facets, routing);
+        }
+      },
+      onFacetClearDark: (key) => {
+        const n = nodeFor(snapshotId);
+        if (n) {
+          const facetsDark = clearFacetProp(n.facetsDark ?? {}, key);
+          setNodeFacetsDark(snapshotId, facetsDark);
+          reprojectNodeTokensDark(snapshotId, facetsDark, routing);
+        }
+      },
+      onResetNode: () => {
+        const restored = resetNode(snapshotId);
+        if (restored) {
+          reprojectNodeTokens(snapshotId, restored.facets, routing);
+          reprojectNodeTokensDark(snapshotId, restored.facetsDark ?? {}, routing);
         }
       },
       deriveDark: (key) => {

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -18,7 +18,7 @@ import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens, reprojectNodeTokensDark } from '@/ui/element-edit';
 import { FACET_PROPS, facetDeclarations } from '@/metadata/facets';
-import { setFacetProp, addGroup, removeGroup, setBackstop, addLayer, setLayer, removeLayer, reorderLayer, addFont, setFont, removeFont, reorderFont } from '@/state/facets-edit';
+import { setFacetProp, addGroup, removeGroup, setBackstop, addLayer, setLayer, removeLayer, reorderLayer, addFont, setFont, removeFont, reorderFont, setSide, setGap } from '@/state/facets-edit';
 import { deriveDarkOklch } from '@/color/derive-dark';
 import type { Oklch } from '@/color/oklch';
 import { effect } from '@preact/signals-core';
@@ -223,6 +223,18 @@ async function main() {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, reorderFont(n.facets, from, to));
+        selectElement(snapshotId);
+      },
+      onSetSide: (group, side, value) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, setSide(n.facets, group, side, value));
+        selectElement(snapshotId);
+      },
+      onSetGap: (slot, value) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, setGap(n.facets, slot, value));
         selectElement(snapshotId);
       },
       colorFormat: () => colorFormat.value,

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -171,7 +171,9 @@ async function main() {
       onBackstop: (color) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
-        setNodeFacets(snapshotId, setBackstop(n.facets, color));
+        const facets = setBackstop(n.facets, color);
+        setNodeFacets(snapshotId, facets);
+        reprojectNodeTokens(snapshotId, facets, routing);
         selectElement(snapshotId);
       },
       onAddLayer: (layer) => {

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -157,17 +157,21 @@ async function main() {
         setNodeFacetsDark(snapshotId, facetsDark);
         reprojectNodeTokensDark(snapshotId, facetsDark, routing);
       },
+      // Composite handlers below NEVER call selectElement: rebuilding the popover
+      // mid-edit tears down the control being typed into (one character per click).
+      // The lever editor's model-change effect re-renders the facet tree instead —
+      // suppressed only while a text-entry control is focused, so structural clicks
+      // (add/remove/reorder, backstop pick, file choose) still refresh. Each handler
+      // re-reads the node via nodeFor so writes always build on current state.
       onAddGroup: (g) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, addGroup(n.facets, g));
-        selectElement(snapshotId);
       },
       onRemoveGroup: (g) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, removeGroup(n.facets, g));
-        selectElement(snapshotId);
       },
       onBackstop: (color) => {
         const n = nodeFor(snapshotId);
@@ -175,67 +179,56 @@ async function main() {
         const facets = setBackstop(n.facets, color);
         setNodeFacets(snapshotId, facets);
         reprojectNodeTokens(snapshotId, facets, routing);
-        selectElement(snapshotId);
       },
       onAddLayer: (layer) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, addLayer(n.facets, layer));
-        selectElement(snapshotId);
       },
       onSetLayer: (index, layer) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, setLayer(n.facets, index, layer));
-        selectElement(snapshotId);
       },
       onRemoveLayer: (index) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, removeLayer(n.facets, index));
-        selectElement(snapshotId);
       },
       onReorderLayer: (from, to) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, reorderLayer(n.facets, from, to));
-        selectElement(snapshotId);
       },
       onAddFont: (value) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, addFont(n.facets, value));
-        selectElement(snapshotId);
       },
       onSetFont: (index, value) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, setFont(n.facets, index, value));
-        selectElement(snapshotId);
       },
       onRemoveFont: (index) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, removeFont(n.facets, index));
-        selectElement(snapshotId);
       },
       onReorderFont: (from, to) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, reorderFont(n.facets, from, to));
-        selectElement(snapshotId);
       },
       onSetSide: (group, side, value) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, setSide(n.facets, group, side, value));
-        selectElement(snapshotId);
       },
       onSetGap: (slot, value) => {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, setGap(n.facets, slot, value));
-        selectElement(snapshotId);
       },
       colorFormat: () => colorFormat.value,
       tokenForKey: (key) => routing.elements[snapshotId]?.properties?.[key]?.token ?? null,

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -196,7 +196,11 @@ async function main() {
         // Copy-on-first-dark-edit: seed the dark background's layer array as a
         // structural copy of the light layers before the first dark layer edit.
         // After this point light and dark layer structures are independent forks —
-        // editing one never touches the other.
+        // editing one never touches the other. Once forked, dark layers are
+        // authoritative: structural light edits (add/remove/reorder) never
+        // re-propagate into dark, and the tree UI (facet-tree.ts) refuses to send
+        // a light-seeded gradient for an already-forked array, so this branch can
+        // no longer be clobbered by a light-seeded overwrite.
         const darkBg = n.facetsDark?.background;
         const seededDarkFacets = darkBg?.layers
           ? n.facetsDark!

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -18,7 +18,7 @@ import { loadGlobalModel } from '@/state/global-branding';
 import { openLeverEditor } from '@/ui/lever-editor';
 import { applyEdit, buildVisibilityCompanion, reprojectNodeTokens, reprojectNodeTokensDark } from '@/ui/element-edit';
 import { FACET_PROPS, facetDeclarations } from '@/metadata/facets';
-import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
+import { setFacetProp, addGroup, removeGroup, setBackstop, addLayer, setLayer, removeLayer, reorderLayer } from '@/state/facets-edit';
 import { deriveDarkOklch } from '@/color/derive-dark';
 import type { Oklch } from '@/color/oklch';
 import { effect } from '@preact/signals-core';
@@ -166,6 +166,36 @@ async function main() {
         const n = nodeFor(snapshotId);
         if (!n) return;
         setNodeFacets(snapshotId, removeGroup(n.facets, g));
+        selectElement(snapshotId);
+      },
+      onBackstop: (color) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, setBackstop(n.facets, color));
+        selectElement(snapshotId);
+      },
+      onAddLayer: (layer) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, addLayer(n.facets, layer));
+        selectElement(snapshotId);
+      },
+      onSetLayer: (index, layer) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, setLayer(n.facets, index, layer));
+        selectElement(snapshotId);
+      },
+      onRemoveLayer: (index) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, removeLayer(n.facets, index));
+        selectElement(snapshotId);
+      },
+      onReorderLayer: (from, to) => {
+        const n = nodeFor(snapshotId);
+        if (!n) return;
+        setNodeFacets(snapshotId, reorderLayer(n.facets, from, to));
         selectElement(snapshotId);
       },
       colorFormat: () => colorFormat.value,

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -113,13 +113,32 @@ function layerCss(l: Layer): string {
   return l.kind === 'image' ? `url(${l.ref})` : gradientCss(l.gradient);
 }
 
-/** 0-2 CSS declarations for a background composite. Layers reversed: CSS wants topmost first. */
+/** Composed CSS background-image value: layers reversed to CSS topmost-first order.
+ *  undefined if no layers. Shared by backgroundCss and backgroundPatch so the two
+ *  emission paths (scoped-block CSS vs. live-preview inline style) can't drift apart. */
+function composeLayerImage(bg: BackgroundFacet): string | undefined {
+  if (!bg.layers || !bg.layers.length) return undefined;
+  return [...bg.layers].reverse().map(layerCss).join(', ');
+}
+
+/** 0-2 CSS declarations for a background composite. Layers reversed: CSS wants topmost first.
+ *  Only a literal color is emitted here — a {token} color is routed separately via
+ *  facetDeclarations/projectColorTokens to avoid emitting it twice. */
 export function backgroundCss(bg: BackgroundFacet): string[] {
   const out: string[] = [];
   if (bg.color && 'literal' in bg.color) out.push(`background-color: ${facetValueCss(bg.color, true)};`);
-  if (bg.layers && bg.layers.length) {
-    const images = [...bg.layers].reverse().map(layerCss).join(', ');
-    out.push(`background-image: ${images};`);
-  }
+  const images = composeLayerImage(bg);
+  if (images !== undefined) out.push(`background-image: ${images};`);
+  return out;
+}
+
+/** Raw-value counterpart to backgroundCss for the live-preview LeverPatch pipeline (Task 7):
+ *  no decl-string parsing, and (unlike backgroundCss) a {token} color IS included here —
+ *  this patch is inline-style-only, so there's no separate token-routed emission to collide with. */
+export function backgroundPatch(bg: BackgroundFacet): { backgroundColor?: string; backgroundImage?: string } {
+  const out: { backgroundColor?: string; backgroundImage?: string } = {};
+  if (bg.color) out.backgroundColor = facetValueCss(bg.color, true);
+  const images = composeLayerImage(bg);
+  if (images !== undefined) out.backgroundImage = images;
   return out;
 }

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -85,6 +85,11 @@ export function facetValueCss(v: FacetValue, isColor: boolean): string {
   return isColor ? normalizeHex(lit) : lit;
 }
 
+/** Font-family fallback list (composite kind 1: ordered comma-list, non-color leaves). */
+export function fontFamilyCss(list: FacetValue[]): string {
+  return `font-family: ${list.map((v) => facetValueCss(v, false)).join(', ')};`;
+}
+
 function stopCss(s: ColorStop): string {
   const color = facetValueCss(s.color, true);
   return s.position ? `${color} ${s.position}` : color;

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -157,8 +157,7 @@ function layerCss(l: Layer): string {
 }
 
 /** Composed CSS background-image value: layers reversed to CSS topmost-first order.
- *  undefined if no layers. Shared by backgroundCss and backgroundPatch so the two
- *  emission paths (scoped-block CSS vs. live-preview inline style) can't drift apart. */
+ *  undefined if no layers. Used by backgroundCss (scoped-block CSS emission). */
 function composeLayerImage(bg: BackgroundFacet): string | undefined {
   if (!bg.layers || !bg.layers.length) return undefined;
   // Blank layers are mid-edit transients — skip an image layer with a blank

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -33,8 +33,17 @@ export function* facetDeclarations(
   }
 }
 
+// Systemic blank-value guard: a blank literal (empty/whitespace-only string) means
+// "unset, emit nothing" at every emit site below. Only literal strings are ever
+// "blank" — a {token} entry, or a literal Oklch color object, never is.
+const isBlankLiteral = (v: FacetValue): boolean =>
+  'literal' in v && typeof v.literal === 'string' && v.literal.trim() === '';
+
+const isBlankRef = (ref: string): boolean => ref.trim() === '';
+
 export function facetLiteralCss(spec: FacetPropSpec, v: FacetValue): string | null {
   if ('token' in v) return null;
+  if (isBlankLiteral(v)) return null;
   return spec.isColor ? oklchToHex(v.literal as Oklch) : String(v.literal);
 }
 
@@ -53,7 +62,9 @@ export function* contentAssetDeclarations(
   const layers = facets.background?.layers ?? [];
   for (let i = layers.length - 1; i >= 0; i--) {
     const l = layers[i]!;
-    if (l.kind === 'image') {
+    // A blank ref (mid-edit transient) doesn't count as "topmost" — keep
+    // scanning downward instead of masking a real lower image.
+    if (l.kind === 'image' && !isBlankRef(l.ref)) {
       topmost = l.ref;
       break;
     }
@@ -85,9 +96,11 @@ export function facetValueCss(v: FacetValue, isColor: boolean): string {
   return isColor ? normalizeHex(lit) : lit;
 }
 
-/** Font-family fallback list (composite kind 1: ordered comma-list, non-color leaves). */
-export function fontFamilyCss(list: FacetValue[]): string {
-  return `font-family: ${list.map((v) => facetValueCss(v, false)).join(', ')};`;
+/** Font-family fallback list (composite kind 1: ordered comma-list, non-color leaves).
+ *  Blank literal entries are skipped (no dangling commas); null if nothing is left to emit. */
+export function fontFamilyCss(list: FacetValue[]): string | null {
+  const parts = list.filter((v) => !isBlankLiteral(v)).map((v) => facetValueCss(v, false));
+  return parts.length ? `font-family: ${parts.join(', ')};` : null;
 }
 
 const SIDE_ORDER = ['top', 'right', 'bottom', 'left'] as const;
@@ -102,11 +115,11 @@ export function spacingDeclarations(sp: SpacingFacet): string[] {
     if (!t) continue;
     for (const side of SIDE_ORDER) {
       const v = t[side];
-      if (v) out.push(`${group}-${side}: ${facetValueCss(v, false)};`);
+      if (v && !isBlankLiteral(v)) out.push(`${group}-${side}: ${facetValueCss(v, false)};`);
     }
   }
-  if (sp.gap?.row) out.push(`row-gap: ${facetValueCss(sp.gap.row, false)};`);
-  if (sp.gap?.column) out.push(`column-gap: ${facetValueCss(sp.gap.column, false)};`);
+  if (sp.gap?.row && !isBlankLiteral(sp.gap.row)) out.push(`row-gap: ${facetValueCss(sp.gap.row, false)};`);
+  if (sp.gap?.column && !isBlankLiteral(sp.gap.column)) out.push(`column-gap: ${facetValueCss(sp.gap.column, false)};`);
   return out;
 }
 
@@ -143,7 +156,11 @@ function layerCss(l: Layer): string {
  *  emission paths (scoped-block CSS vs. live-preview inline style) can't drift apart. */
 function composeLayerImage(bg: BackgroundFacet): string | undefined {
   if (!bg.layers || !bg.layers.length) return undefined;
-  return [...bg.layers].reverse().map(layerCss).join(', ');
+  // An image layer with a blank ref is a mid-edit transient — skip it rather
+  // than emit `url()`; a gradient layer at the same slot always has real stops.
+  const layers = bg.layers.filter((l) => l.kind !== 'image' || !isBlankRef(l.ref));
+  if (!layers.length) return undefined;
+  return [...layers].reverse().map(layerCss).join(', ');
 }
 
 /** 0-2 CSS declarations for a background composite. Layers reversed: CSS wants topmost first.
@@ -151,7 +168,7 @@ function composeLayerImage(bg: BackgroundFacet): string | undefined {
  *  facetDeclarations/projectColorTokens to avoid emitting it twice. */
 export function backgroundCss(bg: BackgroundFacet): string[] {
   const out: string[] = [];
-  if (bg.color && 'literal' in bg.color) out.push(`background-color: ${facetValueCss(bg.color, true)};`);
+  if (bg.color && 'literal' in bg.color && !isBlankLiteral(bg.color)) out.push(`background-color: ${facetValueCss(bg.color, true)};`);
   const images = composeLayerImage(bg);
   if (images !== undefined) out.push(`background-image: ${images};`);
   return out;

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -1,4 +1,4 @@
-import type { Facets, FacetValue, BackgroundFacet, Gradient, ColorStop, Layer } from '@/metadata/types';
+import type { Facets, FacetValue, BackgroundFacet, Gradient, ColorStop, Layer, SpacingFacet } from '@/metadata/types';
 import { oklchToHex, type Oklch } from '@/color/oklch';
 
 export interface FacetPropSpec { cssProp: string; isColor: boolean; }
@@ -88,6 +88,26 @@ export function facetValueCss(v: FacetValue, isColor: boolean): string {
 /** Font-family fallback list (composite kind 1: ordered comma-list, non-color leaves). */
 export function fontFamilyCss(list: FacetValue[]): string {
   return `font-family: ${list.map((v) => facetValueCss(v, false)).join(', ')};`;
+}
+
+const SIDE_ORDER = ['top', 'right', 'bottom', 'left'] as const;
+
+/** Spacing composite (kind 2: positional tuple): per-side padding/margin longhands
+ *  plus row/column-gap, for whichever slots are set. Non-color leaves, so
+ *  facetValueCss is always called with isColor=false, same as fontFamilyCss. */
+export function spacingDeclarations(sp: SpacingFacet): string[] {
+  const out: string[] = [];
+  for (const group of ['padding', 'margin'] as const) {
+    const t = sp[group];
+    if (!t) continue;
+    for (const side of SIDE_ORDER) {
+      const v = t[side];
+      if (v) out.push(`${group}-${side}: ${facetValueCss(v, false)};`);
+    }
+  }
+  if (sp.gap?.row) out.push(`row-gap: ${facetValueCss(sp.gap.row, false)};`);
+  if (sp.gap?.column) out.push(`column-gap: ${facetValueCss(sp.gap.column, false)};`);
+  return out;
 }
 
 function stopCss(s: ColorStop): string {

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -128,8 +128,13 @@ function stopCss(s: ColorStop): string {
   return s.position ? `${color} ${s.position}` : color;
 }
 
+// Same isBlankLiteral rule as every emit site above: a blank stop literal is a
+// mid-edit transient — skip it rather than emit a dangling empty stop
+// (`linear-gradient(, #fff)`). A gradient with no real stop emits nothing.
+const hasRealStops = (g: Gradient): boolean => g.stops.some((s) => !isBlankLiteral(s.color));
+
 export function gradientCss(g: Gradient): string {
-  const stops = g.stops.map(stopCss).join(', ');
+  const stops = g.stops.filter((s) => !isBlankLiteral(s.color)).map(stopCss).join(', ');
   const pre = g.repeating ? 'repeating-' : '';
   if (g.type === 'linear') {
     const head = g.angle ? `${g.angle}, ` : '';
@@ -156,9 +161,11 @@ function layerCss(l: Layer): string {
  *  emission paths (scoped-block CSS vs. live-preview inline style) can't drift apart. */
 function composeLayerImage(bg: BackgroundFacet): string | undefined {
   if (!bg.layers || !bg.layers.length) return undefined;
-  // An image layer with a blank ref is a mid-edit transient — skip it rather
-  // than emit `url()`; a gradient layer at the same slot always has real stops.
-  const layers = bg.layers.filter((l) => l.kind !== 'image' || !isBlankRef(l.ref));
+  // Blank layers are mid-edit transients — skip an image layer with a blank
+  // ref rather than emit `url()`, and skip a gradient layer whose stops are
+  // ALL blank rather than emit an empty gradient.
+  const layers = bg.layers.filter((l) =>
+    l.kind === 'image' ? !isBlankRef(l.ref) : hasRealStops(l.gradient));
   if (!layers.length) return undefined;
   return [...layers].reverse().map(layerCss).join(', ');
 }

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -1,25 +1,21 @@
-import type { Facets, FacetValue } from '@/metadata/types';
+import type { Facets, FacetValue, BackgroundFacet, Gradient, ColorStop, Layer } from '@/metadata/types';
 import { oklchToHex, type Oklch } from '@/color/oklch';
 
 export interface FacetPropSpec { cssProp: string; isColor: boolean; }
 
 export const FACET_PROPS: Record<string, FacetPropSpec> = {
   'text.color':           { cssProp: 'color',         isColor: true  },
-  'text.fontFamily':      { cssProp: 'font-family',   isColor: false },
   'text.fontSize':        { cssProp: 'font-size',     isColor: false },
   'text.fontWeight':      { cssProp: 'font-weight',   isColor: false },
   'text.lineHeight':      { cssProp: 'line-height',   isColor: false },
-  'surface.background':   { cssProp: 'background',     isColor: true  },
   'surface.border':       { cssProp: 'border',         isColor: false },
   'surface.borderRadius': { cssProp: 'border-radius',  isColor: false },
-  'spacing.padding':      { cssProp: 'padding',        isColor: false },
-  'spacing.margin':       { cssProp: 'margin',         isColor: false },
-  'spacing.gap':          { cssProp: 'gap',            isColor: false },
+  'background.color':     { cssProp: 'background-color', isColor: true },
 };
 
-const STYLE_GROUPS = ['text', 'surface', 'spacing'] as const;
+const STYLE_GROUPS = ['text', 'surface', 'spacing', 'background'] as const;
 
-/** Yield typed style groups (text/surface/spacing) as FacetValue + CSS spec for property-level routing.
+/** Yield typed style groups (text/surface/spacing/background) as FacetValue + CSS spec for property-level routing.
  *  Structurally distinct from contentAssetDeclarations (plain string payloads, no FacetValue/isColor);
  *  the two generators are intentionally separate, not duplicated. */
 export function* facetDeclarations(
@@ -46,10 +42,84 @@ export interface ContentAssetDeclaration { key: 'content' | 'asset'; value: stri
 
 /** Yield content/asset facet declarations for property-level routing.
  *  Plain string payloads only — no FacetValue wrapper or isColor flag.
- *  Kept separate from facetDeclarations (style groups) intentionally: the two are structurally different. */
+ *  Kept separate from facetDeclarations (style groups) intentionally: the two are structurally different.
+ *  Topmost image from background.layers takes precedence over explicit asset.ref. */
 export function* contentAssetDeclarations(
   facets: Facets,
 ): Generator<ContentAssetDeclaration> {
   if (facets.content) yield { key: 'content', value: facets.content.text };
-  if (facets.asset) yield { key: 'asset', value: facets.asset.ref };
+  // Topmost image from background.layers takes precedence over asset (iterate backwards for topmost)
+  let topmost: string | null = null;
+  const layers = facets.background?.layers ?? [];
+  for (let i = layers.length - 1; i >= 0; i--) {
+    const l = layers[i]!;
+    if (l.kind === 'image') {
+      topmost = l.ref;
+      break;
+    }
+  }
+  if (topmost) {
+    yield { key: 'asset', value: topmost };
+  } else if (facets.asset) {
+    yield { key: 'asset', value: facets.asset.ref };
+  }
+}
+
+// Tokens come in two shapes: a full custom-property name already carrying the
+// `--` prefix (e.g. `--color-brand-900`), or a dotted logical name
+// (e.g. `brand.500`). Emit `var(--…)` without doubling the prefix.
+const tokenVar = (t: string) => `var(${t.startsWith('--') ? t : '--' + t.replace(/\./g, '-')})`;
+
+const normalizeHex = (h: string): string => {
+  const m = h.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+  return m ? `#${m[1]}${m[1]}${m[2]}${m[2]}${m[3]}${m[3]}` : h;
+};
+
+/** Leaf formatter that also handles {token} (→ var(--…)); facetLiteralCss returns null for tokens. */
+export function facetValueCss(v: FacetValue, isColor: boolean): string {
+  if ('token' in v) return tokenVar(v.token);
+  if (isColor && typeof v.literal === 'object') {
+    return oklchToHex(v.literal as Oklch);
+  }
+  const lit = String(v.literal);
+  return isColor ? normalizeHex(lit) : lit;
+}
+
+function stopCss(s: ColorStop): string {
+  const color = facetValueCss(s.color, true);
+  return s.position ? `${color} ${s.position}` : color;
+}
+
+export function gradientCss(g: Gradient): string {
+  const stops = g.stops.map(stopCss).join(', ');
+  const pre = g.repeating ? 'repeating-' : '';
+  if (g.type === 'linear') {
+    const head = g.angle ? `${g.angle}, ` : '';
+    return `${pre}linear-gradient(${head}${stops})`;
+  }
+  if (g.type === 'radial') {
+    const shape = [g.shape, g.size].filter(Boolean).join(' ');
+    const at = g.position ? `at ${g.position}` : '';
+    const head = [shape, at].filter(Boolean).join(' ');
+    return `${pre}radial-gradient(${head ? head + ', ' : ''}${stops})`;
+  }
+  const from = g.fromAngle ? `from ${g.fromAngle}` : '';
+  const at = g.position ? `at ${g.position}` : '';
+  const head = [from, at].filter(Boolean).join(' ');
+  return `${pre}conic-gradient(${head ? head + ', ' : ''}${stops})`;
+}
+
+function layerCss(l: Layer): string {
+  return l.kind === 'image' ? `url(${l.ref})` : gradientCss(l.gradient);
+}
+
+/** 0-2 CSS declarations for a background composite. Layers reversed: CSS wants topmost first. */
+export function backgroundCss(bg: BackgroundFacet): string[] {
+  const out: string[] = [];
+  if (bg.color && 'literal' in bg.color) out.push(`background-color: ${facetValueCss(bg.color, true)};`);
+  if (bg.layers && bg.layers.length) {
+    const images = [...bg.layers].reverse().map(layerCss).join(', ');
+    out.push(`background-image: ${images};`);
+  }
+  return out;
 }

--- a/tools/stb/src/metadata/facets.ts
+++ b/tools/stb/src/metadata/facets.ts
@@ -180,14 +180,3 @@ export function backgroundCss(bg: BackgroundFacet): string[] {
   if (images !== undefined) out.push(`background-image: ${images};`);
   return out;
 }
-
-/** Raw-value counterpart to backgroundCss for the live-preview LeverPatch pipeline (Task 7):
- *  no decl-string parsing, and (unlike backgroundCss) a {token} color IS included here —
- *  this patch is inline-style-only, so there's no separate token-routed emission to collide with. */
-export function backgroundPatch(bg: BackgroundFacet): { backgroundColor?: string; backgroundImage?: string } {
-  const out: { backgroundColor?: string; backgroundImage?: string } = {};
-  if (bg.color) out.backgroundColor = facetValueCss(bg.color, true);
-  const images = composeLayerImage(bg);
-  if (images !== undefined) out.backgroundImage = images;
-  return out;
-}

--- a/tools/stb/src/metadata/migrate-facets.ts
+++ b/tools/stb/src/metadata/migrate-facets.ts
@@ -1,3 +1,6 @@
+// One-shot fixture/migration tooling. Models load pre-migrated committed JSON,
+// so this module has no production callers by design — do NOT wire it into any
+// runtime loader; it exists to convert legacy fixtures once, by hand, offline.
 import type { Facets, FacetValue, Sides, GapTuple, BackgroundFacet } from '@/metadata/types';
 
 const isFacetValue = (v: unknown): v is FacetValue =>

--- a/tools/stb/src/metadata/migrate-facets.ts
+++ b/tools/stb/src/metadata/migrate-facets.ts
@@ -1,0 +1,47 @@
+import type { Facets, FacetValue, Sides, GapTuple, BackgroundFacet } from '@/metadata/types';
+
+const isFacetValue = (v: unknown): v is FacetValue =>
+  !!v && typeof v === 'object' && ('token' in (v as object) || 'literal' in (v as object));
+
+const allSides = (v: FacetValue): Sides => ({ top: v, right: v, bottom: v, left: v });
+
+/** Migrate a legacy flat facet bundle to the composite shapes. Idempotent:
+ *  already-composite values pass through untouched. */
+export function migrateFacets(legacy: unknown, isImageElement: boolean): Facets {
+  const src = (legacy ?? {}) as Record<string, any>;
+  const out: Facets = {};
+
+  if (src.content) out.content = src.content;
+
+  // background composite starts from any existing composite, then absorbs legacy sources
+  const bg: { color?: FacetValue; layers?: any[] } = { ...(src.background ?? {}) };
+
+  // legacy surface.background color → background.color
+  const surface = { ...(src.surface ?? {}) };
+  if (isFacetValue(surface.background)) { bg.color ??= surface.background; delete surface.background; }
+  if (Object.keys(surface).length) out.surface = surface;
+
+  // asset: <img> src stays; background-use becomes an image layer
+  if (src.asset?.ref) {
+    if (isImageElement) out.asset = src.asset;
+    else bg.layers = [...(bg.layers ?? []), { kind: 'image', ref: src.asset.ref }];
+  }
+  if (bg.color !== undefined || bg.layers !== undefined) out.background = bg as BackgroundFacet;
+
+  // text.fontFamily single → one-entry list
+  if (src.text) {
+    const text = { ...src.text };
+    if (isFacetValue(text.fontFamily)) text.fontFamily = [text.fontFamily];
+    out.text = text;
+  }
+
+  // spacing single values → tuples
+  if (src.spacing) {
+    const sp = { ...src.spacing };
+    if (isFacetValue(sp.padding)) sp.padding = allSides(sp.padding);
+    if (isFacetValue(sp.margin))  sp.margin  = allSides(sp.margin);
+    if (isFacetValue(sp.gap))     sp.gap     = { row: sp.gap, column: sp.gap } as GapTuple;
+    out.spacing = sp;
+  }
+  return out;
+}

--- a/tools/stb/src/metadata/types.ts
+++ b/tools/stb/src/metadata/types.ts
@@ -2,9 +2,13 @@ import type { Oklch } from '@/color/oklch';
 
 export type LeverKind = 'color' | 'content' | 'asset';
 
+// Content text format: 'plain' (default, absent = plain, rendered via textContent)
+// or 'subset' (closed-grammar formatting — see src/content/subset-format.ts).
+export type ContentFormat = 'plain' | 'subset';
+
 export type LeverValue =
   | { kind: 'color'; oklch: Oklch }
-  | { kind: 'content'; text: string }
+  | { kind: 'content'; text: string; format?: ContentFormat }
   | { kind: 'asset'; ref: string };
 
 // Raw element-scoped CSS declaration body — the R1 facet escape hatch.
@@ -51,7 +55,7 @@ export interface SurfaceFacet { border?: FacetValue; borderRadius?: FacetValue; 
 export interface SpacingFacet { padding?: Sides; margin?: Sides; gap?: GapTuple; }
 
 export interface Facets {
-  content?: { text: string };
+  content?: { text: string; format?: ContentFormat };
   asset?: { ref: string };
   background?: BackgroundFacet;
   text?: TextFacet;

--- a/tools/stb/src/metadata/types.ts
+++ b/tools/stb/src/metadata/types.ts
@@ -30,13 +30,30 @@ export interface BrandingModel {
 
 export type FacetValue = { token: string } | { literal: Oklch | string };
 
-export interface TextFacet { color?: FacetValue; fontFamily?: FacetValue; fontSize?: FacetValue; fontWeight?: FacetValue; lineHeight?: FacetValue; }
-export interface SurfaceFacet { background?: FacetValue; border?: FacetValue; borderRadius?: FacetValue; }
-export interface SpacingFacet { padding?: FacetValue; margin?: FacetValue; gap?: FacetValue; }
+// --- kind 1: ordered comma-list ---
+export type ColorStop = { color: FacetValue; position?: string };
+export type Gradient =
+  | { type: 'linear'; repeating?: boolean; angle?: string; stops: ColorStop[] }
+  | { type: 'radial'; repeating?: boolean; shape?: 'circle' | 'ellipse'; size?: string; position?: string; stops: ColorStop[] }
+  | { type: 'conic';  repeating?: boolean; fromAngle?: string; position?: string; stops: ColorStop[] };
+export type Layer =
+  | { kind: 'image';    ref: string }
+  | { kind: 'gradient'; gradient: Gradient };
+export interface BackgroundFacet { color?: FacetValue; layers?: Layer[]; }
+
+// --- kind 2: positional tuple ---
+export interface Sides { top?: FacetValue; right?: FacetValue; bottom?: FacetValue; left?: FacetValue; }
+export interface GapTuple { row?: FacetValue; column?: FacetValue; }
+
+// --- groups ---
+export interface TextFacet { color?: FacetValue; fontFamily?: FacetValue[]; fontSize?: FacetValue; fontWeight?: FacetValue; lineHeight?: FacetValue; }
+export interface SurfaceFacet { border?: FacetValue; borderRadius?: FacetValue; }
+export interface SpacingFacet { padding?: Sides; margin?: Sides; gap?: GapTuple; }
 
 export interface Facets {
   content?: { text: string };
   asset?: { ref: string };
+  background?: BackgroundFacet;
   text?: TextFacet;
   surface?: SurfaceFacet;
   spacing?: SpacingFacet;

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -1,5 +1,5 @@
 import type { ElementNode } from '@/metadata/types';
-import { facetDeclarations, facetLiteralCss } from '@/metadata/facets';
+import { facetDeclarations, facetLiteralCss, backgroundCss } from '@/metadata/facets';
 
 export function emitCss(root: Map<string, string>, dark: Map<string, string>): string {
   const parts: string[] = [];
@@ -27,8 +27,12 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       // Light block: literal facet declarations first, then the free-form scopedBlock.
       // Gated to :not(.dark-theme) so an element with no dark facet value falls through
       // to the snapshot's built-in dark rule rather than being pinned to its light value.
+      const bgLines = node.facets.background ? backgroundCss(node.facets.background).map((d) => `  ${d}`) : [];
       const facetLines: string[] = [];
       for (const d of facetDeclarations(node.facets)) {
+        // backgroundCss (bgLines) owns the whole background composite; skip it
+        // here so a literal backstop color isn't emitted twice.
+        if (d.key.startsWith('background.')) continue;
         const css = facetLiteralCss(d.spec, d.value);
         if (css !== null) facetLines.push(`  ${d.spec.cssProp}: ${css};`);
       }
@@ -38,7 +42,7 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
           .filter((l) => l.length > 0)
           .map((l) => `  ${/[;{},]$/.test(l) ? l : l + ';'}`)
         : [];
-      const lightBody = [...facetLines, ...scopedLines].join('\n');
+      const lightBody = [...bgLines, ...facetLines, ...scopedLines].join('\n');
       if (lightBody) rules.push(`html:not(.dark-theme) ${selector} {\n${lightBody}\n}`);
 
       // Dark block: literal facetsDark declarations, gated by .dark-theme — (0,4,0).
@@ -47,7 +51,9 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       // (dark beats `.dark-theme .x` (0,2,0)). {token} dark values are skipped (projector territory).
       if (node.facetsDark) {
         const darkLines: string[] = [];
+        if (node.facetsDark.background) darkLines.push(...backgroundCss(node.facetsDark.background).map((d) => `  ${d}`));
         for (const d of facetDeclarations(node.facetsDark)) {
+          if (d.key.startsWith('background.')) continue; // backgroundCss owns background
           const css = facetLiteralCss(d.spec, d.value);
           if (css !== null) darkLines.push(`  ${d.spec.cssProp}: ${css};`);
         }

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -1,5 +1,5 @@
 import type { ElementNode } from '@/metadata/types';
-import { facetDeclarations, facetLiteralCss, backgroundCss, fontFamilyCss } from '@/metadata/facets';
+import { facetDeclarations, facetLiteralCss, backgroundCss, fontFamilyCss, spacingDeclarations } from '@/metadata/facets';
 
 export function emitCss(root: Map<string, string>, dark: Map<string, string>): string {
   const parts: string[] = [];
@@ -32,6 +32,9 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       // font-family is a kind-1 ordered comma-list, not in FACET_PROPS (no single
       // FacetValue leaf to route) — emitted here explicitly, same shape as background.
       if (node.facets.text?.fontFamily?.length) facetLines.push(`  ${fontFamilyCss(node.facets.text.fontFamily)}`);
+      // spacing is a kind-2 positional tuple (per-side longhands), not in FACET_PROPS
+      // (no single FacetValue leaf to route) — emitted here explicitly, same shape as font-family.
+      if (node.facets.spacing) facetLines.push(...spacingDeclarations(node.facets.spacing).map((d) => `  ${d}`));
       for (const d of facetDeclarations(node.facets)) {
         // backgroundCss (bgLines) owns the whole background composite; skip it
         // here so a literal backstop color isn't emitted twice.
@@ -55,6 +58,7 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       if (node.facetsDark) {
         const darkLines: string[] = [];
         if (node.facetsDark.background) darkLines.push(...backgroundCss(node.facetsDark.background).map((d) => `  ${d}`));
+        if (node.facetsDark.spacing) darkLines.push(...spacingDeclarations(node.facetsDark.spacing).map((d) => `  ${d}`));
         for (const d of facetDeclarations(node.facetsDark)) {
           if (d.key.startsWith('background.')) continue; // backgroundCss owns background
           const css = facetLiteralCss(d.spec, d.value);

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -1,5 +1,5 @@
 import type { ElementNode } from '@/metadata/types';
-import { facetDeclarations, facetLiteralCss, backgroundCss } from '@/metadata/facets';
+import { facetDeclarations, facetLiteralCss, backgroundCss, fontFamilyCss } from '@/metadata/facets';
 
 export function emitCss(root: Map<string, string>, dark: Map<string, string>): string {
   const parts: string[] = [];
@@ -29,6 +29,9 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       // to the snapshot's built-in dark rule rather than being pinned to its light value.
       const bgLines = node.facets.background ? backgroundCss(node.facets.background).map((d) => `  ${d}`) : [];
       const facetLines: string[] = [];
+      // font-family is a kind-1 ordered comma-list, not in FACET_PROPS (no single
+      // FacetValue leaf to route) — emitted here explicitly, same shape as background.
+      if (node.facets.text?.fontFamily?.length) facetLines.push(`  ${fontFamilyCss(node.facets.text.fontFamily)}`);
       for (const d of facetDeclarations(node.facets)) {
         // backgroundCss (bgLines) owns the whole background composite; skip it
         // here so a literal backstop color isn't emitted twice.

--- a/tools/stb/src/parse/css-emitter.ts
+++ b/tools/stb/src/parse/css-emitter.ts
@@ -31,7 +31,11 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       const facetLines: string[] = [];
       // font-family is a kind-1 ordered comma-list, not in FACET_PROPS (no single
       // FacetValue leaf to route) — emitted here explicitly, same shape as background.
-      if (node.facets.text?.fontFamily?.length) facetLines.push(`  ${fontFamilyCss(node.facets.text.fontFamily)}`);
+      // fontFamilyCss returns null when nothing survives the blank-literal guard.
+      if (node.facets.text?.fontFamily?.length) {
+        const fontFamily = fontFamilyCss(node.facets.text.fontFamily);
+        if (fontFamily) facetLines.push(`  ${fontFamily}`);
+      }
       // spacing is a kind-2 positional tuple (per-side longhands), not in FACET_PROPS
       // (no single FacetValue leaf to route) — emitted here explicitly, same shape as font-family.
       if (node.facets.spacing) facetLines.push(...spacingDeclarations(node.facets.spacing).map((d) => `  ${d}`));
@@ -55,6 +59,9 @@ export function emitScopedBlocks(nodes: ElementNode[]): string {
       // Light (`:not(.dark-theme)`) and dark (`.dark-theme`) are mutually exclusive by
       // mode, so they never compete; each just beats the snapshot's rules in its mode
       // (dark beats `.dark-theme .x` (0,2,0)). {token} dark values are skipped (projector territory).
+      // Design rule (decided 2026-07-01): the dark axis is a COLOR axis — a font
+      // choice (e.g. font-family) is never mode-dependent by design, so there is
+      // deliberately no dark fontFamilyCss call here, unlike backgroundCss/spacingDeclarations.
       if (node.facetsDark) {
         const darkLines: string[] = [];
         if (node.facetsDark.background) darkLines.push(...backgroundCss(node.facetsDark.background).map((d) => `  ${d}`));

--- a/tools/stb/src/projection/projector.ts
+++ b/tools/stb/src/projection/projector.ts
@@ -39,7 +39,10 @@ function topmostImageRef(node: { facets: Facets }): string | null {
   return null;
 }
 
-/** Derive the leaf projection value from facets: content → text, topmost image → ref, backstop color → hex, asset → ref. */
+/** Derive the leaf projection value from facets: content → text, topmost image → ref, backstop color → hex, asset → ref.
+ *  This precedence IS the CSS cascade/paint order (content over topmost image over backstop color) — deliberate,
+ *  per the resolved leafValueOf precedence decision. Color deliberately sits below the image: background color is
+ *  also token-routed (projectColorTokens), so letting it win here would emit the same color twice. */
 function leafValueOf(node: { facets: Facets }): unknown {
   if (node.facets.content) return node.facets.content.text;
   const topmost = topmostImageRef(node);

--- a/tools/stb/src/projection/projector.ts
+++ b/tools/stb/src/projection/projector.ts
@@ -22,20 +22,31 @@ export interface ProjectionResult {
   unmapped: string[];
 }
 
-/** Read an Oklch color from facets (text.color > surface.background). */
+/** Read an Oklch color from facets (text.color > background.color). */
 function colorOf(node: { facets: Facets }): Oklch | null {
-  const c = node.facets.text?.color ?? node.facets.surface?.background;
+  const c = node.facets.text?.color ?? node.facets.background?.color;
   if (c && 'literal' in c && typeof c.literal === 'object') return c.literal as Oklch;
   return null;
 }
 
-/** Derive the leaf projection value from facets: color → hex, content → text, asset → ref. */
+/** Read the topmost (last) image layer ref from background.layers. */
+function topmostImageRef(node: { facets: Facets }): string | null {
+  const layers = node.facets.background?.layers ?? [];
+  for (let i = layers.length - 1; i >= 0; i--) {           // last = topmost
+    const l = layers[i]!;
+    if (l.kind === 'image') return l.ref;
+  }
+  return null;
+}
+
+/** Derive the leaf projection value from facets: content → text, topmost image → ref, backstop color → hex, asset → ref. */
 function leafValueOf(node: { facets: Facets }): unknown {
+  if (node.facets.content) return node.facets.content.text;
+  const topmost = topmostImageRef(node);
+  if (topmost) return topmost;
   const color = colorOf(node);
   if (color) return oklchToHex(color);
-  if (node.facets.content) return node.facets.content.text;
-  if (node.facets.asset) return node.facets.asset.ref;
-  return null;
+  return node.facets.asset?.ref ?? null;
 }
 
 function namespaceFor(snapshotId: string, containers: Record<string, string>): string | null {

--- a/tools/stb/src/state/branding-assets.ts
+++ b/tools/stb/src/state/branding-assets.ts
@@ -34,29 +34,59 @@ export function attachAssetBlobs(patches: LeverPatch[], store: Map<string, Brand
   });
 }
 
-// Object URLs minted by the most recent rewriteAssetUrls call, keyed per caller (e.g. one
-// key per preview pane) so revoking one pane's stale URLs never touches another pane's
-// still-displayed blob: URLs.
-const mintedByCallsite = new Map<string, string[]>();
+// Object URLs minted by rewriteAssetUrls, keyed per caller (e.g. one key per preview
+// pane) so revoking one pane's stale URLs never touches another pane's still-displayed
+// blob: URLs. Double-buffered per key: `current` is this call's mint, `previous` is the
+// batch before it — see the revoke comment in rewriteAssetUrls for why both stay alive.
+const mintedByCallsite = new Map<string, { current: string[]; previous: string[] }>();
+
+/** Strip surrounding whitespace and (at most) one matching pair of quotes from a raw
+ *  `url(...)` capture. Machine-generated CSS emits unquoted refs; user-authored
+ *  scopedBlock CSS (the R1 escape hatch) conventionally quotes them — store keys are
+ *  always unquoted, so an unstripped quoted ref would miss the lookup. */
+function stripUrlRef(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
 
 /** Substitute url(<ref>) -> url(<objectURL>) for any asset ref in `css` with a stored blob;
- *  unknown refs (snapshot-bundled files, not user uploads) pass through untouched. Scoped-block
- *  CSS is the only preview-facing consumer — the export path keeps raw refs on purpose, since
- *  the exported bundle ships real files at those paths and a blob: URL would be invalid there.
+ *  unknown refs (snapshot-bundled files, not user uploads) pass through completely
+ *  untouched — original text, quotes and whitespace intact. Scoped-block CSS is the only
+ *  preview-facing consumer — the export path keeps raw refs on purpose, since the exported
+ *  bundle ships real files at those paths and a blob: URL would be invalid there.
  *
- *  Mints a fresh object URL per call and revokes the previous call's URLs for the same
- *  `callsiteKey`, so repeated re-renders (token/model changes) don't leak blob URLs. */
+ *  Mints one object URL per distinct ref per call (a ref repeated N times in the CSS
+ *  shares one mint) and double-buffers revocation per `callsiteKey`: on call N, the
+ *  batch from call N-1 is what the iframe's CURRENT stylesheet is still painting (the
+ *  STB_APPLY_BLOCKS message hasn't necessarily been applied yet), so revoking it
+ *  immediately can blank the painted background. Only the batch from N-2 — already
+ *  superseded twice over — is revoked. This is deterministic (no setTimeout guess at
+ *  when the iframe has applied the message) at the cost of one extra batch's worth of
+ *  blob memory alive at a time, which is bounded and freed on the next call. */
 export function rewriteAssetUrls(css: string, store: Map<string, BrandingAsset>, callsiteKey: string): string {
-  const prev = mintedByCallsite.get(callsiteKey);
-  if (prev) for (const url of prev) URL.revokeObjectURL(url);
+  const mintedForRef = new Map<string, string>();
   const minted: string[] = [];
-  const out = css.replace(/url\(([^)]+)\)/g, (whole, ref: string) => {
+  const out = css.replace(/url\(([^)]+)\)/g, (whole, rawRef: string) => {
+    const ref = stripUrlRef(rawRef);
+    const cached = mintedForRef.get(ref);
+    if (cached) return `url(${cached})`;
     const a = store.get(ref);
     if (!a) return whole;
     const url = URL.createObjectURL(a.blob);
+    mintedForRef.set(ref, url);
     minted.push(url);
     return `url(${url})`;
   });
-  mintedByCallsite.set(callsiteKey, minted);
+
+  const batches = mintedByCallsite.get(callsiteKey);
+  if (batches) for (const url of batches.previous) URL.revokeObjectURL(url);
+  mintedByCallsite.set(callsiteKey, { current: minted, previous: batches?.current ?? [] });
   return out;
 }

--- a/tools/stb/src/state/branding-assets.ts
+++ b/tools/stb/src/state/branding-assets.ts
@@ -30,16 +30,33 @@ export function attachAssetBlobs(patches: LeverPatch[], store: Map<string, Brand
       const a = store.get(p.ref);
       return a ? { ...p, blob: a.blob } : p;
     }
-    if (p.kind === 'background') {
-      if (!p.backgroundImage) return p;
-      // Substitute url(<ref>) -> url(<objectURL>) for any layer ref with an uploaded blob;
-      // leverPatchesFor stays pure (no store access), so the swap happens here instead.
-      const swapped = p.backgroundImage.replace(/url\(([^)]+)\)/g, (whole, ref: string) => {
-        const a = store.get(ref);
-        return a ? `url(${URL.createObjectURL(a.blob)})` : whole;
-      });
-      return { ...p, backgroundImage: swapped };
-    }
     return p;
   });
+}
+
+// Object URLs minted by the most recent rewriteAssetUrls call, keyed per caller (e.g. one
+// key per preview pane) so revoking one pane's stale URLs never touches another pane's
+// still-displayed blob: URLs.
+const mintedByCallsite = new Map<string, string[]>();
+
+/** Substitute url(<ref>) -> url(<objectURL>) for any asset ref in `css` with a stored blob;
+ *  unknown refs (snapshot-bundled files, not user uploads) pass through untouched. Scoped-block
+ *  CSS is the only preview-facing consumer — the export path keeps raw refs on purpose, since
+ *  the exported bundle ships real files at those paths and a blob: URL would be invalid there.
+ *
+ *  Mints a fresh object URL per call and revokes the previous call's URLs for the same
+ *  `callsiteKey`, so repeated re-renders (token/model changes) don't leak blob URLs. */
+export function rewriteAssetUrls(css: string, store: Map<string, BrandingAsset>, callsiteKey: string): string {
+  const prev = mintedByCallsite.get(callsiteKey);
+  if (prev) for (const url of prev) URL.revokeObjectURL(url);
+  const minted: string[] = [];
+  const out = css.replace(/url\(([^)]+)\)/g, (whole, ref: string) => {
+    const a = store.get(ref);
+    if (!a) return whole;
+    const url = URL.createObjectURL(a.blob);
+    minted.push(url);
+    return `url(${url})`;
+  });
+  mintedByCallsite.set(callsiteKey, minted);
+  return out;
 }

--- a/tools/stb/src/state/branding-assets.ts
+++ b/tools/stb/src/state/branding-assets.ts
@@ -4,12 +4,13 @@ import type { LeverPatch } from '@/iframe-bridge/apply-levers';
 
 export interface BrandingAsset { blob: Blob; filename: string; }
 
-// keyed by snapshotId — parallel to the logo/favicon `assets` slots, untouched here
+// keyed by asset ref (e.g. `assets/<filename>`) — a single node can carry multiple
+// image blobs (background layers), so snapshotId is no longer a unique enough key.
 export const brandingAssets = signal<Map<string, BrandingAsset>>(new Map());
 
-export function setBrandingAsset(snapshotId: string, blob: Blob, filename: string): void {
+export function setBrandingAsset(ref: string, blob: Blob, filename: string): void {
   const next = new Map(brandingAssets.value);
-  next.set(snapshotId, { blob, filename });
+  next.set(ref, { blob, filename });
   brandingAssets.value = next;
 }
 
@@ -18,13 +19,27 @@ export function assetRefFor(filename: string): string {
 }
 
 export function brandingAssetInputs(store: Map<string, BrandingAsset>): AssetInput[] {
-  return [...store.values()].map((a) => ({ path: assetRefFor(a.filename), blob: a.blob }));
+  // Store keys are already full refs — do not re-wrap with assetRefFor (would double-prefix).
+  return [...store.entries()].map(([ref, a]) => ({ path: ref, blob: a.blob }));
 }
 
 export function attachAssetBlobs(patches: LeverPatch[], store: Map<string, BrandingAsset>): LeverPatch[] {
   return patches.map((p) => {
-    if (p.kind !== 'asset') return p;
-    const a = store.get(p.snapshotId);
-    return a ? { ...p, blob: a.blob } : p;
+    if (p.kind === 'asset') {
+      if (!p.ref) return p;
+      const a = store.get(p.ref);
+      return a ? { ...p, blob: a.blob } : p;
+    }
+    if (p.kind === 'background') {
+      if (!p.backgroundImage) return p;
+      // Substitute url(<ref>) -> url(<objectURL>) for any layer ref with an uploaded blob;
+      // leverPatchesFor stays pure (no store access), so the swap happens here instead.
+      const swapped = p.backgroundImage.replace(/url\(([^)]+)\)/g, (whole, ref: string) => {
+        const a = store.get(ref);
+        return a ? `url(${URL.createObjectURL(a.blob)})` : whole;
+      });
+      return { ...p, backgroundImage: swapped };
+    }
+    return p;
   });
 }

--- a/tools/stb/src/state/branding.ts
+++ b/tools/stb/src/state/branding.ts
@@ -3,6 +3,11 @@ import type { BrandingModel, ElementNode, Facets, ScopedBlock } from '@/metadata
 
 export const brandingModel = signal<BrandingModel | null>(null);
 
+// Pristine copy of the loaded model — the "delete my edits" baseline. Close
+// puts the editor away; resetNode restores THIS. Kept outside the signal so
+// edits can never touch it.
+let pristineModel: BrandingModel | null = null;
+
 export async function loadBrandingModel(scene: string): Promise<void> {
   // A scene may ship no branding-model.json; the dev server then answers with a
   // 404 page or the SPA HTML fallback. Guard so a missing/non-JSON model clears
@@ -12,12 +17,31 @@ export async function loadBrandingModel(scene: string): Promise<void> {
     const contentType = res.headers.get('content-type') ?? '';
     if (!res.ok || !contentType.includes('json')) {
       brandingModel.value = null;
+      pristineModel = null;
       return;
     }
-    brandingModel.value = (await res.json()) as BrandingModel;
+    const model = (await res.json()) as BrandingModel;
+    pristineModel = structuredClone(model);
+    brandingModel.value = model;
   } catch {
     brandingModel.value = null;
+    pristineModel = null;
   }
+}
+
+/** Discard every edit on one element — facets, dark bundle, scoped block,
+ *  visibility — restoring the node exactly as the generated model shipped it.
+ *  Returns the restored node so callers can re-project its tokens. */
+export function resetNode(snapshotId: string): ElementNode | undefined {
+  const m = brandingModel.value;
+  const p = pristineModel?.nodes.find((n) => n.snapshotId === snapshotId);
+  if (!m || !p) return undefined;
+  const restored = structuredClone(p);
+  brandingModel.value = {
+    ...m,
+    nodes: m.nodes.map((n) => (n.snapshotId === snapshotId ? restored : n)),
+  };
+  return restored;
 }
 
 export function nodeFor(snapshotId: string): ElementNode | undefined {

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -14,6 +14,15 @@ export function setFacetProp(f: Facets, key: string, value: FacetValue): Facets 
   const g = groupOf(key);
   return { ...f, [g]: { ...(f[g] ?? {}), [propOf(key)]: value } };
 }
+/** Revert a single value to "snapshot decides": remove the prop, keep the group.
+ *  Covers the background backstop too (key 'background.color'). */
+export function clearFacetProp(f: Facets, key: string): Facets {
+  const g = groupOf(key) as keyof Facets;
+  if (!f[g]) return f;
+  const group = { ...(f[g] as Record<string, unknown>) };
+  delete group[propOf(key)];
+  return { ...f, [g]: group };
+}
 export function addGroup(f: Facets, group: AddableGroup): Facets {
   return f[group] ? f : { ...f, [group]: {} };
 }

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -45,3 +45,26 @@ export function reorderLayer(f: Facets, from: number, to: number): Facets {
   layers.splice(to, 0, moved!);
   return { ...f, background: { ...bg(f), layers } };
 }
+
+// --- font-family composite: ordered comma-list fallback stack (same kind-1 shape as background.layers) ---
+const fonts = (f: Facets) => f.text?.fontFamily ?? [];
+
+export function addFont(f: Facets, value: FacetValue): Facets {
+  return { ...f, text: { ...(f.text ?? {}), fontFamily: [...fonts(f), value] } };
+}
+export function setFont(f: Facets, index: number, value: FacetValue): Facets {
+  const fontFamily = [...fonts(f)];
+  fontFamily[index] = value;
+  return { ...f, text: { ...(f.text ?? {}), fontFamily } };
+}
+export function removeFont(f: Facets, index: number): Facets {
+  const fontFamily = [...fonts(f)];
+  fontFamily.splice(index, 1);
+  return { ...f, text: { ...(f.text ?? {}), fontFamily } };
+}
+export function reorderFont(f: Facets, from: number, to: number): Facets {
+  const fontFamily = [...fonts(f)];
+  const [moved] = fontFamily.splice(from, 1);
+  fontFamily.splice(to, 0, moved!);
+  return { ...f, text: { ...(f.text ?? {}), fontFamily } };
+}

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -1,4 +1,4 @@
-import type { Facets, FacetValue } from '@/metadata/types';
+import type { Facets, FacetValue, Layer } from '@/metadata/types';
 
 type Group = 'text' | 'surface' | 'spacing';
 const groupOf = (key: string) => key.split('.')[0] as Group;
@@ -16,4 +16,32 @@ export function removeGroup(f: Facets, group: Group): Facets {
   const next = { ...f };
   delete next[group];
   return next;
+}
+
+// --- background composite: backstop color + bottom-up layer stack ---
+// Layers append on top (last index = topmost); the emitter reverses this
+// order so CSS sees topmost-first, per the bottom-up authoring model.
+const bg = (f: Facets) => f.background ?? {};
+
+export function setBackstop(f: Facets, color: FacetValue): Facets {
+  return { ...f, background: { ...bg(f), color } };
+}
+export function addLayer(f: Facets, layer: Layer): Facets {
+  return { ...f, background: { ...bg(f), layers: [...(bg(f).layers ?? []), layer] } };
+}
+export function setLayer(f: Facets, index: number, layer: Layer): Facets {
+  const layers = [...(bg(f).layers ?? [])];
+  layers[index] = layer;
+  return { ...f, background: { ...bg(f), layers } };
+}
+export function removeLayer(f: Facets, index: number): Facets {
+  const layers = [...(bg(f).layers ?? [])];
+  layers.splice(index, 1);
+  return { ...f, background: { ...bg(f), layers } };
+}
+export function reorderLayer(f: Facets, from: number, to: number): Facets {
+  const layers = [...(bg(f).layers ?? [])];
+  const [moved] = layers.splice(from, 1);
+  layers.splice(to, 0, moved!);
+  return { ...f, background: { ...bg(f), layers } };
 }

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -1,6 +1,12 @@
 import type { Facets, FacetValue, Layer } from '@/metadata/types';
 
 type Group = 'text' | 'surface' | 'spacing';
+// addGroup additionally accepts 'background' — a node without one can gain an
+// empty background composite from the add-group select. removeGroup does NOT
+// widen to match: background removal isn't sanctioned (consistent with the
+// background branch's no-remove-button treatment in facet-tree.ts), so this
+// is a deliberate asymmetry, not an oversight.
+type AddableGroup = Group | 'background';
 const groupOf = (key: string) => key.split('.')[0] as Group;
 const propOf  = (key: string) => key.split('.')[1]!;
 
@@ -8,7 +14,7 @@ export function setFacetProp(f: Facets, key: string, value: FacetValue): Facets 
   const g = groupOf(key);
   return { ...f, [g]: { ...(f[g] ?? {}), [propOf(key)]: value } };
 }
-export function addGroup(f: Facets, group: Group): Facets {
+export function addGroup(f: Facets, group: AddableGroup): Facets {
   return f[group] ? f : { ...f, [group]: {} };
 }
 export function removeGroup(f: Facets, group: Group): Facets {

--- a/tools/stb/src/state/facets-edit.ts
+++ b/tools/stb/src/state/facets-edit.ts
@@ -68,3 +68,15 @@ export function reorderFont(f: Facets, from: number, to: number): Facets {
   fontFamily.splice(to, 0, moved!);
   return { ...f, text: { ...(f.text ?? {}), fontFamily } };
 }
+
+// --- spacing composite: positional tuples (T/R/B/L padding/margin, row/column gap) ---
+const spacing = (f: Facets) => f.spacing ?? {};
+
+export function setSide(f: Facets, group: 'padding' | 'margin', side: 'top' | 'right' | 'bottom' | 'left', value: FacetValue): Facets {
+  const sp = spacing(f);
+  return { ...f, spacing: { ...sp, [group]: { ...(sp[group] ?? {}), [side]: value } } };
+}
+export function setGap(f: Facets, slot: 'row' | 'column', value: FacetValue): Facets {
+  const sp = spacing(f);
+  return { ...f, spacing: { ...sp, gap: { ...(sp.gap ?? {}), [slot]: value } } };
+}

--- a/tools/stb/src/state/scene.ts
+++ b/tools/stb/src/state/scene.ts
@@ -2,3 +2,6 @@ import { signal } from '@preact/signals-core';
 
 export const activeSceneId = signal<string>('login');
 export const previewDark = signal<boolean>(false);
+// Dual read-only compare: two panes pinned light/dark side by side. While on,
+// previewDark is pinned false and its control is inert (compare owns the axis).
+export const compareMode = signal<boolean>(false);

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -72,11 +72,18 @@ body {
   border-left: 1px solid var(--border, #e5e7eb);
 }
 
-/* Preview takes all remaining height */
+/* Preview takes all remaining height. Panes sit side by side (compare mode
+   shows two: light left, dark right) with a minimal gap; single mode shows
+   one, which flex:1 stretches to the full width — no layout flip needed. */
 .stb-preview-host {
   flex: 1;
   min-height: 0;
+  display: flex;
+  gap: 4px;
 }
+.stb-preview-pane { flex: 1 1 0; min-width: 0; }
+/* belt-and-braces vs the .stb-view [hidden] trap if a display rule is ever added */
+.stb-preview-pane[hidden] { display: none; }
 
 .stb-sidebar { padding: 0.5rem; overflow-y: auto; border-right: 1px solid var(--border, #ddd); }
 .stb-group h3 { font-size: 0.85rem; text-transform: uppercase; color: var(--muted-foreground, #666); margin: 0.75rem 0 0.25rem; }

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -177,12 +177,31 @@ body {
   font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .stb-facet-bg-row[data-stb-bg-row="color"] .stb-facet-bg-subtitle { flex: 0 0 5.5rem; }
+/* MDN help link — one per gradient layer, sits beside the subtitle. */
+.stb-facet-bg-gradient-help {
+  flex: 0 0 auto; font-size: 0.7rem; line-height: 1; width: 1.1rem; height: 1.1rem;
+  display: inline-flex; align-items: center; justify-content: center; border-radius: 50%;
+  border: 1px solid var(--border, #cbd5e1); color: var(--text-muted, #64748b); text-decoration: none;
+}
 .stb-facet-bg-gradient {
   display: flex; flex-wrap: wrap; align-items: center; gap: 0.3rem; flex: 1 1 100%; min-width: 0;
+}
+/* Inline field labels ("type" / "angle" / "position") — visible text, not
+   placeholder-only, so the label survives once the control is filled. */
+.stb-facet-bg-gradient-field-label {
+  font-size: 0.7rem; color: var(--text-muted, #64748b); white-space: nowrap;
 }
 .stb-facet-bg-gradient-type, .stb-facet-bg-gradient-pos { font-size: 0.75rem; padding: 0.1rem 0.25rem; }
 .stb-facet-bg-gradient-stops {
   display: flex; flex-direction: column; gap: 0.25rem; flex: 1 1 100%; margin-top: 0.15rem;
+}
+/* Column header for the stops list — one labeled header rather than a label
+   per row; aligned to the stop-position input via the same trailing flex slot. */
+.stb-facet-bg-gradient-stops-header {
+  display: flex; justify-content: flex-end; padding: 0 0.3rem;
+}
+.stb-facet-bg-gradient-stops-header-pos {
+  flex: 1; min-width: 0; font-size: 0.68rem; color: var(--text-muted, #64748b);
 }
 .stb-facet-bg-gradient-stop {
   display: flex; align-items: center; gap: 0.3rem; padding: 0.15rem 0.3rem;

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -89,10 +89,18 @@ body {
 /* One consistent editor popover surface for both element levers and tokens:
    opaque + firm border + strong shadow so it never blends into the light
    nav-band / preview; stretchable for larger / multi-paragraph content. */
+/* Sizes to content by default (no fixed width/height set anywhere) and grows
+   as sections are added (background layers, font fallbacks, ...), capped at
+   a viewport margin so it can never run off-screen — past that the panel
+   body scrolls instead of growing further. `resize: both` remains available
+   for a manual override; once dragged, the browser pins an inline
+   width/height on the element which then wins over further auto-growth
+   (v1: auto-grow until first manual resize — a per-drag "unpin" affordance
+   is deferred as disproportionate to this pass). */
 .stb-lever-editor, .stb-color-picker {
   background: var(--card, #fff); border: 1px solid var(--border, #cbd5e1);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3); padding: 0.6rem; border-radius: 8px;
-  z-index: 1000; min-width: 240px; max-width: 90vw; max-height: 80vh;
+  z-index: 1000; min-width: 240px; max-width: min(640px, 92vw); max-height: calc(100vh - 2rem);
   resize: both; overflow: auto;
 }
 /* drag handle: a grab bar spanning the popover top, overrides auto-placement */
@@ -148,6 +156,43 @@ body {
 .stb-lever-editor:not(.stb-preview-dark) .stb-facet-swatch-dark,
 .stb-lever-editor:not(.stb-preview-dark) .stb-facet-derive-dark,
 .stb-lever-editor:not(.stb-preview-dark) .stb-facet-dual-header-dark { opacity: 0.4; }
+
+/* Background composite: each row (color base, then each layer) gets visible
+   separation — a bordered, tinted card — so the stack reads as distinct rows
+   rather than a run-on list. Layer rows are indented + left-rule to show they
+   sit ON TOP of the color base, matching the bottom-up authoring order. */
+.stb-facet-bg-row {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem;
+  padding: 0.3rem 0.4rem; margin: 0.2rem 0; border-radius: 4px;
+  border: 1px solid var(--border, #e5e7eb); background: var(--content-secondary, #f8fafc);
+}
+.stb-facet-bg-row[data-stb-bg-row="layer"] {
+  margin-left: 0.85rem; border-left: 3px solid var(--border, #cbd5e1);
+}
+/* Kind label ("color" / "image — ..." / "gradient — ...") — same visual
+   weight as a leaf label, but not width-locked to the leaf grid since
+   gradient/image subtitles run longer than a css-prop name. */
+.stb-facet-bg-subtitle {
+  flex: 1 1 100%; color: var(--text-muted, #64748b); font-size: 0.74rem;
+  font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.stb-facet-bg-row[data-stb-bg-row="color"] .stb-facet-bg-subtitle { flex: 0 0 5.5rem; }
+.stb-facet-bg-gradient {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 0.3rem; flex: 1 1 100%; min-width: 0;
+}
+.stb-facet-bg-gradient-type, .stb-facet-bg-gradient-pos { font-size: 0.75rem; padding: 0.1rem 0.25rem; }
+.stb-facet-bg-gradient-stops {
+  display: flex; flex-direction: column; gap: 0.25rem; flex: 1 1 100%; margin-top: 0.15rem;
+}
+.stb-facet-bg-gradient-stop {
+  display: flex; align-items: center; gap: 0.3rem; padding: 0.15rem 0.3rem;
+  border-radius: 3px; background: var(--card, #fff); border: 1px solid var(--border, #e5e7eb);
+}
+.stb-facet-bg-gradient-stop-pos { flex: 1; min-width: 0; font-size: 0.72rem; padding: 0.1rem 0.25rem; }
+.stb-facet-bg-footer { display: flex; gap: 0.35rem; margin: 0.2rem 0 0.4rem; }
+.stb-facet-bg-footer button, .stb-facet-bg-add-stop,
+.stb-facet-bg-move-up, .stb-facet-bg-move-down, .stb-facet-bg-remove,
+.stb-facet-bg-gradient-stop-remove { font-size: 0.72rem; padding: 0.1rem 0.35rem; }
 
 .stb-flash { background-color: var(--warning, #ffeaa7); transition: background-color 0.3s; }
 

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -200,6 +200,14 @@ body {
 .stb-facet-bg-backdrop-jump {
   font-size: 0.7rem; padding: 0 0.3rem; cursor: pointer;
 }
+/* Live paint-stack summary — the CSS the background group emits right now,
+   paint order (image layers left-to-right = top-to-bottom, color beneath). */
+.stb-facet-bg-css {
+  margin: 0.2rem 0; padding: 0.3rem 0.4rem; border-radius: 4px;
+  background: var(--content-tertiary, #f1f5f9); border: 1px dashed var(--border, #e2e8f0);
+  font-size: 0.66rem; line-height: 1.5; color: var(--text-muted, #475569);
+  white-space: pre-wrap; word-break: break-all; cursor: help;
+}
 /* MDN help link — one per gradient layer, sits beside the subtitle. */
 .stb-facet-bg-gradient-help {
   flex: 0 0 auto; font-size: 0.7rem; line-height: 1; width: 1.1rem; height: 1.1rem;

--- a/tools/stb/src/styles/stb.css
+++ b/tools/stb/src/styles/stb.css
@@ -184,6 +184,22 @@ body {
   font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .stb-facet-bg-row[data-stb-bg-row="color"] .stb-facet-bg-subtitle { flex: 0 0 5.5rem; }
+/* Covered-backstop note — the color paints beneath the layer stack, so a color
+   edit is invisible until the layers above are removed/transparent. Say so. */
+.stb-facet-bg-covered-note {
+  flex: 0 0 auto; font-size: 0.68rem; font-style: italic;
+  color: var(--text-muted, #94a3b8); cursor: help;
+}
+/* Backdrop hint — a full-bleed child (e.g. login's Background overlay) owns
+   the page's visible background; background edits on the page are painted
+   over by it. Note + jump link at the top of the background group. */
+.stb-facet-bg-backdrop-hint {
+  font-size: 0.7rem; font-style: italic; color: var(--text-muted, #64748b);
+  padding: 0.25rem 0.4rem; margin: 0.2rem 0;
+}
+.stb-facet-bg-backdrop-jump {
+  font-size: 0.7rem; padding: 0 0.3rem; cursor: pointer;
+}
 /* MDN help link — one per gradient layer, sits beside the subtitle. */
 .stb-facet-bg-gradient-help {
   flex: 0 0 auto; font-size: 0.7rem; line-height: 1; width: 1.1rem; height: 1.1rem;

--- a/tools/stb/src/ui/color-picker.ts
+++ b/tools/stb/src/ui/color-picker.ts
@@ -63,7 +63,12 @@ export function openColorPicker(opts: OpenColorPickerOptions): void {
     opts.onClose?.();
   });
 
+  // Deferred so the click that opened the picker doesn't immediately close it.
+  // Guard on isConnected: if the picker was already torn down within this tick
+  // (another picker opened), registering would leave a stale handler behind.
   setTimeout(() => {
+    if (!panel.isConnected) return;
+    activeOutsideHandler = outsideClickHandler;
     document.addEventListener('click', outsideClickHandler, { once: false });
   }, 0);
 
@@ -72,10 +77,18 @@ export function openColorPicker(opts: OpenColorPickerOptions): void {
     if (panel.contains(e.target)) return;
     closeOpenPicker();
     opts.onClose?.();
-    document.removeEventListener('click', outsideClickHandler);
   }
 }
 
+// Every close path funnels through here so the document-level outside-click
+// handler can never outlive its picker — a stale one would instantly close
+// the next picker opened (each swatch click after the first appeared dead).
+let activeOutsideHandler: ((e: MouseEvent) => void) | null = null;
+
 export function closeOpenPicker(): void {
   document.getElementById('stb-color-picker-active')?.remove();
+  if (activeOutsideHandler) {
+    document.removeEventListener('click', activeOutsideHandler);
+    activeOutsideHandler = null;
+  }
 }

--- a/tools/stb/src/ui/color-picker.ts
+++ b/tools/stb/src/ui/color-picker.ts
@@ -1,5 +1,6 @@
 import { parseColor, formatColor, type ColorFormat } from '@/color/format';
-import { positionInPreviewGutter } from '@/ui/popover';
+import { positionInPreviewGutter, positionAbovePanes } from '@/ui/popover';
+import { compareMode } from '@/state/scene';
 
 export interface OpenColorPickerOptions {
   previewHost: HTMLElement;
@@ -32,7 +33,11 @@ export function openColorPicker(opts: OpenColorPickerOptions): void {
   `;
 
   document.body.appendChild(panel);
-  positionInPreviewGutter(panel, opts.previewHost);
+  // Same compare-mode branch as the lever editor (positionAbovePanes): with two
+  // full-width panes there's no left gutter, so the gutter placement would
+  // fall back to overlaying the light pane dead-centre.
+  if (compareMode.value) positionAbovePanes(panel, opts.previewHost);
+  else positionInPreviewGutter(panel, opts.previewHost);
 
   const native = panel.querySelector<HTMLInputElement>('.stb-color-native')!;
   const text = panel.querySelector<HTMLInputElement>('.stb-color-text')!;

--- a/tools/stb/src/ui/color-picker.ts
+++ b/tools/stb/src/ui/color-picker.ts
@@ -7,6 +7,10 @@ export interface OpenColorPickerOptions {
   initial: string;
   format: ColorFormat;
   onChange: (newValue: string) => void;
+  /** Revert affordance: clear the value back to "snapshot decides".
+   *  Rendered as a Clear button only when provided — gradient stops, which
+   *  must always have a color, simply don't pass it. */
+  onClear?: () => void;
   onClose?: () => void;
 }
 
@@ -28,6 +32,7 @@ export function openColorPicker(opts: OpenColorPickerOptions): void {
       <input type="text" class="stb-color-text" value="${initialText}" />
     </div>
     <div class="stb-color-picker__row">
+      ${opts.onClear ? '<button class="stb-color-clear" title="Remove this value — the snapshot\'s own style applies again">Clear</button>' : ''}
       <button class="stb-close">Close</button>
     </div>
   `;
@@ -52,10 +57,23 @@ export function openColorPicker(opts: OpenColorPickerOptions): void {
   });
 
   text.addEventListener('input', () => {
+    // `transparent` is a deliberate "paint nothing" — a valid CSS color the
+    // rgb-tuple parser can't represent, so it bypasses parseColor.
+    if (text.value.trim().toLowerCase() === 'transparent') {
+      opts.onChange('transparent');
+      return;
+    }
     const c = parseColor(text.value);
     if (!c) return;
     native.value = formatColor(c, 'hex');
     opts.onChange(text.value);
+  });
+
+  const clear = panel.querySelector<HTMLButtonElement>('.stb-color-clear');
+  clear?.addEventListener('click', () => {
+    closeOpenPicker();
+    opts.onClear?.();
+    opts.onClose?.();
   });
 
   close.addEventListener('click', () => {

--- a/tools/stb/src/ui/element-columns.ts
+++ b/tools/stb/src/ui/element-columns.ts
@@ -33,7 +33,7 @@ export function swatchFor(p: PathNode): { color?: string; glyph?: string } {
   const f = p.node.facets;
   if (f?.content) return { glyph: 'T' };
   if (f?.asset) return { glyph: '🖼' };
-  const colorFacet = f?.text?.color ?? f?.surface?.background;
+  const colorFacet = f?.text?.color ?? f?.background?.color;
   if (colorFacet && 'literal' in colorFacet && typeof colorFacet.literal === 'object') {
     return { color: oklchToHex(colorFacet.literal as Oklch) };
   }

--- a/tools/stb/src/ui/element-edit.ts
+++ b/tools/stb/src/ui/element-edit.ts
@@ -21,12 +21,12 @@ export function buildVisibilityCompanion(
 function leverValueToFacets(value: LeverValue, existing: Facets): Facets {
   if (value.kind === 'content') return { ...existing, content: { text: value.text } };
   if (value.kind === 'asset') return { ...existing, asset: { ref: value.ref } };
-  // color: write into text.color if present, else surface.background
+  // color: write into text.color if present, else background.color
   const colorFacet: FacetValue = { literal: value.oklch };
   if (existing.text?.color !== undefined) {
     return { ...existing, text: { ...existing.text, color: colorFacet } };
   }
-  return { ...existing, surface: { ...existing.surface, background: colorFacet } };
+  return { ...existing, background: { ...existing.background, color: colorFacet } };
 }
 
 export function reprojectNodeTokens(snapshotId: string, facets: Facets, routing: RoutingMap): void {

--- a/tools/stb/src/ui/element-edit.ts
+++ b/tools/stb/src/ui/element-edit.ts
@@ -19,7 +19,10 @@ export function buildVisibilityCompanion(
 
 /** Map a LeverValue edit back into the Facets bundle it was sourced from. */
 function leverValueToFacets(value: LeverValue, existing: Facets): Facets {
-  if (value.kind === 'content') return { ...existing, content: { text: value.text } };
+  if (value.kind === 'content') {
+    // 'plain'/absent stores no format key — keeps plain content byte-identical
+    return { ...existing, content: { text: value.text, ...(value.format === 'subset' ? { format: 'subset' as const } : {}) } };
+  }
   if (value.kind === 'asset') return { ...existing, asset: { ref: value.ref } };
   // color: write into text.color if present, else background.color
   const colorFacet: FacetValue = { literal: value.oklch };

--- a/tools/stb/src/ui/element-tree.ts
+++ b/tools/stb/src/ui/element-tree.ts
@@ -20,7 +20,7 @@ export function valuePreview(node: NavNode): { swatch?: string; text: string; ki
   const f = node.facets;
   if (f?.content) return { text: `”${f.content.text}”`, kind: 'text' };
   if (f?.asset) return { text: f.asset.ref, kind: 'image' };
-  const colorFacet = f?.text?.color ?? f?.surface?.background;
+  const colorFacet = f?.text?.color ?? f?.background?.color;
   if (colorFacet && 'literal' in colorFacet && typeof colorFacet.literal === 'object') {
     const hex = oklchToHex(colorFacet.literal as Oklch);
     return { swatch: hex, text: hex, kind: 'color' };

--- a/tools/stb/src/ui/export-dialog.ts
+++ b/tools/stb/src/ui/export-dialog.ts
@@ -24,6 +24,9 @@ export function exportInputs(
     const r = project(model, routing);
     for (const [k, v] of r.tokens) merged.set(k, v);
     companyConfig = r.companyConfig;
+    // Deliberately NOT run through rewriteAssetUrls (preview-pane.ts's blob: URL rewrite):
+    // the exported bundle ships real asset files at their `assets/<file>` paths, so raw
+    // refs are correct here — a blob: URL would be invalid outside this session's iframe.
     scopedCss = emitScopedBlocks(model.nodes) || undefined;
   }
   return {

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -3,7 +3,7 @@ import type { Facets, FacetValue, Layer, Gradient, ContentFormat } from '@/metad
 import type { Oklch } from '@/color/oklch';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import type { ColorFormat } from '@/color/format';
-import { FACET_PROPS } from '@/metadata/facets';
+import { FACET_PROPS, backgroundCss } from '@/metadata/facets';
 import { openColorPicker } from '@/ui/color-picker';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 import { deriveDarkOklch } from '@/color/derive-dark';
@@ -15,6 +15,11 @@ const GROUPS = ['text', 'surface', 'spacing'] as const;
 const ADDABLE_GROUPS = ['background', ...GROUPS] as const;
 const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.startsWith(g + '.'));
 
+// Picker → facet value. `transparent` is a deliberate "paint nothing" with no
+// Oklch representation, so it stays a string literal (emitters pass it through).
+const colorFacetValue = (value: string): FacetValue =>
+  value === 'transparent' ? { literal: 'transparent' } : { literal: toOklch(value) };
+
 export interface FacetTreeOptions {
   facets: Facets;
   /** Parallel dark-mode overrides, rendered as a second value column beside each color row. */
@@ -23,6 +28,11 @@ export interface FacetTreeOptions {
   onEdit: (key: string, value: FacetValue) => void;
   /** Dark-mode counterpart of onEdit; fired when the dark swatch is edited directly. */
   onDarkEdit?: (key: string, value: FacetValue) => void;
+  /** Revert one value to "snapshot decides" (the picker's Clear button).
+   *  Covers the background backstop via key 'background.color'. */
+  onClearEdit?: (key: string) => void;
+  /** Dark-mode counterpart of onClearEdit — back to "inherits the snapshot's built-in dark". */
+  onClearEditDark?: (key: string) => void;
   /** Fired when the per-row "derive dark from light" button is clicked. Caller computes
    *  deriveDarkOklch and routes the result through its own dark-edit path. */
   deriveDark?: (key: string) => void;
@@ -56,6 +66,10 @@ export interface FacetTreeOptions {
   /** Spacing composite (Task 11): T/R/B/L padding/margin + row/column gap positional tuples. */
   onSetSide?: (group: 'padding' | 'margin', side: 'top' | 'right' | 'bottom' | 'left', value: FacetValue) => void;
   onSetGap?: (slot: 'row' | 'column', value: FacetValue) => void;
+  /** Each page stands alone: when a full-bleed backdrop child owns this
+   *  element's visible background, background edits here are painted over.
+   *  Rendered as a note + jump link at the top of the background group. */
+  backdropHint?: { name: string; onJump: () => void };
 }
 
 const FONT_WEIGHTS = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
@@ -217,6 +231,20 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     // Track focused group for isolate, same as the per-leaf hook in the style-group loop below.
     bgLeaves.addEventListener('focusin', () => { focusedGroup = 'background'; });
 
+    if (opts.backdropHint) {
+      const hint = document.createElement('div');
+      hint.className = 'stb-facet-bg-backdrop-hint';
+      hint.append(`the page's visible background is painted by ${opts.backdropHint.name} — `);
+      const jump = document.createElement('button');
+      jump.type = 'button';
+      jump.className = 'stb-facet-bg-backdrop-jump';
+      jump.textContent = 'edit it there';
+      jump.title = `${opts.backdropHint.name} covers this element edge-to-edge, so background edits made here stay hidden behind it`;
+      jump.addEventListener('click', () => opts.backdropHint!.onJump());
+      hint.appendChild(jump);
+      bgLeaves.appendChild(hint);
+    }
+
     const colorRow = document.createElement('div');
     colorRow.className = 'stb-facet-bg-row';
     colorRow.dataset.stbBgRow = 'color';
@@ -225,6 +253,18 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     colorLab.textContent = 'color';
     colorRow.appendChild(colorLab);
 
+    // An invisible edit reads as a broken editor: the backstop paints beneath
+    // every image/gradient layer, so say so whenever a real layer covers it.
+    // backgroundCss already knows which layers actually paint (blank-edit
+    // transients are skipped) — reuse it instead of re-deriving blankness.
+    if (backgroundCss({ layers }).some((d) => d.startsWith('background-image'))) {
+      const note = document.createElement('span');
+      note.className = 'stb-facet-bg-covered-note';
+      note.textContent = 'beneath layers';
+      note.title = 'The color backstop paints beneath every image/gradient layer above — it only shows through where they are transparent or removed';
+      colorRow.appendChild(note);
+    }
+
     const colorLit = background.color && 'literal' in background.color && typeof background.color.literal === 'object'
       ? background.color.literal as Oklch
       : null;
@@ -232,11 +272,16 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     colorBtn.type = 'button';
     colorBtn.className = 'stb-facet-swatch';
     if (colorLit) colorBtn.style.backgroundColor = oklchToHex(colorLit);
+    else if (background.color && 'literal' in background.color && typeof background.color.literal === 'string') {
+      colorBtn.style.backgroundColor = background.color.literal;
+      colorBtn.title = background.color.literal;
+    }
     colorBtn.addEventListener('click', () => openColorPicker({
       previewHost: opts.previewHost,
       initial: colorLit ? oklchToHex(colorLit) : '#000000',
       format: opts.colorFormat?.() ?? 'hex',
-      onChange: (value) => opts.onBackstop?.({ literal: toOklch(value) }),
+      onChange: (value) => opts.onBackstop?.(colorFacetValue(value)),
+      onClear: () => opts.onClearEdit?.('background.color'),
     }));
     colorRow.appendChild(colorBtn);
 
@@ -259,7 +304,8 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       previewHost: opts.previewHost,
       initial: colorLitDark ? oklchToHex(colorLitDark) : '#000000',
       format: opts.colorFormat?.() ?? 'hex',
-      onChange: (value) => opts.onDarkEdit?.('background.color', { literal: toOklch(value) }),
+      onChange: (value) => opts.onDarkEdit?.('background.color', colorFacetValue(value)),
+      onClear: () => opts.onClearEditDark?.('background.color'),
     }));
     colorRow.appendChild(colorDarkBtn);
 
@@ -368,8 +414,23 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         const helpLink = document.createElement('a');
         helpLink.className = 'stb-facet-bg-gradient-help';
         helpLink.textContent = '?';
-        helpLink.target = '_blank';
         helpLink.rel = 'noopener';
+        // Narrow named popup, not a new tab: stb stays visible behind it (a
+        // full tab loses the user's place), MDN's responsive layout gives a
+        // readable narrow view, and the shared name means every ? reuses one
+        // window instead of accumulating tabs. MDN blocks framing (X-Frame-
+        // Options: DENY, verified 2026-07-02 — as do w3schools/W3C/css-tricks),
+        // so an in-app panel is not an option.
+        helpLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          // Docked to the screen's right edge so it overlays stb's right side
+          // (tokens pane) rather than the editing area — the popover and
+          // preview stay visible while the help floats above. A page cannot
+          // resize the user's own browser window, so docking the popup is the
+          // available half of "help beside the app".
+          const left = Math.max(0, (window.screen.availWidth ?? 1280) - 500);
+          window.open(helpLink.href, 'stb-help', `width=480,height=640,left=${left},top=80,noopener`);
+        });
         const updateHelpLink = () => {
           helpLink.href = `${MDN_GRADIENT_BASE}${gradient.type}-gradient`;
           helpLink.title = `MDN reference for ${gradient.type}-gradient()`;
@@ -765,13 +826,18 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           ? current.literal as Oklch
           : null;
         if (lit) btn.style.backgroundColor = oklchToHex(lit);
+        else if (current && 'literal' in current && typeof current.literal === 'string') {
+          btn.style.backgroundColor = current.literal;
+          btn.title = current.literal;
+        }
         btn.addEventListener('click', () => openColorPicker({
           previewHost: opts.previewHost,
           initial: lit ? oklchToHex(lit) : '#000000',
           // Value is stored as Oklch, but the picker's text field shows the format
           // chosen in the top bar (hex/rgb/oklch) so the editor tracks that setting.
           format: opts.colorFormat?.() ?? 'hex',
-          onChange: (value) => opts.onEdit(key, { literal: toOklch(value) }),
+          onChange: (value) => opts.onEdit(key, colorFacetValue(value)),
+          onClear: () => opts.onClearEdit?.(key),
         }));
         leaf.appendChild(btn);
 
@@ -794,7 +860,8 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           previewHost: opts.previewHost,
           initial: litDark ? oklchToHex(litDark) : '#000000',
           format: opts.colorFormat?.() ?? 'hex',
-          onChange: (value) => opts.onDarkEdit?.(key, { literal: toOklch(value) }),
+          onChange: (value) => opts.onDarkEdit?.(key, colorFacetValue(value)),
+          onClear: () => opts.onClearEditDark?.(key),
         }));
         leaf.appendChild(darkBtn);
 

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -1,10 +1,11 @@
 // src/ui/facet-tree.ts
-import type { Facets, FacetValue } from '@/metadata/types';
+import type { Facets, FacetValue, Layer } from '@/metadata/types';
 import type { Oklch } from '@/color/oklch';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import type { ColorFormat } from '@/color/format';
-import { FACET_PROPS } from '@/metadata/facets';
+import { FACET_PROPS, gradientCss } from '@/metadata/facets';
 import { openColorPicker } from '@/ui/color-picker';
+import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 
 const GROUPS = ['text', 'surface', 'spacing'] as const;
 const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.startsWith(g + '.'));
@@ -31,6 +32,12 @@ export interface FacetTreeOptions {
   /** Live color-format accessor (hex/rgb/oklch), read when a color picker opens so the
    *  picker's text field matches the format chosen in the top bar. */
   colorFormat?: () => ColorFormat;
+  /** Background composite (Task 8/9): backstop color + bottom-up layer stack. */
+  onBackstop?: (value: FacetValue) => void;
+  onAddLayer?: (layer: Layer) => void;
+  onSetLayer?: (index: number, layer: Layer) => void;
+  onRemoveLayer?: (index: number) => void;
+  onReorderLayer?: (from: number, to: number) => void;
 }
 
 const FONT_FAMILIES = [
@@ -129,8 +136,10 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     host.appendChild(leaf);
   }
 
-  // Standalone asset leaf — not part of any style group
-  if (opts.facets.asset) {
+  // Standalone asset leaf — not part of any style group. Only for genuine
+  // <img>-role elements: a background composite (below) owns asset display
+  // for anything with a background facet, superseding this slot.
+  if (opts.facets.asset && !opts.facets.background) {
     const leaf = document.createElement('div');
     leaf.className = 'stb-facet-leaf';
     leaf.dataset.key = 'asset';
@@ -147,6 +156,104 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     });
     leaf.appendChild(input);
     host.appendChild(leaf);
+  }
+
+  // Background composite — bottom-up stack rendered top-to-bottom in the DOM:
+  // the backstop color row first, then each layer in array order (last =
+  // topmost, matching the authoring model; the emitter reverses for CSS).
+  if (opts.facets.background) {
+    const background = opts.facets.background;
+    const layers = background.layers ?? [];
+
+    const colorRow = document.createElement('div');
+    colorRow.className = 'stb-facet-bg-row';
+    colorRow.dataset.stbBgRow = 'color';
+    const colorLab = document.createElement('span');
+    colorLab.className = 'stb-facet-leaf-label';
+    colorLab.textContent = 'backstop';
+    colorRow.appendChild(colorLab);
+
+    const colorLit = background.color && 'literal' in background.color && typeof background.color.literal === 'object'
+      ? background.color.literal as Oklch
+      : null;
+    const colorBtn = document.createElement('button');
+    colorBtn.type = 'button';
+    colorBtn.className = 'stb-facet-swatch';
+    if (colorLit) colorBtn.style.backgroundColor = oklchToHex(colorLit);
+    colorBtn.addEventListener('click', () => openColorPicker({
+      previewHost: opts.previewHost,
+      initial: colorLit ? oklchToHex(colorLit) : '#000000',
+      format: opts.colorFormat?.() ?? 'hex',
+      onChange: (value) => opts.onBackstop?.({ literal: toOklch(value) }),
+    }));
+    colorRow.appendChild(colorBtn);
+    host.appendChild(colorRow);
+
+    layers.forEach((layer, i) => {
+      const row = document.createElement('div');
+      row.className = 'stb-facet-bg-row';
+      row.dataset.stbBgRow = 'layer';
+
+      if (layer.kind === 'image') {
+        const lab = document.createElement('span');
+        lab.className = 'stb-facet-leaf-label';
+        lab.textContent = layer.ref || '(no image)';
+        row.appendChild(lab);
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/*';
+        input.addEventListener('change', () => {
+          const file = input.files?.[0];
+          if (!file) return;
+          const ref = assetRefFor(file.name);
+          setBrandingAsset(ref, file, file.name);
+          opts.onSetLayer?.(i, { kind: 'image', ref });
+        });
+        row.appendChild(input);
+      } else {
+        // Gradient layer: read-only summary this slice — full type/angle/stop
+        // editing lands in the next slice (4b).
+        const summary = document.createElement('span');
+        summary.className = 'stb-facet-bg-gradient-summary';
+        summary.textContent = gradientCss(layer.gradient);
+        row.appendChild(summary);
+      }
+
+      const upBtn = document.createElement('button');
+      upBtn.type = 'button';
+      upBtn.className = 'stb-facet-bg-move-up';
+      upBtn.textContent = '↑';
+      upBtn.disabled = i === 0;
+      upBtn.addEventListener('click', () => opts.onReorderLayer?.(i, i - 1));
+      row.appendChild(upBtn);
+
+      const downBtn = document.createElement('button');
+      downBtn.type = 'button';
+      downBtn.className = 'stb-facet-bg-move-down';
+      downBtn.textContent = '↓';
+      downBtn.disabled = i === layers.length - 1;
+      downBtn.addEventListener('click', () => opts.onReorderLayer?.(i, i + 1));
+      row.appendChild(downBtn);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'stb-facet-bg-remove';
+      removeBtn.textContent = '×';
+      removeBtn.addEventListener('click', () => opts.onRemoveLayer?.(i));
+      row.appendChild(removeBtn);
+
+      host.appendChild(row);
+    });
+
+    const footer = document.createElement('div');
+    footer.className = 'stb-facet-bg-footer';
+    const addImageBtn = document.createElement('button');
+    addImageBtn.type = 'button';
+    addImageBtn.className = 'stb-facet-bg-add-image';
+    addImageBtn.textContent = '+ image';
+    addImageBtn.addEventListener('click', () => opts.onAddLayer?.({ kind: 'image', ref: '' }));
+    footer.appendChild(addImageBtn);
+    host.appendChild(footer);
   }
 
   for (const g of GROUPS) {

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -177,12 +177,30 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     const background = opts.facets.background;
     const layers = background.layers ?? [];
 
+    // Background is a collapsible group like text/surface/spacing, but it has
+    // no onRemoveGroup wiring (background isn't addable/removable through the
+    // add-group select), so its branch header carries no remove button.
+    const bgBranch = document.createElement('div');
+    bgBranch.className = 'stb-facet-group';
+    bgBranch.textContent = 'background';
+    host.appendChild(bgBranch);
+
+    const bgLeaves = document.createElement('div');
+    bgLeaves.className = 'stb-facet-leaves';
+    host.appendChild(bgLeaves);
+
+    const bgEntry: GroupEntry = { group: 'background', branch: bgBranch, leaves: bgLeaves, collapsed: false };
+    groupEntries.push(bgEntry);
+    bgBranch.addEventListener('click', () => setCollapsed(bgEntry, !bgEntry.collapsed));
+    // Track focused group for isolate, same as the per-leaf hook in the style-group loop below.
+    bgLeaves.addEventListener('focusin', () => { focusedGroup = 'background'; });
+
     const colorRow = document.createElement('div');
     colorRow.className = 'stb-facet-bg-row';
     colorRow.dataset.stbBgRow = 'color';
     const colorLab = document.createElement('span');
-    colorLab.className = 'stb-facet-leaf-label';
-    colorLab.textContent = 'backstop';
+    colorLab.className = 'stb-facet-bg-subtitle';
+    colorLab.textContent = 'color';
     colorRow.appendChild(colorLab);
 
     const colorLit = background.color && 'literal' in background.color && typeof background.color.literal === 'object'
@@ -232,7 +250,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     colorDeriveBtn.addEventListener('click', () => { if (colorLit) opts.deriveDark?.('background.color'); });
     colorRow.appendChild(colorDeriveBtn);
 
-    host.appendChild(colorRow);
+    bgLeaves.appendChild(colorRow);
 
     layers.forEach((layer, i) => {
       const row = document.createElement('div');
@@ -241,8 +259,8 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
 
       if (layer.kind === 'image') {
         const lab = document.createElement('span');
-        lab.className = 'stb-facet-leaf-label';
-        lab.textContent = layer.ref || '(no image)';
+        lab.className = 'stb-facet-bg-subtitle';
+        lab.textContent = `image — ${layer.ref || '(no image)'}`;
         row.appendChild(lab);
         const input = document.createElement('input');
         input.type = 'file';
@@ -313,6 +331,11 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           const stops = seed.stops.map((s, idx) => (idx === si ? { ...s, color } : s));
           opts.onSetLayerDark?.(i, { kind: 'gradient', gradient: { ...seed, stops } as Gradient });
         };
+
+        const subtitle = document.createElement('span');
+        subtitle.className = 'stb-facet-bg-subtitle';
+        subtitle.textContent = `gradient — ${gradient.type}`;
+        row.appendChild(subtitle);
 
         const editor = document.createElement('div');
         editor.className = 'stb-facet-bg-gradient';
@@ -476,7 +499,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       removeBtn.addEventListener('click', () => opts.onRemoveLayer?.(i));
       row.appendChild(removeBtn);
 
-      host.appendChild(row);
+      bgLeaves.appendChild(row);
     });
 
     const footer = document.createElement('div');
@@ -498,7 +521,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     }));
     footer.appendChild(addGradientBtn);
 
-    host.appendChild(footer);
+    bgLeaves.appendChild(footer);
   }
 
   for (const g of GROUPS) {
@@ -770,7 +793,8 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     }
   }
 
-  // Expand/Collapse all act on the style groups (text/surface/spacing) only.
+  // Expand/Collapse all act on every entry in groupEntries — the style groups
+  // (text/surface/spacing) plus background, all collapsible GroupEntry branches.
   // The content/asset "default group" is a standalone always-on field (the
   // element's payload), so it's deliberately excluded — it has no group header
   // to fold into and is usually the thing you came to edit.

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -43,6 +43,9 @@ export interface FacetTreeOptions {
   onSetFont?: (index: number, value: FacetValue) => void;
   onRemoveFont?: (index: number) => void;
   onReorderFont?: (from: number, to: number) => void;
+  /** Spacing composite (Task 11): T/R/B/L padding/margin + row/column gap positional tuples. */
+  onSetSide?: (group: 'padding' | 'margin', side: 'top' | 'right' | 'bottom' | 'left', value: FacetValue) => void;
+  onSetGap?: (slot: 'row' | 'column', value: FacetValue) => void;
 }
 
 const FONT_WEIGHTS = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
@@ -478,6 +481,62 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       addFontBtn.addEventListener('click', () => opts.onAddFont?.({ literal: '' }));
       fontFooter.appendChild(addFontBtn);
       leavesEl.appendChild(fontFooter);
+    }
+
+    // Spacing tuples — a kind-2 positional tuple (T/R/B/L padding/margin, row/column
+    // gap) rather than a single FacetValue leaf, so it's not in FACET_PROPS/props and
+    // is rendered here explicitly rather than through the per-key leaf loop below.
+    if (g === 'spacing') {
+      const spacingFacet = opts.facets.spacing ?? {};
+
+      const sideRow = (group: 'padding' | 'margin', label: string) => {
+        const row = document.createElement('div');
+        row.className = 'stb-facet-spacing-row';
+        row.dataset.stbSpacingGroup = group;
+        const lab = document.createElement('span');
+        lab.className = 'stb-facet-leaf-label';
+        lab.textContent = label;
+        row.appendChild(lab);
+        const sides = ['top', 'right', 'bottom', 'left'] as const;
+        for (const side of sides) {
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.className = 'stb-facet-spacing-side';
+          input.dataset.stbSide = side;
+          input.placeholder = side[0]!.toUpperCase();
+          const current = spacingFacet[group]?.[side];
+          if (current && 'literal' in current && typeof current.literal === 'string') {
+            input.value = current.literal;
+          }
+          input.addEventListener('input', () => opts.onSetSide?.(group, side, { literal: input.value }));
+          row.appendChild(input);
+        }
+        leavesEl.appendChild(row);
+      };
+      sideRow('padding', 'padding');
+      sideRow('margin', 'margin');
+
+      const gapRow = document.createElement('div');
+      gapRow.className = 'stb-facet-spacing-row';
+      gapRow.dataset.stbSpacingGroup = 'gap';
+      const gapLab = document.createElement('span');
+      gapLab.className = 'stb-facet-leaf-label';
+      gapLab.textContent = 'gap';
+      gapRow.appendChild(gapLab);
+      for (const slot of ['row', 'column'] as const) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'stb-facet-spacing-gap';
+        input.dataset.stbSlot = slot;
+        input.placeholder = slot[0]!.toUpperCase();
+        const current = spacingFacet.gap?.[slot];
+        if (current && 'literal' in current && typeof current.literal === 'string') {
+          input.value = current.literal;
+        }
+        input.addEventListener('input', () => opts.onSetGap?.(slot, { literal: input.value }));
+        gapRow.appendChild(input);
+      }
+      leavesEl.appendChild(gapRow);
     }
 
     for (const [key, spec] of props) {

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -245,6 +245,19 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       bgLeaves.appendChild(hint);
     }
 
+    // Live paint-stack summary: the exact CSS this group emits (topmost layer
+    // first, color always the bottom backstop). The layer ROWS list bottom-up
+    // for authoring; this is the same stack in paint order with real values —
+    // "what is actually covering what" at a glance.
+    const emittedBg = backgroundCss(background);
+    if (emittedBg.length) {
+      const stack = document.createElement('pre');
+      stack.className = 'stb-facet-bg-css';
+      stack.title = 'The CSS this background group currently emits — background-image layers paint left-to-right (first = on top), the color always paints beneath them all';
+      stack.textContent = emittedBg.join('\n');
+      bgLeaves.appendChild(stack);
+    }
+
     const colorRow = document.createElement('div');
     colorRow.className = 'stb-facet-bg-row';
     colorRow.dataset.stbBgRow = 'color';
@@ -578,6 +591,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           removeStopBtn.type = 'button';
           removeStopBtn.className = 'stb-facet-bg-gradient-stop-remove';
           removeStopBtn.textContent = '×';
+          removeStopBtn.title = 'Remove this color stop (the gradient itself stays — delete the layer with its × remove)';
           removeStopBtn.disabled = gradient.stops.length <= 1;
           removeStopBtn.addEventListener('click', () => {
             const stops = gradient.stops.filter((_, idx) => idx !== si);
@@ -609,6 +623,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       upBtn.type = 'button';
       upBtn.className = 'stb-facet-bg-move-up';
       upBtn.textContent = '↑';
+      upBtn.title = 'Move this layer down the paint stack (list is bottom-up: last row paints on top)';
       upBtn.disabled = i === 0;
       upBtn.addEventListener('click', () => opts.onReorderLayer?.(i, i - 1));
       row.appendChild(upBtn);
@@ -617,14 +632,20 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       downBtn.type = 'button';
       downBtn.className = 'stb-facet-bg-move-down';
       downBtn.textContent = '↓';
+      downBtn.title = 'Move this layer up the paint stack (list is bottom-up: last row paints on top)';
       downBtn.disabled = i === layers.length - 1;
       downBtn.addEventListener('click', () => opts.onReorderLayer?.(i, i + 1));
       row.appendChild(downBtn);
 
+      // Visible word, not a bare glyph: an unlabeled 12px × is where "how do I
+      // delete a layer?" went to die during the 2026-07-02 live pass.
       const removeBtn = document.createElement('button');
       removeBtn.type = 'button';
       removeBtn.className = 'stb-facet-bg-remove';
-      removeBtn.textContent = '×';
+      removeBtn.textContent = '× remove';
+      removeBtn.title = layer.kind === 'image'
+        ? 'Delete this image layer — whatever is beneath it (other layers, then the color) shows through'
+        : 'Delete this gradient layer — whatever is beneath it (other layers, then the color) shows through';
       removeBtn.addEventListener('click', () => opts.onRemoveLayer?.(i));
       row.appendChild(removeBtn);
 

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -9,6 +9,10 @@ import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 import { deriveDarkOklch } from '@/color/derive-dark';
 
 const GROUPS = ['text', 'surface', 'spacing'] as const;
+// Offered by the add-group select — GROUPS plus 'background', which is
+// addable (empty composite) but not part of the style-group render loop
+// below (it has its own dedicated block, guarded by opts.facets.background).
+const ADDABLE_GROUPS = ['background', ...GROUPS] as const;
 const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.startsWith(g + '.'));
 
 export interface FacetTreeOptions {
@@ -22,7 +26,10 @@ export interface FacetTreeOptions {
   /** Fired when the per-row "derive dark from light" button is clicked. Caller computes
    *  deriveDarkOklch and routes the result through its own dark-edit path. */
   deriveDark?: (key: string) => void;
-  onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
+  /** Widened over onRemoveGroup: 'background' is addable (creates an empty
+   *  background facet) but deliberately not removable — see AddableGroup in
+   *  facets-edit.ts. */
+  onAddGroup?: (g: 'text' | 'surface' | 'spacing' | 'background') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   /** Returns the token name mapped to this element's property, or null if none. */
   tokenForKey?: (key: string) => string | null;
@@ -110,7 +117,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
   placeholder.textContent = '+ add group';
   placeholder.disabled = true;
   addSelect.appendChild(placeholder);
-  for (const g of GROUPS) {
+  for (const g of ADDABLE_GROUPS) {
     if (!opts.facets[g]) {
       const opt = document.createElement('option');
       opt.value = g;
@@ -120,7 +127,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
   }
   addSelect.value = '';
   addSelect.addEventListener('change', () => {
-    const g = addSelect.value as 'text' | 'surface' | 'spacing';
+    const g = addSelect.value as 'text' | 'surface' | 'spacing' | 'background';
     if (g) {
       opts.onAddGroup?.(g);
       addSelect.value = '';
@@ -177,9 +184,10 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     const background = opts.facets.background;
     const layers = background.layers ?? [];
 
-    // Background is a collapsible group like text/surface/spacing, but it has
-    // no onRemoveGroup wiring (background isn't addable/removable through the
-    // add-group select), so its branch header carries no remove button.
+    // Background is a collapsible group like text/surface/spacing. It IS
+    // addable through the add-group select (ADDABLE_GROUPS, above), but has
+    // no onRemoveGroup wiring — removal isn't sanctioned — so its branch
+    // header carries no remove button.
     const bgBranch = document.createElement('div');
     bgBranch.className = 'stb-facet-group';
     bgBranch.textContent = 'background';
@@ -337,11 +345,35 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         subtitle.textContent = `gradient — ${gradient.type}`;
         row.appendChild(subtitle);
 
+        // One MDN help link per gradient layer — points at the current
+        // gradient function's page (linear-gradient/radial-gradient/
+        // conic-gradient), refreshed on type switch. No custom prose: the
+        // CSS spec is the source of truth, not a paraphrase we'd have to
+        // keep in sync.
+        const MDN_GRADIENT_BASE = 'https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/';
+        const helpLink = document.createElement('a');
+        helpLink.className = 'stb-facet-bg-gradient-help';
+        helpLink.textContent = '?';
+        helpLink.target = '_blank';
+        helpLink.rel = 'noopener';
+        const updateHelpLink = () => {
+          helpLink.href = `${MDN_GRADIENT_BASE}${gradient.type}-gradient`;
+          helpLink.title = `MDN reference for ${gradient.type}-gradient()`;
+        };
+        updateHelpLink();
+        row.appendChild(helpLink);
+
         const editor = document.createElement('div');
         editor.className = 'stb-facet-bg-gradient';
 
+        const typeLab = document.createElement('span');
+        typeLab.className = 'stb-facet-bg-gradient-field-label';
+        typeLab.textContent = 'type';
+        editor.appendChild(typeLab);
+
         const typeSel = document.createElement('select');
         typeSel.className = 'stb-facet-bg-gradient-type';
+        typeSel.title = 'Gradient function: linear-gradient, radial-gradient, or conic-gradient';
         for (const t of ['linear', 'radial', 'conic'] as const) {
           const opt = document.createElement('option');
           opt.value = t;
@@ -351,14 +383,21 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         typeSel.value = gradient.type;
         typeSel.addEventListener('change', () => {
           setGradient(convertType(gradient, typeSel.value as Gradient['type']));
+          updateHelpLink();
         });
         editor.appendChild(typeSel);
 
         // One angle/position field: linear owns `angle`, radial/conic own `position`.
+        const posLab = document.createElement('span');
+        posLab.className = 'stb-facet-bg-gradient-field-label';
         const posInput = document.createElement('input');
         posInput.type = 'text';
         posInput.className = 'stb-facet-bg-gradient-pos';
-        posInput.placeholder = gradient.type === 'linear' ? 'angle' : 'position';
+        const isAngle = gradient.type === 'linear';
+        posLab.textContent = isAngle ? 'angle' : 'position';
+        posInput.title = isAngle
+          ? 'CSS <angle>, e.g. 45deg'
+          : 'CSS <position>, e.g. center or top left';
         posInput.value = gradient.type === 'linear' ? (gradient.angle ?? '') : (gradient.position ?? '');
         posInput.addEventListener('input', () => {
           const patch: Partial<Gradient> = gradient.type === 'linear'
@@ -366,10 +405,21 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
             : { position: posInput.value };
           setGradient(rebuild(patch));
         });
+        editor.appendChild(posLab);
         editor.appendChild(posInput);
 
         const stopsEl = document.createElement('div');
         stopsEl.className = 'stb-facet-bg-gradient-stops';
+        if (gradient.stops.length > 0) {
+          const stopsHeader = document.createElement('div');
+          stopsHeader.className = 'stb-facet-bg-gradient-stops-header';
+          const posHeaderLab = document.createElement('span');
+          posHeaderLab.className = 'stb-facet-bg-gradient-stops-header-pos';
+          posHeaderLab.textContent = 'position';
+          posHeaderLab.title = 'CSS <length-percentage>, e.g. 25%';
+          stopsHeader.appendChild(posHeaderLab);
+          stopsEl.appendChild(stopsHeader);
+        }
         gradient.stops.forEach((stop, si) => {
           const stopRow = document.createElement('div');
           stopRow.className = 'stb-facet-bg-gradient-stop';
@@ -437,6 +487,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           stopPos.type = 'text';
           stopPos.className = 'stb-facet-bg-gradient-stop-pos';
           stopPos.placeholder = 'position';
+          stopPos.title = 'CSS <length-percentage>, e.g. 25%';
           stopPos.value = stop.position ?? '';
           stopPos.addEventListener('input', () => {
             const stops = gradient.stops.map((s, idx) => {
@@ -468,7 +519,10 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         addStopBtn.className = 'stb-facet-bg-gradient-add-stop';
         addStopBtn.textContent = '+ stop';
         addStopBtn.addEventListener('click', () => {
-          const stops = [...gradient.stops, { color: { literal: '#000000' } }];
+          // Oklch object, not a raw hex string: string literals round-trip fine
+          // (swatchHex handles both), but only an Oklch literal drives per-stop
+          // dark derive — a fresh stop should have that available immediately.
+          const stops = [...gradient.stops, { color: { literal: toOklch('#000000') } }];
           setGradient(rebuild({ stops }));
         });
         editor.appendChild(addStopBtn);
@@ -517,7 +571,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     addGradientBtn.textContent = '+ gradient';
     addGradientBtn.addEventListener('click', () => opts.onAddLayer?.({
       kind: 'gradient',
-      gradient: { type: 'linear', stops: [{ color: { literal: '#000000' } }, { color: { literal: '#ffffff' } }] },
+      gradient: { type: 'linear', stops: [{ color: { literal: toOklch('#000000') } }, { color: { literal: toOklch('#ffffff') } }] },
     }));
     footer.appendChild(addGradientBtn);
 

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -38,15 +38,13 @@ export interface FacetTreeOptions {
   onSetLayer?: (index: number, layer: Layer) => void;
   onRemoveLayer?: (index: number) => void;
   onReorderLayer?: (from: number, to: number) => void;
+  /** Font-family fallback list (Task 10): ordered comma-list, same kind-1 shape as background.layers. */
+  onAddFont?: (value: FacetValue) => void;
+  onSetFont?: (index: number, value: FacetValue) => void;
+  onRemoveFont?: (index: number) => void;
+  onReorderFont?: (from: number, to: number) => void;
 }
 
-const FONT_FAMILIES = [
-  'inherit',
-  'system-ui',
-  'Arial, sans-serif',
-  'Georgia, serif',
-  '"Courier New", monospace',
-];
 const FONT_WEIGHTS = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'];
 
 interface GroupEntry {
@@ -429,6 +427,59 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       leavesEl.appendChild(header);
     }
 
+    // Font-family fallback list — a kind-1 ordered comma-list (like background.layers)
+    // rather than a single FacetValue leaf, so it's not in FACET_PROPS/props and is
+    // rendered here explicitly rather than through the per-key leaf loop below.
+    if (g === 'text') {
+      const fontList = opts.facets.text?.fontFamily ?? [];
+      fontList.forEach((v, i) => {
+        const row = document.createElement('div');
+        row.className = 'stb-facet-fontfamily-row';
+        row.dataset.stbFontfamilyRow = 'font';
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = 'literal' in v ? String(v.literal) : '';
+        input.addEventListener('input', () => opts.onSetFont?.(i, { literal: input.value }));
+        row.appendChild(input);
+
+        const upBtn = document.createElement('button');
+        upBtn.type = 'button';
+        upBtn.className = 'stb-facet-fontfamily-move-up';
+        upBtn.textContent = '↑';
+        upBtn.disabled = i === 0;
+        upBtn.addEventListener('click', () => opts.onReorderFont?.(i, i - 1));
+        row.appendChild(upBtn);
+
+        const downBtn = document.createElement('button');
+        downBtn.type = 'button';
+        downBtn.className = 'stb-facet-fontfamily-move-down';
+        downBtn.textContent = '↓';
+        downBtn.disabled = i === fontList.length - 1;
+        downBtn.addEventListener('click', () => opts.onReorderFont?.(i, i + 1));
+        row.appendChild(downBtn);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'stb-facet-fontfamily-remove';
+        removeBtn.textContent = '×';
+        removeBtn.addEventListener('click', () => opts.onRemoveFont?.(i));
+        row.appendChild(removeBtn);
+
+        leavesEl.appendChild(row);
+      });
+
+      const fontFooter = document.createElement('div');
+      fontFooter.className = 'stb-facet-fontfamily-footer';
+      const addFontBtn = document.createElement('button');
+      addFontBtn.type = 'button';
+      addFontBtn.className = 'stb-facet-fontfamily-add';
+      addFontBtn.textContent = '+ font';
+      addFontBtn.addEventListener('click', () => opts.onAddFont?.({ literal: '' }));
+      fontFooter.appendChild(addFontBtn);
+      leavesEl.appendChild(fontFooter);
+    }
+
     for (const [key, spec] of props) {
       const leaf = document.createElement('div');
       leaf.className = 'stb-facet-leaf';
@@ -491,9 +542,9 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         deriveBtn.disabled = !lit;
         deriveBtn.addEventListener('click', () => { if (lit) opts.deriveDark?.(key); });
         leaf.appendChild(deriveBtn);
-      } else if (key === 'text.fontFamily' || key === 'text.fontWeight') {
+      } else if (key === 'text.fontWeight') {
         const sel = document.createElement('select');
-        const options = key === 'text.fontWeight' ? FONT_WEIGHTS : FONT_FAMILIES;
+        const options = FONT_WEIGHTS;
         for (const o of options) {
           const opt = document.createElement('option');
           opt.value = o;

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -227,6 +227,17 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         // these controls own — exotic values go through scopedBlock instead.
         const gradient = layer.gradient;
         const rebuild = (patch: Partial<Gradient>): Gradient => ({ ...gradient, ...patch }) as Gradient;
+        // Type switch rebuilds the gradient per target arm rather than spreading,
+        // so arm-specific fields (angle/shape/size/fromAngle) can't leak into an
+        // arm that doesn't own them. Shared fields carry: stops, repeating, and
+        // position where the target supports it (radial/conic).
+        const convertType = (g: Gradient, type: Gradient['type']): Gradient => {
+          if (type === g.type) return g;
+          const base = { stops: g.stops, ...(g.repeating !== undefined ? { repeating: g.repeating } : {}) };
+          if (type === 'linear') return { type, ...base };
+          const pos = 'position' in g && g.position !== undefined ? { position: g.position } : {};
+          return { type, ...base, ...pos };
+        };
         const setGradient = (g: Gradient) => opts.onSetLayer?.(i, { kind: 'gradient', gradient: g });
 
         const editor = document.createElement('div');
@@ -242,7 +253,7 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         }
         typeSel.value = gradient.type;
         typeSel.addEventListener('change', () => {
-          setGradient(rebuild({ type: typeSel.value as Gradient['type'] } as Partial<Gradient>));
+          setGradient(convertType(gradient, typeSel.value as Gradient['type']));
         });
         editor.appendChild(typeSel);
 

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -288,16 +288,27 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         // Dark counterpart of this layer, if one has been forked already (copy-on-
         // first-dark-edit, applied in main.ts). Read fresh on every mount so it
         // tracks state changes the same way the light `gradient` local does.
-        const darkLayer = opts.darkFacets?.background?.layers?.[i];
+        const darkLayers = opts.darkFacets?.background?.layers;
+        const isDarkForked = !!darkLayers;
+        const darkLayer = darkLayers?.[i];
         const darkGradient = darkLayer?.kind === 'gradient' ? darkLayer.gradient : null;
-        // Seed for the first dark edit: the existing dark gradient if this layer has
-        // already been forked, otherwise a structural copy of the CURRENT light
-        // gradient (so the fork starts from what's on screen, not the mount-time
-        // snapshot). Once forked, light and dark gradients are independent — later
-        // edits to one never touch the other.
+        // Once the dark array is forked, the dark side is authoritative. If a
+        // structural light edit (add/remove/reorder) has since broken index
+        // correspondence — this index is missing or not a gradient on the dark
+        // side — there is no correct dark value to show or seed from: re-seeding
+        // from the CURRENT light gradient would silently clobber whatever real
+        // dark fork exists elsewhere in the array once main.ts's array-level
+        // setLayer writes it back. Surface the mismatch instead of guessing.
+        const darkMismatch = isDarkForked && !darkGradient;
+        // Seed for the first dark edit: the existing dark gradient if this layer
+        // has already been forked, otherwise (unforked case only) a structural
+        // copy of the CURRENT light gradient so the fork starts from what's on
+        // screen, not the mount-time snapshot. Once forked, light and dark
+        // gradients are independent — later edits to one never touch the other.
         const seedDarkGradient = (): Gradient =>
           darkGradient ?? (JSON.parse(JSON.stringify(gradient)) as Gradient);
         const setDarkStop = (si: number, color: FacetValue) => {
+          if (darkMismatch) return;
           const seed = seedDarkGradient();
           const stops = seed.stops.map((s, idx) => (idx === si ? { ...s, color } : s));
           opts.onSetLayerDark?.(i, { kind: 'gradient', gradient: { ...seed, stops } as Gradient });
@@ -369,12 +380,17 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           } else {
             darkSwatch.classList.add('stb-facet-swatch-empty');
           }
-          darkSwatch.addEventListener('click', () => openColorPicker({
-            previewHost: opts.previewHost,
-            initial: darkStopHex ?? '#000000',
-            format: opts.colorFormat?.() ?? 'hex',
-            onChange: (value) => setDarkStop(si, { literal: toOklch(value) }),
-          }));
+          // Forked-but-mismatched rows are disabled, not re-seeded: see darkMismatch above.
+          darkSwatch.disabled = darkMismatch;
+          darkSwatch.addEventListener('click', () => {
+            if (darkMismatch) return;
+            openColorPicker({
+              previewHost: opts.previewHost,
+              initial: darkStopHex ?? '#000000',
+              format: opts.colorFormat?.() ?? 'hex',
+              onChange: (value) => setDarkStop(si, { literal: toOklch(value) }),
+            });
+          });
           stopRow.appendChild(darkSwatch);
 
           // Per-stop derive: only meaningful when the light stop resolves to a
@@ -387,9 +403,9 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           stopDeriveBtn.className = 'stb-facet-derive-dark';
           stopDeriveBtn.textContent = '↓';
           stopDeriveBtn.title = 'Derive dark from light';
-          stopDeriveBtn.disabled = !stopOklch;
+          stopDeriveBtn.disabled = !stopOklch || darkMismatch;
           stopDeriveBtn.addEventListener('click', () => {
-            if (!stopOklch) return;
+            if (!stopOklch || darkMismatch) return;
             setDarkStop(si, { literal: deriveDarkOklch(stopOklch, { role: 'background' }) });
           });
           stopRow.appendChild(stopDeriveBtn);

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -6,6 +6,7 @@ import type { ColorFormat } from '@/color/format';
 import { FACET_PROPS } from '@/metadata/facets';
 import { openColorPicker } from '@/ui/color-picker';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
+import { deriveDarkOklch } from '@/color/derive-dark';
 
 const GROUPS = ['text', 'surface', 'spacing'] as const;
 const propsOf = (g: string) => Object.entries(FACET_PROPS).filter(([k]) => k.startsWith(g + '.'));
@@ -36,6 +37,8 @@ export interface FacetTreeOptions {
   onBackstop?: (value: FacetValue) => void;
   onAddLayer?: (layer: Layer) => void;
   onSetLayer?: (index: number, layer: Layer) => void;
+  /** Dark-mode counterpart of onSetLayer, for gradient stop dark-swatch/derive edits. */
+  onSetLayerDark?: (index: number, layer: Layer) => void;
   onRemoveLayer?: (index: number) => void;
   onReorderLayer?: (from: number, to: number) => void;
   /** Font-family fallback list (Task 10): ordered comma-list, same kind-1 shape as background.layers. */
@@ -196,6 +199,39 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
       onChange: (value) => opts.onBackstop?.({ literal: toOklch(value) }),
     }));
     colorRow.appendChild(colorBtn);
+
+    // Dark counterpart, mirroring the leaf color-loop's light/dark/derive pattern
+    // (locked layout: light, dark, derive) — routes through onDarkEdit/deriveDark
+    // keyed on 'background.color', same as any other FACET_PROPS color leaf.
+    const colorDark = opts.darkFacets?.background?.color;
+    const colorLitDark = colorDark && 'literal' in colorDark && typeof colorDark.literal === 'object'
+      ? colorDark.literal as Oklch
+      : null;
+    const colorDarkBtn = document.createElement('button');
+    colorDarkBtn.type = 'button';
+    colorDarkBtn.className = 'stb-facet-swatch-dark';
+    if (colorLitDark) {
+      colorDarkBtn.style.backgroundColor = oklchToHex(colorLitDark);
+    } else {
+      colorDarkBtn.classList.add('stb-facet-swatch-empty');
+    }
+    colorDarkBtn.addEventListener('click', () => openColorPicker({
+      previewHost: opts.previewHost,
+      initial: colorLitDark ? oklchToHex(colorLitDark) : '#000000',
+      format: opts.colorFormat?.() ?? 'hex',
+      onChange: (value) => opts.onDarkEdit?.('background.color', { literal: toOklch(value) }),
+    }));
+    colorRow.appendChild(colorDarkBtn);
+
+    const colorDeriveBtn = document.createElement('button');
+    colorDeriveBtn.type = 'button';
+    colorDeriveBtn.className = 'stb-facet-derive-dark';
+    colorDeriveBtn.textContent = '↓';
+    colorDeriveBtn.title = 'Derive dark from light';
+    colorDeriveBtn.disabled = !colorLit;
+    colorDeriveBtn.addEventListener('click', () => { if (colorLit) opts.deriveDark?.('background.color'); });
+    colorRow.appendChild(colorDeriveBtn);
+
     host.appendChild(colorRow);
 
     layers.forEach((layer, i) => {
@@ -247,6 +283,24 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         const setGradient = (g: Gradient) => {
           gradient = g;
           opts.onSetLayer?.(i, { kind: 'gradient', gradient: g });
+        };
+
+        // Dark counterpart of this layer, if one has been forked already (copy-on-
+        // first-dark-edit, applied in main.ts). Read fresh on every mount so it
+        // tracks state changes the same way the light `gradient` local does.
+        const darkLayer = opts.darkFacets?.background?.layers?.[i];
+        const darkGradient = darkLayer?.kind === 'gradient' ? darkLayer.gradient : null;
+        // Seed for the first dark edit: the existing dark gradient if this layer has
+        // already been forked, otherwise a structural copy of the CURRENT light
+        // gradient (so the fork starts from what's on screen, not the mount-time
+        // snapshot). Once forked, light and dark gradients are independent — later
+        // edits to one never touch the other.
+        const seedDarkGradient = (): Gradient =>
+          darkGradient ?? (JSON.parse(JSON.stringify(gradient)) as Gradient);
+        const setDarkStop = (si: number, color: FacetValue) => {
+          const seed = seedDarkGradient();
+          const stops = seed.stops.map((s, idx) => (idx === si ? { ...s, color } : s));
+          opts.onSetLayerDark?.(i, { kind: 'gradient', gradient: { ...seed, stops } as Gradient });
         };
 
         const editor = document.createElement('div');
@@ -302,6 +356,43 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
             },
           }));
           stopRow.appendChild(swatch);
+
+          // Dark counterpart of this stop, mirroring the leaf color-loop's
+          // light/dark/derive layout.
+          const darkStop = darkGradient?.stops[si];
+          const darkStopHex = swatchHex(darkStop?.color);
+          const darkSwatch = document.createElement('button');
+          darkSwatch.type = 'button';
+          darkSwatch.className = 'stb-facet-swatch-dark';
+          if (darkStopHex) {
+            darkSwatch.style.backgroundColor = darkStopHex;
+          } else {
+            darkSwatch.classList.add('stb-facet-swatch-empty');
+          }
+          darkSwatch.addEventListener('click', () => openColorPicker({
+            previewHost: opts.previewHost,
+            initial: darkStopHex ?? '#000000',
+            format: opts.colorFormat?.() ?? 'hex',
+            onChange: (value) => setDarkStop(si, { literal: toOklch(value) }),
+          }));
+          stopRow.appendChild(darkSwatch);
+
+          // Per-stop derive: only meaningful when the light stop resolves to a
+          // literal Oklch — a token stop has nothing to derive from.
+          const stopOklch: Oklch | null = stop.color && !('token' in stop.color)
+            ? (typeof stop.color.literal === 'object' ? stop.color.literal as Oklch : toOklch(stop.color.literal))
+            : null;
+          const stopDeriveBtn = document.createElement('button');
+          stopDeriveBtn.type = 'button';
+          stopDeriveBtn.className = 'stb-facet-derive-dark';
+          stopDeriveBtn.textContent = '↓';
+          stopDeriveBtn.title = 'Derive dark from light';
+          stopDeriveBtn.disabled = !stopOklch;
+          stopDeriveBtn.addEventListener('click', () => {
+            if (!stopOklch) return;
+            setDarkStop(si, { literal: deriveDarkOklch(stopOklch, { role: 'background' }) });
+          });
+          stopRow.appendChild(stopDeriveBtn);
 
           const stopPos = document.createElement('input');
           stopPos.type = 'text';

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -226,7 +226,12 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         // gradientCss and the model if present; it is preserved (not edited)
         // by spreading the existing gradient and overriding only the fields
         // these controls own — exotic values go through scopedBlock instead.
-        const gradient = layer.gradient;
+        // Held in a `let` updated by every setGradient call: re-render is
+        // suppressed while a text input is focused, so consecutive edits to two
+        // different gradient fields land on the SAME mounted row — each patch
+        // must build on the latest written gradient, not the mount-time snapshot,
+        // or the second edit clobbers the first.
+        let gradient = layer.gradient;
         const rebuild = (patch: Partial<Gradient>): Gradient => ({ ...gradient, ...patch }) as Gradient;
         // Type switch rebuilds the gradient per target arm rather than spreading,
         // so arm-specific fields (angle/shape/size/fromAngle) can't leak into an
@@ -239,7 +244,10 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
           const pos = 'position' in g && g.position !== undefined ? { position: g.position } : {};
           return { type, ...base, ...pos };
         };
-        const setGradient = (g: Gradient) => opts.onSetLayer?.(i, { kind: 'gradient', gradient: g });
+        const setGradient = (g: Gradient) => {
+          gradient = g;
+          opts.onSetLayer?.(i, { kind: 'gradient', gradient: g });
+        };
 
         const editor = document.createElement('div');
         editor.className = 'stb-facet-bg-gradient';

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -1,5 +1,5 @@
 // src/ui/facet-tree.ts
-import type { Facets, FacetValue, Layer, Gradient } from '@/metadata/types';
+import type { Facets, FacetValue, Layer, Gradient, ContentFormat } from '@/metadata/types';
 import type { Oklch } from '@/color/oklch';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import type { ColorFormat } from '@/color/format';
@@ -35,7 +35,7 @@ export interface FacetTreeOptions {
   tokenForKey?: (key: string) => string | null;
   /** Resolves the literal FacetValue to detach TO (token's current value). */
   resolveLiteral?: (key: string, token: string) => FacetValue;
-  onContentEdit?: (text: string) => void;
+  onContentEdit?: (text: string, format?: ContentFormat) => void;
   onAssetEdit?: (file: File) => void;
   /** Live color-format accessor (hex/rgb/oklch), read when a color picker opens so the
    *  picker's text field matches the format chosen in the top bar. */
@@ -150,8 +150,22 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     leaf.appendChild(lab);
     const ta = document.createElement('textarea');
     ta.value = opts.facets.content.text;
-    ta.addEventListener('input', () => opts.onContentEdit?.(ta.value));
+    // Format select (plain | formatted): 'formatted' = the closed subset grammar
+    // (src/content/subset-format.ts). Both controls report through onContentEdit
+    // so an edit always carries the currently selected format.
+    const fmt = document.createElement('select');
+    fmt.className = 'stb-facet-content-format';
+    for (const [value, label] of [['plain', 'plain'], ['subset', 'formatted']] as const) {
+      const opt = document.createElement('option');
+      opt.value = value;
+      opt.textContent = label;
+      fmt.appendChild(opt);
+    }
+    fmt.value = opts.facets.content.format === 'subset' ? 'subset' : 'plain';
+    ta.addEventListener('input', () => opts.onContentEdit?.(ta.value, fmt.value as ContentFormat));
+    fmt.addEventListener('change', () => opts.onContentEdit?.(ta.value, fmt.value as ContentFormat));
     leaf.appendChild(ta);
+    leaf.appendChild(fmt);
     host.appendChild(leaf);
   }
 

--- a/tools/stb/src/ui/facet-tree.ts
+++ b/tools/stb/src/ui/facet-tree.ts
@@ -1,9 +1,9 @@
 // src/ui/facet-tree.ts
-import type { Facets, FacetValue, Layer } from '@/metadata/types';
+import type { Facets, FacetValue, Layer, Gradient } from '@/metadata/types';
 import type { Oklch } from '@/color/oklch';
 import { toOklch, oklchToHex } from '@/color/oklch';
 import type { ColorFormat } from '@/color/format';
-import { FACET_PROPS, gradientCss } from '@/metadata/facets';
+import { FACET_PROPS } from '@/metadata/facets';
 import { openColorPicker } from '@/ui/color-picker';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 
@@ -54,6 +54,14 @@ interface GroupEntry {
   branch: HTMLElement;
   leaves: HTMLElement;
   collapsed: boolean;
+}
+
+/** Swatch hex for a color-carrying FacetValue — literal may be a resolved Oklch
+ *  object or a raw string (gradient stops round-trip either shape). Returns
+ *  null for a token reference or a missing value (empty swatch). */
+function swatchHex(v: FacetValue | undefined): string | null {
+  if (!v || 'token' in v) return null;
+  return typeof v.literal === 'object' ? oklchToHex(v.literal as Oklch) : v.literal;
 }
 
 function setCollapsed(entry: GroupEntry, collapsed: boolean): void {
@@ -211,12 +219,111 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
         });
         row.appendChild(input);
       } else {
-        // Gradient layer: read-only summary this slice — full type/angle/stop
-        // editing lands in the next slice (4b).
-        const summary = document.createElement('span');
-        summary.className = 'stb-facet-bg-gradient-summary';
-        summary.textContent = gradientCss(layer.gradient);
-        row.appendChild(summary);
+        // Gradient layer: inline editor covering what Stratos themes today —
+        // type, ONE angle/position field, and a color-stop list. Anything more
+        // exotic (shape/size/fromAngle/repeating) already round-trips through
+        // gradientCss and the model if present; it is preserved (not edited)
+        // by spreading the existing gradient and overriding only the fields
+        // these controls own — exotic values go through scopedBlock instead.
+        const gradient = layer.gradient;
+        const rebuild = (patch: Partial<Gradient>): Gradient => ({ ...gradient, ...patch }) as Gradient;
+        const setGradient = (g: Gradient) => opts.onSetLayer?.(i, { kind: 'gradient', gradient: g });
+
+        const editor = document.createElement('div');
+        editor.className = 'stb-facet-bg-gradient';
+
+        const typeSel = document.createElement('select');
+        typeSel.className = 'stb-facet-bg-gradient-type';
+        for (const t of ['linear', 'radial', 'conic'] as const) {
+          const opt = document.createElement('option');
+          opt.value = t;
+          opt.textContent = t;
+          typeSel.appendChild(opt);
+        }
+        typeSel.value = gradient.type;
+        typeSel.addEventListener('change', () => {
+          setGradient(rebuild({ type: typeSel.value as Gradient['type'] } as Partial<Gradient>));
+        });
+        editor.appendChild(typeSel);
+
+        // One angle/position field: linear owns `angle`, radial/conic own `position`.
+        const posInput = document.createElement('input');
+        posInput.type = 'text';
+        posInput.className = 'stb-facet-bg-gradient-pos';
+        posInput.placeholder = gradient.type === 'linear' ? 'angle' : 'position';
+        posInput.value = gradient.type === 'linear' ? (gradient.angle ?? '') : (gradient.position ?? '');
+        posInput.addEventListener('input', () => {
+          const patch: Partial<Gradient> = gradient.type === 'linear'
+            ? { angle: posInput.value }
+            : { position: posInput.value };
+          setGradient(rebuild(patch));
+        });
+        editor.appendChild(posInput);
+
+        const stopsEl = document.createElement('div');
+        stopsEl.className = 'stb-facet-bg-gradient-stops';
+        gradient.stops.forEach((stop, si) => {
+          const stopRow = document.createElement('div');
+          stopRow.className = 'stb-facet-bg-gradient-stop';
+
+          const stopHex = swatchHex(stop.color);
+          const swatch = document.createElement('button');
+          swatch.type = 'button';
+          swatch.className = 'stb-facet-swatch';
+          if (stopHex) swatch.style.backgroundColor = stopHex;
+          swatch.addEventListener('click', () => openColorPicker({
+            previewHost: opts.previewHost,
+            initial: stopHex ?? '#000000',
+            format: opts.colorFormat?.() ?? 'hex',
+            onChange: (value) => {
+              const stops = gradient.stops.map((s, idx) =>
+                idx === si ? { ...s, color: { literal: toOklch(value) } } : s);
+              setGradient(rebuild({ stops }));
+            },
+          }));
+          stopRow.appendChild(swatch);
+
+          const stopPos = document.createElement('input');
+          stopPos.type = 'text';
+          stopPos.className = 'stb-facet-bg-gradient-stop-pos';
+          stopPos.placeholder = 'position';
+          stopPos.value = stop.position ?? '';
+          stopPos.addEventListener('input', () => {
+            const stops = gradient.stops.map((s, idx) => {
+              if (idx !== si) return s;
+              const { position: _drop, ...rest } = s;
+              return stopPos.value ? { ...rest, position: stopPos.value } : rest;
+            });
+            setGradient(rebuild({ stops }));
+          });
+          stopRow.appendChild(stopPos);
+
+          const removeStopBtn = document.createElement('button');
+          removeStopBtn.type = 'button';
+          removeStopBtn.className = 'stb-facet-bg-gradient-stop-remove';
+          removeStopBtn.textContent = '×';
+          removeStopBtn.disabled = gradient.stops.length <= 1;
+          removeStopBtn.addEventListener('click', () => {
+            const stops = gradient.stops.filter((_, idx) => idx !== si);
+            setGradient(rebuild({ stops }));
+          });
+          stopRow.appendChild(removeStopBtn);
+
+          stopsEl.appendChild(stopRow);
+        });
+        editor.appendChild(stopsEl);
+
+        const addStopBtn = document.createElement('button');
+        addStopBtn.type = 'button';
+        addStopBtn.className = 'stb-facet-bg-gradient-add-stop';
+        addStopBtn.textContent = '+ stop';
+        addStopBtn.addEventListener('click', () => {
+          const stops = [...gradient.stops, { color: { literal: '#000000' } }];
+          setGradient(rebuild({ stops }));
+        });
+        editor.appendChild(addStopBtn);
+
+        row.appendChild(editor);
       }
 
       const upBtn = document.createElement('button');
@@ -253,6 +360,17 @@ export function mountFacetTree(host: HTMLElement, opts: FacetTreeOptions): { des
     addImageBtn.textContent = '+ image';
     addImageBtn.addEventListener('click', () => opts.onAddLayer?.({ kind: 'image', ref: '' }));
     footer.appendChild(addImageBtn);
+
+    const addGradientBtn = document.createElement('button');
+    addGradientBtn.type = 'button';
+    addGradientBtn.className = 'stb-facet-bg-add-gradient';
+    addGradientBtn.textContent = '+ gradient';
+    addGradientBtn.addEventListener('click', () => opts.onAddLayer?.({
+      kind: 'gradient',
+      gradient: { type: 'linear', stops: [{ color: { literal: '#000000' } }, { color: { literal: '#ffffff' } }] },
+    }));
+    footer.appendChild(addGradientBtn);
+
     host.appendChild(footer);
   }
 

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -1,4 +1,4 @@
-import type { LeverValue, Facets, FacetValue, Layer } from '@/metadata/types';
+import type { LeverValue, Facets, FacetValue, Layer, ContentFormat } from '@/metadata/types';
 import type { EditorView } from 'codemirror';
 import { effect } from '@preact/signals-core';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
@@ -47,8 +47,9 @@ export interface OpenLeverEditorOptions {
   onSetGap?: (slot: 'row' | 'column', value: FacetValue) => void;
 }
 
-export function contentValue(text: string): LeverValue {
-  return { kind: 'content', text };
+export function contentValue(text: string, format?: ContentFormat): LeverValue {
+  // 'plain'/absent carries no format key — plain content stays byte-identical
+  return format === 'subset' ? { kind: 'content', text, format } : { kind: 'content', text };
 }
 export function assetValue(filename: string): LeverValue {
   return { kind: 'asset', ref: filename };
@@ -141,7 +142,7 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(opts.onReorderFont ? { onReorderFont: opts.onReorderFont } : {}),
       ...(opts.onSetSide ? { onSetSide: opts.onSetSide } : {}),
       ...(opts.onSetGap ? { onSetGap: opts.onSetGap } : {}),
-      onContentEdit: (text: string) => opts.onChange(contentValue(text)),
+      onContentEdit: (text: string, format?: ContentFormat) => opts.onChange(contentValue(text, format)),
       onAssetEdit: (file: File) => { setBrandingAsset(assetRefFor(file.name), file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
     });
   }

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -145,9 +145,13 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
     void brandingModel.value;                         // subscribe to model changes
     // Don't yank focus from an in-flight TYPED edit (text input / textarea).
     // A focused button (e.g. the derive-dark ↓) must NOT suppress the re-render,
-    // or its own swatch would keep the stale value it just changed.
+    // or its own swatch would keep the stale value it just changed. Same for a
+    // file input: it holds no in-flight text but keeps focus after the native
+    // dialog, and its row label must refresh with the chosen ref.
     const ae = document.activeElement;
-    if (ae && treeHost.contains(ae) && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) return;
+    const typing = ae && treeHost.contains(ae) &&
+      (ae.tagName === 'TEXTAREA' || (ae.tagName === 'INPUT' && (ae as HTMLInputElement).type !== 'file'));
+    if (typing) return;
     renderTree();
   });
 

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -22,7 +22,8 @@ export interface OpenLeverEditorOptions {
   onFacetEditDark?: (key: string, value: FacetValue) => void;
   /** Per-row "derive dark from light" — caller computes deriveDarkOklch and routes it through its own dark-edit path. */
   deriveDark?: (key: string) => void;
-  onAddGroup?: (g: 'text' | 'surface' | 'spacing') => void;
+  /** 'background' is addable but deliberately not removable — see the matching note in facet-tree.ts. */
+  onAddGroup?: (g: 'text' | 'surface' | 'spacing' | 'background') => void;
   onRemoveGroup?: (g: 'text' | 'surface' | 'spacing') => void;
   tokenForKey?: (key: string) => string | null;
   resolveLiteral?: (key: string, token: string) => FacetValue;

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -73,9 +73,11 @@ interface RememberedRect { left: number; top: number; width?: number; height?: n
 let rememberedRect: RememberedRect | null = null;
 let openedSize: { width: number; height: number } | null = null;
 let draggedSinceOpen = false;
-// One-line policy (pending preference — flip to false to keep memory across an
-// explicit Close): Close CLEARS the memory, so the next open is default-placed.
-const CLEAR_MEMORY_ON_CLOSE = true;
+// One-line policy (Norm 2026-07-01): the dragged position persists across an
+// explicit Close — re-placing the editor every time would irritate. Broader
+// editor-session memory (open/isolated groups, unsaved values, …) is deferred
+// until it demonstrably bothers users; position is just its first property.
+const CLEAR_MEMORY_ON_CLOSE = false;
 
 /** Forget the remembered panel rect (Close policy; exported for tests). */
 export function clearRememberedPanelRect(): void { rememberedRect = null; }

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -20,6 +20,13 @@ export interface OpenLeverEditorOptions {
   facetsDark?: Facets;
   onFacetEdit?: (key: string, value: FacetValue) => void;
   onFacetEditDark?: (key: string, value: FacetValue) => void;
+  /** Revert one value to "snapshot decides" (picker Clear), light / dark legs. */
+  onFacetClear?: (key: string) => void;
+  onFacetClearDark?: (key: string) => void;
+  /** Discard ALL edits on this element (Reset button) — close ≠ delete. */
+  onResetNode?: () => void;
+  /** Forwarded to the facet tree: a full-bleed backdrop child owns this element's visible background. */
+  backdropHint?: { name: string; onJump: () => void };
   /** Per-row "derive dark from light" — caller computes deriveDarkOklch and routes it through its own dark-edit path. */
   deriveDark?: (key: string) => void;
   /** 'background' is addable but deliberately not removable — see the matching note in facet-tree.ts. */
@@ -166,6 +173,9 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       previewHost: opts.previewHost,
       onEdit: opts.onFacetEdit ?? (() => {}),
       onDarkEdit: opts.onFacetEditDark ?? (() => {}),
+      ...(opts.onFacetClear ? { onClearEdit: opts.onFacetClear } : {}),
+      ...(opts.onFacetClearDark ? { onClearEditDark: opts.onFacetClearDark } : {}),
+      ...(opts.backdropHint ? { backdropHint: opts.backdropHint } : {}),
       // Structural edits + token promote/detach + content/asset live on the light bundle only.
       ...(opts.deriveDark ? { deriveDark: opts.deriveDark } : {}),
       ...(opts.onAddGroup ? { onAddGroup: opts.onAddGroup } : {}),
@@ -202,6 +212,17 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
     if (typing) return;
     renderTree();
   });
+
+  // Close ≠ delete: Close only puts the panel away (every edit is already
+  // committed live). Reset is the delete — discard all edits on this element.
+  if (opts.onResetNode) {
+    const reset = document.createElement('button');
+    reset.className = 'stb-lever-reset';
+    reset.textContent = 'Reset';
+    reset.title = 'Discard all edits on this element — back to the snapshot defaults';
+    reset.addEventListener('click', () => opts.onResetNode?.());
+    panel.appendChild(reset);
+  }
 
   const close = document.createElement('button');
   close.className = 'stb-lever-close';

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -113,7 +113,7 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
       ...(opts.colorFormat ? { colorFormat: opts.colorFormat } : {}),
       onContentEdit: (text: string) => opts.onChange(contentValue(text)),
-      onAssetEdit: (file: File) => { setBrandingAsset(opts.snapshotId, file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
+      onAssetEdit: (file: File) => { setBrandingAsset(assetRefFor(file.name), file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
     });
   }
   openTreeEffect = effect(() => {

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -39,6 +39,9 @@ export interface OpenLeverEditorOptions {
   onSetFont?: (index: number, value: FacetValue) => void;
   onRemoveFont?: (index: number) => void;
   onReorderFont?: (from: number, to: number) => void;
+  /** Spacing composite (Task 11), forwarded to the facet tree's T/R/B/L + row/column tuple editor. */
+  onSetSide?: (group: 'padding' | 'margin', side: 'top' | 'right' | 'bottom' | 'left', value: FacetValue) => void;
+  onSetGap?: (slot: 'row' | 'column', value: FacetValue) => void;
 }
 
 export function contentValue(text: string): LeverValue {
@@ -132,6 +135,8 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(opts.onSetFont ? { onSetFont: opts.onSetFont } : {}),
       ...(opts.onRemoveFont ? { onRemoveFont: opts.onRemoveFont } : {}),
       ...(opts.onReorderFont ? { onReorderFont: opts.onReorderFont } : {}),
+      ...(opts.onSetSide ? { onSetSide: opts.onSetSide } : {}),
+      ...(opts.onSetGap ? { onSetGap: opts.onSetGap } : {}),
       onContentEdit: (text: string) => opts.onChange(contentValue(text)),
       onAssetEdit: (file: File) => { setBrandingAsset(assetRefFor(file.name), file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
     });

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -5,7 +5,7 @@ import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
 import { brandingModel, nodeFor } from '@/state/branding';
 import { mountCssEditor } from '@/ui/css-editor';
 import { mountFacetTree } from '@/ui/facet-tree';
-import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
+import { positionInPreviewGutter, positionAbovePanes, makeDraggable } from '@/ui/popover';
 import { previewDark, compareMode } from '@/state/scene';
 
 export interface OpenLeverEditorOptions {
@@ -179,20 +179,11 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
 
   // Flag the active preview mode on the panel so CSS can mute the inactive
   // (dark) column — editing a dark value while the preview is in light mode
-  // otherwise reads as "no change".
-  openDarkEffect = effect(() => { panel.classList.toggle('stb-preview-dark', previewDark.value); });
-}
-
-// Compare-mode initial placement. With two panes splitting the full preview
-// width there is NO left gutter at typical widths — the gutter placement would
-// fall back to overlaying the light pane dead-centre. So the editor opens
-// ABOVE the panes (over the nav band, left-aligned) instead: "left of the
-// panes" (the primary choice) degenerates to covering a pane, so the fallback
-// position won. Still draggable, as always.
-function positionAbovePanes(panel: HTMLElement, previewHost: HTMLElement): void {
-  const host = previewHost.getBoundingClientRect();
-  const top = Math.max(8, host.top - panel.offsetHeight - 8);
-  panel.style.position = 'absolute';
-  panel.style.left = `${8 + window.scrollX}px`;
-  panel.style.top = `${top + window.scrollY}px`;
+  // otherwise reads as "no change". In compare mode previewDark is pinned
+  // false (the live dark pane sits alongside the light one), so gate on
+  // compareMode too — otherwise the dark column reads as inactive when a
+  // dark pane is visibly on-screen.
+  openDarkEffect = effect(() => {
+    panel.classList.toggle('stb-preview-dark', previewDark.value || compareMode.value);
+  });
 }

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -34,6 +34,11 @@ export interface OpenLeverEditorOptions {
   onSetLayer?: (index: number, layer: Layer) => void;
   onRemoveLayer?: (index: number) => void;
   onReorderLayer?: (from: number, to: number) => void;
+  /** Font-family fallback list (Task 10), forwarded to the facet tree's ordered-list editor. */
+  onAddFont?: (value: FacetValue) => void;
+  onSetFont?: (index: number, value: FacetValue) => void;
+  onRemoveFont?: (index: number) => void;
+  onReorderFont?: (from: number, to: number) => void;
 }
 
 export function contentValue(text: string): LeverValue {
@@ -123,6 +128,10 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(opts.onSetLayer ? { onSetLayer: opts.onSetLayer } : {}),
       ...(opts.onRemoveLayer ? { onRemoveLayer: opts.onRemoveLayer } : {}),
       ...(opts.onReorderLayer ? { onReorderLayer: opts.onReorderLayer } : {}),
+      ...(opts.onAddFont ? { onAddFont: opts.onAddFont } : {}),
+      ...(opts.onSetFont ? { onSetFont: opts.onSetFont } : {}),
+      ...(opts.onRemoveFont ? { onRemoveFont: opts.onRemoveFont } : {}),
+      ...(opts.onReorderFont ? { onReorderFont: opts.onReorderFont } : {}),
       onContentEdit: (text: string) => opts.onChange(contentValue(text)),
       onAssetEdit: (file: File) => { setBrandingAsset(assetRefFor(file.name), file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
     });

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -60,7 +60,48 @@ let openScopedEditor: EditorView | null = null;
 let openFacetTree: { destroy(): void } | null = null;
 let openTreeEffect: (() => void) | null = null;
 let openDarkEffect: (() => void) | null = null;
+
+// --- panel placement memory ---
+// selectElement tears the panel down and rebuilds it on every selection;
+// without memory each rebuild snaps back to the computed initial position,
+// discarding the user's drag/resize. Once the user has dragged (drag-end on
+// the handle) or resized (size delta at close vs. mount), the rect is
+// remembered module-level and reused — clamped to the viewport, the window
+// may have shrunk — on the next open. Size is only re-applied when it was a
+// real user resize, so an untouched panel keeps its CSS-driven intrinsic size.
+interface RememberedRect { left: number; top: number; width?: number; height?: number }
+let rememberedRect: RememberedRect | null = null;
+let openedSize: { width: number; height: number } | null = null;
+let draggedSinceOpen = false;
+// One-line policy (pending preference — flip to false to keep memory across an
+// explicit Close): Close CLEARS the memory, so the next open is default-placed.
+const CLEAR_MEMORY_ON_CLOSE = true;
+
+/** Forget the remembered panel rect (Close policy; exported for tests). */
+export function clearRememberedPanelRect(): void { rememberedRect = null; }
+
+function capturePanelRect(): void {
+  if (!openPanel) return;
+  const r = openPanel.getBoundingClientRect();
+  const resized = openedSize !== null && (r.width !== openedSize.width || r.height !== openedSize.height);
+  if (!draggedSinceOpen && !resized) return; // no user placement intent this open — keep prior memory
+  rememberedRect = { left: r.left, top: r.top, ...(resized ? { width: r.width, height: r.height } : {}) };
+}
+
+function applyRememberedRect(panel: HTMLElement, r: RememberedRect): void {
+  panel.style.position = 'absolute';
+  if (r.width !== undefined) panel.style.width = `${r.width}px`;
+  if (r.height !== undefined) panel.style.height = `${r.height}px`;
+  const w = r.width ?? panel.offsetWidth;
+  const h = r.height ?? panel.offsetHeight;
+  const left = Math.min(Math.max(0, r.left), Math.max(0, window.innerWidth - w));
+  const top = Math.min(Math.max(0, r.top), Math.max(0, window.innerHeight - h));
+  panel.style.left = `${left + window.scrollX}px`;
+  panel.style.top = `${top + window.scrollY}px`;
+}
+
 function closeOpen(): void {
+  capturePanelRect();
   if (openDarkEffect) { openDarkEffect(); openDarkEffect = null; }
   if (openTreeEffect) { openTreeEffect(); openTreeEffect = null; }
   if (openFacetTree) { openFacetTree.destroy(); openFacetTree = null; }
@@ -163,7 +204,11 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   const close = document.createElement('button');
   close.className = 'stb-lever-close';
   close.textContent = 'Close';
-  close.addEventListener('click', () => { closeOpen(); opts.onClose?.(); });
+  close.addEventListener('click', () => {
+    closeOpen();
+    if (CLEAR_MEMORY_ON_CLOSE) clearRememberedPanelRect();
+    opts.onClose?.();
+  });
   panel.appendChild(close);
 
   const drag = document.createElement('div');
@@ -173,10 +218,20 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   panel.prepend(drag);
 
   document.body.appendChild(panel);
-  if (compareMode.value) positionAbovePanes(panel, opts.previewHost);
+  // Remembered rect wins over initial placement (gutter / above-panes-in-compare)
+  if (rememberedRect) applyRememberedRect(panel, rememberedRect);
+  else if (compareMode.value) positionAbovePanes(panel, opts.previewHost);
   else positionInPreviewGutter(panel, opts.previewHost);
   makeDraggable(panel, drag);
+  // Drag-end marks the placement as user-chosen; capturePanelRect reads the
+  // final rect at close-time (the dragged inline position is still live then).
+  drag.addEventListener('mousedown', () => {
+    window.addEventListener('mouseup', () => { draggedSinceOpen = true; }, { once: true });
+  });
   openPanel = panel;
+  const mounted = panel.getBoundingClientRect();
+  openedSize = { width: mounted.width, height: mounted.height };
+  draggedSinceOpen = false;
 
   // Flag the active preview mode on the panel so CSS can mute the inactive
   // (dark) column — editing a dark value while the preview is in light mode

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -1,4 +1,4 @@
-import type { LeverValue, Facets, FacetValue } from '@/metadata/types';
+import type { LeverValue, Facets, FacetValue, Layer } from '@/metadata/types';
 import type { EditorView } from 'codemirror';
 import { effect } from '@preact/signals-core';
 import { setBrandingAsset, assetRefFor } from '@/state/branding-assets';
@@ -28,6 +28,12 @@ export interface OpenLeverEditorOptions {
   resolveLiteral?: (key: string, token: string) => FacetValue;
   /** Live color-format accessor, forwarded to the facet tree's color pickers. */
   colorFormat?: () => import('@/color/format').ColorFormat;
+  /** Background composite (Task 8/9), forwarded to the facet tree's background stack editor. */
+  onBackstop?: (value: FacetValue) => void;
+  onAddLayer?: (layer: Layer) => void;
+  onSetLayer?: (index: number, layer: Layer) => void;
+  onRemoveLayer?: (index: number) => void;
+  onReorderLayer?: (from: number, to: number) => void;
 }
 
 export function contentValue(text: string): LeverValue {
@@ -112,6 +118,11 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(opts.tokenForKey ? { tokenForKey: opts.tokenForKey } : {}),
       ...(opts.resolveLiteral ? { resolveLiteral: opts.resolveLiteral } : {}),
       ...(opts.colorFormat ? { colorFormat: opts.colorFormat } : {}),
+      ...(opts.onBackstop ? { onBackstop: opts.onBackstop } : {}),
+      ...(opts.onAddLayer ? { onAddLayer: opts.onAddLayer } : {}),
+      ...(opts.onSetLayer ? { onSetLayer: opts.onSetLayer } : {}),
+      ...(opts.onRemoveLayer ? { onRemoveLayer: opts.onRemoveLayer } : {}),
+      ...(opts.onReorderLayer ? { onReorderLayer: opts.onReorderLayer } : {}),
       onContentEdit: (text: string) => opts.onChange(contentValue(text)),
       onAssetEdit: (file: File) => { setBrandingAsset(assetRefFor(file.name), file, file.name); opts.onChange(assetValue(assetRefFor(file.name))); },
     });

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -6,7 +6,7 @@ import { brandingModel, nodeFor } from '@/state/branding';
 import { mountCssEditor } from '@/ui/css-editor';
 import { mountFacetTree } from '@/ui/facet-tree';
 import { positionInPreviewGutter, makeDraggable } from '@/ui/popover';
-import { previewDark } from '@/state/scene';
+import { previewDark, compareMode } from '@/state/scene';
 
 export interface OpenLeverEditorOptions {
   previewHost: HTMLElement;
@@ -172,7 +172,8 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   panel.prepend(drag);
 
   document.body.appendChild(panel);
-  positionInPreviewGutter(panel, opts.previewHost);
+  if (compareMode.value) positionAbovePanes(panel, opts.previewHost);
+  else positionInPreviewGutter(panel, opts.previewHost);
   makeDraggable(panel, drag);
   openPanel = panel;
 
@@ -180,4 +181,18 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
   // (dark) column — editing a dark value while the preview is in light mode
   // otherwise reads as "no change".
   openDarkEffect = effect(() => { panel.classList.toggle('stb-preview-dark', previewDark.value); });
+}
+
+// Compare-mode initial placement. With two panes splitting the full preview
+// width there is NO left gutter at typical widths — the gutter placement would
+// fall back to overlaying the light pane dead-centre. So the editor opens
+// ABOVE the panes (over the nav band, left-aligned) instead: "left of the
+// panes" (the primary choice) degenerates to covering a pane, so the fallback
+// position won. Still draggable, as always.
+function positionAbovePanes(panel: HTMLElement, previewHost: HTMLElement): void {
+  const host = previewHost.getBoundingClientRect();
+  const top = Math.max(8, host.top - panel.offsetHeight - 8);
+  panel.style.position = 'absolute';
+  panel.style.left = `${8 + window.scrollX}px`;
+  panel.style.top = `${top + window.scrollY}px`;
 }

--- a/tools/stb/src/ui/lever-editor.ts
+++ b/tools/stb/src/ui/lever-editor.ts
@@ -32,6 +32,8 @@ export interface OpenLeverEditorOptions {
   onBackstop?: (value: FacetValue) => void;
   onAddLayer?: (layer: Layer) => void;
   onSetLayer?: (index: number, layer: Layer) => void;
+  /** Dark-mode counterpart of onSetLayer, forwarded to the facet tree's gradient-stop dark axis. */
+  onSetLayerDark?: (index: number, layer: Layer) => void;
   onRemoveLayer?: (index: number) => void;
   onReorderLayer?: (from: number, to: number) => void;
   /** Font-family fallback list (Task 10), forwarded to the facet tree's ordered-list editor. */
@@ -129,6 +131,7 @@ export function openLeverEditor(opts: OpenLeverEditorOptions): void {
       ...(opts.onBackstop ? { onBackstop: opts.onBackstop } : {}),
       ...(opts.onAddLayer ? { onAddLayer: opts.onAddLayer } : {}),
       ...(opts.onSetLayer ? { onSetLayer: opts.onSetLayer } : {}),
+      ...(opts.onSetLayerDark ? { onSetLayerDark: opts.onSetLayerDark } : {}),
       ...(opts.onRemoveLayer ? { onRemoveLayer: opts.onRemoveLayer } : {}),
       ...(opts.onReorderLayer ? { onReorderLayer: opts.onReorderLayer } : {}),
       ...(opts.onAddFont ? { onAddFont: opts.onAddFont } : {}),

--- a/tools/stb/src/ui/popover.ts
+++ b/tools/stb/src/ui/popover.ts
@@ -21,6 +21,21 @@ export function positionInPreviewGutter(panel: HTMLElement, previewHost: HTMLEle
   panel.style.top = `${Math.max(8, top) + window.scrollY}px`;
 }
 
+// Compare-mode placement, shared by every popover that opens over the preview
+// (lever editor, color picker, …). With two panes splitting the full preview
+// width there is NO left gutter at typical widths — positionInPreviewGutter
+// would fall back to overlaying the light pane dead-centre. So the popover
+// opens ABOVE the panes (over the nav band, left-aligned) instead: "left of
+// the panes" (the primary choice) degenerates to covering a pane, so the
+// fallback position won. Still draggable, as always.
+export function positionAbovePanes(panel: HTMLElement, previewHost: HTMLElement): void {
+  const host = previewHost.getBoundingClientRect();
+  const top = Math.max(8, host.top - panel.offsetHeight - 8);
+  panel.style.position = 'absolute';
+  panel.style.left = `${8 + window.scrollX}px`;
+  panel.style.top = `${top + window.scrollY}px`;
+}
+
 // Let the user drag the popover by a handle, overriding the auto-placement.
 // Position stays clamped to the viewport so it can't be dragged off-screen.
 export function makeDraggable(panel: HTMLElement, handle: HTMLElement): void {

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -7,12 +7,14 @@ import type { BrandingModel } from '@/metadata/types';
 import type { LeverPatch } from '@/iframe-bridge/apply-levers';
 import { attachAssetBlobs, brandingAssets } from '@/state/branding-assets';
 import { emitScopedBlocks } from '@/parse/css-emitter';
+import { backgroundPatch } from '@/metadata/facets';
 
 export function leverPatchesFor(model: BrandingModel): LeverPatch[] {
   const out: LeverPatch[] = [];
   for (const n of model.nodes) {
     if (n.facets.content) out.push({ snapshotId: n.snapshotId, kind: 'content', text: n.facets.content.text });
     else if (n.facets.asset) out.push({ snapshotId: n.snapshotId, kind: 'asset', ref: n.facets.asset.ref });
+    if (n.facets.background) out.push({ snapshotId: n.snapshotId, kind: 'background', ...backgroundPatch(n.facets.background) });
     if (n.visibility !== undefined) out.push({ snapshotId: n.snapshotId, kind: 'visibility', shown: n.visibility });
   }
   return out;

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -5,11 +5,15 @@ import { brandingModel, loadBrandingModel } from '@/state/branding';
 import type { ParentToPreview, PreviewToParent } from '@/iframe-bridge/messages';
 import type { BrandingModel } from '@/metadata/types';
 import type { LeverPatch } from '@/iframe-bridge/apply-levers';
-import { attachAssetBlobs, brandingAssets } from '@/state/branding-assets';
+import { attachAssetBlobs, brandingAssets, rewriteAssetUrls } from '@/state/branding-assets';
 import { emitScopedBlocks } from '@/parse/css-emitter';
-import { backgroundPatch } from '@/metadata/facets';
 
-export function leverPatchesFor(model: BrandingModel, dark = false): LeverPatch[] {
+// Background is no longer patched here: the scoped-blocks CSS (emitScopedBlocks, sent via
+// STB_APPLY_BLOCKS) is the sole owner of preview backgrounds, light and dark alike — see
+// applyScopedBlocksToPreview below. Keeping a single leg avoids the two legs drifting apart
+// and lets uploaded background images resolve (raw asset refs get rewritten to blob: URLs
+// there; an inline-style leg would need the same rewrite duplicated).
+export function leverPatchesFor(model: BrandingModel): LeverPatch[] {
   const out: LeverPatch[] = [];
   for (const n of model.nodes) {
     if (n.facets.content) {
@@ -20,12 +24,6 @@ export function leverPatchesFor(model: BrandingModel, dark = false): LeverPatch[
       });
     }
     else if (n.facets.asset) out.push({ snapshotId: n.snapshotId, kind: 'asset', ref: n.facets.asset.ref });
-    // The inline background leg is mode-aware: in dark preview it composes from
-    // the dark bundle only. A light-bundle inline style would override the
-    // snapshot's .dark-theme rules AND the emitted dark scoped block; with no
-    // dark override we send no patch at all and let that CSS own the background.
-    const bg = dark ? n.facetsDark?.background : n.facets.background;
-    if (bg) out.push({ snapshotId: n.snapshotId, kind: 'background', ...backgroundPatch(bg) });
     if (n.visibility !== undefined) out.push({ snapshotId: n.snapshotId, kind: 'visibility', shown: n.visibility });
   }
   return out;
@@ -50,11 +48,17 @@ export interface PreviewPane {
   showLevers(on: boolean): void;
 }
 
+let paneCounter = 0;
+
 export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
   let iframe: HTMLIFrameElement | null = null;
   let ready = false;
   const mode = opts.mode ?? 'follow-global';
   const isDark = (): boolean => (mode === 'follow-global' ? previewDark.value : mode === 'dark');
+  // Distinct key per pane instance so rewriteAssetUrls's revoke-on-replace never
+  // clobbers another live pane's still-displayed blob: URLs (e.g. compare mode's
+  // light + pinned-dark panes both hold scoped-block CSS with rewritten refs).
+  const assetUrlKey = `preview-pane-${paneCounter++}`;
 
   function send(msg: ParentToPreview): void {
     if (!iframe || !iframe.contentWindow || !ready) return;
@@ -74,7 +78,7 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
   function applyLeversToPreview(): void {
     const m = brandingModel.value;
     if (!m) return;
-    send({ type: 'STB_APPLY_LEVERS', levers: attachAssetBlobs(leverPatchesFor(m, isDark()), brandingAssets.value) });
+    send({ type: 'STB_APPLY_LEVERS', levers: attachAssetBlobs(leverPatchesFor(m), brandingAssets.value) });
     // tell the shim which elements are editable (name rides along so a revealed
     // empty element can label itself with its real name, not invented text)
     send({ type: 'STB_SET_LEVERS', levers: m.nodes.map((n) => ({ id: n.snapshotId, name: n.name })) });
@@ -82,8 +86,11 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
 
   function applyScopedBlocksToPreview(): void {
     const m = brandingModel.value;
-    // send even when empty so clearing a block removes the rule from the iframe
-    send({ type: 'STB_APPLY_BLOCKS', css: m ? emitScopedBlocks(m.nodes) : '' });
+    const css = m ? emitScopedBlocks(m.nodes) : '';
+    // send even when empty so clearing a block removes the rule from the iframe;
+    // rewrite user-uploaded asset refs to blob: URLs so they resolve inside the iframe
+    // (snapshot-bundled refs pass through untouched — no stored blob for those).
+    send({ type: 'STB_APPLY_BLOCKS', css: css ? rewriteAssetUrls(css, brandingAssets.value, assetUrlKey) : '' });
   }
 
   function onMessage(event: MessageEvent): void {

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -9,12 +9,17 @@ import { attachAssetBlobs, brandingAssets } from '@/state/branding-assets';
 import { emitScopedBlocks } from '@/parse/css-emitter';
 import { backgroundPatch } from '@/metadata/facets';
 
-export function leverPatchesFor(model: BrandingModel): LeverPatch[] {
+export function leverPatchesFor(model: BrandingModel, dark = false): LeverPatch[] {
   const out: LeverPatch[] = [];
   for (const n of model.nodes) {
     if (n.facets.content) out.push({ snapshotId: n.snapshotId, kind: 'content', text: n.facets.content.text });
     else if (n.facets.asset) out.push({ snapshotId: n.snapshotId, kind: 'asset', ref: n.facets.asset.ref });
-    if (n.facets.background) out.push({ snapshotId: n.snapshotId, kind: 'background', ...backgroundPatch(n.facets.background) });
+    // The inline background leg is mode-aware: in dark preview it composes from
+    // the dark bundle only. A light-bundle inline style would override the
+    // snapshot's .dark-theme rules AND the emitted dark scoped block; with no
+    // dark override we send no patch at all and let that CSS own the background.
+    const bg = dark ? n.facetsDark?.background : n.facets.background;
+    if (bg) out.push({ snapshotId: n.snapshotId, kind: 'background', ...backgroundPatch(bg) });
     if (n.visibility !== undefined) out.push({ snapshotId: n.snapshotId, kind: 'visibility', shown: n.visibility });
   }
   return out;
@@ -54,7 +59,7 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
   function applyLeversToPreview(): void {
     const m = brandingModel.value;
     if (!m) return;
-    send({ type: 'STB_APPLY_LEVERS', levers: attachAssetBlobs(leverPatchesFor(m), brandingAssets.value) });
+    send({ type: 'STB_APPLY_LEVERS', levers: attachAssetBlobs(leverPatchesFor(m, previewDark.value), brandingAssets.value) });
     // tell the shim which elements are editable (name rides along so a revealed
     // empty element can label itself with its real name, not invented text)
     send({ type: 'STB_SET_LEVERS', levers: m.nodes.map((n) => ({ id: n.snapshotId, name: n.name })) });
@@ -116,7 +121,11 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
       });
 
       effect(() => {
+        // previewDark is subscribed unconditionally (not just via the guarded
+        // applyLeversToPreview read) so a dark toggle re-sends the mode-aware
+        // background patches even if the model hasn't changed since ready.
         void brandingModel.value;
+        void previewDark.value;
         if (ready) { applyLeversToPreview(); applyScopedBlocksToPreview(); }
       });
     },

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -1,6 +1,6 @@
 import { effect } from '@preact/signals-core';
 import { rootValues, darkValues } from '@/state/tokens';
-import { activeSceneId, previewDark } from '@/state/scene';
+import { activeSceneId, previewDark, compareMode } from '@/state/scene';
 import { brandingModel, loadBrandingModel } from '@/state/branding';
 import type { ParentToPreview, PreviewToParent } from '@/iframe-bridge/messages';
 import type { BrandingModel } from '@/metadata/types';
@@ -27,6 +27,13 @@ export function leverPatchesFor(model: BrandingModel, dark = false): LeverPatch[
 
 export interface PreviewPaneOptions {
   onElementSelected?: (selector: string, tokens: string[], snapshotId: string | null) => void;
+  /**
+   * Which mode this pane renders. 'follow-global' (default) tracks the
+   * previewDark signal — today's single-pane behavior. 'light'/'dark' pin the
+   * pane regardless of the global signal (the compare panes), so the dark pane
+   * stays dark while previewDark is false.
+   */
+  mode?: 'light' | 'dark' | 'follow-global';
 }
 
 export interface PreviewPane {
@@ -40,6 +47,8 @@ export interface PreviewPane {
 export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
   let iframe: HTMLIFrameElement | null = null;
   let ready = false;
+  const mode = opts.mode ?? 'follow-global';
+  const isDark = (): boolean => (mode === 'follow-global' ? previewDark.value : mode === 'dark');
 
   function send(msg: ParentToPreview): void {
     if (!iframe || !iframe.contentWindow || !ready) return;
@@ -53,13 +62,13 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
   }
 
   function applyDark(): void {
-    send({ type: 'STB_SET_DARK', dark: previewDark.value });
+    send({ type: 'STB_SET_DARK', dark: isDark() });
   }
 
   function applyLeversToPreview(): void {
     const m = brandingModel.value;
     if (!m) return;
-    send({ type: 'STB_APPLY_LEVERS', levers: attachAssetBlobs(leverPatchesFor(m, previewDark.value), brandingAssets.value) });
+    send({ type: 'STB_APPLY_LEVERS', levers: attachAssetBlobs(leverPatchesFor(m, isDark()), brandingAssets.value) });
     // tell the shim which elements are editable (name rides along so a revealed
     // empty element can label itself with its real name, not invented text)
     send({ type: 'STB_SET_LEVERS', levers: m.nodes.map((n) => ({ id: n.snapshotId, name: n.name })) });
@@ -72,6 +81,10 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
   }
 
   function onMessage(event: MessageEvent): void {
+    // Pane-scoped: with two live panes every instance hears every iframe's
+    // messages on window — without this filter pane B would mark itself ready
+    // on pane A's READY and a click would select through BOTH panes.
+    if (!iframe || event.source !== iframe.contentWindow) return;
     const msg = event.data as PreviewToParent | undefined;
     if (!msg || typeof msg !== 'object') return;
     if (msg.type === 'STB_PREVIEW_READY') {
@@ -116,7 +129,8 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
       });
 
       effect(() => {
-        void previewDark.value;
+        // pinned panes never react to the global toggle — their mode is fixed
+        if (mode === 'follow-global') void previewDark.value;
         if (ready) applyDark();
       });
 
@@ -125,7 +139,7 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
         // applyLeversToPreview read) so a dark toggle re-sends the mode-aware
         // background patches even if the model hasn't changed since ready.
         void brandingModel.value;
-        void previewDark.value;
+        if (mode === 'follow-global') void previewDark.value;
         if (ready) { applyLeversToPreview(); applyScopedBlocksToPreview(); }
       });
     },
@@ -146,4 +160,53 @@ export function createPreviewPane(opts: PreviewPaneOptions = {}): PreviewPane {
       send({ type: 'STB_SET_LEVER_OUTLINE', on });
     },
   };
+}
+
+export interface CompareToggleOptions {
+  /** `.stb-preview-host` — gains `.stb-compare` while compare is on. */
+  panesHost: HTMLElement;
+  /** The second (pinned-dark) pane's container; hidden while compare is off. */
+  darkPaneHost: HTMLElement;
+  /** The global "Dark preview" checkbox — made inert (disabled) during compare. */
+  darkToggle?: HTMLInputElement | null;
+  /** Lazy dark-pane creation: fires exactly once, on the first enable. */
+  onFirstEnable?: () => void;
+}
+
+/**
+ * The "Compare" mode switch. OFF (default): today's single follow-global pane +
+ * Dark preview checkbox, unchanged. ON: two panes pinned light|dark; the global
+ * Dark preview is forced off and DISABLED (not hidden — it stays discoverable
+ * and visibly "managed by compare" rather than silently missing), and restored
+ * to its prior state when compare turns off. The full single-source-of-truth
+ * mode redesign is deliberately deferred (design doc, "Open / deferred").
+ */
+export function mountCompareToggle(host: HTMLElement, opts: CompareToggleOptions): void {
+  const label = document.createElement('label');
+  label.className = 'stb-compare-toggle';
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.id = 'stb-compare-mode';
+  label.appendChild(cb);
+  label.append(' Compare');
+  host.appendChild(label);
+
+  let created = false;
+  let savedDark = false;
+  cb.addEventListener('change', () => {
+    compareMode.value = cb.checked;
+    if (cb.checked) {
+      savedDark = previewDark.value;
+      previewDark.value = false; // primary pane renders light; dark is the second pane's job
+      if (opts.darkToggle) { opts.darkToggle.checked = false; opts.darkToggle.disabled = true; }
+      opts.darkPaneHost.hidden = false;
+      opts.panesHost.classList.add('stb-compare');
+      if (!created) { created = true; opts.onFirstEnable?.(); }
+    } else {
+      previewDark.value = savedDark;
+      if (opts.darkToggle) { opts.darkToggle.checked = savedDark; opts.darkToggle.disabled = false; }
+      opts.darkPaneHost.hidden = true;
+      opts.panesHost.classList.remove('stb-compare');
+    }
+  });
 }

--- a/tools/stb/src/ui/preview-pane.ts
+++ b/tools/stb/src/ui/preview-pane.ts
@@ -12,7 +12,13 @@ import { backgroundPatch } from '@/metadata/facets';
 export function leverPatchesFor(model: BrandingModel, dark = false): LeverPatch[] {
   const out: LeverPatch[] = [];
   for (const n of model.nodes) {
-    if (n.facets.content) out.push({ snapshotId: n.snapshotId, kind: 'content', text: n.facets.content.text });
+    if (n.facets.content) {
+      out.push({
+        snapshotId: n.snapshotId, kind: 'content', text: n.facets.content.text,
+        // plain content stays byte-identical to the pre-format patch shape
+        ...(n.facets.content.format === 'subset' ? { format: 'subset' as const } : {}),
+      });
+    }
     else if (n.facets.asset) out.push({ snapshotId: n.snapshotId, kind: 'asset', ref: n.facets.asset.ref });
     // The inline background leg is mode-aware: in dark preview it composes from
     // the dark bundle only. A light-bundle inline style would override the

--- a/tools/stb/tests/content/subset-format.test.ts
+++ b/tools/stb/tests/content/subset-format.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { renderSubsetInto, subsetToSafeHtml } from '@/content/subset-format';
+
+const ALLOWED_TAGS = new Set(['STRONG', 'EM', 'BR']);
+
+function render(text: string): HTMLElement {
+  const el = document.createElement('div');
+  renderSubsetInto(el, text);
+  return el;
+}
+
+/** Strip the closed-set tags from the HTML form; nothing tag-like may remain. */
+function residue(html: string): string {
+  return html.replace(/<\/?(strong|em)>|<br>/g, '');
+}
+
+describe('subset-format grammar v1', () => {
+  it('plain text becomes a single text node', () => {
+    const el = render('hello world');
+    expect(el.childNodes.length).toBe(1);
+    expect(el.firstChild!.nodeType).toBe(Node.TEXT_NODE);
+    expect(el.textContent).toBe('hello world');
+  });
+
+  it('**bold** renders a strong element', () => {
+    const el = render('a **b** c');
+    expect(el.querySelector('strong')!.textContent).toBe('b');
+    expect(el.textContent).toBe('a b c');
+  });
+
+  it('_italic_ renders an em element', () => {
+    const el = render('a _b_ c');
+    expect(el.querySelector('em')!.textContent).toBe('b');
+    expect(el.textContent).toBe('a b c');
+  });
+
+  it('newline renders a br element', () => {
+    const el = render('a\nb');
+    expect(el.querySelectorAll('br').length).toBe(1);
+  });
+
+  it('nested **_mixed_** renders em inside strong', () => {
+    const el = render('**_mixed_**');
+    const strong = el.querySelector('strong')!;
+    expect(strong.querySelector('em')!.textContent).toBe('mixed');
+  });
+
+  it('unterminated ** renders literally as text', () => {
+    const el = render('a **b');
+    expect(el.querySelector('strong')).toBeNull();
+    expect(el.textContent).toBe('a **b');
+  });
+
+  it('unterminated _ renders literally as text', () => {
+    const el = render('snake_case');
+    expect(el.querySelector('em')).toBeNull();
+    expect(el.textContent).toBe('snake_case');
+  });
+
+  it('overlapping markers resolve deterministically without extra elements', () => {
+    const el = render('**a_b**c_');
+    expect(el.querySelector('strong')!.textContent).toBe('a_b'); // inner _ unterminated → literal
+    expect(el.querySelector('em')).toBeNull();
+    expect(el.textContent).toBe('a_b' + 'c_');
+  });
+});
+
+describe('subset-format safety (closed element set, no injection)', () => {
+  const adversarial = [
+    '<script>alert(1)</script>',
+    '<img src=x onerror=alert(1)>',
+    '**<script>**',
+    '_<img onerror=x>_',
+    '</strong><script>x</script>',
+    'a<b>c</b>d',
+    '&lt;already escaped&gt;',
+    '"quoted" & \'single\'',
+    '**_mixed_**',
+    '**_a**_b',
+    '****',
+    '__',
+    '_**_**',
+    '\n\n**\n**',
+    'javascript:alert(1)',
+    '<svg/onload=alert(1)>',
+    '**<svg/onload=alert(1)>**',
+  ];
+
+  it.each(adversarial)('DOM form of %j only ever contains strong/em/br elements', (text) => {
+    const el = render(text);
+    for (const child of el.querySelectorAll('*')) {
+      expect(ALLOWED_TAGS.has(child.tagName)).toBe(true);
+    }
+    // no markup interpretation of the input: raw < survives as text
+    expect(el.querySelector('script, img, svg')).toBeNull();
+  });
+
+  it.each(adversarial)('HTML form of %j has no unescaped angle brackets outside the closed tag set', (text) => {
+    const html = subsetToSafeHtml(text);
+    expect(residue(html)).not.toMatch(/[<>]/);
+  });
+
+  it('escapes &, <, >, ", \' in text segments of the HTML form', () => {
+    expect(subsetToSafeHtml(`<a href="x">&'`)).toBe('&lt;a href=&quot;x&quot;&gt;&amp;&#39;');
+  });
+
+  it('fuzz: random marker/angle-bracket soup never escapes the closed set', () => {
+    const alphabet = ['*', '**', '_', '\n', '<', '>', '&', '"', "'", 'a', '<script>', '</em>', 'onerror='];
+    let seed = 42;
+    const rnd = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x80000000;
+    for (let i = 0; i < 200; i++) {
+      let s = '';
+      const len = Math.floor(rnd() * 12);
+      for (let j = 0; j < len; j++) s += alphabet[Math.floor(rnd() * alphabet.length)]!;
+      const el = render(s);
+      for (const child of el.querySelectorAll('*')) {
+        expect(ALLOWED_TAGS.has(child.tagName), `input ${JSON.stringify(s)} produced <${child.tagName}>`).toBe(true);
+      }
+      expect(residue(subsetToSafeHtml(s))).not.toMatch(/[<>]/);
+    }
+  });
+
+  it('DOM and HTML forms agree on text content', () => {
+    const text = '**bold** and _italic_\n<script>x</script>';
+    const el = render(text);
+    const viaHtml = document.createElement('div');
+    viaHtml.innerHTML = subsetToSafeHtml(text); // test-only innerHTML, on already-safe output
+    expect(viaHtml.textContent).toBe(el.textContent);
+  });
+});

--- a/tools/stb/tests/integration/element-edit.test.ts
+++ b/tools/stb/tests/integration/element-edit.test.ts
@@ -20,6 +20,14 @@ describe('applyEdit', () => {
     applyEdit('auth.login.title', { kind: 'content', text: 'B' }, routing);
     expect(nodeFor('auth.login.title')?.facets.content?.text).toBe('B');
   });
+  it('content edit with format subset stores the format on the facet', () => {
+    applyEdit('auth.login.title', { kind: 'content', text: '**B**', format: 'subset' }, routing);
+    expect(nodeFor('auth.login.title')?.facets.content).toEqual({ text: '**B**', format: 'subset' });
+  });
+  it('plain content edit stores no format key (byte-identical to pre-format shape)', () => {
+    applyEdit('auth.login.title', { kind: 'content', text: 'B' }, routing);
+    expect(nodeFor('auth.login.title')?.facets.content).toEqual({ text: 'B' });
+  });
   it('color edit re-projects to the bound token', () => {
     applyEdit('auth.login.sign-in', { kind: 'color', oklch: { l: 0.6, c: 0.12, h: 200 } }, routing);
     expect(rootValues.value.get('--color-brand-500')).toMatch(/^#[0-9a-f]{6}$/);

--- a/tools/stb/tests/integration/element-edit.test.ts
+++ b/tools/stb/tests/integration/element-edit.test.ts
@@ -32,7 +32,7 @@ describe('reprojectNodeTokens', () => {
   it('re-projects a color edit from facets to the bound CSS token', () => {
     reprojectNodeTokens(
       'auth.login.sign-in',
-      { surface: { background: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
+      { background: { color: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
       routing,
     );
     expect(rootValues.value.get('--color-brand-500')).toMatch(/^#[0-9a-f]{6}$/);
@@ -44,7 +44,7 @@ describe('applyEdit facets write-back', () => {
     { snapshotId: 'auth.login.title', role: 'heading', name: 'T', description: 'title',
       facets: { content: { text: 'A' } } },
     { snapshotId: 'auth.login.sign-in', role: 'button', name: 'S', description: 'btn',
-      facets: { surface: { background: { literal: { l: 0.5, c: 0.1, h: 250 } } } } },
+      facets: { background: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } } },
     { snapshotId: 'auth.login.text-label', role: 'text', name: 'Label', description: 'text label',
       facets: { text: { color: { literal: { l: 0.4, c: 0.1, h: 120 } } } } },
   ] };
@@ -55,14 +55,14 @@ describe('applyEdit facets write-back', () => {
     expect(nodeFor('auth.login.title')?.facets.content?.text).toEqual('B');
   });
 
-  it('writes a color edit back into the surface.background facet', () => {
+  it('writes a color edit back into the background.color facet', () => {
     const newOklch = { l: 0.6, c: 0.12, h: 200 };
     applyEdit('auth.login.sign-in', { kind: 'color', oklch: newOklch }, routing);
-    expect(nodeFor('auth.login.sign-in')?.facets.surface?.background).toEqual({ literal: newOklch });
+    expect(nodeFor('auth.login.sign-in')?.facets.background?.color).toEqual({ literal: newOklch });
   });
 
   it('writes a color edit back into the text.color facet', () => {
-    // Exercises the text.color write-back branch — surface.background branch already covered above.
+    // Exercises the text.color write-back branch — background.color branch already covered above.
     const newOklch = { l: 0.3, c: 0.08, h: 180 };
     applyEdit('auth.login.text-label', { kind: 'color', oklch: newOklch }, routing);
     expect(nodeFor('auth.login.text-label')?.facets.text?.color).toEqual({ literal: newOklch });

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -190,6 +190,38 @@ it('renders a content leaf with a textarea initialized to the content text', () 
   expect(collected).toContain('B');
 });
 
+it('content leaf format select defaults to plain and reports edits with the chosen format', () => {
+  const host = document.createElement('div');
+  const collected: [string, string | undefined][] = [];
+  mountFacetTree(host, {
+    facets: { content: { text: 'A' } },
+    onEdit: () => {},
+    previewHost: document.createElement('div'),
+    onContentEdit: (t, f) => collected.push([t, f]),
+  });
+  const sel = host.querySelector('.stb-facet-leaf[data-key="content"] select.stb-facet-content-format') as HTMLSelectElement;
+  expect(sel).not.toBeNull();
+  expect(sel.value).toBe('plain');
+  const ta = host.querySelector('.stb-facet-leaf[data-key="content"] textarea') as HTMLTextAreaElement;
+  ta.value = 'B';
+  ta.dispatchEvent(new Event('input'));
+  expect(collected).toContainEqual(['B', 'plain']);
+  sel.value = 'subset';
+  sel.dispatchEvent(new Event('change'));
+  expect(collected).toContainEqual(['B', 'subset']);
+});
+
+it('content leaf format select reflects an existing subset format', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { content: { text: 'A', format: 'subset' } },
+    onEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  const sel = host.querySelector('.stb-facet-leaf[data-key="content"] select.stb-facet-content-format') as HTMLSelectElement;
+  expect(sel.value).toBe('subset');
+});
+
 it('renders an asset leaf with a file input', () => {
   const host = document.createElement('div');
   mountFacetTree(host, {

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -2,6 +2,7 @@
 import { it, expect } from 'vitest';
 import { mountFacetTree } from '@/ui/facet-tree';
 import { deriveDarkOklch } from '@/color/derive-dark';
+import { toOklch } from '@/color/oklch';
 
 it('renders a branch per present group and a leaf per property', () => {
   const host = document.createElement('div');
@@ -117,6 +118,26 @@ it('offers absent groups and adds one on select', () => {
   expect(add.value).toBe('');
 });
 
+it('offers background in the add-group select for a node without one, and fires onAddGroup', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  const added: string[] = [];
+  mountFacetTree(host, { facets: { text: {} }, previewHost, onEdit: () => {}, onAddGroup: (g) => added.push(g) });
+  const add = host.querySelector('.stb-facet-add') as HTMLSelectElement;
+  expect([...add.options].map((o) => o.value)).toContain('background');
+  add.value = 'background';
+  add.dispatchEvent(new Event('change'));
+  expect(added).toContain('background');
+});
+
+it('does not offer background in the add-group select when one is already present', () => {
+  const host = document.createElement('div');
+  const previewHost = document.createElement('div');
+  mountFacetTree(host, { facets: { background: {}, text: {} }, previewHost, onEdit: () => {} });
+  const add = host.querySelector('.stb-facet-add') as HTMLSelectElement;
+  expect([...add.options].map((o) => o.value)).not.toContain('background');
+});
+
 it('remove button calls onRemoveGroup and does not trigger collapse', () => {
   const host = document.createElement('div');
   const previewHost = document.createElement('div');
@@ -225,6 +246,106 @@ it('renders a gradient layer with a type select and stop swatches, plus remove/m
   expect(row.querySelector('.stb-facet-bg-remove')).not.toBeNull();
   expect(row.querySelector('.stb-facet-bg-move-up')).not.toBeNull();
   expect(row.querySelector('.stb-facet-bg-move-down')).not.toBeNull();
+});
+
+it('gives the gradient type and angle fields visible inline labels and CSS-value tooltips', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const labels = [...row.querySelectorAll('.stb-facet-bg-gradient-field-label')].map((l) => l.textContent);
+  expect(labels).toContain('type');
+  expect(labels).toContain('angle');
+  const angleInput = row.querySelector('.stb-facet-bg-gradient-pos') as HTMLInputElement;
+  expect(angleInput.title).toMatch(/angle/i);
+  expect(angleInput.title).toMatch(/45deg/);
+});
+
+it('relabels the angle field as position for radial/conic gradients, with a length-percentage-free position hint', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'radial', position: 'center',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const labels = [...row.querySelectorAll('.stb-facet-bg-gradient-field-label')].map((l) => l.textContent);
+  expect(labels).toContain('position');
+  expect(labels).not.toContain('angle');
+});
+
+it('carries a position tooltip and a labeled column header for the gradient stop list', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' }, position: '25%' }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const header = row.querySelector('.stb-facet-bg-gradient-stops-header-pos');
+  expect(header?.textContent).toBe('position');
+  const stopPosInput = row.querySelector('.stb-facet-bg-gradient-stop-pos') as HTMLInputElement;
+  expect(stopPosInput.title).toMatch(/length-percentage/i);
+  expect(stopPosInput.title).toMatch(/25%/);
+});
+
+it('renders one MDN gradient help link per gradient layer, targeting the current type', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'radial', position: 'center',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const help = row.querySelector('.stb-facet-bg-gradient-help') as HTMLAnchorElement;
+  expect(help).not.toBeNull();
+  expect(help.href).toBe('https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/radial-gradient');
+  expect(help.target).toBe('_blank');
+  expect(help.rel).toBe('noopener');
+});
+
+it('updates the MDN help link href when the gradient type select changes', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const typeSel = row.querySelector('select') as HTMLSelectElement;
+  const help = row.querySelector('.stb-facet-bg-gradient-help') as HTMLAnchorElement;
+  expect(help.href).toBe('https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient');
+  typeSel.value = 'conic';
+  typeSel.dispatchEvent(new Event('change'));
+  expect(help.href).toBe('https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/conic-gradient');
 });
 
 it('fires onSetLayer with an updated type when the gradient type select changes', () => {
@@ -390,7 +511,10 @@ it('appends a stop when + stop is clicked and removes one via the stop remove bu
   const [, removed] = setLayers[1] as [number, { gradient: { stops: Array<{ color: { literal: unknown } }> } }];
   expect(removed.gradient.stops.length).toBe(2);
   expect(removed.gradient.stops[0]!.color.literal).toBe('#000');
-  expect(removed.gradient.stops[1]!.color.literal).toBe('#000000');
+  // A fresh stop carries an Oklch object literal, not a raw hex string — matching
+  // the shape produced by every other stop edit — so per-stop dark derive is
+  // enabled immediately rather than disabled until the user first edits the color.
+  expect(removed.gradient.stops[1]!.color.literal).toEqual(toOklch('#000000'));
 });
 
 it('disables the stop remove button when only one stop remains', () => {
@@ -476,9 +600,14 @@ it('fires onAddLayer with a default linear gradient when + gradient is clicked',
   const addGradientBtn = host.querySelector('.stb-facet-bg-add-gradient') as HTMLButtonElement;
   expect(addGradientBtn).not.toBeNull();
   addGradientBtn.click();
+  // Oklch object literals, not raw hex strings — same normalization as + stop,
+  // so a freshly added gradient's stops support dark derive immediately.
   expect(added).toEqual([{
     kind: 'gradient',
-    gradient: { type: 'linear', stops: [{ color: { literal: '#000000' } }, { color: { literal: '#ffffff' } }] },
+    gradient: {
+      type: 'linear',
+      stops: [{ color: { literal: toOklch('#000000') } }, { color: { literal: toOklch('#ffffff') } }],
+    },
   }]);
 });
 

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -888,3 +888,259 @@ it('consecutive edits to two gradient fields both survive without a re-mount (no
   expect(last.gradient.angle).toBe('45deg');       // first edit survives
   expect(last.gradient.stops[0]!.position).toBe('10%'); // second edit applied
 });
+
+// --- background backstop dark axis ---
+
+it('renders a dark swatch and derive button beside the backstop light swatch', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onDarkEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="color"]')!;
+  expect(row.querySelectorAll('.stb-facet-swatch').length).toBe(1);
+  expect(row.querySelector('.stb-facet-swatch-dark')).not.toBeNull();
+  expect(row.querySelector('.stb-facet-derive-dark')).not.toBeNull();
+});
+
+it('backstop dark swatch is neutral/empty when no dark backstop is set', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onDarkEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="color"]')!;
+  const darkBtn = row.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  expect(darkBtn.classList.contains('stb-facet-swatch-empty')).toBe(true);
+  expect(darkBtn.style.backgroundColor).toBe('');
+});
+
+it('backstop dark swatch reflects an existing dark literal', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } } },
+    darkFacets: { background: { color: { literal: { l: 0.2, c: 0.05, h: 100 } } } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onDarkEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="color"]')!;
+  const darkBtn = row.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  expect(darkBtn.classList.contains('stb-facet-swatch-empty')).toBe(false);
+  expect(darkBtn.style.backgroundColor).not.toBe('');
+});
+
+it('editing the backstop dark swatch invokes onDarkEdit with background.color', () => {
+  const host = document.createElement('div');
+  const darkEdits: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onDarkEdit: (k, v) => darkEdits.push([k, v]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="color"]')!;
+  (row.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement).click();
+  const textInput = document.querySelector('.stb-color-text') as HTMLInputElement;
+  expect(textInput).toBeTruthy();
+  textInput.value = '#112233';
+  textInput.dispatchEvent(new Event('input'));
+  expect(darkEdits.length).toBe(1);
+  expect(darkEdits[0]![0]).toBe('background.color');
+  expect(darkEdits[0]![1]).toHaveProperty('literal');
+});
+
+it('clicking the backstop derive button calls deriveDark with background.color', () => {
+  const host = document.createElement('div');
+  const derived: string[] = [];
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } } },
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    deriveDark: (k) => derived.push(k),
+  });
+  const row = host.querySelector('[data-stb-bg-row="color"]')!;
+  (row.querySelector('.stb-facet-derive-dark') as HTMLButtonElement).click();
+  expect(derived).toEqual(['background.color']);
+});
+
+it('backstop derive button is disabled when the light backstop has no literal Oklch', () => {
+  const host = document.createElement('div');
+  const derived: string[] = [];
+  mountFacetTree(host, {
+    facets: { background: {} },
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onDarkEdit: () => {},
+    deriveDark: (k) => derived.push(k),
+  });
+  const row = host.querySelector('[data-stb-bg-row="color"]')!;
+  const deriveBtn = row.querySelector('.stb-facet-derive-dark') as HTMLButtonElement;
+  expect(deriveBtn.disabled).toBe(true);
+  deriveBtn.click();
+  expect(derived).toEqual([]);
+});
+
+// --- gradient stop dark axis ---
+
+function gradientLayerFacets() {
+  return {
+    background: {
+      layers: [{ kind: 'gradient' as const, gradient: {
+        type: 'linear' as const, angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    },
+  };
+}
+
+it('renders a dark swatch and per-stop derive button for each gradient stop', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: gradientLayerFacets(),
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const stopRows = host.querySelectorAll('.stb-facet-bg-gradient-stop');
+  expect(stopRows.length).toBe(2);
+  for (const row of stopRows) {
+    expect(row.querySelectorAll('.stb-facet-swatch').length).toBe(1);
+    expect(row.querySelector('.stb-facet-swatch-dark')).not.toBeNull();
+    expect(row.querySelector('.stb-facet-derive-dark')).not.toBeNull();
+  }
+});
+
+it('gradient stop dark swatch is empty when no dark gradient layer exists yet', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: gradientLayerFacets(),
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const stopRow = host.querySelectorAll('.stb-facet-bg-gradient-stop')[0]!;
+  const darkSwatch = stopRow.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  expect(darkSwatch.classList.contains('stb-facet-swatch-empty')).toBe(true);
+});
+
+it('editing a gradient stop dark swatch seeds the dark gradient from the light structure (copy-on-first-edit)', () => {
+  const host = document.createElement('div');
+  const setLayersDark: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: gradientLayerFacets(),
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayerDark: (i, l) => setLayersDark.push([i, l]),
+  });
+  const stopRow = host.querySelectorAll('.stb-facet-bg-gradient-stop')[0]!;
+  const darkSwatch = stopRow.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  darkSwatch.click();
+  const textInput = document.querySelector('.stb-color-text') as HTMLInputElement;
+  expect(textInput).toBeTruthy();
+  textInput.value = '#101010';
+  textInput.dispatchEvent(new Event('input'));
+  expect(setLayersDark.length).toBe(1);
+  const [index, layer] = setLayersDark[0] as [number, { kind: string; gradient: { angle?: string; stops: Array<{ color: { literal?: unknown } }> } }];
+  expect(index).toBe(0);
+  // Copy-on-first-edit: the seeded gradient carries the light gradient's
+  // structure (angle, stop count) with only stop 0's color replaced.
+  expect(layer.gradient.angle).toBe('90deg');
+  expect(layer.gradient.stops.length).toBe(2);
+  expect(layer.gradient.stops[0]!.color.literal).toBeTruthy();
+  expect(layer.gradient.stops[1]!.color).toEqual({ literal: '#000' });
+});
+
+it('a second dark stop edit builds on the existing dark layers, not a fresh seed from light', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: gradientLayerFacets(),
+    darkFacets: { background: { layers: [{ kind: 'gradient', gradient: {
+      type: 'linear', angle: '180deg',
+      stops: [{ color: { literal: '#111111' } }, { color: { literal: '#222222' } }],
+    } }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayerDark: () => {},
+  });
+  const stopRow = host.querySelectorAll('.stb-facet-bg-gradient-stop')[1]!;
+  const darkSwatch = stopRow.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  // The existing dark stop 1 color (#222222) is reflected, not empty — proving
+  // the render read from darkFacets rather than re-seeding from light.
+  expect(darkSwatch.classList.contains('stb-facet-swatch-empty')).toBe(false);
+});
+
+it('a dark gradient edit builds on the pre-existing dark layer angle, not the light angle', () => {
+  const host = document.createElement('div');
+  const setLayersDark: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: gradientLayerFacets(),
+    darkFacets: { background: { layers: [{ kind: 'gradient', gradient: {
+      type: 'linear', angle: '180deg',
+      stops: [{ color: { literal: '#111111' } }, { color: { literal: '#222222' } }],
+    } }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayerDark: (i, l) => setLayersDark.push([i, l]),
+  });
+  const stopRow = host.querySelectorAll('.stb-facet-bg-gradient-stop')[1]!;
+  const darkSwatch = stopRow.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  darkSwatch.click();
+  const textInput = document.querySelector('.stb-color-text') as HTMLInputElement;
+  textInput.value = '#303030';
+  textInput.dispatchEvent(new Event('input'));
+  const [, layer] = setLayersDark[0] as [number, { gradient: { angle?: string; stops: Array<{ color: { literal?: unknown } }> } }];
+  // Fork pinned: the pre-existing dark angle (180deg) survives, not the light one (90deg).
+  expect(layer.gradient.angle).toBe('180deg');
+  expect(layer.gradient.stops[0]!.color).toEqual({ literal: '#111111' });
+});
+
+it('per-stop derive produces a dark literal distinct from the light stop and calls onSetLayerDark', () => {
+  const host = document.createElement('div');
+  const setLayersDark: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: { layers: [{ kind: 'gradient', gradient: {
+      type: 'linear', angle: '90deg',
+      stops: [{ color: { literal: { l: 0.3, c: 0.1, h: 250 } } }, { color: { literal: '#000' } }],
+    } }] } },
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayerDark: (i, l) => setLayersDark.push([i, l]),
+  });
+  const stopRow = host.querySelectorAll('.stb-facet-bg-gradient-stop')[0]!;
+  const deriveBtn = stopRow.querySelector('.stb-facet-derive-dark') as HTMLButtonElement;
+  expect(deriveBtn.disabled).toBe(false);
+  deriveBtn.click();
+  expect(setLayersDark.length).toBe(1);
+  const [, layer] = setLayersDark[0] as [number, { gradient: { stops: Array<{ color: { literal?: unknown } }> } }];
+  expect(layer.gradient.stops[0]!.color.literal).not.toEqual({ l: 0.3, c: 0.1, h: 250 });
+});
+
+it('per-stop derive is disabled for a token stop', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { layers: [{ kind: 'gradient', gradient: {
+      type: 'linear', angle: '90deg',
+      stops: [{ color: { token: 'brand' } }, { color: { literal: '#000' } }],
+    } }] } },
+    darkFacets: {},
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayerDark: () => {},
+  });
+  const stopRow = host.querySelectorAll('.stb-facet-bg-gradient-stop')[0]!;
+  const deriveBtn = stopRow.querySelector('.stb-facet-derive-dark') as HTMLButtonElement;
+  expect(deriveBtn.disabled).toBe(true);
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -718,3 +718,76 @@ it('shows promote for a literal property with a token mapping, none without', ()
   const sizeLeaf = host.querySelector('.stb-facet-leaf[data-key="text.fontSize"]')!;
   expect(sizeLeaf.querySelector('.stb-facet-promote')).toBeNull();
 });
+
+it('renders a font-family row per fallback entry, in order', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { text: { fontFamily: [{ literal: 'Inter' }, { literal: 'system-ui' }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const rows = [...host.querySelectorAll('[data-stb-fontfamily-row]')];
+  expect(rows.length).toBe(2);
+  const inputs = rows.map((r) => (r.querySelector('input') as HTMLInputElement).value);
+  expect(inputs).toEqual(['Inter', 'system-ui']);
+});
+
+it('fires onAddFont from the footer add button', () => {
+  const host = document.createElement('div');
+  const added: unknown[] = [];
+  mountFacetTree(host, {
+    facets: { text: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onAddFont: (v) => added.push(v),
+  });
+  (host.querySelector('.stb-facet-fontfamily-add') as HTMLButtonElement).click();
+  expect(added).toEqual([{ literal: '' }]);
+});
+
+it('fires onSetFont when a row input changes', () => {
+  const host = document.createElement('div');
+  const sets: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { text: { fontFamily: [{ literal: 'Inter' }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetFont: (i, v) => sets.push([i, v]),
+  });
+  const input = host.querySelector('[data-stb-fontfamily-row] input') as HTMLInputElement;
+  input.value = 'Roboto';
+  input.dispatchEvent(new Event('input'));
+  expect(sets).toEqual([[0, { literal: 'Roboto' }]]);
+});
+
+it('fires onRemoveFont from a row remove button', () => {
+  const host = document.createElement('div');
+  const removed: number[] = [];
+  mountFacetTree(host, {
+    facets: { text: { fontFamily: [{ literal: 'Inter' }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onRemoveFont: (i) => removed.push(i),
+  });
+  (host.querySelector('[data-stb-fontfamily-row] .stb-facet-fontfamily-remove') as HTMLButtonElement).click();
+  expect(removed).toEqual([0]);
+});
+
+it('fires onReorderFont from a row move button, disabling at the ends', () => {
+  const host = document.createElement('div');
+  const reorders: [number, number][] = [];
+  mountFacetTree(host, {
+    facets: { text: { fontFamily: [{ literal: 'Inter' }, { literal: 'system-ui' }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onReorderFont: (from, to) => reorders.push([from, to]),
+  });
+  const rows = [...host.querySelectorAll('[data-stb-fontfamily-row]')];
+  const firstUp = rows[0]!.querySelector('.stb-facet-fontfamily-move-up') as HTMLButtonElement;
+  const firstDown = rows[0]!.querySelector('.stb-facet-fontfamily-move-down') as HTMLButtonElement;
+  const lastDown = rows[1]!.querySelector('.stb-facet-fontfamily-move-down') as HTMLButtonElement;
+  expect(firstUp.disabled).toBe(true);
+  expect(lastDown.disabled).toBe(true);
+  firstDown.click();
+  expect(reorders).toEqual([[0, 1]]);
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -180,6 +180,120 @@ it('renders an asset leaf with a file input', () => {
   expect(fileInput).not.toBeNull();
 });
 
+it('does not render the standalone asset slot when a background facet is present', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { asset: { ref: 'logo.svg' }, background: { color: { literal: '#000' } } },
+    onEdit: () => {},
+    previewHost: document.createElement('div'),
+  });
+  expect(host.querySelector('.stb-facet-leaf[data-key="asset"]')).toBeNull();
+});
+
+it('renders the backstop color first, then layers, for a background facet', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      color: { literal: { l: 0.4, c: 0.1, h: 250 } },
+      layers: [{ kind: 'image', ref: 'assets/hero.jpg' }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const rows = [...host.querySelectorAll('[data-stb-bg-row]')];
+  expect(rows[0]!.getAttribute('data-stb-bg-row')).toBe('color');
+  expect(rows[1]!.getAttribute('data-stb-bg-row')).toBe('layer');
+});
+
+it('renders a gradient layer as a read-only summary row with remove/move controls, no type-select', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  expect(row.querySelector('select')).toBeNull();
+  expect(row.textContent).toContain('linear-gradient');
+  expect(row.querySelector('.stb-facet-bg-remove')).not.toBeNull();
+  expect(row.querySelector('.stb-facet-bg-move-up')).not.toBeNull();
+  expect(row.querySelector('.stb-facet-bg-move-down')).not.toBeNull();
+});
+
+it('fires onBackstop when the backstop swatch color changes', () => {
+  const host = document.createElement('div');
+  const backstops: unknown[] = [];
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onBackstop: (v) => backstops.push(v),
+  });
+  const btn = host.querySelector('[data-stb-bg-row="color"] .stb-facet-swatch') as HTMLButtonElement;
+  expect(btn).toBeTruthy();
+  btn.click();
+  const textInput = document.querySelector('.stb-color-text') as HTMLInputElement;
+  expect(textInput).toBeTruthy();
+  textInput.value = '#112233';
+  textInput.dispatchEvent(new Event('input'));
+  expect(backstops.length).toBe(1);
+  expect(backstops[0]).toHaveProperty('literal');
+});
+
+it('fires onAddLayer, onRemoveLayer and onReorderLayer for layer row controls', () => {
+  const host = document.createElement('div');
+  const added: unknown[] = [];
+  const removed: number[] = [];
+  const reordered: [number, number][] = [];
+  mountFacetTree(host, {
+    facets: { background: { layers: [
+      { kind: 'image', ref: 'a' },
+      { kind: 'image', ref: 'b' },
+    ] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onAddLayer: (l) => added.push(l),
+    onRemoveLayer: (i) => removed.push(i),
+    onReorderLayer: (from, to) => reordered.push([from, to]),
+  });
+  const rows = [...host.querySelectorAll('[data-stb-bg-row="layer"]')];
+  expect(rows.length).toBe(2);
+  // first row (index 0) has no move-up (already bottom); second has no move-down (already top)
+  expect((rows[0]!.querySelector('.stb-facet-bg-move-up') as HTMLButtonElement).disabled).toBe(true);
+  expect((rows[1]!.querySelector('.stb-facet-bg-move-down') as HTMLButtonElement).disabled).toBe(true);
+  (rows[0]!.querySelector('.stb-facet-bg-move-down') as HTMLButtonElement).click();
+  expect(reordered).toContainEqual([0, 1]);
+  (rows[1]!.querySelector('.stb-facet-bg-remove') as HTMLButtonElement).click();
+  expect(removed).toContain(1);
+  (host.querySelector('.stb-facet-bg-add-image') as HTMLButtonElement).click();
+  expect(added).toContainEqual({ kind: 'image', ref: '' });
+  // only the image footer button exists in this slice — gradient editing is next
+  expect(host.querySelector('.stb-facet-bg-add-gradient')).toBeNull();
+});
+
+it('fires onSetLayer with a stored asset ref when a file is chosen for an image layer row', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: { layers: [{ kind: 'image', ref: '' }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const input = row.querySelector('input[type="file"]') as HTMLInputElement;
+  expect(input).toBeTruthy();
+  const file = new File(['x'], 'hero.jpg', { type: 'image/jpeg' });
+  Object.defineProperty(input, 'files', { value: [file] });
+  input.dispatchEvent(new Event('change'));
+  expect(setLayers).toEqual([[0, { kind: 'image', ref: 'assets/hero.jpg' }]]);
+});
+
 it('renders a light swatch, a dark swatch and a derive button for a color leaf', () => {
   const host = document.createElement('div');
   mountFacetTree(host, {

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -205,7 +205,7 @@ it('renders the backstop color first, then layers, for a background facet', () =
   expect(rows[1]!.getAttribute('data-stb-bg-row')).toBe('layer');
 });
 
-it('renders a gradient layer as a read-only summary row with remove/move controls, no type-select', () => {
+it('renders a gradient layer with a type select and stop swatches, plus remove/move controls', () => {
   const host = document.createElement('div');
   mountFacetTree(host, {
     facets: { background: {
@@ -218,11 +218,139 @@ it('renders a gradient layer as a read-only summary row with remove/move control
     onEdit: () => {},
   });
   const row = host.querySelector('[data-stb-bg-row="layer"]')!;
-  expect(row.querySelector('select')).toBeNull();
-  expect(row.textContent).toContain('linear-gradient');
+  const typeSel = row.querySelector('select') as HTMLSelectElement;
+  expect(typeSel).not.toBeNull();
+  expect(typeSel.value).toBe('linear');
+  expect(row.querySelectorAll('.stb-facet-swatch').length).toBe(2);
   expect(row.querySelector('.stb-facet-bg-remove')).not.toBeNull();
   expect(row.querySelector('.stb-facet-bg-move-up')).not.toBeNull();
   expect(row.querySelector('.stb-facet-bg-move-down')).not.toBeNull();
+});
+
+it('fires onSetLayer with an updated type when the gradient type select changes', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const typeSel = row.querySelector('select') as HTMLSelectElement;
+  typeSel.value = 'radial';
+  typeSel.dispatchEvent(new Event('change'));
+  expect(setLayers.length).toBe(1);
+  const [index, layer] = setLayers[0] as [number, { kind: string; gradient: { type: string } }];
+  expect(index).toBe(0);
+  expect(layer.kind).toBe('gradient');
+  expect(layer.gradient.type).toBe('radial');
+});
+
+it('fires onSetLayer with an updated angle when the linear angle/position input changes', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const angleInput = row.querySelector('.stb-facet-bg-gradient-pos') as HTMLInputElement;
+  angleInput.value = '45deg';
+  angleInput.dispatchEvent(new Event('input'));
+  expect(setLayers.length).toBe(1);
+  const [, layer] = setLayers[0] as [number, { gradient: { angle?: string } }];
+  expect(layer.gradient.angle).toBe('45deg');
+});
+
+it('fires onSetLayer with an updated stop color when a stop swatch changes', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const swatch = row.querySelectorAll('.stb-facet-swatch')[0] as HTMLButtonElement;
+  swatch.click();
+  const textInput = document.querySelector('.stb-color-text') as HTMLInputElement;
+  expect(textInput).toBeTruthy();
+  textInput.value = '#123456';
+  textInput.dispatchEvent(new Event('input'));
+  expect(setLayers.length).toBe(1);
+  const [, layer] = setLayers[0] as [number, { gradient: { stops: Array<{ color: { literal: unknown } }> } }];
+  expect(layer.gradient.stops[0]!.color.literal).toBeTruthy();
+  expect(layer.gradient.stops[1]!.color.literal).toEqual('#000');
+});
+
+it('preserves exotic radial gradient fields (shape, size) when editing the position or a stop color', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'radial', shape: 'circle', size: '40px', position: 'center',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const posInput = row.querySelector('.stb-facet-bg-gradient-pos') as HTMLInputElement;
+  posInput.value = 'top left';
+  posInput.dispatchEvent(new Event('input'));
+  const [, layer1] = setLayers[0] as [number, { gradient: { shape?: string; size?: string; position?: string } }];
+  expect(layer1.gradient.shape).toBe('circle');
+  expect(layer1.gradient.size).toBe('40px');
+  expect(layer1.gradient.position).toBe('top left');
+
+  const swatch = row.querySelectorAll('.stb-facet-swatch')[1] as HTMLButtonElement;
+  swatch.click();
+  const textInput = document.querySelector('.stb-color-text') as HTMLInputElement;
+  textInput.value = '#abcdef';
+  textInput.dispatchEvent(new Event('input'));
+  const [, layer2] = setLayers[1] as [number, { gradient: { shape?: string; size?: string } }];
+  expect(layer2.gradient.shape).toBe('circle');
+  expect(layer2.gradient.size).toBe('40px');
+});
+
+it('fires onAddLayer with a default linear gradient when + gradient is clicked', () => {
+  const host = document.createElement('div');
+  const added: unknown[] = [];
+  mountFacetTree(host, {
+    facets: { background: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onAddLayer: (l) => added.push(l),
+  });
+  const addGradientBtn = host.querySelector('.stb-facet-bg-add-gradient') as HTMLButtonElement;
+  expect(addGradientBtn).not.toBeNull();
+  addGradientBtn.click();
+  expect(added).toEqual([{
+    kind: 'gradient',
+    gradient: { type: 'linear', stops: [{ color: { literal: '#000000' } }, { color: { literal: '#ffffff' } }] },
+  }]);
 });
 
 it('fires onBackstop when the backstop swatch color changes', () => {
@@ -272,8 +400,7 @@ it('fires onAddLayer, onRemoveLayer and onReorderLayer for layer row controls', 
   expect(removed).toContain(1);
   (host.querySelector('.stb-facet-bg-add-image') as HTMLButtonElement).click();
   expect(added).toContainEqual({ kind: 'image', ref: '' });
-  // only the image footer button exists in this slice — gradient editing is next
-  expect(host.querySelector('.stb-facet-bg-add-gradient')).toBeNull();
+  expect(host.querySelector('.stb-facet-bg-add-gradient')).not.toBeNull();
 });
 
 it('fires onSetLayer with a stored asset ref when a file is chosen for an image layer row', () => {

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -385,9 +385,12 @@ it('appends a stop when + stop is clicked and removes one via the stop remove bu
 
   const removeBtns = row.querySelectorAll('.stb-facet-bg-gradient-stop-remove');
   (removeBtns[0] as HTMLButtonElement).click();
+  // sequential edits compose: remove acts on the 3-stop result of the add
+  // (current gradient state), not on the mount-time 2-stop snapshot
   const [, removed] = setLayers[1] as [number, { gradient: { stops: Array<{ color: { literal: unknown } }> } }];
-  expect(removed.gradient.stops.length).toBe(1);
+  expect(removed.gradient.stops.length).toBe(2);
   expect(removed.gradient.stops[0]!.color.literal).toBe('#000');
+  expect(removed.gradient.stops[1]!.color.literal).toBe('#000000');
 });
 
 it('disables the stop remove button when only one stop remains', () => {
@@ -854,4 +857,34 @@ it('fires onSetGap with (slot, value) when a gap input changes', () => {
   colInput.value = '6px';
   colInput.dispatchEvent(new Event('input'));
   expect(sets).toEqual([['column', { literal: '6px' }]]);
+});
+
+it('consecutive edits to two gradient fields both survive without a re-mount (no stale-closure clobber)', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  // Re-render is suppressed while an input is focused, so the tree stays
+  // mounted across BOTH edits — the second must build on the first, not on
+  // the mount-time gradient snapshot.
+  const angleInput = row.querySelector('.stb-facet-bg-gradient-pos') as HTMLInputElement;
+  angleInput.value = '45deg';
+  angleInput.dispatchEvent(new Event('input'));
+  const stopPos = row.querySelector('.stb-facet-bg-gradient-stop-pos') as HTMLInputElement;
+  stopPos.value = '10%';
+  stopPos.dispatchEvent(new Event('input'));
+  const [, last] = setLayers[setLayers.length - 1] as
+    [number, { gradient: { angle?: string; stops: { position?: string }[] } }];
+  expect(last.gradient.angle).toBe('45deg');       // first edit survives
+  expect(last.gradient.stops[0]!.position).toBe('10%'); // second edit applied
 });

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -791,3 +791,67 @@ it('fires onReorderFont from a row move button, disabling at the ends', () => {
   firstDown.click();
   expect(reorders).toEqual([[0, 1]]);
 });
+
+it('renders T/R/B/L inputs for padding and margin, and row/column inputs for gap, populated from existing values', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: {
+      spacing: {
+        padding: { top: { literal: '8px' }, left: { literal: '4px' } },
+        gap: { row: { literal: '2px' } },
+      },
+    },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const paddingRow = host.querySelector('[data-stb-spacing-group="padding"]')!;
+  const paddingInputs = [...paddingRow.querySelectorAll('.stb-facet-spacing-side')] as HTMLInputElement[];
+  expect(paddingInputs.length).toBe(4);
+  expect(paddingInputs.map((i) => i.value)).toEqual(['8px', '', '', '4px']);
+
+  const marginRow = host.querySelector('[data-stb-spacing-group="margin"]')!;
+  expect(marginRow.querySelectorAll('.stb-facet-spacing-side').length).toBe(4);
+
+  const gapRow = host.querySelector('[data-stb-spacing-group="gap"]')!;
+  const gapInputs = [...gapRow.querySelectorAll('.stb-facet-spacing-gap')] as HTMLInputElement[];
+  expect(gapInputs.length).toBe(2);
+  expect(gapInputs.map((i) => i.value)).toEqual(['2px', '']);
+});
+
+it('fires onSetSide with (group, side, value) when a padding/margin input changes', () => {
+  const host = document.createElement('div');
+  const sets: [string, string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { spacing: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetSide: (group, side, value) => sets.push([group, side, value]),
+  });
+  const paddingRow = host.querySelector('[data-stb-spacing-group="padding"]')!;
+  const topInput = paddingRow.querySelector('[data-stb-side="top"]') as HTMLInputElement;
+  topInput.value = '10px';
+  topInput.dispatchEvent(new Event('input'));
+  expect(sets).toEqual([['padding', 'top', { literal: '10px' }]]);
+
+  const marginRow = host.querySelector('[data-stb-spacing-group="margin"]')!;
+  const bottomInput = marginRow.querySelector('[data-stb-side="bottom"]') as HTMLInputElement;
+  bottomInput.value = '5px';
+  bottomInput.dispatchEvent(new Event('input'));
+  expect(sets).toEqual([['padding', 'top', { literal: '10px' }], ['margin', 'bottom', { literal: '5px' }]]);
+});
+
+it('fires onSetGap with (slot, value) when a gap input changes', () => {
+  const host = document.createElement('div');
+  const sets: [string, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { spacing: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetGap: (slot, value) => sets.push([slot, value]),
+  });
+  const gapRow = host.querySelector('[data-stb-spacing-group="gap"]')!;
+  const colInput = gapRow.querySelector('[data-stb-slot="column"]') as HTMLInputElement;
+  colInput.value = '6px';
+  colInput.dispatchEvent(new Event('input'));
+  expect(sets).toEqual([['column', { literal: '6px' }]]);
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -532,6 +532,98 @@ it('fires onAddLayer, onRemoveLayer and onReorderLayer for layer row controls', 
   expect(host.querySelector('.stb-facet-bg-add-gradient')).not.toBeNull();
 });
 
+// --- background as a collapsible group ---
+
+it('renders background as a collapsible group branch, like text/surface/spacing', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } }, text: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const branches = [...host.querySelectorAll('.stb-facet-group')] as HTMLElement[];
+  const bgBranch = branches.find((b) => b.textContent?.includes('background'))!;
+  expect(bgBranch).toBeTruthy();
+  // No remove affordance: background isn't addable/removable via onRemoveGroup.
+  expect(bgBranch.querySelector('.stb-facet-remove')).toBeNull();
+  bgBranch.click();
+  expect(bgBranch.classList.contains('stb-facet-collapsed')).toBe(true);
+  const bgRow = host.querySelector('[data-stb-bg-row="color"]') as HTMLElement;
+  expect(bgRow.closest('.stb-facet-leaves')?.hasAttribute('hidden')).toBe(true);
+  bgBranch.click();
+  expect(bgBranch.classList.contains('stb-facet-collapsed')).toBe(false);
+});
+
+it('collapse-all/expand-all fold and unfold the background group alongside style groups', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } }, text: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  (host.querySelector('.stb-facet-collapse-all') as HTMLButtonElement).click();
+  expect(host.querySelectorAll('.stb-facet-group.stb-facet-collapsed').length).toBe(2);
+  (host.querySelector('.stb-facet-expand-all') as HTMLButtonElement).click();
+  expect(host.querySelectorAll('.stb-facet-group.stb-facet-collapsed').length).toBe(0);
+});
+
+it('isolate collapses text but not background when a background control is focused', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } }, text: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const bgSwatch = host.querySelector('[data-stb-bg-row="color"] .stb-facet-swatch') as HTMLElement;
+  bgSwatch.dispatchEvent(new Event('focusin', { bubbles: true }));
+  (host.querySelector('.stb-facet-isolate') as HTMLButtonElement).click();
+  const collapsed = [...host.querySelectorAll('.stb-facet-group.stb-facet-collapsed')];
+  expect(collapsed.length).toBe(1);
+  expect(collapsed[0]!.textContent).toContain('text');
+});
+
+// --- background row subtitles ---
+
+it('labels the color row "color"', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 250 } } } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="color"]')!;
+  const subtitle = row.querySelector('.stb-facet-bg-subtitle') as HTMLElement;
+  expect(subtitle.textContent).toBe('color');
+});
+
+it('labels an image layer row with its ref, or "(no image)" when empty', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { layers: [{ kind: 'image', ref: 'assets/hero.jpg' }, { kind: 'image', ref: '' }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const rows = [...host.querySelectorAll('[data-stb-bg-row="layer"]')];
+  expect((rows[0]!.querySelector('.stb-facet-bg-subtitle') as HTMLElement).textContent)
+    .toBe('image — assets/hero.jpg');
+  expect((rows[1]!.querySelector('.stb-facet-bg-subtitle') as HTMLElement).textContent)
+    .toBe('image — (no image)');
+});
+
+it('labels a gradient layer row with its type', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: { layers: [{ kind: 'gradient', gradient: {
+      type: 'radial', stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+    } }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const subtitle = row.querySelector('.stb-facet-bg-subtitle') as HTMLElement;
+  expect(subtitle.textContent).toBe('gradient — radial');
+});
+
 it('fires onSetLayer with a stored asset ref when a file is chosen for an image layer row', () => {
   const host = document.createElement('div');
   const setLayers: [number, unknown][] = [];

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -1144,3 +1144,76 @@ it('per-stop derive is disabled for a token stop', () => {
   const deriveBtn = stopRow.querySelector('.stb-facet-derive-dark') as HTMLButtonElement;
   expect(deriveBtn.disabled).toBe(true);
 });
+
+it('forked dark layers are authoritative: a light reorder that breaks index correspondence disables that row instead of re-seeding from light', () => {
+  // Reviewed regression (#5517): dark was forked as [gradientA, imageB]. A light
+  // structural edit (add/remove/reorder) — which only ever touches light — then
+  // left light index 1 as a gradient while dark index 1 is still the image layer.
+  // Per-index correspondence is broken at that row: it must render empty/disabled,
+  // never silently re-seed from the current light gradient and clobber the real
+  // dark fork sitting at that index once main.ts's array-level onSetLayerDark
+  // writes the whole array back.
+  const host = document.createElement('div');
+  const setLayersDark: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: {
+      background: {
+        layers: [
+          { kind: 'gradient', gradient: {
+            type: 'linear', angle: '90deg',
+            stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+          } },
+          // Post-reorder: light index 1 is now a gradient (used to be at index 0,
+          // or a fresh gradient) while dark index 1 (below) is still the image
+          // layer that was forked before the reorder happened.
+          { kind: 'gradient', gradient: {
+            type: 'linear', angle: '45deg',
+            stops: [{ color: { literal: '#abcabc' } }, { color: { literal: '#defdef' } }],
+          } },
+        ],
+      },
+    },
+    darkFacets: {
+      background: {
+        layers: [
+          { kind: 'gradient', gradient: {
+            type: 'linear', angle: '90deg',
+            stops: [{ color: { literal: '#111111' } }, { color: { literal: '#222222' } }],
+          } },
+          { kind: 'image', ref: 'assets/dark-hero.jpg' },
+        ],
+      },
+    },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayerDark: (i, l) => setLayersDark.push([i, l]),
+  });
+
+  const gradientRows = host.querySelectorAll('.stb-facet-bg-gradient');
+  expect(gradientRows.length).toBe(2);
+  const mismatchedStopRows = gradientRows[1]!.querySelectorAll('.stb-facet-bg-gradient-stop');
+  expect(mismatchedStopRows.length).toBe(2);
+
+  for (const stopRow of mismatchedStopRows) {
+    const darkSwatch = stopRow.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+    const deriveBtn = stopRow.querySelector('.stb-facet-derive-dark') as HTMLButtonElement;
+
+    // Empty, not a re-seeded light color.
+    expect(darkSwatch.classList.contains('stb-facet-swatch-empty')).toBe(true);
+    // Disabled: no picker, no derive.
+    expect(darkSwatch.disabled).toBe(true);
+    expect(deriveBtn.disabled).toBe(true);
+
+    // Clicking either control must not fire onSetLayerDark with a light-seeded
+    // clobber of the real dark image layer sitting at this index.
+    darkSwatch.click();
+    deriveBtn.click();
+  }
+  expect(setLayersDark.length).toBe(0);
+
+  // The row that DOES still correspond (index 0) is unaffected and still works.
+  const okStopRow = gradientRows[0]!.querySelectorAll('.stb-facet-bg-gradient-stop')[0]!;
+  const okDarkSwatch = okStopRow.querySelector('.stb-facet-swatch-dark') as HTMLButtonElement;
+  expect(okDarkSwatch.disabled).toBe(false);
+  expect(okDarkSwatch.classList.contains('stb-facet-swatch-empty')).toBe(false);
+});

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -246,10 +246,39 @@ it('fires onSetLayer with an updated type when the gradient type select changes'
   typeSel.value = 'radial';
   typeSel.dispatchEvent(new Event('change'));
   expect(setLayers.length).toBe(1);
-  const [index, layer] = setLayers[0] as [number, { kind: string; gradient: { type: string } }];
+  const [index, layer] = setLayers[0] as [number, { kind: string; gradient: { type: string; angle?: string; stops: unknown[] } }];
   expect(index).toBe(0);
   expect(layer.kind).toBe('gradient');
   expect(layer.gradient.type).toBe('radial');
+  // Arm-specific fields must not leak across the union: linear's angle is
+  // not a valid radial field and would make the persisted shape schema-invalid.
+  expect('angle' in layer.gradient).toBe(false);
+  expect(layer.gradient.stops.length).toBe(2);
+});
+
+it('carries position and repeating (but drops shape/size) when switching radial to conic', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'radial', repeating: true, shape: 'circle', size: '40px', position: 'top left',
+        stops: [{ color: { literal: '#fff' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const typeSel = host.querySelector('[data-stb-bg-row="layer"] select') as HTMLSelectElement;
+  typeSel.value = 'conic';
+  typeSel.dispatchEvent(new Event('change'));
+  const [, layer] = setLayers[0] as [number, { gradient: Record<string, unknown> }];
+  expect(layer.gradient.type).toBe('conic');
+  expect(layer.gradient.repeating).toBe(true);
+  expect(layer.gradient.position).toBe('top left');
+  expect('shape' in layer.gradient).toBe(false);
+  expect('size' in layer.gradient).toBe(false);
 });
 
 it('fires onSetLayer with an updated angle when the linear angle/position input changes', () => {
@@ -333,6 +362,103 @@ it('preserves exotic radial gradient fields (shape, size) when editing the posit
   const [, layer2] = setLayers[1] as [number, { gradient: { shape?: string; size?: string } }];
   expect(layer2.gradient.shape).toBe('circle');
   expect(layer2.gradient.size).toBe('40px');
+});
+
+it('appends a stop when + stop is clicked and removes one via the stop remove button', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', angle: '90deg',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  (row.querySelector('.stb-facet-bg-gradient-add-stop') as HTMLButtonElement).click();
+  const [, added] = setLayers[0] as [number, { gradient: { stops: Array<{ color: unknown }> } }];
+  expect(added.gradient.stops.length).toBe(3);
+
+  const removeBtns = row.querySelectorAll('.stb-facet-bg-gradient-stop-remove');
+  (removeBtns[0] as HTMLButtonElement).click();
+  const [, removed] = setLayers[1] as [number, { gradient: { stops: Array<{ color: { literal: unknown } }> } }];
+  expect(removed.gradient.stops.length).toBe(1);
+  expect(removed.gradient.stops[0]!.color.literal).toBe('#000');
+});
+
+it('disables the stop remove button when only one stop remains', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear', stops: [{ color: { literal: '#fff' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const removeBtn = host.querySelector('.stb-facet-bg-gradient-stop-remove') as HTMLButtonElement;
+  expect(removeBtn.disabled).toBe(true);
+});
+
+it('sets and clears a stop position via the stop position input', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'linear',
+        stops: [{ color: { literal: '#fff' }, position: '10%' }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const posInputs = row.querySelectorAll('.stb-facet-bg-gradient-stop-pos');
+  const second = posInputs[1] as HTMLInputElement;
+  second.value = '80%';
+  second.dispatchEvent(new Event('input'));
+  const [, withPos] = setLayers[0] as [number, { gradient: { stops: Array<{ position?: string }> } }];
+  expect(withPos.gradient.stops[1]!.position).toBe('80%');
+
+  const first = posInputs[0] as HTMLInputElement;
+  first.value = '';
+  first.dispatchEvent(new Event('input'));
+  const [, cleared] = setLayers[1] as [number, { gradient: { stops: Array<Record<string, unknown>> } }];
+  // Clearing removes the key entirely (exactOptionalPropertyTypes: no position: undefined).
+  expect('position' in cleared.gradient.stops[0]!).toBe(false);
+});
+
+it('edits the position field of a conic gradient', () => {
+  const host = document.createElement('div');
+  const setLayers: [number, unknown][] = [];
+  mountFacetTree(host, {
+    facets: { background: {
+      layers: [{ kind: 'gradient', gradient: {
+        type: 'conic', fromAngle: '45deg', position: 'center',
+        stops: [{ color: { literal: '#fff' } }, { color: { literal: '#000' } }],
+      } }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    onSetLayer: (i, l) => setLayers.push([i, l]),
+  });
+  const row = host.querySelector('[data-stb-bg-row="layer"]')!;
+  const posInput = row.querySelector('.stb-facet-bg-gradient-pos') as HTMLInputElement;
+  expect(posInput.value).toBe('center');
+  posInput.value = 'top';
+  posInput.dispatchEvent(new Event('input'));
+  const [, layer] = setLayers[0] as [number, { gradient: { type: string; fromAngle?: string; position?: string } }];
+  expect(layer.gradient.type).toBe('conic');
+  expect(layer.gradient.position).toBe('top');
+  // Exotic conic field preserved by the same-arm spread.
+  expect(layer.gradient.fromAngle).toBe('45deg');
 });
 
 it('fires onAddLayer with a default linear gradient when + gradient is clicked', () => {

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -225,7 +225,7 @@ it('shows the light/dark header once per group that has a color leaf', () => {
 it('omits the light/dark header for a group with no color leaves', () => {
   const host = document.createElement('div');
   mountFacetTree(host, {
-    facets: { spacing: { padding: { literal: '4px' } } },
+    facets: { spacing: { padding: { top: { literal: '4px' } } } },
     onEdit: () => {},
     previewHost: document.createElement('div'),
   });

--- a/tools/stb/tests/integration/facet-tree.test.ts
+++ b/tools/stb/tests/integration/facet-tree.test.ts
@@ -1,5 +1,5 @@
 // tests/integration/facet-tree.test.ts
-import { it, expect } from 'vitest';
+import { it, expect, vi } from 'vitest';
 import { mountFacetTree } from '@/ui/facet-tree';
 import { deriveDarkOklch } from '@/color/derive-dark';
 import { toOklch } from '@/color/oklch';
@@ -339,6 +339,46 @@ it('carries a position tooltip and a labeled column header for the gradient stop
   expect(stopPosInput.title).toMatch(/25%/);
 });
 
+it('annotates the color backstop when a painting layer covers it', () => {
+  const host = document.createElement('div');
+  mountFacetTree(host, {
+    facets: { background: {
+      color: { literal: { l: 0.9, c: 0.05, h: 100 } },
+      layers: [{ kind: 'image', ref: 'bg.svg' }],
+    } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  const note = host.querySelector('[data-stb-bg-row="color"] .stb-facet-bg-covered-note');
+  expect(note).not.toBeNull();
+  expect(note!.textContent).toBe('beneath layers');
+
+  // no painting layers (blank-edit transient) → no note
+  const bare = document.createElement('div');
+  mountFacetTree(bare, {
+    facets: { background: { color: { literal: { l: 0.9, c: 0.05, h: 100 } }, layers: [{ kind: 'image', ref: '' }] } },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+  });
+  expect(bare.querySelector('.stb-facet-bg-covered-note')).toBeNull();
+});
+
+it('renders the backdrop hint with a working jump link when provided', () => {
+  const host = document.createElement('div');
+  const onJump = vi.fn();
+  mountFacetTree(host, {
+    facets: { background: {} },
+    previewHost: document.createElement('div'),
+    onEdit: () => {},
+    backdropHint: { name: 'Background', onJump },
+  });
+  const hint = host.querySelector('.stb-facet-bg-backdrop-hint');
+  expect(hint).not.toBeNull();
+  expect(hint!.textContent).toContain('painted by Background');
+  (hint!.querySelector('.stb-facet-bg-backdrop-jump') as HTMLButtonElement).click();
+  expect(onJump).toHaveBeenCalledOnce();
+});
+
 it('renders one MDN gradient help link per gradient layer, targeting the current type', () => {
   const host = document.createElement('div');
   mountFacetTree(host, {
@@ -355,8 +395,23 @@ it('renders one MDN gradient help link per gradient layer, targeting the current
   const help = row.querySelector('.stb-facet-bg-gradient-help') as HTMLAnchorElement;
   expect(help).not.toBeNull();
   expect(help.href).toBe('https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/radial-gradient');
-  expect(help.target).toBe('_blank');
   expect(help.rel).toBe('noopener');
+  // Opens as a reusable narrow popup over stb, not a new tab — a full tab
+  // hides the app and loses the user's place (MDN can't be framed, so a
+  // positioned popup is the only "help beside the app" available).
+  expect(help.target).toBe('');
+  const opened: unknown[][] = [];
+  const origOpen = window.open;
+  window.open = ((...args: unknown[]) => { opened.push(args); return null; }) as typeof window.open;
+  try {
+    help.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  } finally {
+    window.open = origOpen;
+  }
+  expect(opened).toHaveLength(1);
+  expect(opened[0]![0]).toBe('https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/radial-gradient');
+  expect(opened[0]![1]).toBe('stb-help');
+  expect(String(opened[0]![2])).toMatch(/width=480/);
 });
 
 it('updates the MDN help link href when the gradient type select changes', () => {

--- a/tools/stb/tests/metadata/background-css.test.ts
+++ b/tools/stb/tests/metadata/background-css.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { gradientCss, backgroundCss, fontFamilyCss } from '@/metadata/facets';
+import { gradientCss, backgroundCss, fontFamilyCss, spacingDeclarations } from '@/metadata/facets';
 
 describe('gradientCss', () => {
   it('reconstructs a linear gradient with angle and stops', () => {
@@ -51,5 +51,30 @@ describe('fontFamilyCss', () => {
   it('joins the font-family fallback list', () => {
     expect(fontFamilyCss([{ literal: 'Inter' }, { literal: 'system-ui' }, { literal: 'sans-serif' }]))
       .toBe('font-family: Inter, system-ui, sans-serif;');
+  });
+});
+
+describe('spacingDeclarations', () => {
+  it('emits per-side longhands for set spacing slots', () => {
+    expect(spacingDeclarations({
+      padding: { top: { literal: '8px' }, left: { literal: '4px' } },
+      gap: { row: { literal: '2px' } },
+    })).toEqual(['padding-top: 8px;', 'padding-left: 4px;', 'row-gap: 2px;']);
+  });
+  it('emits margin longhands in T/R/B/L order and column-gap', () => {
+    expect(spacingDeclarations({
+      margin: { top: { literal: '1px' }, right: { literal: '2px' }, bottom: { literal: '3px' }, left: { literal: '4px' } },
+      gap: { column: { literal: '6px' } },
+    })).toEqual([
+      'margin-top: 1px;', 'margin-right: 2px;', 'margin-bottom: 3px;', 'margin-left: 4px;',
+      'column-gap: 6px;',
+    ]);
+  });
+  it('emits nothing for an empty spacing facet', () => {
+    expect(spacingDeclarations({})).toEqual([]);
+  });
+  it('resolves a token slot via facetValueCss', () => {
+    expect(spacingDeclarations({ padding: { top: { token: 'space.md' } } }))
+      .toEqual(['padding-top: var(--space-md);']);
   });
 });

--- a/tools/stb/tests/metadata/background-css.test.ts
+++ b/tools/stb/tests/metadata/background-css.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { gradientCss, backgroundCss } from '@/metadata/facets';
+
+describe('gradientCss', () => {
+  it('reconstructs a linear gradient with angle and stops', () => {
+    expect(gradientCss({ type: 'linear', angle: '45deg', stops: [
+      { color: { token: 'brand.500' }, position: '0%' },
+      { color: { literal: 'transparent' } },
+    ] })).toBe('linear-gradient(45deg, var(--brand-500) 0%, transparent)');
+  });
+  it('supports repeating + radial', () => {
+    expect(gradientCss({ type: 'radial', repeating: true, shape: 'circle', stops: [
+      { color: { literal: '#fff' } }, { color: { literal: '#000' } },
+    ] })).toBe('repeating-radial-gradient(circle, #ffffff, #000000)');
+  });
+  it('reconstructs a conic gradient with from-angle and position', () => {
+    expect(gradientCss({ type: 'conic', fromAngle: '90deg', position: 'center', stops: [
+      { color: { literal: '#fff' } }, { color: { literal: '#000' } },
+    ] })).toBe('conic-gradient(from 90deg at center, #ffffff, #000000)');
+  });
+  it('emits a var() for a fully-prefixed token stop without doubling the dashes', () => {
+    expect(gradientCss({ type: 'linear', stops: [
+      { color: { token: '--color-brand-900' } }, { color: { literal: 'transparent' } },
+    ] })).toBe('linear-gradient(var(--color-brand-900), transparent)');
+  });
+});
+
+describe('backgroundCss', () => {
+  it('emits color backstop + layers reversed to CSS order (topmost first)', () => {
+    const decls = backgroundCss({
+      color: { literal: '#0b3d91' },
+      layers: [
+        { kind: 'image', ref: 'assets/hero.jpg' },                 // authoring[0] = bottom
+        { kind: 'gradient', gradient: { type: 'linear', stops: [   // authoring[1] = top
+          { color: { literal: 'rgba(0,0,0,.6)' } }, { color: { literal: 'transparent' } } ] } },
+      ],
+    });
+    expect(decls).toEqual([
+      'background-color: #0b3d91;',
+      'background-image: linear-gradient(rgba(0,0,0,.6), transparent), url(assets/hero.jpg);',
+    ]);
+  });
+  it('emits only color when no layers, only image when no color, nothing when empty', () => {
+    expect(backgroundCss({ color: { literal: '#fff' } })).toEqual(['background-color: #ffffff;']);
+    expect(backgroundCss({ layers: [{ kind: 'image', ref: 'a.png' }] })).toEqual(['background-image: url(a.png);']);
+    expect(backgroundCss({})).toEqual([]);
+  });
+});

--- a/tools/stb/tests/metadata/background-css.test.ts
+++ b/tools/stb/tests/metadata/background-css.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { gradientCss, backgroundCss, backgroundPatch, fontFamilyCss, spacingDeclarations } from '@/metadata/facets';
+import { gradientCss, backgroundCss, fontFamilyCss, spacingDeclarations } from '@/metadata/facets';
 
 describe('gradientCss', () => {
   it('reconstructs a linear gradient with angle and stops', () => {
@@ -82,14 +82,6 @@ describe('backgroundCss', () => {
         { color: { literal: '' } }, { color: { literal: '#fff' } },
       ] } }],
     })).toEqual(['background-image: linear-gradient(#ffffff);']);
-  });
-});
-
-describe('backgroundPatch blank-layer guard (live-preview leg)', () => {
-  it('omits backgroundImage when the only gradient layer has all-blank stops', () => {
-    expect(backgroundPatch({
-      layers: [{ kind: 'gradient', gradient: { type: 'linear', stops: [{ color: { literal: '' } }] } }],
-    })).toEqual({});
   });
 });
 

--- a/tools/stb/tests/metadata/background-css.test.ts
+++ b/tools/stb/tests/metadata/background-css.test.ts
@@ -45,12 +45,36 @@ describe('backgroundCss', () => {
     expect(backgroundCss({ layers: [{ kind: 'image', ref: 'a.png' }] })).toEqual(['background-image: url(a.png);']);
     expect(backgroundCss({})).toEqual([]);
   });
+  it('skips a blank/whitespace literal color (no dangling background-color:;)', () => {
+    expect(backgroundCss({ color: { literal: '' } })).toEqual([]);
+    expect(backgroundCss({ color: { literal: '   ' } })).toEqual([]);
+  });
+  it('skips an empty-ref image layer, keeping other layers', () => {
+    expect(backgroundCss({ layers: [{ kind: 'image', ref: '' }] })).toEqual([]);
+    expect(backgroundCss({
+      layers: [
+        { kind: 'image', ref: 'a.png' },
+        { kind: 'image', ref: '   ' },
+      ],
+    })).toEqual(['background-image: url(a.png);']);
+  });
 });
 
 describe('fontFamilyCss', () => {
   it('joins the font-family fallback list', () => {
     expect(fontFamilyCss([{ literal: 'Inter' }, { literal: 'system-ui' }, { literal: 'sans-serif' }]))
       .toBe('font-family: Inter, system-ui, sans-serif;');
+  });
+  it('returns null when every entry is a blank/whitespace-only literal', () => {
+    expect(fontFamilyCss([{ literal: '' }, { literal: '   ' }])).toBeNull();
+  });
+  it('skips blank entries but keeps real ones, with clean commas', () => {
+    expect(fontFamilyCss([{ literal: '' }, { literal: 'Inter' }, { literal: '  ' }, { literal: 'sans-serif' }]))
+      .toBe('font-family: Inter, sans-serif;');
+  });
+  it('never treats a token entry as blank', () => {
+    expect(fontFamilyCss([{ token: 'font.brand' }, { literal: '' }]))
+      .toBe('font-family: var(--font-brand);');
   });
 });
 
@@ -74,6 +98,16 @@ describe('spacingDeclarations', () => {
     expect(spacingDeclarations({})).toEqual([]);
   });
   it('resolves a token slot via facetValueCss', () => {
+    expect(spacingDeclarations({ padding: { top: { token: 'space.md' } } }))
+      .toEqual(['padding-top: var(--space-md);']);
+  });
+  it('skips a blank literal side while emitting set siblings (no dangling padding-top:;)', () => {
+    expect(spacingDeclarations({
+      padding: { top: { literal: '' }, left: { literal: '4px' } },
+      gap: { row: { literal: '   ' } },
+    })).toEqual(['padding-left: 4px;']);
+  });
+  it('never treats a token slot as blank', () => {
     expect(spacingDeclarations({ padding: { top: { token: 'space.md' } } }))
       .toEqual(['padding-top: var(--space-md);']);
   });

--- a/tools/stb/tests/metadata/background-css.test.ts
+++ b/tools/stb/tests/metadata/background-css.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { gradientCss, backgroundCss, fontFamilyCss, spacingDeclarations } from '@/metadata/facets';
+import { gradientCss, backgroundCss, backgroundPatch, fontFamilyCss, spacingDeclarations } from '@/metadata/facets';
 
 describe('gradientCss', () => {
   it('reconstructs a linear gradient with angle and stops', () => {
@@ -17,6 +17,14 @@ describe('gradientCss', () => {
     expect(gradientCss({ type: 'conic', fromAngle: '90deg', position: 'center', stops: [
       { color: { literal: '#fff' } }, { color: { literal: '#000' } },
     ] })).toBe('conic-gradient(from 90deg at center, #ffffff, #000000)');
+  });
+  it('skips blank stop literals — no dangling comma or empty stop', () => {
+    expect(gradientCss({ type: 'linear', stops: [
+      { color: { literal: '  ' } }, { color: { literal: '#fff' } },
+    ] })).toBe('linear-gradient(#ffffff)');
+    expect(gradientCss({ type: 'linear', angle: '45deg', stops: [
+      { color: { literal: '#fff' } }, { color: { literal: '' }, position: '50%' }, { color: { literal: '#000' } },
+    ] })).toBe('linear-gradient(45deg, #ffffff, #000000)');
   });
   it('emits a var() for a fully-prefixed token stop without doubling the dashes', () => {
     expect(gradientCss({ type: 'linear', stops: [
@@ -57,6 +65,31 @@ describe('backgroundCss', () => {
         { kind: 'image', ref: '   ' },
       ],
     })).toEqual(['background-image: url(a.png);']);
+  });
+  it('skips a gradient layer whose stops are ALL blank (mid-edit transient)', () => {
+    const allBlank = { type: 'linear' as const, stops: [{ color: { literal: '' } }, { color: { literal: '  ' } }] };
+    expect(backgroundCss({ layers: [{ kind: 'gradient', gradient: allBlank }] })).toEqual([]);
+    expect(backgroundCss({
+      layers: [
+        { kind: 'image', ref: 'a.png' },
+        { kind: 'gradient', gradient: allBlank },
+      ],
+    })).toEqual(['background-image: url(a.png);']);
+  });
+  it('keeps a gradient layer with at least one real stop, dropping only the blank stops', () => {
+    expect(backgroundCss({
+      layers: [{ kind: 'gradient', gradient: { type: 'linear', stops: [
+        { color: { literal: '' } }, { color: { literal: '#fff' } },
+      ] } }],
+    })).toEqual(['background-image: linear-gradient(#ffffff);']);
+  });
+});
+
+describe('backgroundPatch blank-layer guard (live-preview leg)', () => {
+  it('omits backgroundImage when the only gradient layer has all-blank stops', () => {
+    expect(backgroundPatch({
+      layers: [{ kind: 'gradient', gradient: { type: 'linear', stops: [{ color: { literal: '' } }] } }],
+    })).toEqual({});
   });
 });
 

--- a/tools/stb/tests/metadata/background-css.test.ts
+++ b/tools/stb/tests/metadata/background-css.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { gradientCss, backgroundCss } from '@/metadata/facets';
+import { gradientCss, backgroundCss, fontFamilyCss } from '@/metadata/facets';
 
 describe('gradientCss', () => {
   it('reconstructs a linear gradient with angle and stops', () => {
@@ -44,5 +44,12 @@ describe('backgroundCss', () => {
     expect(backgroundCss({ color: { literal: '#fff' } })).toEqual(['background-color: #ffffff;']);
     expect(backgroundCss({ layers: [{ kind: 'image', ref: 'a.png' }] })).toEqual(['background-image: url(a.png);']);
     expect(backgroundCss({})).toEqual([]);
+  });
+});
+
+describe('fontFamilyCss', () => {
+  it('joins the font-family fallback list', () => {
+    expect(fontFamilyCss([{ literal: 'Inter' }, { literal: 'system-ui' }, { literal: 'sans-serif' }]))
+      .toBe('font-family: Inter, system-ui, sans-serif;');
   });
 });

--- a/tools/stb/tests/metadata/facets.test.ts
+++ b/tools/stb/tests/metadata/facets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { FACET_PROPS, facetDeclarations, facetLiteralCss } from '@/metadata/facets';
+import { FACET_PROPS, facetDeclarations, facetLiteralCss, backgroundPatch } from '@/metadata/facets';
 import type { Facets } from '@/metadata/types';
 
 describe('FACET_PROPS', () => {
@@ -25,5 +25,23 @@ describe('facetLiteralCss', () => {
     expect(facetLiteralCss(FACET_PROPS['text.fontSize']!, { literal: '18px' })).toBe('18px');
     expect(facetLiteralCss(FACET_PROPS['text.color']!, { literal: { l: 0, c: 0, h: 0 } })).toMatch(/^#/);
     expect(facetLiteralCss(FACET_PROPS['text.color']!, { token: 'x' })).toBeNull();
+  });
+});
+
+describe('backgroundPatch', () => {
+  it('returns raw color + reversed-layer image values (unlike backgroundCss, a {token} color is included)', () => {
+    expect(backgroundPatch({
+      color: { literal: '#0b3d91' },
+      layers: [
+        { kind: 'image', ref: 'assets/hero.jpg' },
+        { kind: 'gradient', gradient: { type: 'linear', stops: [
+          { color: { literal: 'rgba(0,0,0,.6)' } }, { color: { literal: 'transparent' } } ] } },
+      ],
+    })).toEqual({
+      backgroundColor: '#0b3d91',
+      backgroundImage: 'linear-gradient(rgba(0,0,0,.6), transparent), url(assets/hero.jpg)',
+    });
+    expect(backgroundPatch({ color: { token: 'brand.500' } })).toEqual({ backgroundColor: 'var(--brand-500)' });
+    expect(backgroundPatch({})).toEqual({});
   });
 });

--- a/tools/stb/tests/metadata/facets.test.ts
+++ b/tools/stb/tests/metadata/facets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { FACET_PROPS, facetDeclarations, facetLiteralCss, backgroundPatch, contentAssetDeclarations } from '@/metadata/facets';
+import { FACET_PROPS, facetDeclarations, facetLiteralCss, contentAssetDeclarations } from '@/metadata/facets';
 import type { Facets } from '@/metadata/types';
 
 describe('FACET_PROPS', () => {
@@ -53,23 +53,5 @@ describe('contentAssetDeclarations topmost-image scan', () => {
     };
     const out = [...contentAssetDeclarations(f)];
     expect(out).toEqual([{ key: 'asset', value: 'assets/logo.png' }]);
-  });
-});
-
-describe('backgroundPatch', () => {
-  it('returns raw color + reversed-layer image values (unlike backgroundCss, a {token} color is included)', () => {
-    expect(backgroundPatch({
-      color: { literal: '#0b3d91' },
-      layers: [
-        { kind: 'image', ref: 'assets/hero.jpg' },
-        { kind: 'gradient', gradient: { type: 'linear', stops: [
-          { color: { literal: 'rgba(0,0,0,.6)' } }, { color: { literal: 'transparent' } } ] } },
-      ],
-    })).toEqual({
-      backgroundColor: '#0b3d91',
-      backgroundImage: 'linear-gradient(rgba(0,0,0,.6), transparent), url(assets/hero.jpg)',
-    });
-    expect(backgroundPatch({ color: { token: 'brand.500' } })).toEqual({ backgroundColor: 'var(--brand-500)' });
-    expect(backgroundPatch({})).toEqual({});
   });
 });

--- a/tools/stb/tests/metadata/facets.test.ts
+++ b/tools/stb/tests/metadata/facets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { FACET_PROPS, facetDeclarations, facetLiteralCss, backgroundPatch } from '@/metadata/facets';
+import { FACET_PROPS, facetDeclarations, facetLiteralCss, backgroundPatch, contentAssetDeclarations } from '@/metadata/facets';
 import type { Facets } from '@/metadata/types';
 
 describe('FACET_PROPS', () => {
@@ -25,6 +25,34 @@ describe('facetLiteralCss', () => {
     expect(facetLiteralCss(FACET_PROPS['text.fontSize']!, { literal: '18px' })).toBe('18px');
     expect(facetLiteralCss(FACET_PROPS['text.color']!, { literal: { l: 0, c: 0, h: 0 } })).toMatch(/^#/);
     expect(facetLiteralCss(FACET_PROPS['text.color']!, { token: 'x' })).toBeNull();
+  });
+  it('returns null for a blank/whitespace-only string literal (unset, emit nothing)', () => {
+    expect(facetLiteralCss(FACET_PROPS['text.fontSize']!, { literal: '' })).toBeNull();
+    expect(facetLiteralCss(FACET_PROPS['text.fontSize']!, { literal: '   ' })).toBeNull();
+  });
+});
+
+describe('contentAssetDeclarations topmost-image scan', () => {
+  it('skips an empty-ref topmost image layer and keeps scanning down to a real one', () => {
+    const f: Facets = {
+      background: {
+        layers: [
+          { kind: 'image', ref: 'assets/lower.png' },
+          { kind: 'image', ref: '   ' },
+        ],
+      },
+    };
+    const out = [...contentAssetDeclarations(f)];
+    expect(out).toEqual([{ key: 'asset', value: 'assets/lower.png' }]);
+  });
+
+  it('falls back to facets.asset when every layer image ref is blank', () => {
+    const f: Facets = {
+      background: { layers: [{ kind: 'image', ref: '' }] },
+      asset: { ref: 'assets/logo.png' },
+    };
+    const out = [...contentAssetDeclarations(f)];
+    expect(out).toEqual([{ key: 'asset', value: 'assets/logo.png' }]);
   });
 });
 

--- a/tools/stb/tests/metadata/facets.test.ts
+++ b/tools/stb/tests/metadata/facets.test.ts
@@ -7,15 +7,16 @@ describe('FACET_PROPS', () => {
     expect(FACET_PROPS['text.color']!).toEqual({ cssProp: 'color', isColor: true });
     expect(FACET_PROPS['text.fontSize']!).toEqual({ cssProp: 'font-size', isColor: false });
     expect(FACET_PROPS['surface.borderRadius']!).toEqual({ cssProp: 'border-radius', isColor: false });
-    expect(Object.keys(FACET_PROPS)).toHaveLength(11);
+    expect(FACET_PROPS['background.color']!).toEqual({ cssProp: 'background-color', isColor: true });
+    expect(Object.keys(FACET_PROPS)).toHaveLength(7);
   });
 });
 
 describe('facetDeclarations', () => {
   it('yields one entry per set group property, skipping undefined', () => {
-    const f: Facets = { text: { fontSize: { literal: '18px' } }, surface: { background: { token: 'card-bg' } } };
+    const f: Facets = { text: { fontSize: { literal: '18px' } }, surface: { borderRadius: { literal: '8px' } } };
     const out = [...facetDeclarations(f)].map((d) => d.key);
-    expect(out).toEqual(['text.fontSize', 'surface.background']);
+    expect(out).toEqual(['text.fontSize', 'surface.borderRadius']);
   });
 });
 

--- a/tools/stb/tests/metadata/migrate-facets.test.ts
+++ b/tools/stb/tests/metadata/migrate-facets.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { migrateFacets } from '@/metadata/migrate-facets';
+
+describe('migrateFacets', () => {
+  it('moves surface.background color to background.color', () => {
+    const out = migrateFacets({ surface: { background: { literal: '#fff' }, border: { literal: '1px' } } }, false);
+    expect(out.background).toEqual({ color: { literal: '#fff' } });
+    expect(out.surface).toEqual({ border: { literal: '1px' } });
+  });
+  it('wraps a single fontFamily into a one-entry list', () => {
+    const out = migrateFacets({ text: { fontFamily: { literal: 'Inter' } } }, false);
+    expect(out.text!.fontFamily).toEqual([{ literal: 'Inter' }]);
+  });
+  it('expands single padding/margin to all four sides and gap to row+column', () => {
+    const out = migrateFacets({ spacing: { padding: { literal: '8px' }, gap: { literal: '4px' } } }, false);
+    expect(out.spacing!.padding).toEqual({ top: { literal: '8px' }, right: { literal: '8px' }, bottom: { literal: '8px' }, left: { literal: '8px' } });
+    expect(out.spacing!.gap).toEqual({ row: { literal: '4px' }, column: { literal: '4px' } });
+  });
+  it('turns a background-use asset into an image layer, keeps <img> asset as-is', () => {
+    const bg = migrateFacets({ asset: { ref: 'assets/hero.jpg' } }, false);
+    expect(bg.background).toEqual({ layers: [{ kind: 'image', ref: 'assets/hero.jpg' }] });
+    expect(bg.asset).toBeUndefined();
+    const img = migrateFacets({ asset: { ref: 'assets/logo.svg' } }, true);
+    expect(img.asset).toEqual({ ref: 'assets/logo.svg' });
+    expect(img.background).toBeUndefined();
+  });
+  it('passes already-composite facets through unchanged', () => {
+    const composite = { background: { color: { literal: '#000' }, layers: [] }, text: { fontFamily: [{ literal: 'Inter' }] } };
+    expect(migrateFacets(composite, false)).toEqual(composite);
+  });
+});

--- a/tools/stb/tests/metadata/types.test.ts
+++ b/tools/stb/tests/metadata/types.test.ts
@@ -17,7 +17,7 @@ describe('composite facet types', () => {
       spacing: { padding: { top: { literal: '8px' } }, gap: { row: { literal: '4px' } } },
     };
     expect(f.background!.layers).toHaveLength(2);
-    expect(f.background!.layers![0].kind).toBe('image');
+    expect(f.background!.layers![0]!.kind).toBe('image');
     expect(f.text!.fontFamily).toHaveLength(2);
     expect(f.spacing!.padding!.top).toEqual({ literal: '8px' });
   });

--- a/tools/stb/tests/metadata/types.test.ts
+++ b/tools/stb/tests/metadata/types.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import type { Facets, Layer, Gradient } from '@/metadata/types';
+
+describe('composite facet types', () => {
+  it('models a background as backstop color + ordered layers (image|gradient)', () => {
+    const grad: Gradient = { type: 'linear', angle: '45deg', stops: [
+      { color: { literal: '#000' }, position: '0%' },
+      { color: { token: 'brand.500' } },
+    ] };
+    const layers: Layer[] = [
+      { kind: 'image', ref: 'assets/hero.jpg' },
+      { kind: 'gradient', gradient: grad },
+    ];
+    const f: Facets = {
+      background: { color: { literal: '#0b3d91' }, layers },
+      text: { fontFamily: [{ literal: 'Inter' }, { literal: 'sans-serif' }] },
+      spacing: { padding: { top: { literal: '8px' } }, gap: { row: { literal: '4px' } } },
+    };
+    expect(f.background!.layers).toHaveLength(2);
+    expect(f.background!.layers![0].kind).toBe('image');
+    expect(f.text!.fontFamily).toHaveLength(2);
+    expect(f.spacing!.padding!.top).toEqual({ literal: '8px' });
+  });
+});

--- a/tools/stb/tests/parse/css-emitter.test.ts
+++ b/tools/stb/tests/parse/css-emitter.test.ts
@@ -111,4 +111,27 @@ describe('emitScopedBlocks', () => {
       `${lightSel('a.one')} {\n  color: red;\n}\n\n${lightSel('a.two')} {\n  color: blue;\n}`,
     );
   });
+
+  it('emits a dark gradient layer stack in the .dark-theme block for a node with facetsDark.background', () => {
+    const n: ElementNode = {
+      snapshotId: 'a.hero',
+      role: '',
+      name: null,
+      description: '',
+      facets: {},
+      facetsDark: {
+        background: {
+          layers: [{ kind: 'gradient', gradient: {
+            type: 'linear', angle: '90deg',
+            stops: [{ color: { literal: '#111111' } }, { color: { literal: '#222222' } }],
+          } }],
+        },
+      },
+    };
+    const out = emitScopedBlocks([n]);
+    const darkSel = `.dark-theme ${sel('a.hero')}`;
+    expect(out).toContain(`${darkSel} {`);
+    expect(out).toContain('background-image: linear-gradient(90deg, #111111, #222222);');
+    expect(out).not.toContain('html:not(.dark-theme)'); // no light block: facets is empty
+  });
 });

--- a/tools/stb/tests/parse/facet-emit.test.ts
+++ b/tools/stb/tests/parse/facet-emit.test.ts
@@ -80,6 +80,11 @@ it('omits font-family entirely when the list is empty or absent', () => {
   expect(emitScopedBlocks([n('a.card', { text: {} })])).not.toContain('font-family');
 });
 
+it('omits font-family entirely when every entry is a blank literal (no dangling font-family: ;)', () => {
+  const css = emitScopedBlocks([n('a.card', { text: { fontFamily: [{ literal: '' }, { literal: '  ' }] } })]);
+  expect(css).not.toContain('font-family');
+});
+
 it('emits spacing per-side longhands in the light block (not in FACET_PROPS)', () => {
   const css = emitScopedBlocks([
     n('a.card', { spacing: { padding: { top: { literal: '8px' }, left: { literal: '4px' } }, gap: { row: { literal: '2px' } } } }),

--- a/tools/stb/tests/parse/facet-emit.test.ts
+++ b/tools/stb/tests/parse/facet-emit.test.ts
@@ -18,17 +18,17 @@ it('emits literal facet props into the scoped rule and skips token values', () =
 });
 
 it('merges facet declarations with a free-form scopedBlock', () => {
-  const nodes = [{ snapshotId: 'x', facets: { spacing: { padding: { literal: '8px' } } }, scopedBlock: 'opacity: 0.9' }];
+  const nodes = [{ snapshotId: 'x', facets: { surface: { borderRadius: { literal: '8px' } } }, scopedBlock: 'opacity: 0.9' }];
   const css = emitScopedBlocks(nodes as any);
-  expect(css).toContain('padding: 8px;');
+  expect(css).toContain('border-radius: 8px;');
   expect(css).toContain('opacity: 0.9;');
 });
 
 it('emits a .dark-theme scoped block from facetsDark, after the light block', () => {
   const css = emitScopedBlocks([
     n('auth.login.page',
-      { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
-      { surface: { background: { literal: { l: 0.2, c: 0.02, h: 250 } } } }),
+      { background: { color: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
+      { background: { color: { literal: { l: 0.2, c: 0.02, h: 250 } } } }),
   ]);
   const attrSel = '[stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"][stb-snapshot-id="auth.login.page"]';
   const light = `html:not(.dark-theme) ${attrSel}`;
@@ -43,7 +43,7 @@ it('emits a .dark-theme scoped block from facetsDark, after the light block', ()
 
 it('skips a node with no facetsDark (no dark block)', () => {
   const css = emitScopedBlocks([
-    n('auth.login.page', { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } }),
+    n('auth.login.page', { background: { color: { literal: { l: 0.95, c: 0.02, h: 250 } } } }),
   ]);
   // The light selector contains :not(.dark-theme) but no standalone dark override block should appear.
   expect(css).not.toContain('.dark-theme [stb-snapshot-id');
@@ -52,9 +52,18 @@ it('skips a node with no facetsDark (no dark block)', () => {
 it('skips a dark {token} value (literals only in this slice)', () => {
   const css = emitScopedBlocks([
     n('auth.login.page',
-      { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
-      { surface: { background: { token: '--color-brand-900' } } }),
+      { background: { color: { literal: { l: 0.95, c: 0.02, h: 250 } } } },
+      { background: { color: { token: '--color-brand-900' } } }),
   ]);
   // token-dark routing is out of scope; nothing literal to emit — no standalone dark block.
   expect(css).not.toContain('.dark-theme [stb-snapshot-id');
+});
+
+it('emits background composite (color backstop + reversed image layer) in the light block', () => {
+  const css = emitScopedBlocks([{
+    snapshotId: 'a.card', role: 'region', name: null, description: '',
+    facets: { background: { color: { literal: '#0b3d91' }, layers: [{ kind: 'image', ref: 'assets/hero.jpg' }] } },
+  } as any]);
+  expect(css).toContain('background-color: #0b3d91;');
+  expect(css).toContain('background-image: url(assets/hero.jpg);');
 });

--- a/tools/stb/tests/parse/facet-emit.test.ts
+++ b/tools/stb/tests/parse/facet-emit.test.ts
@@ -79,3 +79,28 @@ it('omits font-family entirely when the list is empty or absent', () => {
   expect(emitScopedBlocks([n('a.card', { text: { fontFamily: [] } })])).not.toContain('font-family');
   expect(emitScopedBlocks([n('a.card', { text: {} })])).not.toContain('font-family');
 });
+
+it('emits spacing per-side longhands in the light block (not in FACET_PROPS)', () => {
+  const css = emitScopedBlocks([
+    n('a.card', { spacing: { padding: { top: { literal: '8px' }, left: { literal: '4px' } }, gap: { row: { literal: '2px' } } } }),
+  ]);
+  expect(css).toContain('padding-top: 8px;');
+  expect(css).toContain('padding-left: 4px;');
+  expect(css).toContain('row-gap: 2px;');
+});
+
+it('emits dark spacing per-side longhands in the .dark-theme block', () => {
+  const css = emitScopedBlocks([
+    n('a.card',
+      { spacing: { padding: { top: { literal: '8px' } } } },
+      { spacing: { padding: { top: { literal: '4px' } } } }),
+  ]);
+  const attrSel = '[stb-snapshot-id="a.card"][stb-snapshot-id="a.card"][stb-snapshot-id="a.card"]';
+  const darkBlock = css.slice(css.indexOf(`.dark-theme ${attrSel}`));
+  expect(darkBlock).toContain('padding-top: 4px;');
+});
+
+it('omits spacing entirely when the group is present but empty', () => {
+  expect(emitScopedBlocks([n('a.card', { spacing: {} })])).not.toContain('padding');
+  expect(emitScopedBlocks([n('a.card', { spacing: {} })])).not.toContain('gap');
+});

--- a/tools/stb/tests/parse/facet-emit.test.ts
+++ b/tools/stb/tests/parse/facet-emit.test.ts
@@ -67,3 +67,15 @@ it('emits background composite (color backstop + reversed image layer) in the li
   expect(css).toContain('background-color: #0b3d91;');
   expect(css).toContain('background-image: url(assets/hero.jpg);');
 });
+
+it('emits the font-family fallback list in the light block (not in FACET_PROPS)', () => {
+  const css = emitScopedBlocks([
+    n('a.card', { text: { fontFamily: [{ literal: 'Inter' }, { literal: 'system-ui' }] } }),
+  ]);
+  expect(css).toContain('font-family: Inter, system-ui;');
+});
+
+it('omits font-family entirely when the list is empty or absent', () => {
+  expect(emitScopedBlocks([n('a.card', { text: { fontFamily: [] } })])).not.toContain('font-family');
+  expect(emitScopedBlocks([n('a.card', { text: {} })])).not.toContain('font-family');
+});

--- a/tools/stb/tests/projection/projector.test.ts
+++ b/tools/stb/tests/projection/projector.test.ts
@@ -66,10 +66,10 @@ describe('project', () => {
     expect(r.companyConfig).toMatchObject({ login: { title: 'Hi' } });
   });
 
-  it('reads color from facets (surface.background literal)', () => {
+  it('reads color from facets (background.color literal)', () => {
     const m = { scene: 'login', nodes: [{
       snapshotId: 'auth.login.page', role: '', name: null, description: '',
-      facets: { surface: { background: { literal: { l: 0.97, c: 0.01, h: 250 } } } },
+      facets: { background: { color: { literal: { l: 0.97, c: 0.01, h: 250 } } } },
     }] };
     const r = project(m, {
       containers: { 'auth.login': 'login' },
@@ -114,6 +114,17 @@ describe('project', () => {
     expect(r.tokens.get('--color-brand-50')).toMatch(/^#[0-9a-f]{6}$/);
     expect(r.tokens.get('--color-brand-900')).toMatch(/^#[0-9a-f]{6}$/);
     expect(r.tokens.size).toBe(10);
+  });
+
+  it('projects background.color as the element color and topmost image ref as the leaf value', () => {
+    const model = { scene: 's', nodes: [{
+      snapshotId: 'a.card', role: 'region', name: null, description: '',
+      facets: { background: { color: { literal: { l: 0.3, c: 0.1, h: 250 } as any }, layers: [{ kind: 'image', ref: 'assets/hero.jpg' }] } },
+    }] } as any;
+    const routing = { elements: { 'a.card': { token: 'card.bg', config: 'cardImage' } } } as any;
+    const { tokens, companyConfig } = project(model, routing);
+    expect(tokens.get('card.bg')).toMatch(/^#/);
+    expect(companyConfig.cardImage).toBe('assets/hero.jpg');
   });
 });
 

--- a/tools/stb/tests/state/branding-assets.test.ts
+++ b/tools/stb/tests/state/branding-assets.test.ts
@@ -4,6 +4,8 @@ import {
   type BrandingAsset,
 } from '@/state/branding-assets';
 import type { LeverPatch } from '@/iframe-bridge/apply-levers';
+import { emitScopedBlocks } from '@/parse/css-emitter';
+import type { ElementNode } from '@/metadata/types';
 
 const blobA = new Blob(['a'], { type: 'image/png' });
 const blobB = new Blob(['b'], { type: 'image/jpeg' });
@@ -81,17 +83,19 @@ describe('rewriteAssetUrls', () => {
     } finally { restore(); }
   });
 
-  it('revokes the previous call\'s object URLs for the same callsite key when minting new ones', () => {
+  it('double-buffers: keeps the last TWO batches alive, revokes only the batch two calls back', () => {
     const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
-    const restore = stubCreateObjectURL({ a: 'blob:mock/1', b: 'blob:mock/2' });
+    const restore = stubCreateObjectURL({ a: 'blob:mock/1', b: 'blob:mock/2', c: 'blob:mock/3' });
     const revoked: string[] = [];
     const origRevoke = URL.revokeObjectURL;
     URL.revokeObjectURL = ((u: string) => revoked.push(u)) as typeof URL.revokeObjectURL;
     try {
-      rewriteAssetUrls('url(assets/hero.jpg)', store, 'test-2');
+      rewriteAssetUrls('url(assets/hero.jpg)', store, 'test-2'); // mints blob:mock/1
       expect(revoked).toEqual([]); // nothing to revoke on first call
-      rewriteAssetUrls('url(assets/hero.jpg)', store, 'test-2');
-      expect(revoked).toEqual(['blob:mock/1']); // first call's URL revoked on replace
+      rewriteAssetUrls('url(assets/hero.jpg)', store, 'test-2'); // mints blob:mock/2
+      expect(revoked).toEqual([]); // still nothing — call 1's URL is what the iframe is currently painting
+      rewriteAssetUrls('url(assets/hero.jpg)', store, 'test-2'); // mints blob:mock/3
+      expect(revoked).toEqual(['blob:mock/1']); // only the batch from TWO calls back is revoked
     } finally { restore(); URL.revokeObjectURL = origRevoke; }
   });
 
@@ -106,5 +110,71 @@ describe('rewriteAssetUrls', () => {
       rewriteAssetUrls('url(assets/hero.jpg)', store, 'pane-dark');
       expect(revoked).toEqual([]); // distinct keys, nothing revoked
     } finally { restore(); URL.revokeObjectURL = origRevoke; }
+  });
+
+  it('rewrites a single-quoted url() ref (user-authored scopedBlock CSS convention)', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    const restore = stubCreateObjectURL({ hero: 'blob:mock/hero' });
+    try {
+      const out = rewriteAssetUrls("background-image: url('assets/hero.jpg');", store, 'test-quote-1');
+      expect(out).toBe('background-image: url(blob:mock/hero);');
+    } finally { restore(); }
+  });
+
+  it('rewrites a double-quoted url() ref', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    const restore = stubCreateObjectURL({ hero: 'blob:mock/hero' });
+    try {
+      const out = rewriteAssetUrls('background-image: url("assets/hero.jpg");', store, 'test-quote-2');
+      expect(out).toBe('background-image: url(blob:mock/hero);');
+    } finally { restore(); }
+  });
+
+  it('rewrites a whitespace-padded url() ref', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    const restore = stubCreateObjectURL({ hero: 'blob:mock/hero' });
+    try {
+      const out = rewriteAssetUrls('background-image: url(  assets/hero.jpg  );', store, 'test-quote-3');
+      expect(out).toBe('background-image: url(blob:mock/hero);');
+    } finally { restore(); }
+  });
+
+  it('leaves an unknown quoted ref completely untouched (original text, quotes and all)', () => {
+    const store = new Map<string, BrandingAsset>();
+    const css = "background-image: url('assets/unknown.jpg');";
+    const out = rewriteAssetUrls(css, store, 'test-quote-4');
+    expect(out).toBe(css);
+  });
+
+  it('mints one object URL per distinct ref within a single call, even if it appears N times', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    let calls = 0;
+    const orig = URL.createObjectURL;
+    URL.createObjectURL = (() => { calls++; return `blob:mock/${calls}`; }) as typeof URL.createObjectURL;
+    try {
+      const css = 'a { background-image: url(assets/hero.jpg); } b { background-image: url(assets/hero.jpg); }';
+      const out = rewriteAssetUrls(css, store, 'test-dedupe');
+      expect(calls).toBe(1); // one mint for two occurrences of the same ref
+      expect(out).toBe('a { background-image: url(blob:mock/1); } b { background-image: url(blob:mock/1); }');
+    } finally { URL.createObjectURL = orig; }
+  });
+
+  it('end-to-end: a quoted asset ref inside a scopedBlock (the R1 escape hatch) resolves through emitScopedBlocks + rewriteAssetUrls, matching applyScopedBlocksToPreview\'s path', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    const restore = stubCreateObjectURL({ hero: 'blob:mock/hero' });
+    try {
+      const nodes: ElementNode[] = [{
+        snapshotId: 'auth.login.card',
+        role: '',
+        name: null,
+        description: '',
+        facets: {},
+        scopedBlock: "background-image: url('assets/hero.jpg')",
+      }];
+      const css = emitScopedBlocks(nodes);
+      const out = rewriteAssetUrls(css, store, 'test-e2e');
+      expect(out).toContain('background-image: url(blob:mock/hero);');
+      expect(out).not.toContain("assets/hero.jpg");
+    } finally { restore(); }
   });
 });

--- a/tools/stb/tests/state/branding-assets.test.ts
+++ b/tools/stb/tests/state/branding-assets.test.ts
@@ -14,19 +14,19 @@ describe('branding-assets', () => {
     expect(assetRefFor('logo.png')).toBe('assets/logo.png');
   });
 
-  it('setBrandingAsset stores per snapshotId immutably and keeps both logo and background', () => {
+  it('setBrandingAsset stores per ref immutably and keeps multiple blobs', () => {
     const before = brandingAssets.value;
-    setBrandingAsset('auth.login.logo', blobA, 'logo.png');
-    setBrandingAsset('auth.login.background', blobB, 'bg.jpg');
+    setBrandingAsset('assets/logo.png', blobA, 'logo.png');
+    setBrandingAsset('assets/bg.jpg', blobB, 'bg.jpg');
     expect(brandingAssets.value).not.toBe(before);            // new ref → reactivity
-    expect(brandingAssets.value.get('auth.login.logo')?.filename).toBe('logo.png');
-    expect(brandingAssets.value.get('auth.login.background')?.filename).toBe('bg.jpg'); // no overwrite
+    expect(brandingAssets.value.get('assets/logo.png')?.filename).toBe('logo.png');
+    expect(brandingAssets.value.get('assets/bg.jpg')?.filename).toBe('bg.jpg'); // no overwrite
   });
 
-  it('brandingAssetInputs maps the store to bundle asset inputs', () => {
+  it('brandingAssetInputs maps the store to bundle asset inputs by ref key (no double-prefixing)', () => {
     const store = new Map<string, BrandingAsset>([
-      ['auth.login.logo', { blob: blobA, filename: 'logo.png' }],
-      ['auth.login.background', { blob: blobB, filename: 'bg.jpg' }],
+      ['assets/logo.png', { blob: blobA, filename: 'logo.png' }],
+      ['assets/bg.jpg', { blob: blobB, filename: 'bg.jpg' }],
     ]);
     expect(brandingAssetInputs(store)).toEqual([
       { path: 'assets/logo.png', blob: blobA },
@@ -34,8 +34,17 @@ describe('branding-assets', () => {
     ]);
   });
 
+  it('stores multiple blobs keyed by ref', () => {
+    const store = new Map();
+    const a = new Blob(['a']); const b = new Blob(['b']);
+    store.set('assets/one.png', { blob: a, filename: 'one.png' });
+    store.set('assets/two.png', { blob: b, filename: 'two.png' });
+    const inputs = brandingAssetInputs(store);
+    expect(inputs.map((i) => i.path).sort()).toEqual(['assets/one.png', 'assets/two.png']);
+  });
+
   it('attachAssetBlobs attaches a stored blob to matching asset patches, leaves others untouched', () => {
-    const store = new Map<string, BrandingAsset>([['auth.login.logo', { blob: blobA, filename: 'logo.png' }]]);
+    const store = new Map<string, BrandingAsset>([['assets/logo.png', { blob: blobA, filename: 'logo.png' }]]);
     const patches: LeverPatch[] = [
       { snapshotId: 'auth.login.logo', kind: 'asset', ref: 'assets/logo.png' },
       { snapshotId: 'auth.login.title', kind: 'content', text: 'Hi' },
@@ -45,5 +54,26 @@ describe('branding-assets', () => {
     expect(out[0]).toEqual({ snapshotId: 'auth.login.logo', kind: 'asset', ref: 'assets/logo.png', blob: blobA });
     expect(out[1]).toEqual(patches[1]);                       // content untouched
     expect(out[2]).toEqual(patches[2]);                       // asset w/o stored blob untouched (no blob key)
+  });
+
+  it('attachAssetBlobs swaps url(<ref>) with an object URL for background patches with a stored blob', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob: blobA, filename: 'hero.jpg' }]]);
+    const patches: LeverPatch[] = [
+      {
+        snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91',
+        backgroundImage: 'linear-gradient(rgba(0,0,0,.6), transparent), url(assets/hero.jpg), url(assets/none.jpg)',
+      },
+    ];
+    // jsdom doesn't implement URL.createObjectURL — stub it locally for this assertion only.
+    const orig = URL.createObjectURL;
+    URL.createObjectURL = ((b: Blob) => (b === blobA ? 'blob:mock/hero' : 'blob:mock/other')) as typeof URL.createObjectURL;
+    try {
+      const out = attachAssetBlobs(patches, store);
+      const img = (out[0] as LeverPatch).backgroundImage!;
+      expect(img).toContain('url(blob:mock/hero)');
+      expect(img).toContain('url(assets/none.jpg)'); // untouched ref with no stored blob
+    } finally {
+      URL.createObjectURL = orig;
+    }
   });
 });

--- a/tools/stb/tests/state/branding-assets.test.ts
+++ b/tools/stb/tests/state/branding-assets.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
-  brandingAssets, setBrandingAsset, assetRefFor, brandingAssetInputs, attachAssetBlobs, type BrandingAsset,
+  brandingAssets, setBrandingAsset, assetRefFor, brandingAssetInputs, attachAssetBlobs, rewriteAssetUrls,
+  type BrandingAsset,
 } from '@/state/branding-assets';
 import type { LeverPatch } from '@/iframe-bridge/apply-levers';
 
@@ -56,24 +57,54 @@ describe('branding-assets', () => {
     expect(out[2]).toEqual(patches[2]);                       // asset w/o stored blob untouched (no blob key)
   });
 
-  it('attachAssetBlobs swaps url(<ref>) with an object URL for background patches with a stored blob', () => {
-    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob: blobA, filename: 'hero.jpg' }]]);
-    const patches: LeverPatch[] = [
-      {
-        snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91',
-        backgroundImage: 'linear-gradient(rgba(0,0,0,.6), transparent), url(assets/hero.jpg), url(assets/none.jpg)',
-      },
-    ];
-    // jsdom doesn't implement URL.createObjectURL — stub it locally for this assertion only.
+});
+
+describe('rewriteAssetUrls', () => {
+  const blob = new Blob(['a'], { type: 'image/jpeg' });
+
+  function stubCreateObjectURL(map: Record<string, string>): () => void {
     const orig = URL.createObjectURL;
-    URL.createObjectURL = ((b: Blob) => (b === blobA ? 'blob:mock/hero' : 'blob:mock/other')) as typeof URL.createObjectURL;
+    let n = 0;
+    const urls = Object.values(map);
+    URL.createObjectURL = (() => urls[n++] ?? `blob:mock/${n}`) as typeof URL.createObjectURL;
+    return () => { URL.createObjectURL = orig; };
+  }
+
+  it('rewrites url(<ref>) to url(<objectURL>) for a stored asset, leaves unknown refs untouched', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    const restore = stubCreateObjectURL({ hero: 'blob:mock/hero' });
     try {
-      const out = attachAssetBlobs(patches, store);
-      const img = (out[0] as LeverPatch).backgroundImage!;
-      expect(img).toContain('url(blob:mock/hero)');
-      expect(img).toContain('url(assets/none.jpg)'); // untouched ref with no stored blob
-    } finally {
-      URL.createObjectURL = orig;
-    }
+      const css = 'html .a { background-image: linear-gradient(red, blue), url(assets/hero.jpg), url(assets/none.jpg); }';
+      const out = rewriteAssetUrls(css, store, 'test-1');
+      expect(out).toContain('url(blob:mock/hero)');
+      expect(out).toContain('url(assets/none.jpg)'); // no stored blob → passed through
+    } finally { restore(); }
+  });
+
+  it('revokes the previous call\'s object URLs for the same callsite key when minting new ones', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    const restore = stubCreateObjectURL({ a: 'blob:mock/1', b: 'blob:mock/2' });
+    const revoked: string[] = [];
+    const origRevoke = URL.revokeObjectURL;
+    URL.revokeObjectURL = ((u: string) => revoked.push(u)) as typeof URL.revokeObjectURL;
+    try {
+      rewriteAssetUrls('url(assets/hero.jpg)', store, 'test-2');
+      expect(revoked).toEqual([]); // nothing to revoke on first call
+      rewriteAssetUrls('url(assets/hero.jpg)', store, 'test-2');
+      expect(revoked).toEqual(['blob:mock/1']); // first call's URL revoked on replace
+    } finally { restore(); URL.revokeObjectURL = origRevoke; }
+  });
+
+  it('does not revoke a different callsite key\'s URLs', () => {
+    const store = new Map<string, BrandingAsset>([['assets/hero.jpg', { blob, filename: 'hero.jpg' }]]);
+    const restore = stubCreateObjectURL({ a: 'blob:mock/1', b: 'blob:mock/2' });
+    const revoked: string[] = [];
+    const origRevoke = URL.revokeObjectURL;
+    URL.revokeObjectURL = ((u: string) => revoked.push(u)) as typeof URL.revokeObjectURL;
+    try {
+      rewriteAssetUrls('url(assets/hero.jpg)', store, 'pane-light');
+      rewriteAssetUrls('url(assets/hero.jpg)', store, 'pane-dark');
+      expect(revoked).toEqual([]); // distinct keys, nothing revoked
+    } finally { restore(); URL.revokeObjectURL = origRevoke; }
   });
 });

--- a/tools/stb/tests/state/branding.test.ts
+++ b/tools/stb/tests/state/branding.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { brandingModel, nodeFor, setNodeFacets, setNodeFacetsDark, setNodeVisibility, setNodeScopedBlock, loadBrandingModel } from '@/state/branding';
+import { brandingModel, nodeFor, setNodeFacets, setNodeFacetsDark, setNodeVisibility, setNodeScopedBlock, loadBrandingModel, resetNode } from '@/state/branding';
 import type { BrandingModel } from '@/metadata/types';
 
 const model: BrandingModel = {
@@ -62,6 +62,37 @@ describe('branding state', () => {
     expect(nodeFor('auth.login.title')?.scopedBlock).toBe('font-size: 18px');
     expect(brandingModel.value).not.toBe(before); // new reference → reactivity
     expect(nodeFor('auth.login.sign-in')?.scopedBlock).toBeUndefined(); // others untouched
+  });
+});
+
+describe('resetNode', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('restores one node to the loaded pristine state, leaving other edits alone', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(model), { headers: { 'content-type': 'application/json' } })));
+    await loadBrandingModel('login');
+    setNodeFacets('auth.login.title', { content: { text: 'Edited' } });
+    setNodeFacetsDark('auth.login.title', { text: { color: { literal: 'transparent' } } });
+    setNodeScopedBlock('auth.login.title', 'color: red');
+    setNodeFacets('auth.login.sign-in', { text: {} });
+
+    const restored = resetNode('auth.login.title');
+    expect(restored?.facets.content?.text).toBe('Sign in to Stratos');
+    const n = nodeFor('auth.login.title')!;
+    expect(n.facets.content?.text).toBe('Sign in to Stratos');
+    expect(n.facetsDark).toBeUndefined();
+    expect(n.scopedBlock).toBeUndefined();
+    // sibling's edit survives — reset is per-element, not per-scene
+    expect(nodeFor('auth.login.sign-in')?.facets.text).toEqual({});
+  });
+
+  it('is a safe no-op when no pristine model is loaded', async () => {
+    // a failed load clears the pristine copy left by any earlier test
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    await loadBrandingModel('whatever');
+    brandingModel.value = JSON.parse(JSON.stringify(model));
+    expect(resetNode('auth.login.title')).toBeUndefined();
   });
 });
 

--- a/tools/stb/tests/state/branding.test.ts
+++ b/tools/stb/tests/state/branding.test.ts
@@ -47,13 +47,13 @@ describe('branding state', () => {
       scene: 'login',
       nodes: [
         { snapshotId: 'auth.login.page', role: 'region', name: 'P', description: 'page',
-          facets: { surface: { background: { literal: { l: 0.95, c: 0.02, h: 250 } } } } },
+          facets: { background: { color: { literal: { l: 0.95, c: 0.02, h: 250 } } } } },
       ],
     };
-    setNodeFacetsDark('auth.login.page', { surface: { background: { literal: { l: 0.2, c: 0.02, h: 250 } } } });
+    setNodeFacetsDark('auth.login.page', { background: { color: { literal: { l: 0.2, c: 0.02, h: 250 } } } });
     const n = nodeFor('auth.login.page')!;
-    expect(n.facetsDark?.surface?.background).toEqual({ literal: { l: 0.2, c: 0.02, h: 250 } });
-    expect(n.facets.surface?.background).toEqual({ literal: { l: 0.95, c: 0.02, h: 250 } }); // light untouched
+    expect(n.facetsDark?.background?.color).toEqual({ literal: { l: 0.2, c: 0.02, h: 250 } });
+    expect(n.facets.background?.color).toEqual({ literal: { l: 0.95, c: 0.02, h: 250 } }); // light untouched
   });
 
   it('setNodeScopedBlock sets the scoped block on one node immutably', () => {

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -8,6 +8,6 @@ describe('facets-edit', () => {
   });
   it('adds and removes a group', () => {
     expect(addGroup({}, 'surface').surface).toEqual({});
-    expect(removeGroup({ surface: { background: { literal: '#fff' } } }, 'surface').surface).toBeUndefined();
+    expect(removeGroup({ surface: { border: { literal: '1px' } } }, 'surface').surface).toBeUndefined();
   });
 });

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   setFacetProp, addGroup, removeGroup,
   setBackstop, addLayer, removeLayer, reorderLayer, setLayer,
+  addFont, removeFont, reorderFont, setFont,
 } from '@/state/facets-edit';
 
 describe('facets-edit', () => {
@@ -33,5 +34,27 @@ describe('facets-edit', () => {
     f = setLayer(f, 0, gradientLayer);
     expect(f.background!.layers![0]).toEqual(gradientLayer);
     expect((f.background!.layers![1] as { ref: string }).ref).toBe('b');
+  });
+
+  it('adds font-family fallbacks in order and reorders them', () => {
+    let f = addFont({}, { literal: 'Inter' });
+    f = addFont(f, { literal: 'system-ui' });
+    expect(f.text!.fontFamily).toEqual([{ literal: 'Inter' }, { literal: 'system-ui' }]);
+    f = reorderFont(f, 1, 0);
+    expect(f.text!.fontFamily).toEqual([{ literal: 'system-ui' }, { literal: 'Inter' }]);
+  });
+
+  it('sets a font-family entry at an index in place, preserving order', () => {
+    let f = addFont({}, { literal: 'Inter' });
+    f = addFont(f, { literal: 'system-ui' });
+    f = setFont(f, 0, { literal: 'Roboto' });
+    expect(f.text!.fontFamily).toEqual([{ literal: 'Roboto' }, { literal: 'system-ui' }]);
+  });
+
+  it('removes a font-family entry at an index', () => {
+    let f = addFont({}, { literal: 'Inter' });
+    f = addFont(f, { literal: 'system-ui' });
+    f = removeFont(f, 0);
+    expect(f.text!.fontFamily).toEqual([{ literal: 'system-ui' }]);
   });
 });

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { setFacetProp, addGroup, removeGroup } from '@/state/facets-edit';
+import {
+  setFacetProp, addGroup, removeGroup,
+  setBackstop, addLayer, removeLayer, reorderLayer, setLayer,
+} from '@/state/facets-edit';
 
 describe('facets-edit', () => {
   it('sets a nested property immutably', () => {
@@ -9,5 +12,26 @@ describe('facets-edit', () => {
   it('adds and removes a group', () => {
     expect(addGroup({}, 'surface').surface).toEqual({});
     expect(removeGroup({ surface: { border: { literal: '1px' } } }, 'surface').surface).toBeUndefined();
+  });
+
+  it('adds layers on top (append) and reorders', () => {
+    let f = setBackstop({}, { literal: '#000' });
+    f = addLayer(f, { kind: 'image', ref: 'a' });
+    f = addLayer(f, { kind: 'image', ref: 'b' });   // b is now topmost
+    expect(f.background!.layers!.map((l) => (l as { ref: string }).ref)).toEqual(['a', 'b']);
+    f = reorderLayer(f, 1, 0);
+    expect(f.background!.layers!.map((l) => (l as { ref: string }).ref)).toEqual(['b', 'a']);
+    f = removeLayer(f, 0);
+    expect(f.background!.layers!.map((l) => (l as { ref: string }).ref)).toEqual(['a']);
+    expect(f.background!.color).toEqual({ literal: '#000' });
+  });
+
+  it('replaces a layer at an index in place, preserving order', () => {
+    let f = addLayer({}, { kind: 'image', ref: 'a' });
+    f = addLayer(f, { kind: 'image', ref: 'b' });
+    const gradientLayer = { kind: 'gradient' as const, gradient: { type: 'linear' as const, stops: [{ color: { literal: '#fff' } }] } };
+    f = setLayer(f, 0, gradientLayer);
+    expect(f.background!.layers![0]).toEqual(gradientLayer);
+    expect((f.background!.layers![1] as { ref: string }).ref).toBe('b');
   });
 });

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -3,6 +3,7 @@ import {
   setFacetProp, addGroup, removeGroup,
   setBackstop, addLayer, removeLayer, reorderLayer, setLayer,
   addFont, removeFont, reorderFont, setFont,
+  setSide, setGap,
 } from '@/state/facets-edit';
 
 describe('facets-edit', () => {
@@ -56,5 +57,34 @@ describe('facets-edit', () => {
     f = addFont(f, { literal: 'system-ui' });
     f = removeFont(f, 0);
     expect(f.text!.fontFamily).toEqual([{ literal: 'system-ui' }]);
+  });
+
+  it('sets a spacing side into an absent group, creating it', () => {
+    const f = setSide({}, 'padding', 'top', { literal: '8px' });
+    expect(f.spacing!.padding).toEqual({ top: { literal: '8px' } });
+  });
+
+  it('sets a spacing side alongside an existing sibling side', () => {
+    let f = setSide({}, 'padding', 'top', { literal: '8px' });
+    f = setSide(f, 'padding', 'left', { literal: '4px' });
+    expect(f.spacing!.padding).toEqual({ top: { literal: '8px' }, left: { literal: '4px' } });
+  });
+
+  it('sets padding and margin sides independently', () => {
+    let f = setSide({}, 'padding', 'top', { literal: '8px' });
+    f = setSide(f, 'margin', 'bottom', { literal: '2px' });
+    expect(f.spacing!.padding).toEqual({ top: { literal: '8px' } });
+    expect(f.spacing!.margin).toEqual({ bottom: { literal: '2px' } });
+  });
+
+  it('sets a gap slot into an absent group, creating it', () => {
+    const f = setGap({}, 'row', { literal: '2px' });
+    expect(f.spacing!.gap).toEqual({ row: { literal: '2px' } });
+  });
+
+  it('sets a gap slot alongside an existing sibling slot', () => {
+    let f = setGap({}, 'row', { literal: '2px' });
+    f = setGap(f, 'column', { literal: '6px' });
+    expect(f.spacing!.gap).toEqual({ row: { literal: '2px' }, column: { literal: '6px' } });
   });
 });

--- a/tools/stb/tests/state/facets-edit.test.ts
+++ b/tools/stb/tests/state/facets-edit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  setFacetProp, addGroup, removeGroup,
+  setFacetProp, clearFacetProp, addGroup, removeGroup,
   setBackstop, addLayer, removeLayer, reorderLayer, setLayer,
   addFont, removeFont, reorderFont, setFont,
   setSide, setGap,
@@ -10,6 +10,27 @@ describe('facets-edit', () => {
   it('sets a nested property immutably', () => {
     const a = setFacetProp({}, 'text.fontSize', { literal: '18px' });
     expect(a.text!.fontSize).toEqual({ literal: '18px' });
+  });
+
+  it('clears a property back to unset, keeping the group and siblings', () => {
+    let f = setFacetProp({}, 'text.color', { literal: '#333' });
+    f = setFacetProp(f, 'text.fontSize', { literal: '18px' });
+    f = clearFacetProp(f, 'text.color');
+    expect(f.text!.color).toBeUndefined();
+    expect(f.text!.fontSize).toEqual({ literal: '18px' });
+  });
+
+  it('clears the background backstop via key background.color, keeping layers', () => {
+    let f = setBackstop({}, { literal: '#000' });
+    f = addLayer(f, { kind: 'image', ref: 'bg.svg' });
+    f = clearFacetProp(f, 'background.color');
+    expect(f.background!.color).toBeUndefined();
+    expect(f.background!.layers).toHaveLength(1);
+  });
+
+  it('clearFacetProp is a no-op on an absent group', () => {
+    const f = { text: { color: { literal: '#333' } } };
+    expect(clearFacetProp(f, 'surface.border')).toBe(f);
   });
   it('adds and removes a group', () => {
     expect(addGroup({}, 'surface').surface).toEqual({});

--- a/tools/stb/tests/ui/apply-levers.test.ts
+++ b/tools/stb/tests/ui/apply-levers.test.ts
@@ -37,4 +37,24 @@ describe('applyLevers', () => {
     // the ref substring rather than the exact unquoted form so this isn't jsdom-quirk-fragile.
     expect(el.style.backgroundImage).toContain('assets/hero.jpg');
   });
+  it('clears a previously applied inline background-image when the patch omits it (last layer removed)', () => {
+    const d = doc('<div stb-snapshot-id="a.card"></div>');
+    const el = d.querySelector('[stb-snapshot-id="a.card"]') as HTMLElement;
+    applyLevers(d, [{ snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91', backgroundImage: 'url(assets/hero.jpg)' }]);
+    expect(el.style.backgroundImage).toContain('assets/hero.jpg');
+    // last layer removed: the background patch is still present but has no image component
+    applyLevers(d, [{ snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91' }]);
+    expect(el.style.backgroundImage).toBe('');
+    expect(el.style.backgroundColor).toBeTruthy();
+  });
+  it('leaves inline background untouched when no background patch is present (scoped/dark CSS owns it)', () => {
+    const d = doc('<div stb-snapshot-id="a.card">x</div>');
+    const el = d.querySelector('[stb-snapshot-id="a.card"]') as HTMLElement;
+    applyLevers(d, [{ snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91', backgroundImage: 'url(assets/hero.jpg)' }]);
+    // a later batch WITHOUT a background patch (e.g. dark mode with no dark override)
+    // must not clear what it did not set
+    applyLevers(d, [{ snapshotId: 'a.card', kind: 'content', text: 'y' }]);
+    expect(el.style.backgroundImage).toContain('assets/hero.jpg');
+    expect(el.style.backgroundColor).toBeTruthy();
+  });
 });

--- a/tools/stb/tests/ui/apply-levers.test.ts
+++ b/tools/stb/tests/ui/apply-levers.test.ts
@@ -23,4 +23,18 @@ describe('applyLevers', () => {
     applyLevers(d, [{ snapshotId: 'auth.login.show-logo', kind: 'visibility', shown: false }]);
     expect((d.querySelector('img') as HTMLElement).style.display).toBe('none');
   });
+  it('applies a composed multi-layer background (color + reversed layers)', () => {
+    const d = doc('<div stb-snapshot-id="a.card"></div>');
+    applyLevers(d, [{
+      snapshotId: 'a.card',
+      kind: 'background',
+      backgroundColor: '#0b3d91',
+      backgroundImage: 'linear-gradient(rgba(0,0,0,.6), transparent), url(assets/hero.jpg)',
+    }]);
+    const el = d.querySelector('[stb-snapshot-id="a.card"]') as HTMLElement;
+    expect(el.style.backgroundColor).toBeTruthy();
+    // jsdom's CSSOM re-serializes url(...) with quotes (`url("assets/hero.jpg")`) — assert on
+    // the ref substring rather than the exact unquoted form so this isn't jsdom-quirk-fragile.
+    expect(el.style.backgroundImage).toContain('assets/hero.jpg');
+  });
 });

--- a/tools/stb/tests/ui/apply-levers.test.ts
+++ b/tools/stb/tests/ui/apply-levers.test.ts
@@ -46,38 +46,4 @@ describe('applyLevers', () => {
     applyLevers(d, [{ snapshotId: 'auth.login.show-logo', kind: 'visibility', shown: false }]);
     expect((d.querySelector('img') as HTMLElement).style.display).toBe('none');
   });
-  it('applies a composed multi-layer background (color + reversed layers)', () => {
-    const d = doc('<div stb-snapshot-id="a.card"></div>');
-    applyLevers(d, [{
-      snapshotId: 'a.card',
-      kind: 'background',
-      backgroundColor: '#0b3d91',
-      backgroundImage: 'linear-gradient(rgba(0,0,0,.6), transparent), url(assets/hero.jpg)',
-    }]);
-    const el = d.querySelector('[stb-snapshot-id="a.card"]') as HTMLElement;
-    expect(el.style.backgroundColor).toBeTruthy();
-    // jsdom's CSSOM re-serializes url(...) with quotes (`url("assets/hero.jpg")`) — assert on
-    // the ref substring rather than the exact unquoted form so this isn't jsdom-quirk-fragile.
-    expect(el.style.backgroundImage).toContain('assets/hero.jpg');
-  });
-  it('clears a previously applied inline background-image when the patch omits it (last layer removed)', () => {
-    const d = doc('<div stb-snapshot-id="a.card"></div>');
-    const el = d.querySelector('[stb-snapshot-id="a.card"]') as HTMLElement;
-    applyLevers(d, [{ snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91', backgroundImage: 'url(assets/hero.jpg)' }]);
-    expect(el.style.backgroundImage).toContain('assets/hero.jpg');
-    // last layer removed: the background patch is still present but has no image component
-    applyLevers(d, [{ snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91' }]);
-    expect(el.style.backgroundImage).toBe('');
-    expect(el.style.backgroundColor).toBeTruthy();
-  });
-  it('leaves inline background untouched when no background patch is present (scoped/dark CSS owns it)', () => {
-    const d = doc('<div stb-snapshot-id="a.card">x</div>');
-    const el = d.querySelector('[stb-snapshot-id="a.card"]') as HTMLElement;
-    applyLevers(d, [{ snapshotId: 'a.card', kind: 'background', backgroundColor: '#0b3d91', backgroundImage: 'url(assets/hero.jpg)' }]);
-    // a later batch WITHOUT a background patch (e.g. dark mode with no dark override)
-    // must not clear what it did not set
-    applyLevers(d, [{ snapshotId: 'a.card', kind: 'content', text: 'y' }]);
-    expect(el.style.backgroundImage).toContain('assets/hero.jpg');
-    expect(el.style.backgroundColor).toBeTruthy();
-  });
 });

--- a/tools/stb/tests/ui/apply-levers.test.ts
+++ b/tools/stb/tests/ui/apply-levers.test.ts
@@ -13,6 +13,29 @@ describe('applyLevers', () => {
     applyLevers(d, [{ snapshotId: 'auth.login.title', kind: 'content', text: 'new' }]);
     expect(d.querySelector('h1')!.textContent).toBe('new');
   });
+  it('renders subset-formatted content via DOM construction when the patch carries format subset', () => {
+    const d = doc('<p stb-snapshot-id="shared.confirm-dialog.message">old</p>');
+    applyLevers(d, [{ snapshotId: 'shared.confirm-dialog.message', kind: 'content', text: '**Careful:** this _cannot_ be undone.\nReally.', format: 'subset' }]);
+    const p = d.querySelector('p')!;
+    expect(p.querySelector('strong')!.textContent).toBe('Careful:');
+    expect(p.querySelector('em')!.textContent).toBe('cannot');
+    expect(p.querySelectorAll('br').length).toBe(1);
+  });
+  it('subset content never interprets markup — hostile text stays text', () => {
+    const d = doc('<p stb-snapshot-id="m">old</p>');
+    applyLevers(d, [{ snapshotId: 'm', kind: 'content', text: '<img src=x onerror=alert(1)>**b**', format: 'subset' }]);
+    const p = d.querySelector('p')!;
+    expect(p.querySelector('img')).toBeNull();
+    expect(p.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(p.querySelector('strong')!.textContent).toBe('b');
+  });
+  it('plain content (no format) still uses textContent — markers stay literal', () => {
+    const d = doc('<p stb-snapshot-id="m">old</p>');
+    applyLevers(d, [{ snapshotId: 'm', kind: 'content', text: '**not bold**' }]);
+    const p = d.querySelector('p')!;
+    expect(p.querySelector('strong')).toBeNull();
+    expect(p.textContent).toBe('**not bold**');
+  });
   it('sets img src for an asset lever', () => {
     const d = doc('<img stb-snapshot-id="auth.login.logo" src="a.png" />');
     applyLevers(d, [{ snapshotId: 'auth.login.logo', kind: 'asset', ref: 'b.png' }]);

--- a/tools/stb/tests/ui/color-picker.test.ts
+++ b/tools/stb/tests/ui/color-picker.test.ts
@@ -27,3 +27,53 @@ describe('color-picker compare-mode placement', () => {
     expect(aboveSpy).not.toHaveBeenCalled();
   });
 });
+
+describe('color-picker outside-click handler lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div class="host"></div>';
+  });
+  afterEach(() => { closeOpenPicker(); vi.useRealTimers(); });
+
+  const host = () => document.querySelector('.host') as HTMLElement;
+  const open = () => openColorPicker({ previewHost: host(), initial: '#ff0000', format: 'hex', onChange: () => {} });
+  const active = () => document.getElementById('stb-color-picker-active');
+
+  it('a swatch click while a picker is open leaves the new picker open', () => {
+    open();               // picker A (swatch click #1)
+    vi.runAllTimers();    // A's outside-click handler registers
+    // swatch click #2: the swatch listener opens B, then the same click bubbles to document
+    open();               // picker B
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    vi.runAllTimers();
+    expect(active()).not.toBeNull();
+  });
+
+  it('closing via the Close button leaves no handler that kills the next picker', () => {
+    open();               // picker A
+    vi.runAllTimers();
+    (active()!.querySelector('.stb-close') as HTMLButtonElement).click();
+    expect(active()).toBeNull();
+    open();               // picker B
+    vi.runAllTimers();
+    // a click INSIDE B must not close it (A's stale handler would)
+    active()!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(active()).not.toBeNull();
+  });
+
+  it('reopens after an outside click closed the previous picker', () => {
+    open();
+    vi.runAllTimers();
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true })); // outside → closes
+    expect(active()).toBeNull();
+    open();
+    vi.runAllTimers();
+    expect(active()).not.toBeNull();
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));      // stale handler would kill it
+    vi.runAllTimers();
+    // the picker just opened by this cycle must still be closable/openable, not zombie-closed
+    open();
+    vi.runAllTimers();
+    expect(active()).not.toBeNull();
+  });
+});

--- a/tools/stb/tests/ui/color-picker.test.ts
+++ b/tools/stb/tests/ui/color-picker.test.ts
@@ -28,6 +28,37 @@ describe('color-picker compare-mode placement', () => {
   });
 });
 
+describe('color-picker clear and transparent', () => {
+  beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
+  afterEach(() => { closeOpenPicker(); });
+
+  const host = () => document.querySelector('.host') as HTMLElement;
+  const active = () => document.getElementById('stb-color-picker-active');
+
+  it('renders a Clear button only when onClear is provided; clicking clears and closes', () => {
+    openColorPicker({ previewHost: host(), initial: '#ff0000', format: 'hex', onChange: () => {} });
+    expect(active()!.querySelector('.stb-color-clear')).toBeNull();
+    closeOpenPicker();
+
+    const onClear = vi.fn();
+    openColorPicker({ previewHost: host(), initial: '#ff0000', format: 'hex', onChange: () => {}, onClear });
+    const btn = active()!.querySelector('.stb-color-clear') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    expect(onClear).toHaveBeenCalledOnce();
+    expect(active()).toBeNull();
+  });
+
+  it("accepts the keyword 'transparent' in the text field", () => {
+    const onChange = vi.fn();
+    openColorPicker({ previewHost: host(), initial: '#ff0000', format: 'hex', onChange });
+    const text = active()!.querySelector('.stb-color-text') as HTMLInputElement;
+    text.value = ' Transparent ';
+    text.dispatchEvent(new Event('input'));
+    expect(onChange).toHaveBeenCalledWith('transparent');
+  });
+});
+
 describe('color-picker outside-click handler lifecycle', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/tools/stb/tests/ui/color-picker.test.ts
+++ b/tools/stb/tests/ui/color-picker.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { openColorPicker, closeOpenPicker } from '@/ui/color-picker';
+import { compareMode } from '@/state/scene';
+import * as popover from '@/ui/popover';
+
+describe('color-picker compare-mode placement', () => {
+  beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
+  afterEach(() => { closeOpenPicker(); compareMode.value = false; vi.restoreAllMocks(); });
+
+  it('positions via the above-panes path when compare mode is on', () => {
+    const aboveSpy = vi.spyOn(popover, 'positionAbovePanes');
+    const gutterSpy = vi.spyOn(popover, 'positionInPreviewGutter');
+    compareMode.value = true;
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openColorPicker({ previewHost, initial: '#ff0000', format: 'hex', onChange: () => {} });
+    expect(aboveSpy).toHaveBeenCalledWith(expect.any(HTMLElement), previewHost);
+    expect(gutterSpy).not.toHaveBeenCalled();
+  });
+
+  it('positions via the gutter path outside compare mode', () => {
+    const aboveSpy = vi.spyOn(popover, 'positionAbovePanes');
+    const gutterSpy = vi.spyOn(popover, 'positionInPreviewGutter');
+    compareMode.value = false;
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openColorPicker({ previewHost, initial: '#ff0000', format: 'hex', onChange: () => {} });
+    expect(gutterSpy).toHaveBeenCalledWith(expect.any(HTMLElement), previewHost);
+    expect(aboveSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tools/stb/tests/ui/element-columns.test.ts
+++ b/tools/stb/tests/ui/element-columns.test.ts
@@ -25,7 +25,7 @@ describe('swatchFor', () => {
   });
 
   it('returns color for a node with a color facet', () => {
-    const sw = swatchFor(makePathNode({ surface: { background: { literal: { l: 0.5, c: 0.1, h: 250 } } } }));
+    const sw = swatchFor(makePathNode({ background: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } }));
     expect(sw.color).toBeDefined();
     expect(sw.glyph).toBeUndefined();
   });

--- a/tools/stb/tests/ui/element-edit.test.ts
+++ b/tools/stb/tests/ui/element-edit.test.ts
@@ -5,11 +5,11 @@ import { reprojectNodeTokensDark } from '@/ui/element-edit';
 import type { BrandingModel } from '@/metadata/types';
 
 const routing = { containers: { 'auth.login': 'login' }, elements: {
-  'auth.login.sign-in': { properties: { 'surface.background': { token: '--color-x' } } },
+  'auth.login.sign-in': { properties: { 'background.color': { token: '--color-x' } } },
 } };
 const model: BrandingModel = { scene: 'login', nodes: [
   { snapshotId: 'auth.login.sign-in', role: 'button', name: 'S', description: 'btn',
-    facets: { surface: { background: { literal: { l: 0.4, c: 0.1, h: 30 } } } } },
+    facets: { background: { color: { literal: { l: 0.4, c: 0.1, h: 30 } } } } },
 ] };
 
 describe('reprojectNodeTokensDark', () => {
@@ -22,7 +22,7 @@ describe('reprojectNodeTokensDark', () => {
   it('re-projects a dark facet color edit to the bound token via setDarkValue', () => {
     reprojectNodeTokensDark(
       'auth.login.sign-in',
-      { surface: { background: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
+      { background: { color: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
       routing,
     );
     expect(effectiveValue('--color-x', true)).toMatch(/^#[0-9a-f]{6}$/);
@@ -31,7 +31,7 @@ describe('reprojectNodeTokensDark', () => {
   it('leaves the light value (rootValues) untouched', () => {
     reprojectNodeTokensDark(
       'auth.login.sign-in',
-      { surface: { background: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
+      { background: { color: { literal: { l: 0.6, c: 0.12, h: 200 } } } },
       routing,
     );
     expect(effectiveValue('--color-x', false)).toBe('#112233');

--- a/tools/stb/tests/ui/element-tree.test.ts
+++ b/tools/stb/tests/ui/element-tree.test.ts
@@ -28,7 +28,7 @@ describe('valuePreview', () => {
   it('returns a hex swatch for a node with a color facet', () => {
     const node: NavNode = {
       snapshotId: 'z', scene: 's', name: 'Z', description: '',
-      facets: { surface: { background: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
+      facets: { background: { color: { literal: { l: 0.5, c: 0.1, h: 250 } } } },
     };
     const vp = valuePreview(node);
     expect(vp.kind).toBe('color');

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { contentValue, assetValue, openLeverEditor } from '@/ui/lever-editor';
 import { brandingModel, nodeFor, setNodeFacets, setNodeFacetsDark } from '@/state/branding';
 import { setSide, setLayer } from '@/state/facets-edit';
+import { previewDark, compareMode } from '@/state/scene';
 import type { BrandingModel } from '@/metadata/types';
 
 const cssDir = dirname(fileURLToPath(import.meta.url));
@@ -169,5 +170,34 @@ describe('lever-editor popover sizing', () => {
     // No fixed width/height in the rule — sizing stays intrinsic to content until capped.
     expect(rule).not.toMatch(/(?<!max-|min-)\bheight:/);
     expect(rule).not.toMatch(/(?<!max-|min-)\bwidth:/);
+  });
+});
+
+describe('lever-editor compare-mode dark column', () => {
+  beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
+  afterEach(() => { brandingModel.value = null; previewDark.value = false; compareMode.value = false; });
+
+  it('adds stb-preview-dark when compare mode is on, even though previewDark is pinned false', () => {
+    compareMode.value = true;
+    previewDark.value = false;
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openLeverEditor({
+      previewHost, snapshotId: 'x', onChange: () => {},
+      facets: { text: { fontSize: { literal: '18px' } } },
+    });
+    const panel = document.querySelector('.stb-lever-editor') as HTMLElement;
+    expect(panel.classList.contains('stb-preview-dark')).toBe(true);
+  });
+
+  it('has no stb-preview-dark outside compare mode when previewDark is false', () => {
+    compareMode.value = false;
+    previewDark.value = false;
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openLeverEditor({
+      previewHost, snapshotId: 'x', onChange: () => {},
+      facets: { text: { fontSize: { literal: '18px' } } },
+    });
+    const panel = document.querySelector('.stb-lever-editor') as HTMLElement;
+    expect(panel.classList.contains('stb-preview-dark')).toBe(false);
   });
 });

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -257,13 +257,13 @@ describe('lever-editor position memory across teardown/rebuild', () => {
     expect(p2.style.width).toBe('');
   });
 
-  it('explicit Close clears the memory — next open is default-placed', () => {
+  it('dragged position persists across an explicit Close (policy: no re-placing)', () => {
     const p1 = open();
     p1.getBoundingClientRect = () => rect(120, 80, 300, 200);
     dragPanel(p1);
     (p1.querySelector('.stb-lever-close') as HTMLButtonElement).click();
     const p2 = open();
-    expect(p2.style.left).toBe('8px');
-    expect(p2.style.width).toBe('');
+    expect(p2.style.left).toBe('120px');
+    expect(p2.style.top).toBe('80px');
   });
 });

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { contentValue, assetValue, openLeverEditor } from '@/ui/lever-editor';
+import { contentValue, assetValue, openLeverEditor, clearRememberedPanelRect } from '@/ui/lever-editor';
 import { brandingModel, nodeFor, setNodeFacets, setNodeFacetsDark } from '@/state/branding';
 import { setSide, setLayer } from '@/state/facets-edit';
 import { previewDark, compareMode } from '@/state/scene';
@@ -14,6 +14,8 @@ const stbCss = readFileSync(resolve(cssDir, '../../src/styles/stb.css'), 'utf8')
 describe('lever-editor value helpers', () => {
   it('contentValue / assetValue shape the union', () => {
     expect(contentValue('Hi')).toEqual({ kind: 'content', text: 'Hi' });
+    expect(contentValue('Hi', 'plain')).toEqual({ kind: 'content', text: 'Hi' }); // plain carries no format key
+    expect(contentValue('**Hi**', 'subset')).toEqual({ kind: 'content', text: '**Hi**', format: 'subset' });
     expect(assetValue('logo.png')).toEqual({ kind: 'asset', ref: 'logo.png' });
   });
 });
@@ -199,5 +201,69 @@ describe('lever-editor compare-mode dark column', () => {
     });
     const panel = document.querySelector('.stb-lever-editor') as HTMLElement;
     expect(panel.classList.contains('stb-preview-dark')).toBe(false);
+  });
+});
+
+// --- panel position memory ---
+// jsdom does no layout: getBoundingClientRect is mocked on the live panel to
+// stand in for a user drag/resize; the drag handle's mousedown→mouseup pair is
+// what marks the placement as user-chosen (an undragged rebuild keeps defaults).
+describe('lever-editor position memory across teardown/rebuild', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div class="host"></div>';
+    clearRememberedPanelRect();
+    compareMode.value = false;
+  });
+  afterEach(() => { brandingModel.value = null; });
+
+  const open = () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openLeverEditor({ previewHost, snapshotId: 'x', onChange: () => {}, facets: {} });
+    return document.querySelector('.stb-lever-editor') as HTMLElement;
+  };
+  const rect = (left: number, top: number, width: number, height: number) =>
+    ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top, toJSON: () => ({}) }) as DOMRect;
+  const dragPanel = (panel: HTMLElement) => {
+    const handle = panel.querySelector('.stb-lever-drag') as HTMLElement;
+    handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 10 }));
+    window.dispatchEvent(new MouseEvent('mouseup'));
+  };
+
+  it('reopens at the dragged position and resized size', () => {
+    const p1 = open();
+    p1.getBoundingClientRect = () => rect(120, 80, 300, 200);
+    dragPanel(p1);
+    const p2 = open(); // rebuild (selectElement path): closeOpen captures, reopen restores
+    expect(p2.style.left).toBe('120px');
+    expect(p2.style.top).toBe('80px');
+    expect(p2.style.width).toBe('300px');   // size differed from mount-time size → resized
+    expect(p2.style.height).toBe('200px');
+  });
+
+  it('clamps a remembered rect to the viewport on reuse (window may have shrunk)', () => {
+    const p1 = open();
+    p1.getBoundingClientRect = () => rect(5000, 4000, 300, 200);
+    dragPanel(p1);
+    const p2 = open();
+    expect(p2.style.left).toBe(`${window.innerWidth - 300}px`);
+    expect(p2.style.top).toBe(`${window.innerHeight - 200}px`);
+  });
+
+  it('an undragged, unresized rebuild keeps the default placement (no false memory)', () => {
+    open();
+    const p2 = open();
+    // default gutter placement in jsdom (zero-rect host) resolves to the 8px floor
+    expect(p2.style.left).toBe('8px');
+    expect(p2.style.width).toBe('');
+  });
+
+  it('explicit Close clears the memory — next open is default-placed', () => {
+    const p1 = open();
+    p1.getBoundingClientRect = () => rect(120, 80, 300, 200);
+    dragPanel(p1);
+    (p1.querySelector('.stb-lever-close') as HTMLButtonElement).click();
+    const p2 = open();
+    expect(p2.style.left).toBe('8px');
+    expect(p2.style.width).toBe('');
   });
 });

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { contentValue, assetValue, openLeverEditor } from '@/ui/lever-editor';
-import { brandingModel, setNodeFacetsDark } from '@/state/branding';
+import { brandingModel, nodeFor, setNodeFacets, setNodeFacetsDark } from '@/state/branding';
+import { setSide, setLayer } from '@/state/facets-edit';
 import type { BrandingModel } from '@/metadata/types';
 
 describe('lever-editor value helpers', () => {
@@ -71,5 +72,53 @@ describe('lever-editor light+dark per-row editing (no toggle)', () => {
     // model edit arrives from outside the focused control
     setNodeFacetsDark('x', { text: { color: { literal: { l: 0.2, c: 0.05, h: 100 } } } });
     expect(darkBtn().classList.contains('stb-facet-swatch-empty')).toBe(false); // editor re-rendered from the live model
+  });
+});
+
+describe('lever-editor composite-edit focus survival', () => {
+  beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
+  afterEach(() => { brandingModel.value = null; });
+
+  it('typing into a spacing input mutates the model without unmounting the input (focus survives)', () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    brandingModel.value = { scene: 's', nodes: [
+      { snapshotId: 'x', role: '', name: null, description: '', facets: { spacing: {} } },
+    ] } as unknown as BrandingModel;
+    openLeverEditor({
+      previewHost, snapshotId: 'x', onChange: () => {},
+      facets: nodeFor('x')!.facets,
+      // wired the way main.ts wires it after the focus-survival fix: fresh
+      // model read + single-slot write, NO editor rebuild on a typed edit
+      onSetSide: (group, side, value) => {
+        const n = nodeFor('x')!;
+        setNodeFacets('x', setSide(n.facets, group, side, value));
+      },
+    });
+    const input = document.querySelector('.stb-facet-spacing-side[data-stb-side="top"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    input.focus();
+    input.value = '4px';
+    input.dispatchEvent(new Event('input'));
+    // the typed edit must land in the model AND leave the focused input mounted
+    expect(nodeFor('x')!.facets.spacing?.padding?.top).toEqual({ literal: '4px' });
+    expect(document.contains(input)).toBe(true);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('re-renders an image layer row after a model update even while its file input has focus', () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    brandingModel.value = { scene: 's', nodes: [
+      { snapshotId: 'x', role: '', name: null, description: '',
+        facets: { background: { layers: [{ kind: 'image', ref: '' }] } } },
+    ] } as unknown as BrandingModel;
+    openLeverEditor({ previewHost, snapshotId: 'x', onChange: () => {}, facets: nodeFor('x')!.facets });
+    const fileInput = document.querySelector('[data-stb-bg-row="layer"] input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    fileInput.focus();
+    // as after a native file dialog: focus sits on the file input when the write lands.
+    // A file input carries no in-flight typed text, so it must NOT suppress the re-render.
+    setNodeFacets('x', setLayer(nodeFor('x')!.facets, 0, { kind: 'image', ref: 'assets/new-logo.png' }));
+    const label = document.querySelector('[data-stb-bg-row="layer"] .stb-facet-leaf-label') as HTMLElement;
+    expect(label.textContent).toBe('assets/new-logo.png');
   });
 });

--- a/tools/stb/tests/ui/lever-editor.test.ts
+++ b/tools/stb/tests/ui/lever-editor.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { contentValue, assetValue, openLeverEditor } from '@/ui/lever-editor';
 import { brandingModel, nodeFor, setNodeFacets, setNodeFacetsDark } from '@/state/branding';
 import { setSide, setLayer } from '@/state/facets-edit';
 import type { BrandingModel } from '@/metadata/types';
+
+const cssDir = dirname(fileURLToPath(import.meta.url));
+const stbCss = readFileSync(resolve(cssDir, '../../src/styles/stb.css'), 'utf8');
 
 describe('lever-editor value helpers', () => {
   it('contentValue / assetValue shape the union', () => {
@@ -118,7 +124,50 @@ describe('lever-editor composite-edit focus survival', () => {
     // as after a native file dialog: focus sits on the file input when the write lands.
     // A file input carries no in-flight typed text, so it must NOT suppress the re-render.
     setNodeFacets('x', setLayer(nodeFor('x')!.facets, 0, { kind: 'image', ref: 'assets/new-logo.png' }));
-    const label = document.querySelector('[data-stb-bg-row="layer"] .stb-facet-leaf-label') as HTMLElement;
-    expect(label.textContent).toBe('assets/new-logo.png');
+    const label = document.querySelector('[data-stb-bg-row="layer"] .stb-facet-bg-subtitle') as HTMLElement;
+    expect(label.textContent).toBe('image — assets/new-logo.png');
+  });
+});
+
+// Popover growth is CSS-driven (no fixed width/height, resize:both, a viewport-margin
+// max-height cap) — jsdom doesn't lay out or paint, so pixel sizing can't be asserted
+// here. These tests assert the structural hooks: no inline size is ever hardcoded at
+// mount time (nothing pins the box before a manual resize), the drag handle and the
+// resizable class both survive, and the stylesheet itself carries the intended cap.
+// Visual growth (adding a background group and watching the panel expand) is deferred
+// to the user's live poke.
+describe('lever-editor popover sizing', () => {
+  beforeEach(() => { document.body.innerHTML = '<div class="host"></div>'; });
+  afterEach(() => { brandingModel.value = null; });
+
+  it('mounts with no inline width/height — sizing is left to CSS (content-driven, not pinned)', () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openLeverEditor({
+      previewHost, snapshotId: 'x', onChange: () => {},
+      facets: { text: { fontSize: { literal: '18px' } } },
+    });
+    const panel = document.querySelector('.stb-lever-editor') as HTMLElement;
+    expect(panel).toBeTruthy();
+    expect(panel.style.width).toBe('');
+    expect(panel.style.height).toBe('');
+  });
+
+  it('keeps the drag handle mounted alongside the resizable panel class', () => {
+    const previewHost = document.querySelector('.host') as HTMLElement;
+    openLeverEditor({
+      previewHost, snapshotId: 'x', onChange: () => {},
+      facets: { text: { fontSize: { literal: '18px' } } },
+    });
+    expect(document.querySelector('.stb-lever-drag')).not.toBeNull();
+    expect(document.querySelector('.stb-lever-editor')).not.toBeNull();
+  });
+
+  it('the stylesheet caps popover growth at a viewport margin and keeps manual resize', () => {
+    const rule = stbCss.match(/\.stb-lever-editor,\s*\.stb-color-picker\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(rule).toContain('max-height: calc(100vh - 2rem)');
+    expect(rule).toContain('resize: both');
+    // No fixed width/height in the rule — sizing stays intrinsic to content until capped.
+    expect(rule).not.toMatch(/(?<!max-|min-)\bheight:/);
+    expect(rule).not.toMatch(/(?<!max-|min-)\bwidth:/);
   });
 });

--- a/tools/stb/tests/ui/preview-compare.test.ts
+++ b/tools/stb/tests/ui/preview-compare.test.ts
@@ -65,14 +65,17 @@ describe('pinned-mode preview pane', () => {
     expect(sent(post, 'STB_SET_DARK')).toContainEqual({ type: 'STB_SET_DARK', dark: true });
   });
 
-  it('pinned-dark pane composes lever patches from the dark bundle', async () => {
+  it('pinned-dark pane gets dark background CSS via scoped blocks (background is blocks-only, not a lever patch)', async () => {
     const { iframe, post } = mountPane(document.getElementById('p1')!, { mode: 'dark' });
     await tick();
     brandingModel.value = bgModel;
     dispatchFrom(iframe, { type: 'STB_PREVIEW_READY' });
+    const css = sent(post, 'STB_APPLY_BLOCKS').at(-1)!.css as string;
+    expect(css).toContain('.dark-theme');
+    expect(css).toContain('#111111');
+    // and no background LeverPatch — the blocks leg is the sole owner
     const levers = sent(post, 'STB_APPLY_LEVERS').at(-1)!.levers;
-    expect(levers).toContainEqual({ snapshotId: 'a.hero', kind: 'background', backgroundColor: '#111111' });
-    expect(levers.filter((p: any) => p.backgroundColor === '#dddddd')).toHaveLength(0);
+    expect(levers.filter((p: any) => p.kind === 'background')).toHaveLength(0);
   });
 
   it('follow-global pane (default) still follows previewDark', async () => {

--- a/tools/stb/tests/ui/preview-compare.test.ts
+++ b/tools/stb/tests/ui/preview-compare.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createPreviewPane, mountCompareToggle } from '@/ui/preview-pane';
+import { previewDark, compareMode, activeSceneId } from '@/state/scene';
+import { brandingModel } from '@/state/branding';
+import { openLeverEditor } from '@/ui/lever-editor';
+import type { BrandingModel } from '@/metadata/types';
+
+// Model with divergent light/dark background bundles so we can tell which
+// bundle a pane's lever patches were composed from.
+const bgModel = {
+  scene: 'login',
+  nodes: [
+    { snapshotId: 'a.hero', role: 'region', name: 'H', description: '',
+      facets: { background: { color: { literal: '#dddddd' } } },
+      facetsDark: { background: { color: { literal: '#111111' } } } },
+  ],
+} as unknown as BrandingModel;
+
+function dispatchFrom(iframe: HTMLIFrameElement, data: unknown): void {
+  window.dispatchEvent(new MessageEvent('message', { data, source: iframe.contentWindow as Window }));
+}
+
+async function tick(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function mountPane(host: HTMLElement, opts: Parameters<typeof createPreviewPane>[0] = {}) {
+  const pane = createPreviewPane(opts);
+  pane.mount(host);
+  const iframe = host.querySelector('iframe')!;
+  // Spy on the REAL contentWindow: MessageEvent.source must be a WindowProxy,
+  // so the same object doubles as the event source and the send sink.
+  const post = vi.spyOn(iframe.contentWindow!, 'postMessage').mockImplementation(() => {});
+  return { pane, iframe, post };
+}
+
+function sent(post: { mock: { calls: unknown[][] } }, type: string): any[] {
+  return post.mock.calls.map((c) => c[0]).filter((m: any) => m?.type === type);
+}
+
+beforeEach(() => {
+  // loadBrandingModel/routing fetches must not hit the network from jsdom;
+  // a rejecting stub takes the catch path (brandingModel = null).
+  vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('no network in unit tests'))));
+  document.body.innerHTML = '<div id="p1"></div><div id="p2"></div>';
+  activeSceneId.value = 'login';
+  previewDark.value = false;
+  compareMode.value = false;
+  brandingModel.value = null;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  previewDark.value = false;
+  compareMode.value = false;
+  brandingModel.value = null;
+});
+
+describe('pinned-mode preview pane', () => {
+  it('pinned-dark pane applies dark while the global previewDark stays false', async () => {
+    const { iframe, post } = mountPane(document.getElementById('p1')!, { mode: 'dark' });
+    await tick(); // let the mount-time loadBrandingModel settle
+    dispatchFrom(iframe, { type: 'STB_PREVIEW_READY' });
+    expect(previewDark.value).toBe(false);
+    expect(sent(post, 'STB_SET_DARK')).toContainEqual({ type: 'STB_SET_DARK', dark: true });
+  });
+
+  it('pinned-dark pane composes lever patches from the dark bundle', async () => {
+    const { iframe, post } = mountPane(document.getElementById('p1')!, { mode: 'dark' });
+    await tick();
+    brandingModel.value = bgModel;
+    dispatchFrom(iframe, { type: 'STB_PREVIEW_READY' });
+    const levers = sent(post, 'STB_APPLY_LEVERS').at(-1)!.levers;
+    expect(levers).toContainEqual({ snapshotId: 'a.hero', kind: 'background', backgroundColor: '#111111' });
+    expect(levers.filter((p: any) => p.backgroundColor === '#dddddd')).toHaveLength(0);
+  });
+
+  it('follow-global pane (default) still follows previewDark', async () => {
+    const { iframe, post } = mountPane(document.getElementById('p1')!);
+    await tick();
+    dispatchFrom(iframe, { type: 'STB_PREVIEW_READY' });
+    expect(sent(post, 'STB_SET_DARK')).toContainEqual({ type: 'STB_SET_DARK', dark: false });
+    previewDark.value = true;
+    expect(sent(post, 'STB_SET_DARK')).toContainEqual({ type: 'STB_SET_DARK', dark: true });
+  });
+
+  it('pinned pane ignores previewDark flips (no re-send, mode is pinned)', async () => {
+    const { iframe, post } = mountPane(document.getElementById('p1')!, { mode: 'dark' });
+    await tick();
+    dispatchFrom(iframe, { type: 'STB_PREVIEW_READY' });
+    post.mockClear();
+    previewDark.value = true;
+    expect(sent(post, 'STB_SET_DARK')).toHaveLength(0);
+  });
+});
+
+describe('per-pane message scoping (two live panes)', () => {
+  it('READY from pane A does not ready pane B, and a click selects only via the clicked pane', async () => {
+    const selectedA = vi.fn();
+    const selectedB = vi.fn();
+    const a = mountPane(document.getElementById('p1')!, { onElementSelected: selectedA });
+    const b = mountPane(document.getElementById('p2')!, { mode: 'dark', onElementSelected: selectedB });
+    await tick();
+
+    dispatchFrom(a.iframe, { type: 'STB_PREVIEW_READY' });
+    expect(a.post).toHaveBeenCalled();
+    expect(b.post).not.toHaveBeenCalled(); // B is not ready; A's READY must not leak
+
+    dispatchFrom(a.iframe, { type: 'STB_ELEMENT_SELECTED', selector: 's', tokens: [], snapshotId: 'x' });
+    expect(selectedA).toHaveBeenCalledTimes(1);
+    expect(selectedB).not.toHaveBeenCalled();
+
+    dispatchFrom(b.iframe, { type: 'STB_PREVIEW_READY' });
+    dispatchFrom(b.iframe, { type: 'STB_ELEMENT_SELECTED', selector: 's', tokens: [], snapshotId: 'y' });
+    expect(selectedB).toHaveBeenCalledTimes(1);
+    expect(selectedA).toHaveBeenCalledTimes(1); // unchanged
+  });
+});
+
+describe('mountCompareToggle', () => {
+  function setup(dark = false) {
+    document.body.innerHTML = `
+      <div class="toggle-host"></div>
+      <label><input type="checkbox" id="stb-preview-dark"></label>
+      <div class="stb-preview-host">
+        <div class="pane-a"></div>
+        <div class="pane-b" hidden></div>
+      </div>
+    `;
+    const darkToggle = document.getElementById('stb-preview-dark') as HTMLInputElement;
+    previewDark.value = dark;
+    darkToggle.checked = dark;
+    const panesHost = document.querySelector('.stb-preview-host') as HTMLElement;
+    const darkPaneHost = document.querySelector('.pane-b') as HTMLElement;
+    const onFirstEnable = vi.fn();
+    mountCompareToggle(document.querySelector('.toggle-host') as HTMLElement,
+      { panesHost, darkPaneHost, darkToggle, onFirstEnable });
+    const cb = document.querySelector('.toggle-host input[type="checkbox"]') as HTMLInputElement;
+    return { cb, darkToggle, panesHost, darkPaneHost, onFirstEnable };
+  }
+
+  function flip(cb: HTMLInputElement, on: boolean): void {
+    cb.checked = on;
+    cb.dispatchEvent(new Event('change'));
+  }
+
+  it('renders a Compare checkbox, off by default (single-pane unchanged)', () => {
+    const { cb, darkPaneHost, panesHost } = setup();
+    expect(cb).toBeTruthy();
+    expect(cb.checked).toBe(false);
+    expect(compareMode.value).toBe(false);
+    expect(darkPaneHost.hidden).toBe(true);
+    expect(panesHost.classList.contains('stb-compare')).toBe(false);
+  });
+
+  it('toggle ON: reveals the dark pane host, flags compare, pins light, disables Dark preview', () => {
+    const { cb, darkToggle, panesHost, darkPaneHost, onFirstEnable } = setup(true);
+    flip(cb, true);
+    expect(compareMode.value).toBe(true);
+    expect(darkPaneHost.hidden).toBe(false);
+    expect(panesHost.classList.contains('stb-compare')).toBe(true);
+    // panes own the mode axis: primary pane pinned light, global control inert
+    expect(previewDark.value).toBe(false);
+    expect(darkToggle.checked).toBe(false);
+    expect(darkToggle.disabled).toBe(true);
+    expect(onFirstEnable).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggle OFF: restores single pane and the saved Dark preview state', () => {
+    const { cb, darkToggle, panesHost, darkPaneHost } = setup(true);
+    flip(cb, true);
+    flip(cb, false);
+    expect(compareMode.value).toBe(false);
+    expect(darkPaneHost.hidden).toBe(true);
+    expect(panesHost.classList.contains('stb-compare')).toBe(false);
+    expect(previewDark.value).toBe(true); // restored, not lost
+    expect(darkToggle.checked).toBe(true);
+    expect(darkToggle.disabled).toBe(false);
+  });
+
+  it('onFirstEnable fires once across repeated toggles (dark pane created lazily, kept)', () => {
+    const { cb, onFirstEnable } = setup();
+    flip(cb, true);
+    flip(cb, false);
+    flip(cb, true);
+    expect(onFirstEnable).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('lever editor initial position in compare mode', () => {
+  it('opens ABOVE the panes (not in the left gutter) while compare is on', () => {
+    document.body.innerHTML = '<div class="stb-preview-host"></div>';
+    const previewHost = document.querySelector('.stb-preview-host') as HTMLElement;
+    previewHost.getBoundingClientRect = () =>
+      ({ top: 300, left: 0, width: 800, height: 400, right: 800, bottom: 700, x: 0, y: 300, toJSON: () => ({}) }) as DOMRect;
+    compareMode.value = true;
+    openLeverEditor({ previewHost, snapshotId: 'x', onChange: () => {}, facets: {} });
+    const panel = document.querySelector('.stb-lever-editor') as HTMLElement;
+    // jsdom offsetHeight = 0 → top = host.top - 0 - 8 = 292; left pinned to the edge
+    expect(panel.style.top).toBe('292px');
+    expect(panel.style.left).toBe('8px');
+  });
+
+  it('keeps the gutter placement when compare is off', () => {
+    document.body.innerHTML = '<div class="stb-preview-host"></div>';
+    const previewHost = document.querySelector('.stb-preview-host') as HTMLElement;
+    previewHost.getBoundingClientRect = () =>
+      ({ top: 300, left: 0, width: 800, height: 400, right: 800, bottom: 700, x: 0, y: 300, toJSON: () => ({}) }) as DOMRect;
+    compareMode.value = false;
+    openLeverEditor({ previewHost, snapshotId: 'x', onChange: () => {}, facets: {} });
+    const panel = document.querySelector('.stb-lever-editor') as HTMLElement;
+    // cardW = min(480, 800*0.5) = 400 → gutter = 200; panel width 0 → left = 200/2 = 100
+    expect(panel.style.left).toBe('100px');
+  });
+});

--- a/tools/stb/tests/ui/preview-pane-levers.test.ts
+++ b/tools/stb/tests/ui/preview-pane-levers.test.ts
@@ -68,3 +68,34 @@ describe('leverPatchesFor', () => {
     });
   });
 });
+
+describe('leverPatchesFor dark-aware background', () => {
+  const bgModel = {
+    scene: 's',
+    nodes: [
+      { snapshotId: 'a.card', role: 'region', name: 'C', description: '',
+        facets: { background: { color: { literal: '#eeeeee' } } } },
+      { snapshotId: 'a.hero', role: 'region', name: 'H', description: '',
+        facets: { background: { color: { literal: '#dddddd' } } },
+        facetsDark: { background: { color: { literal: '#111111' } } } },
+    ],
+  } as any;
+
+  it('light mode composes the background patch from facets.background', () => {
+    const patches = leverPatchesFor(bgModel, false);
+    expect(patches).toContainEqual({ snapshotId: 'a.card', kind: 'background', backgroundColor: '#eeeeee' });
+    expect(patches).toContainEqual({ snapshotId: 'a.hero', kind: 'background', backgroundColor: '#dddddd' });
+  });
+
+  it('dark mode with no facetsDark.background emits NO background patch (dark CSS owns it)', () => {
+    const patches = leverPatchesFor(bgModel, true);
+    expect(patches.filter((p) => p.snapshotId === 'a.card' && p.kind === 'background')).toHaveLength(0);
+  });
+
+  it('dark mode composes the background patch from facetsDark.background when present', () => {
+    const patches = leverPatchesFor(bgModel, true);
+    expect(patches).toContainEqual({ snapshotId: 'a.hero', kind: 'background', backgroundColor: '#111111' });
+    // and never from the light bundle
+    expect(patches.filter((p) => p.kind === 'background' && (p as any).backgroundColor === '#dddddd')).toHaveLength(0);
+  });
+});

--- a/tools/stb/tests/ui/preview-pane-levers.test.ts
+++ b/tools/stb/tests/ui/preview-pane-levers.test.ts
@@ -23,6 +23,19 @@ describe('leverPatchesFor', () => {
     expect(patches.filter((p) => p.snapshotId === 'auth.login.sign-in')).toHaveLength(0);
   });
 
+  it('carries format subset on the content patch, and omits format for plain content', () => {
+    const m: BrandingModel = { scene: 's', nodes: [
+      { snapshotId: 'a', role: 'paragraph', name: 'M', description: 'msg',
+        facets: { content: { text: '**b**', format: 'subset' } } },
+      { snapshotId: 'b', role: 'heading', name: 'T', description: 'title',
+        facets: { content: { text: 'Hi' } } },
+    ] };
+    const patches = leverPatchesFor(m);
+    expect(patches).toContainEqual({ snapshotId: 'a', kind: 'content', text: '**b**', format: 'subset' });
+    // plain patch is byte-identical to the pre-format shape — no format key at all
+    expect(patches.find((p) => p.snapshotId === 'b')).toEqual({ snapshotId: 'b', kind: 'content', text: 'Hi' });
+  });
+
   it('emits a visibility patch from the node visibility field', () => {
     const patches = leverPatchesFor(model);
     expect(patches).toContainEqual({ snapshotId: 'auth.login.logo', kind: 'visibility', shown: false });

--- a/tools/stb/tests/ui/preview-pane-levers.test.ts
+++ b/tools/stb/tests/ui/preview-pane-levers.test.ts
@@ -52,4 +52,19 @@ describe('leverPatchesFor', () => {
     expect(patches).toContainEqual({ snapshotId: 'a', kind: 'content', text: 'Hi' });
     expect(patches).toContainEqual({ snapshotId: 'b', kind: 'asset', ref: 'logo.svg' });
   });
+
+  it('emits a composed background patch (raw color + reversed-layer image) for a node with a background facet', () => {
+    const nodes = [
+      { snapshotId: 'a.card', role: 'region', name: 'Card', description: '',
+        facets: { background: {
+          color: { literal: '#0b3d91' },
+          layers: [{ kind: 'image', ref: 'assets/hero.jpg' }],
+        } } },
+    ];
+    const patches = leverPatchesFor({ scene: 's', nodes } as any);
+    expect(patches).toContainEqual({
+      snapshotId: 'a.card', kind: 'background',
+      backgroundColor: '#0b3d91', backgroundImage: 'url(assets/hero.jpg)',
+    });
+  });
 });

--- a/tools/stb/tests/ui/preview-pane-levers.test.ts
+++ b/tools/stb/tests/ui/preview-pane-levers.test.ts
@@ -66,49 +66,7 @@ describe('leverPatchesFor', () => {
     expect(patches).toContainEqual({ snapshotId: 'b', kind: 'asset', ref: 'logo.svg' });
   });
 
-  it('emits a composed background patch (raw color + reversed-layer image) for a node with a background facet', () => {
-    const nodes = [
-      { snapshotId: 'a.card', role: 'region', name: 'Card', description: '',
-        facets: { background: {
-          color: { literal: '#0b3d91' },
-          layers: [{ kind: 'image', ref: 'assets/hero.jpg' }],
-        } } },
-    ];
-    const patches = leverPatchesFor({ scene: 's', nodes } as any);
-    expect(patches).toContainEqual({
-      snapshotId: 'a.card', kind: 'background',
-      backgroundColor: '#0b3d91', backgroundImage: 'url(assets/hero.jpg)',
-    });
-  });
-});
-
-describe('leverPatchesFor dark-aware background', () => {
-  const bgModel = {
-    scene: 's',
-    nodes: [
-      { snapshotId: 'a.card', role: 'region', name: 'C', description: '',
-        facets: { background: { color: { literal: '#eeeeee' } } } },
-      { snapshotId: 'a.hero', role: 'region', name: 'H', description: '',
-        facets: { background: { color: { literal: '#dddddd' } } },
-        facetsDark: { background: { color: { literal: '#111111' } } } },
-    ],
-  } as any;
-
-  it('light mode composes the background patch from facets.background', () => {
-    const patches = leverPatchesFor(bgModel, false);
-    expect(patches).toContainEqual({ snapshotId: 'a.card', kind: 'background', backgroundColor: '#eeeeee' });
-    expect(patches).toContainEqual({ snapshotId: 'a.hero', kind: 'background', backgroundColor: '#dddddd' });
-  });
-
-  it('dark mode with no facetsDark.background emits NO background patch (dark CSS owns it)', () => {
-    const patches = leverPatchesFor(bgModel, true);
-    expect(patches.filter((p) => p.snapshotId === 'a.card' && p.kind === 'background')).toHaveLength(0);
-  });
-
-  it('dark mode composes the background patch from facetsDark.background when present', () => {
-    const patches = leverPatchesFor(bgModel, true);
-    expect(patches).toContainEqual({ snapshotId: 'a.hero', kind: 'background', backgroundColor: '#111111' });
-    // and never from the light bundle
-    expect(patches.filter((p) => p.kind === 'background' && (p as any).backgroundColor === '#dddddd')).toHaveLength(0);
-  });
+  // background is no longer a LeverPatch — emitScopedBlocks (css-emitter.ts) is the sole
+  // owner of preview backgrounds, light and dark alike (see tests/parse/css-emitter.test.ts
+  // and tests/ui/preview-compare.test.ts's "pinned-dark pane" scoped-blocks coverage).
 });


### PR DESCRIPTION
Closes #5517

WIP — still collecting look-and-feel corrections from live testing; the underlying framework is complete (601 stb tests green).

Adds the composite facet framework to the Stratos Theme Builder:

- Composite facet model: comma-list and positional-tuple composites covering themed CSS shorthand properties, with structured gradient editing (per-stop color/position).
- Background layer editing: layer add/remove with labels, live paint-stack summary showing the emitted CSS, dual light/dark preview.
- Delete-tier primitives: per-value Clear (fall back to snapshot), `transparent` keyword, and per-node Reset to the pristine loaded model.
- Occlusion handling: when a page background is covered by an overlay child (e.g. the login backdrop), the editor surfaces a hint and a jump link instead of silently editing an invisible layer.
- Fixes a color-picker outside-click handler leak that made the picker work only once per page load.
- Docs: text contrast against arbitrary backgrounds (`tools/stb/docs/text-contrast-and-dark-mode.md`) — break-even luminance, AA guarantees, gradient/scrim handling.