### PR TITLE
Bk/bug/5511 fix copy icon btn

### DIFF
--- a/src/frontend/packages/core/src/core/click-stop-propagation.directive.ts
+++ b/src/frontend/packages/core/src/core/click-stop-propagation.directive.ts
@@ -6,7 +6,7 @@ import { Directive, HostListener } from '@angular/core';
 })
 export class ClickStopPropagationDirective {
   @HostListener('click', ['$event'])
-  public onClick(event: any) {
+  public onClick(event: Event) {
     event.stopPropagation();
   }
 }

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
@@ -7,14 +7,16 @@
     @case ('not yet')
     @case ('yes and saw succeeded'){
       <button
-         class="inline-flex"
-         appClickStopPropagation
-         (click)="copyToClipboard(text)">
-        <span class="material-icons cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
-         [ngClass]="{'text-sm': compact, 'text-base': !compact}"
-         [class.animate-scale-pop-in]="didUserPressCopy() === 'yes and saw succeeded'"
-         [title]="tooltip">
-         content_copy
+          class="inline-flex"
+          appClickStopPropagation       
+          [class.animate-scale-pop-in]="didUserPressCopy() === 'yes and saw succeeded'"
+          [attr.aria-label]="tooltip || 'Copy to clipboard'"
+          [title]="tooltip"
+          (click)="copyToClipboard(text)">
+        <span 
+          [ngClass]="{'text-sm': compact, 'text-base': !compact}"
+          class="material-icons cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300">
+          content_copy
        </span>
       </button>
     }

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
@@ -6,16 +6,17 @@
   @switch (didUserPressCopy()) {
     @case ('not yet')
     @case ('yes and saw succeeded'){
-      <span class="material-icons col-start-1 row-start-1 justify-self-end cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
-       [ngClass]="{'text-sm': compact, 'text-base': !compact, 'animate-scale-pop-in': didUserPressCopy() === 'yes and saw succeeded'}"
-       role="button" tabindex="0"  
-       appClickStopPropagation
-       (click)="copyToClipboard(text)"
-       (keydown.enter)="copyToClipboard(text)"
-       (keydown.space)="copyToClipboard(text)"
-       [title]="tooltip">
-       content_copy
-     </span>
+      <button
+         class="inline-flex"
+         appClickStopPropagation
+         (click)="copyToClipboard(text)">
+        <span class="material-icons cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
+         [ngClass]="{'text-sm': compact, 'text-base': !compact}"
+         [class.animate-scale-pop-in]="didUserPressCopy() === 'yes and saw succeeded'"
+         [title]="tooltip">
+         content_copy
+       </span>
+      </button>
     }
     @case ('yes but failed') {
       <div class="col-start-1 row-start-1 justify-self-end flex items-center gap-1 transition-opacity duration-300">

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
@@ -8,7 +8,8 @@
     @case ('yes and saw succeeded'){
       <span class="material-icons col-start-1 row-start-1 justify-self-end cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
        [ngClass]="{'text-sm': compact, 'text-base': !compact, 'animate-scale-pop-in': didUserPressCopy() === 'yes and saw succeeded'}"
-       role="button" tabindex="0"
+       role="button" tabindex="0"  
+       appClickStopPropagation
        (click)="copyToClipboard(text)"
        (keydown.enter)="copyToClipboard(text)"
        (keydown.space)="copyToClipboard(text)"

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.html
@@ -3,33 +3,38 @@
      widest child — the "Copied to clipboard" text when shown — and the copy
      icon flows in normal layout so it aligns with its row. -->
 <div class="inline-grid items-center">
-  @if (canCopy) {
-    <span class="material-icons col-start-1 row-start-1 justify-self-end cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
-      [class.opacity-0]="copySuccessWait"
-      [class.opacity-100]="!copySuccessWait"
-      [ngClass]="{'text-sm': compact, 'text-base': !compact}"
-      role="button" tabindex="0"
-      (click)="copyToClipboard($event)"
-      (keydown.enter)="copyToClipboard($event)"
-      (keydown.space)="copyToClipboard($event); $event.preventDefault()"
-      [title]="tooltip"
-      [attr.aria-label]="tooltip || 'Copy to clipboard'">
-      content_copy
-    </span>
-  }
-  <!-- pointer-events-none: this indicator shares the grid cell with (and paints
-       on top of) the copy icon; hidden via opacity it still captures clicks, so
-       without this it swallows every click meant for the icon (see #5511). It is
-       decorative, so it never needs pointer events. -->
-  <div class="col-start-1 row-start-1 justify-self-end pointer-events-none flex items-center gap-1 transition-opacity duration-300"
-    [class.opacity-100]="copySuccessWait"
-    [class.opacity-0]="!copySuccessWait">
-    @if (showSuccessText) {
-      <span class="text-sm text-success-shade-600 whitespace-nowrap">Copied to clipboard</span>
+  @switch (didUserPressCopy()) {
+    @case ('not yet')
+    @case ('yes and saw succeeded'){
+      <span class="material-icons col-start-1 row-start-1 justify-self-end cursor-pointer text-content-muted hover:text-content-text transition-opacity duration-300"
+       [ngClass]="{'text-sm': compact, 'text-base': !compact, 'animate-scale-pop-in': didUserPressCopy() === 'yes and saw succeeded'}"
+       role="button" tabindex="0"
+       (click)="copyToClipboard(text)"
+       (keydown.enter)="copyToClipboard(text)"
+       (keydown.space)="copyToClipboard(text)"
+       [title]="tooltip">
+       content_copy
+     </span>
     }
-    <span class="material-icons text-success-shade-600"
-      [ngClass]="{'text-sm': compact, 'text-base': !compact}">
-      check_circle
-    </span>
-  </div>
+    @case ('yes but failed') {
+      <div class="col-start-1 row-start-1 justify-self-end flex items-center gap-1 transition-opacity duration-300">
+        <span class="material-icons text-status-danger"
+          [title]="'Failed to copy text. This might be due to security settings surrounding the clipboard API.'"
+          [ngClass]="{'text-sm': compact, 'text-base': !compact}">
+          error
+        </span>
+      </div>
+    }
+    @case ('yes and succeeded') {
+      <div class="col-start-1 row-start-1 justify-self-end flex items-center gap-1 transition-opacity duration-300">
+      @if (showSuccessText) {
+        <span class="text-sm text-success-shade-600 whitespace-nowrap">Copied to clipboard</span>
+      }
+      <span class="material-icons text-success-shade-600 animate-scale-pop-in"
+        [ngClass]="{'text-sm': compact, 'text-base': !compact}">
+        check_circle
+      </span>
+    </div>
+    }
+  }
 </div>

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
@@ -1,12 +1,7 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
-import { createBasicStoreModule } from "@test-framework/core-test.helper";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CoreTestingModule } from "@test-framework/core-test.modules";
-import { CoreModule } from '../../../core/core.module';
 import { CopyToClipboardComponent } from './copy-to-clipboard.component';
 
 describe('CopyToClipboardComponent', () => {
@@ -15,47 +10,73 @@ describe('CopyToClipboardComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        provideZonelessChangeDetection()
-      ],
-      imports: [
-        CopyToClipboardComponent, // Now standalone
-        CoreModule,
-        CoreTestingModule,
-        createBasicStoreModule(),
-      ]
+      providers: [provideZonelessChangeDetection()],
+      imports: [CopyToClipboardComponent],
     });
-      TestBed.compileComponents();
-  });
 
-  beforeEach(() => {
+    TestBed.compileComponents();
+
     fixture = TestBed.createComponent(CopyToClipboardComponent);
     component = fixture.componentInstance;
+    component.tooltip = 'Copy to clipboard';
+    component.text = 'hello world';
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
-  it('renders the copy icon in normal flow (not absolutely positioned), stacked via grid', () => {
-    component.canCopy = true;
+  it('renders the copy action initially', () => {
+    const button = fixture.nativeElement.querySelector('[role="button"]');
+
+    expect(component.didUserPressCopy()).toBe('not yet');
+    expect(button).toBeTruthy();
+    expect(button.getAttribute('title')).toBe('Copy to clipboard');
+    expect(button.textContent).toContain('content_copy');
+  });
+
+  it('shows a success state when the clipboard write succeeds and resets after the delay', async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    component.copyToClipboard(component.text);
+    await Promise.resolve();
     fixture.detectChanges();
 
-    const icons = Array.from(
-      fixture.nativeElement.querySelectorAll('.material-icons'),
-    ) as HTMLElement[];
-    const copyIcon = icons.find(el => el.textContent?.trim() === 'content_copy');
+    expect(writeText).toHaveBeenCalledWith('hello world');
+    expect(component.didUserPressCopy()).toBe('yes and succeeded');
+    expect(fixture.nativeElement.textContent).toContain('Copied to clipboard');
 
-    expect(copyIcon).toBeTruthy();
-    // Absolute positioning was the cause of the row-misalignment — the icon
-    // must flow so it tracks its row.
-    expect(copyIcon!.classList.contains('absolute')).toBe(false);
-    // Icon + transient success indicator share one grid cell, so the column
-    // reserves space for the "Copied to clipboard" text without overlap.
-    expect(fixture.nativeElement.querySelector('.inline-grid')).toBeTruthy();
+    await vi.advanceTimersByTimeAsync(700);
+    fixture.detectChanges();
+
+    expect(component.didUserPressCopy()).toBe('not yet');
+    expect(fixture.nativeElement.querySelector('[role="button"]')).toBeTruthy();
+  });
+
+  it('shows an error state when the clipboard write fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    component.copyToClipboard(component.text);
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(writeText).toHaveBeenCalledWith('hello world');
+    expect(component.didUserPressCopy()).toBe('yes but failed');
+    expect(fixture.nativeElement.querySelector('.text-status-danger')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('Failed to copy');
+    expect(fixture.nativeElement.textContent).not.toContain('Copied to clipboard');
+    expect(fixture.nativeElement.textContent).toContain('error');
   });
 
   it('marks the success indicator pointer-events-none so it cannot swallow icon clicks (#5511)', () => {

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
@@ -56,8 +56,10 @@ describe('CopyToClipboardComponent', () => {
     await vi.advanceTimersByTimeAsync(700);
     fixture.detectChanges();
 
-    expect(component.didUserPressCopy()).toBe('not yet');
-    expect(fixture.nativeElement.querySelector('[role="button"]')).toBeTruthy();
+    expect(component.didUserPressCopy()).toBe('yes and saw succeeded');
+    const button = fixture.nativeElement.querySelector('[role="button"]');
+    expect(button).toBeTruthy();
+    expect(button.className).toContain('animate-scale-pop-in');
   });
 
   it('shows an error state when the clipboard write fails', async () => {
@@ -73,74 +75,11 @@ describe('CopyToClipboardComponent', () => {
 
     expect(writeText).toHaveBeenCalledWith('hello world');
     expect(component.didUserPressCopy()).toBe('yes but failed');
-    expect(fixture.nativeElement.querySelector('.text-status-danger')).toBeTruthy();
-    expect(fixture.nativeElement.textContent).toContain('Failed to copy');
+    const errorIcon = fixture.nativeElement.querySelector('.text-status-danger');
+    expect(errorIcon).toBeTruthy();
+    expect(errorIcon.getAttribute('title')).toContain('Failed to copy text');
     expect(fixture.nativeElement.textContent).not.toContain('Copied to clipboard');
     expect(fixture.nativeElement.textContent).toContain('error');
   });
 
-  it('marks the success indicator pointer-events-none so it cannot swallow icon clicks (#5511)', () => {
-    component.canCopy = true;
-    fixture.detectChanges();
-
-    // The indicator shares the copy icon's grid cell and paints on top of it;
-    // without pointer-events-none it intercepts every click while invisible.
-    const indicator = fixture.nativeElement.querySelector(
-      '.pointer-events-none',
-    ) as HTMLElement | null;
-    expect(indicator).toBeTruthy();
-    expect(indicator!.textContent).toContain('Copied to clipboard');
-  });
-
-  describe('copy behaviour', () => {
-    let clipboardDescriptor: PropertyDescriptor | undefined;
-
-    beforeEach(() => {
-      clipboardDescriptor = Object.getOwnPropertyDescriptor(window.navigator, 'clipboard');
-    });
-
-    afterEach(() => {
-      if (clipboardDescriptor) {
-        Object.defineProperty(window.navigator, 'clipboard', clipboardDescriptor);
-      } else {
-        delete (window.navigator as { clipboard?: unknown }).clipboard;
-      }
-    });
-
-    function setClipboard(value: unknown) {
-      Object.defineProperty(window.navigator, 'clipboard', { value, configurable: true });
-    }
-
-    it('prefers the async Clipboard API and reports success', async () => {
-      const writeText = vi.fn().mockResolvedValue(undefined);
-      setClipboard({ writeText });
-      component.text = 'https://api.example.com';
-
-      await component.copyToClipboard();
-
-      expect(writeText).toHaveBeenCalledWith('https://api.example.com');
-      expect(component.copySuccessful).toBe(true);
-      expect(component.copySuccessWait).toBe(true);
-    });
-
-    it('falls back to execCommand when the async Clipboard API is unavailable', async () => {
-      setClipboard(undefined);
-      // jsdom doesn't implement execCommand at all, so assign a stub directly.
-      const exec = vi.fn().mockReturnValue(true);
-      (document as unknown as { execCommand: unknown }).execCommand = exec;
-      component.text = 'fallback-value';
-
-      await component.copyToClipboard();
-
-      expect(exec).toHaveBeenCalledWith('copy');
-      expect(component.copySuccessful).toBe(true);
-      delete (document as unknown as { execCommand?: unknown }).execCommand;
-    });
-
-    it('canCopy is true when only the async Clipboard API is present', () => {
-      setClipboard({ writeText: vi.fn() });
-      component.ngOnInit();
-      expect(component.canCopy).toBe(true);
-    });
-  });
 });

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.spec.ts
@@ -29,7 +29,7 @@ describe('CopyToClipboardComponent', () => {
   });
 
   it('renders the copy action initially', () => {
-    const button = fixture.nativeElement.querySelector('[role="button"]');
+    const button = fixture.nativeElement.querySelector('button')
 
     expect(component.didUserPressCopy()).toBe('not yet');
     expect(button).toBeTruthy();
@@ -53,11 +53,11 @@ describe('CopyToClipboardComponent', () => {
     expect(component.didUserPressCopy()).toBe('yes and succeeded');
     expect(fixture.nativeElement.textContent).toContain('Copied to clipboard');
 
-    await vi.advanceTimersByTimeAsync(700);
+    await vi.advanceTimersByTimeAsync(800);
     fixture.detectChanges();
 
     expect(component.didUserPressCopy()).toBe('yes and saw succeeded');
-    const button = fixture.nativeElement.querySelector('[role="button"]');
+    const button = fixture.nativeElement.querySelector('button');
     expect(button).toBeTruthy();
     expect(button.className).toContain('animate-scale-pop-in');
   });

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.ts
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.ts
@@ -30,22 +30,22 @@ export class CopyToClipboardComponent {
       await this.afterSomeSeconds();
       this.didUserPressCopy.set('yes and saw succeeded');
     } catch (err) {
-      // * manual testing suggestion paste below in browser console to simulate a clipboard failure:
-      // navigator.clipboard.writeText = async () => { throw new Error('Simulated clipboard failure') };
+      // * manual testing suggestion 
       this.didUserPressCopy.set('yes but failed'); 
       console.error('Failed to copy text. This might be due to security settings surrounding the clipboard API.', err);
+      await this.afterSomeSeconds(2_000);
+      this.didUserPressCopy.set(this.defaultCopyState);
     }
   }
 
-  private afterSomeSeconds() {
+  private afterSomeSeconds(howMany: number = 800): Promise<void> {
     return new Promise<void>((resolve) => {
       setTimeout(() => {
         resolve();
-      }, 700);
+      }, howMany);
     });
   }
-
 }
 
-// * manual testing suggestion paste below in browser console to simulate a clipboard failure:
+// * paste below in browser console to simulate a clipboard failure:
 // navigator.clipboard.writeText = async () => { throw new Error('Simulated clipboard failure') };

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.ts
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.ts
@@ -1,112 +1,50 @@
-import { DOCUMENT, CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, Input, signal } from '@angular/core';
 
 @Component({
   selector: 'app-copy-to-clipboard',
   standalone: true,
   imports: [CommonModule],
   templateUrl: './copy-to-clipboard.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class CopyToClipboardComponent implements OnInit {
-  copySuccessful = false;
-  copySuccessWait = false;
-  canCopy = false;
-  private document: Document;
-
-  @Input() tooltip!: string;
+export class CopyToClipboardComponent {
+  /**
+   * Required hover text (tooltip) for the copy action.
+   * Use **"Copy to clipboard"** unless there is a strong reason not to.
+   */
+  @Input({ required: true }) tooltip!: string;
   @Input() showSuccessText = true;
   @Input() text = '';
 
   // Show smaller icon
   @Input() compact = false;
 
-  constructor() {
-    const document = inject<Document>(DOCUMENT);
+  private defaultCopyState = 'not yet' as const;
+  readonly didUserPressCopy = signal<'not yet' | 'yes and succeeded' | 'yes but failed' | 'yes and saw succeeded'>(this.defaultCopyState);
 
-    this.document = document;
-  }
-
-  ngOnInit() {
-    // Show the button if EITHER clipboard mechanism is available. Gating solely
-    // on the deprecated queryCommandSupported hid the button entirely in
-    // browsers that have dropped it, even though the modern async Clipboard API
-    // still works — one way "the copy button stopped working".
-    this.canCopy = this.clipboardAvailable();
-  }
-
-  async copyToClipboard(event: MouseEvent | null = null): Promise<void> {
-    if (event) {
-      event.stopPropagation();
-    }
-
-    const copied = await this.writeToClipboard(this.text || '');
-    this.copySuccessful = copied;
-    if (copied) {
-      this.copySuccessWait = true;
-      setTimeout(() => this.copySuccessWait = false, 2000);
-    }
-  }
-
-  private clipboardAvailable(): boolean {
-    if (this.asyncClipboardAvailable()) {
-      return true;
-    }
+  async copyToClipboard(textToCopy: string) {
     try {
-      return this.document.queryCommandSupported('copy');
-    } catch {
-      return false;
+      await navigator.clipboard.writeText(textToCopy);
+      this.didUserPressCopy.set('yes and succeeded');
+      await this.afterSomeSeconds();
+      this.didUserPressCopy.set('yes and saw succeeded');
+    } catch (err) {
+      // * manual testing suggestion paste below in browser console to simulate a clipboard failure:
+      // navigator.clipboard.writeText = async () => { throw new Error('Simulated clipboard failure') };
+      this.didUserPressCopy.set('yes but failed'); 
+      console.error('Failed to copy text. This might be due to security settings surrounding the clipboard API.', err);
     }
   }
 
-  private asyncClipboardAvailable(): boolean {
-    const nav = this.document.defaultView?.navigator;
-    return typeof nav?.clipboard?.writeText === 'function';
-  }
-
-  // Prefer the modern async Clipboard API (matches service-keys / metadata-item
-  // / page-header, which already use it); fall back to the legacy execCommand
-  // textarea for older browsers or non-secure contexts where it's unavailable.
-  private async writeToClipboard(text: string): Promise<boolean> {
-    if (this.asyncClipboardAvailable()) {
-      try {
-        await this.document.defaultView!.navigator.clipboard.writeText(text);
-        return true;
-      } catch {
-        // fall through to the legacy path
-      }
-    }
-    return this.legacyCopy(text);
-  }
-
-  private legacyCopy(text: string): boolean {
-    const textArea = this.document.createElement('textarea');
-
-    textArea.style.position = 'fixed';
-    textArea.style.top = '0';
-    textArea.style.left = '0';
-    textArea.style.width = '2em';
-    textArea.style.height = '2em';
-    textArea.style.padding = '0';
-    textArea.style.border = 'none';
-    textArea.style.outline = 'none';
-    textArea.style.boxShadow = 'none';
-    textArea.style.background = 'transparent';
-
-    textArea.value = text;
-
-    this.document.body.appendChild(textArea);
-    textArea.select();
-
-    let copied = false;
-    try {
-      copied = this.document.execCommand('copy');
-    } catch (_err) {
-      console.warn('Failed to copy to clipboard');
-    }
-
-    this.document.body.removeChild(textArea);
-    return copied;
+  private afterSomeSeconds() {
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 700);
+    });
   }
 
 }
+
+// * manual testing suggestion paste below in browser console to simulate a clipboard failure:
+// navigator.clipboard.writeText = async () => { throw new Error('Simulated clipboard failure') };

--- a/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.ts
+++ b/src/frontend/packages/core/src/shared/components/copy-to-clipboard/copy-to-clipboard.component.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input, signal } from '@angular/core';
+import { ClickStopPropagationDirective } from '../../../core/click-stop-propagation.directive';
 
 @Component({
   selector: 'app-copy-to-clipboard',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ClickStopPropagationDirective],
   templateUrl: './copy-to-clipboard.component.html',
 })
 export class CopyToClipboardComponent {

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-address/table-cell-endpoint-address.component.html
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-address/table-cell-endpoint-address.component.html
@@ -1,7 +1,7 @@
 @if (endpointAddress$ | async; as address) {
   <div class="flex items-center min-w-0">
     <div class="min-w-0 truncate" [matTooltip]="address">{{ address }}</div>
-    <app-copy-to-clipboard class="w-6" [compact]="true" [text]="address" tooltip="Copy to clipboard" [showSuccessText]="false">
+    <app-copy-to-clipboard class="ml-0.5 w-fit inline-flex" [compact]="true" [text]="address" tooltip="Copy to clipboard" [showSuccessText]="false">
     </app-copy-to-clipboard>
     @if (isDuplicate$ | async) {
       <span class="material-icons text-warning-shade-600 dark:text-warning-shade-300 ml-1 text-base leading-none"

--- a/src/frontend/packages/theme/styles/tailwind.css
+++ b/src/frontend/packages/theme/styles/tailwind.css
@@ -327,6 +327,7 @@
   --ease-in-out-cubic:        cubic-bezier(0.4, 0, 0.2, 1);
   --ease-in-cubic:            cubic-bezier(0.4, 0, 1, 1);
   --ease-out-cubic:           cubic-bezier(0, 0, 0.2, 1);
+  --ease-out-expo:            cubic-bezier(0.16, 1, 0.3, 1);
   --ease-material-standard:     cubic-bezier(0.4, 0.0, 0.2, 1);
   --ease-material-deceleration: cubic-bezier(0.0, 0.0, 0.2, 1);
   --ease-material-acceleration: cubic-bezier(0.4, 0.0, 1, 1);
@@ -341,6 +342,7 @@
   --animate-slide-right: slideRight 0.3s ease-out;
   --animate-scale-in:    scaleIn 0.2s ease-out;
   --animate-scale-out:   scaleOut 0.2s ease-in;
+  --animate-scale-pop-in: scalePopIn 0.5s var(--ease-out-expo);
   --animate-spin-slow:   spin 3s linear infinite;
   --animate-pulse-slow:  pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite;
   --animate-dialog-enter:           dialogEnter 0.25s cubic-bezier(0.0, 0.0, 0.2, 1);
@@ -368,6 +370,7 @@
 @keyframes slideRight { 0% { transform: translateX(-10px); opacity: 0; } 100% { transform: translateX(0); opacity: 1; } }
 @keyframes scaleIn    { 0% { transform: scale(0.95); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
 @keyframes scaleOut   { 0% { transform: scale(1); opacity: 1; } 100% { transform: scale(0.95); opacity: 0; } }
+@keyframes scalePopIn { 0% { transform: scale(0.2); } 100% { transform: scale(1); } }
 @keyframes dialogEnter { 0% { opacity: 0; transform: scale(0.9) translateY(-20px); } 100% { opacity: 1; transform: scale(1) translateY(0); } }
 @keyframes dialogExit  { 0% { opacity: 1; transform: scale(1) translateY(0); } 100% { opacity: 0; transform: scale(0.9) translateY(-20px); } }
 @keyframes backdropEnter { 0% { opacity: 0; } 100% { opacity: 1; } }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix copy-to-clipboard icon behavior and state transitions

## Motivation and Context
This PR refactors the copy-to-clipboard component to use a clear state-driven UI flow. 

## How Has This Been Tested?
Test the temporal nature of the component as well as the error state imagined for the off change that corporate's (clients) that somehow block copying ability. Followed by the fact that the 
```(method) Clipboard.writeText(data: string): Promise<void>```
is a promise hence has a catch implied by its implementation by the browser(s)

besides automated unit test (with integration towards virtual dom nodes) 
There is a manual test instruction in the form of addinga runtime reassignment of a method to mock an error state of the clipboard. Beyond that it has been tested on all modern browsers. 
 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
It uses modern angular approach instead of conditionally hiding elements based on opacity. This is proved fragile with bubbling events. This clean approach can also be extended into the realm of lazy loading so that chunks are reeled in async however (defer syntax) for now that is kept out of scope due to the limited code.

Also the green iconography has been added with animation. New animation was created where a key approach was to keep the scale equal or under 1 to assure it never clips into its parent div. 

Also a conditional animation was added to the clipboard icon to satisfyingly come back from it all. 

also the @Input decorator was used with required: true to give compile time type safety in the components. However due to the strictness level actual the compilation is waived for now. There is a ticket with more info and some scripts: #5505 

Lastly the parent element has been shifted to more natural fit the baseline of the text. Also it has been moved ever so slightly and the width is now determined by its content. 

There are a couple of side effects in the code which can be avoided if rewritten entirely with RxJs however it was deemed more readable to rely on promises and signal state. 

Since zone.js was removed no more need for on push setting

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have followed the guidelines in CONTRIBUTING.md, including the required formatting of the commit message


<img width="752" height="402" alt="functionality" src="https://github.com/user-attachments/assets/2daa07fb-6539-4c92-8e96-6aee448b8c1a" />
<img width="752" height="402" alt="error" src="https://github.com/user-attachments/assets/c8b6487b-34a4-4f28-bdf0-33564132915e" />
<img width="752" height="402" alt="placement" src="https://github.com/user-attachments/assets/0be55b6e-25fb-447b-a650-4e9e198f26e4" />
<img width="752" height="402" alt="alignment" src="https://github.com/user-attachments/assets/ded8a39b-af76-45c5-bd7e-b59741c51c9f" />

