### PR TITLE
ci(pr): skip code suite for docs-only changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,9 +41,14 @@ jobs:
         id: filter
         with:
           filters: |
+            # non_stb = the code path: skip the heavy suite when a PR only
+            # touches stb tooling, docs/, or website/ (each has its own gate).
             non_stb:
               - '**'
               - '!tools/stb/**'
+              - '!docs/**'
+              - '!website/**'
+              - '!README.md'
             docs:
               - 'docs/**'
             website:


### PR DESCRIPTION
Observed on #5563: a `docs/**`-only PR ran Lint, all Frontend Test shards, and Backend Tests (~8 minutes of CI for a markdown change).

Cause: the `non_stb` changes filter is `'**'` minus `tools/stb/**` — it was built to give stb-only PRs a fast path and treats everything else, docs included, as code. The `docs`/`website` filters only switch their own jobs on; they never switch the code path off.

Change: exclude `docs/**`, `website/**`, and `README.md` from `non_stb`. Docs- or website-only PRs now skip lint/frontend/backend/build-check via the existing job-level `if:` gates, which report success so required checks stay green (same pattern the stb gate already relies on). Docs Lint and Website Build keep running off their own filters. Any PR touching code still runs the full suite.

This PR itself touches a workflow file, which rightly counts as code. The proof case is #5563 (docs-only, still open): re-run its checks after this merges and the code suite should skip while Docs Lint stays.
