### PR TITLE
ci(pr): make paths-filter exclusions effective

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,10 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # A file counts only if it matches EVERY pattern — required for the
+          # '!' exclusions below; the default 'some' lets '**' match anything,
+          # making the exclusions dead letters.
+          predicate-quantifier: 'every'
           filters: |
             # non_stb = the code path: skip the heavy suite when a PR only
             # touches stb tooling, docs/, or website/ (each has its own gate).


### PR DESCRIPTION
Follow-up to #5564, which added `!docs/**`/`!website/**`/`!README.md` exclusions to the `non_stb` filter — and didn't work: the refired docs-only #5563 still ran the full suite.

The detect job's log shows why: `dorny/paths-filter` defaults to `predicate-quantifier: some`, meaning a file matches a filter if it matches *any* pattern in the list. `'**'` therefore matches every file and the `!` exclusions are dead letters. This also means the original `'**'` + `'!tools/stb/**'` gate never actually skipped the suite for stb-only PRs.

Fix: `predicate-quantifier: 'every'` — a file counts only when it matches all patterns, which is how dorny documents exclusion-style filters. The positive single-pattern `docs`/`website` filters behave identically under either quantifier.

Verification: after merge, refire #5563 (docs-only) — Lint, Frontend Tests, Backend Tests, and Build Check should report skipped-success instead of executing.