### PR TITLE
test(e2e): diagnostics coverage, isolated e2e database, host-arch backend guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,27 @@ _e2e_toggle = $(if $(filter yes,$(2)),--$(1),)
 
 # ── E2E ───────────────────────────────────────────────────────
 
+# The local webServer needs a host-runnable jetstream at dist/bin/jetstream;
+# cross-compiles leave a foreign binary there (exit 126). Skipped when
+# E2E_BASE_URL targets a remote deployment (no local server started).
+define _ensure_host_backend
+	@if [ -z "$(E2E_BASE_URL)" ]; then \
+		NEED_BUILD=false; \
+		case "$$(uname -s)" in Darwin) BINFMT="Mach-O";; *) BINFMT="ELF";; esac; \
+		if [ ! -f $($(_HIDE)BIN_DIR)/jetstream ]; then \
+			NEED_BUILD=true; \
+		elif ! file $($(_HIDE)BIN_DIR)/jetstream | grep -q "$$BINFMT"; then \
+			echo "Backend binary is not for this platform - rebuilding for $($(_HIDE)HOST_OS)/$($(_HIDE)HOST_ARCH)..."; \
+			NEED_BUILD=true; \
+		fi; \
+		if [ "$$NEED_BUILD" = true ]; then \
+			$(MAKE) build backend PLATFORM=$($(_HIDE)HOST_OS)/$($(_HIDE)HOST_ARCH); \
+		fi; \
+	fi
+endef
+
 define test.e2e
+	$(_ensure_host_backend)
 	@echo "Running Playwright E2E tests..."
 	@$(if $(E2E_VIDEO),E2E_VIDEO=$(E2E_VIDEO) )$(if $(E2E_SCREENSHOTS),E2E_SCREENSHOTS=$(E2E_SCREENSHOTS) )npx playwright test \
 		$(call _e2e_browsers,$(E2E_BROWSERS)) \
@@ -381,6 +401,7 @@ endef
 $(call register, check, coverage)
 
 define check.e2e
+	$(_ensure_host_backend)
 	@echo "Running Playwright E2E core tests..."
 	@$(if $(E2E_VIDEO),E2E_VIDEO=$(E2E_VIDEO) )$(if $(E2E_SCREENSHOTS),E2E_SCREENSHOTS=$(E2E_SCREENSHOTS) )npx playwright test e2e/tests/core/ \
 		$(call _e2e_browsers,$(E2E_BROWSERS)) \

--- a/e2e/tests/core/diagnostics.spec.ts
+++ b/e2e/tests/core/diagnostics.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '../../fixtures/test-base';
+
+/**
+ * Diagnostics Pages E2E Tests
+ *
+ * Covers the About → Diagnostics tab shell and its two proof-of-concept
+ * sub-pages:
+ *  - Entity Counts: per-endpoint entity counts via the jetstream
+ *    `?return=counts` fast paths, with footprint/risk annotations.
+ *  - Load Performance: the Performance-API load report (milestones,
+ *    resource waterfall, transfer sizes) with markdown/JSON export.
+ *
+ * The Load Performance page is the instrument used to compare deployments
+ * (GH #5550/#5391), so these tests guard that it keeps producing a real,
+ * populated report end to end.
+ */
+test.describe('Diagnostics', () => {
+
+  test('redirects to the overview tab and shows all three tabs', async ({ connectedEndpointsAdminPage }) => {
+    const page = connectedEndpointsAdminPage.page;
+    await page.goto('/about/diagnostics');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/about\/diagnostics\/overview$/);
+    await expect(page.locator('a', { hasText: 'Overview' })).toBeVisible();
+    await expect(page.locator('a', { hasText: 'Entity Counts' })).toBeVisible();
+    await expect(page.locator('a', { hasText: 'Load Performance' })).toBeVisible();
+  });
+
+  test('entity counts page shows per-endpoint counts with footprints', async ({ connectedEndpointsAdminPage }) => {
+    const page = connectedEndpointsAdminPage.page;
+    await page.goto('/about/diagnostics/counts');
+    await page.waitForLoadState('networkidle');
+
+    // POC notice and heap line
+    await expect(page.locator('[data-test="poc-notice"]')).toBeVisible();
+    await expect(page.locator('text=/Heap: /')).toBeVisible();
+
+    // The fixture guarantees a connected CF endpoint, so a card must render
+    // with the probed entity rows (scope to table cells — "Organizations"
+    // also appears in the side nav and home shortcuts).
+    await expect(page.locator('td', { hasText: 'Organizations' }).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('td', { hasText: 'Applications' }).first()).toBeVisible();
+
+    // At least one probe must resolve to a numeric count (not stay pending).
+    const orgRow = page.locator('tr', { hasText: 'Organizations' }).first();
+    await expect(orgRow.locator('td').nth(1)).toHaveText(/^[\d,]+$/, { timeout: 20000 });
+  });
+
+  test('load performance page produces a populated report', async ({ connectedEndpointsAdminPage }) => {
+    const page = connectedEndpointsAdminPage.page;
+    await page.goto('/about/diagnostics/performance');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('[data-test="poc-notice"]')).toBeVisible();
+
+    // Summary card with milestones
+    await expect(page.locator('text=Summary')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('td', { hasText: 'DOMContentLoaded' })).toBeVisible();
+    // Scope to the milestone cell — the waterfall caption also mentions LCP.
+    await expect(page.locator('td', { hasText: 'Largest contentful paint' })).toBeVisible();
+
+    // A real load produced resources: the waterfall and top-resources table
+    // both report a count — assert on the first.
+    await expect(page.locator('text=/Showing \\d+ of \\d+ resources/').first()).toBeVisible();
+
+    // Export buttons present
+    await expect(page.locator('[data-test="copy-markdown"]')).toBeVisible();
+    await expect(page.locator('[data-test="copy-json"]')).toBeVisible();
+  });
+
+  test('copy as JSON exports a parseable load report', async ({ connectedEndpointsAdminPage }) => {
+    const page = connectedEndpointsAdminPage.page;
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.goto('/about/diagnostics/performance');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('[data-test="copy-json"]')).toBeVisible({ timeout: 15000 });
+    await page.locator('[data-test="copy-json"]').click();
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    const report = JSON.parse(clipboard);
+    expect(report.collectedAt).toBeTruthy();
+    expect(report.topology === 'cf-pushed' || report.topology === 'local/other').toBe(true);
+    expect(Array.isArray(report.resources)).toBe(true);
+    expect(report.requestCount).toBeGreaterThan(0);
+  });
+
+  test('measure again refreshes the report without breaking the page', async ({ connectedEndpointsAdminPage }) => {
+    const page = connectedEndpointsAdminPage.page;
+    await page.goto('/about/diagnostics/performance');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('button', { hasText: 'Measure again' })).toBeVisible({ timeout: 15000 });
+    await page.locator('button', { hasText: 'Measure again' }).click();
+
+    // Report re-renders (the buffer is drained per measure, so counts may
+    // shrink — the page must still show a coherent summary).
+    await expect(page.locator('text=Summary')).toBeVisible();
+    await expect(page.locator('text=DOMContentLoaded')).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -138,7 +138,13 @@ export default defineConfig({
   ...(process.env.E2E_BASE_URL ? {} : {
     webServer: [
       {
-        command: `cd src/jetstream && STRATOS_E2E=e2e:${BACKEND_PORT} CONSOLE_PROXY_TLS_ADDRESS=:${BACKEND_PORT} SESSION_STORE_EXPIRY=120 ../../dist/bin/jetstream`,
+        // Isolate the e2e database: jetstream runs from src/jetstream, where the
+        // dev stack's config.properties sets SQLITE_KEEP_DB=true — without an
+        // override the e2e server SHARES the dev sqlite and each auth.setup
+        // registers a duplicate endpoint into it (stale duplicates then fail
+        // every list page with "Request failed"). A fresh dedicated file per
+        // run keeps e2e deterministic and leaves the dev database alone.
+        command: `cd src/jetstream && mkdir -p ../../dist/e2e-db && STRATOS_E2E=e2e:${BACKEND_PORT} CONSOLE_PROXY_TLS_ADDRESS=:${BACKEND_PORT} SESSION_STORE_EXPIRY=120 SQLITE_DB_DIR=../../dist/e2e-db SQLITE_KEEP_DB=false ../../dist/bin/jetstream`,
         url: `https://localhost:${BACKEND_PORT}/pp/v1/info`,
         reuseExistingServer: true,
         ignoreHTTPSErrors: true,


### PR DESCRIPTION
Three related e2e improvements:

**Diagnostics coverage** — the About → Diagnostics pages from #5560 had no functional e2e tests. Five new tests: tab-shell redirect, entity counts resolving numeric values from the connected CF, the load-performance report populating, Copy-as-JSON exporting a parseable report (the cross-deployment comparison contract from #5550), and measure-again stability. All green.

**Isolated e2e database** — the Playwright webServer starts jetstream from `src/jetstream`, where the dev config sets `SQLITE_KEEP_DB=true`, so e2e runs shared the developer's persistent sqlite and every `auth.setup` registered a duplicate endpoint into it. Stale duplicates fail their list requests, which poisoned 11 pagination tests and several endpoint specs with 'Request failed' timeouts. The e2e server now gets a fresh dedicated database per run under `dist/e2e-db`. This alone took the failing-spec count from 19 to 8 locally.

**Host-arch backend for e2e** — `make check e2e`/`make test e2e` now rebuild `dist/bin/jetstream` for the host platform when it's missing or a foreign binary (a linux cross-compile there previously killed the webServer with exit 126). Skipped when `E2E_BASE_URL` targets a remote deployment.

**Known-failing specs left untouched** (pre-existing, documented for follow-up): the endpoints Register button never appears for admins on fresh sessions (register-modal ×4 — permission chain never resolves; not fixed here after one attempted fix didn't survive verification), `/api-keys` redirects an admin to home mid-session, the branding spec expects a profile-page theme toggle that was never migrated from 4.x, and two intermittents (pagination 'All', non-admin endpoint visibility).