### PR TITLE
fix(e2e): use execFileSync in global teardown

### DIFF
--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const BACKEND_PORT = process.env.BACKEND_PORT || '5543';
 
@@ -13,11 +13,16 @@ const BACKEND_PORT = process.env.BACKEND_PORT || '5543';
  * A single pkill pattern matches both.
  */
 async function globalTeardown() {
+  if (!/^\d{2,5}$/.test(BACKEND_PORT)) {
+    console.warn(`  Skipping e2e teardown: invalid BACKEND_PORT '${BACKEND_PORT}'.`);
+    return;
+  }
+
   const pattern = `e2e:${BACKEND_PORT}`;
   try {
-    const pids = execSync(`pgrep -f '${pattern}'`, { encoding: 'utf8' }).trim();
+    const pids = execFileSync('pgrep', ['-f', pattern], { encoding: 'utf8' }).trim();
     if (pids) {
-      execSync(`pkill -f '${pattern}'`);
+      execFileSync('pkill', ['-f', pattern]);
       console.log(`  Stopped e2e test servers (session ${BACKEND_PORT}).`);
     }
   } catch {


### PR DESCRIPTION
Replaces execSync shell interpolation of BACKEND_PORT in the Playwright global teardown with execFileSync argument arrays, and validates the port format before use (skips teardown with a warning on a malformed value).

Supersedes #5299, which is blocked on an unsigned EasyCLA. The approach is @tomaioo's; thanks for the report and the original patch.