### PR TITLE
ci(pr): gate frontend matrix at step level

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -134,31 +134,39 @@ jobs:
     name: Frontend Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.non_stb == 'true'
+    # Gate at STEP level, not job level: the per-package names below are
+    # required status checks, and a job-level skip collapses the matrix so
+    # those contexts never report ("expected" forever). With step-level
+    # gating each shard still spins up, no-ops, and reports success.
     strategy:
       fail-fast: false
       matrix:
         package: [core, store, cloud-foundry, kubernetes, git, shared, extension]
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.non_stb == 'true'
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: needs.changes.outputs.non_stb == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Bun
+        if: needs.changes.outputs.non_stb == 'true'
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Get Bun cache directory
+        if: needs.changes.outputs.non_stb == 'true'
         id: bun-cache-dir
         shell: bash
         run: echo "dir=$(bun pm cache)" >> ${GITHUB_OUTPUT}
 
       - name: Cache Bun dependencies
+        if: needs.changes.outputs.non_stb == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ steps.bun-cache-dir.outputs.dir }}
@@ -167,12 +175,15 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        if: needs.changes.outputs.non_stb == 'true'
         run: bun install --frozen-lockfile
 
       - name: Generate build info
+        if: needs.changes.outputs.non_stb == 'true'
         run: make stamp frontend
 
       - name: Run ${{ matrix.package }} tests
+        if: needs.changes.outputs.non_stb == 'true'
         # TODO: Remove --dangerouslyIgnoreUnhandledErrors once test mocks are fixed (FWT-872)
         run: bun run vitest run --dangerouslyIgnoreUnhandledErrors --project=${{ matrix.package }} --passWithNoTests
 


### PR DESCRIPTION
Third and final piece of the docs-only fast path (#5564, #5566).

#5563 (docs-only) is blocked from merging with "7 of 12 required status checks are expected": the seven `Frontend Tests (package)` names are required status checks, and a job-level skip collapses the matrix so those contexts never report. Jobs that are single (Lint Check, Backend Tests, Build Check, STB Tests) report their skipped conclusion and satisfy protection fine — only the matrix job has this problem.

Fix: gate `test-frontend` at step level instead. Each shard spins up, no-ops, and reports success (~10–15 s of runner time per shard on gated PRs, versus never reporting). Job-level gates elsewhere are unchanged.

Longer term, the cleaner setup is requiring only the `PR Quality Gate` summary check (it aggregates all of these and always reports), which would allow reverting this to a job-level skip — that needs repo admin to change the required-checks list.

Verification: after merge, update #5563's branch — it should report all 12 required contexts and become mergeable.