### PR TITLE
feat(about): group waterfall resources by start-time cluster

### DIFF
--- a/e2e/tests/core/diagnostics.spec.ts
+++ b/e2e/tests/core/diagnostics.spec.ts
@@ -86,17 +86,39 @@ test.describe('Diagnostics', () => {
     expect(report.requestCount).toBeGreaterThan(0);
   });
 
-  test('measure again refreshes the report without breaking the page', async ({ connectedEndpointsAdminPage }) => {
+  test('the report persists across tab switches', async ({ connectedEndpointsAdminPage }) => {
     const page = connectedEndpointsAdminPage.page;
     await page.goto('/about/diagnostics/performance');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.locator('button', { hasText: 'Measure again' })).toBeVisible({ timeout: 15000 });
-    await page.locator('button', { hasText: 'Measure again' }).click();
+    const collected = page.locator('text=/\\d{4}-\\d{2}-\\d{2}T[\\d:.]+Z/').first();
+    await expect(collected).toBeVisible({ timeout: 15000 });
+    const before = await collected.textContent();
 
-    // Report re-renders (the buffer is drained per measure, so counts may
-    // shrink — the page must still show a coherent summary).
-    await expect(page.locator('text=Summary')).toBeVisible();
-    await expect(page.locator('text=DOMContentLoaded')).toBeVisible();
+    // Soft-navigate away and back: the same report must re-display, not a
+    // fresh (and semantically wrong) re-measurement of leftover buffer.
+    await page.locator('a', { hasText: 'Entity Counts' }).click();
+    await expect(page).toHaveURL(/\/counts$/);
+    await page.locator('a', { hasText: 'Load Performance' }).click();
+    await expect(collected).toBeVisible({ timeout: 15000 });
+    expect(await collected.textContent()).toBe(before);
+  });
+
+  test('reload & measure collects a fresh report', async ({ connectedEndpointsAdminPage }) => {
+    const page = connectedEndpointsAdminPage.page;
+    await page.goto('/about/diagnostics/performance');
+    await page.waitForLoadState('networkidle');
+
+    const collected = page.locator('text=/\\d{4}-\\d{2}-\\d{2}T[\\d:.]+Z/').first();
+    await expect(collected).toBeVisible({ timeout: 15000 });
+    const before = await collected.textContent();
+
+    await page.locator('[data-test="reload-measure"]').click();
+    await page.waitForLoadState('networkidle');
+
+    // A document reload produces a new measurement with a cache verdict.
+    await expect(collected).toBeVisible({ timeout: 20000 });
+    expect(await collected.textContent()).not.toBe(before);
+    await expect(page.locator('[data-test="cache-verdict"]')).toHaveText(/(cold|warm)/);
   });
 });

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.html
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.html
@@ -7,8 +7,9 @@
     <!-- Actions -->
     <div class="flex flex-wrap items-center gap-3">
       <button
+        data-test="reload-measure"
         class="px-3 py-1.5 text-sm font-medium rounded border border-content-border hover:bg-content-secondary transition-colors"
-        (click)="measure()">Measure again</button>
+        (click)="reload()">Reload &amp; measure</button>
       <button
         data-test="copy-markdown"
         class="px-3 py-1.5 text-sm font-medium rounded border border-content-border hover:bg-content-secondary transition-colors"
@@ -25,9 +26,12 @@
     <!-- Scope note -->
     <app-card>
       <div class="px-4 py-3 text-sm text-content-muted">
-        These numbers reflect this page load in this browser. For login-page numbers,
-        reload the app and open this page immediately &mdash; the performance buffer
-        persists across route changes, but not across reloads.
+        These numbers reflect this browsing session's initial page load and stay put
+        as you move around the app. Reload &amp; measure captures a fresh warm
+        (cached) load; for a cold load, hard-reload the browser with the cache
+        bypassed (&#8984;&#8679;R in Chrome/Firefox on macOS, Ctrl+Shift+R elsewhere).
+        Numbers are cleanest when this page is opened soon after the app loads &mdash;
+        background requests made before the first visit are included.
       </div>
     </app-card>
 
@@ -46,6 +50,14 @@
           <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">Protocol</span>
           <span class="text-sm font-medium">{{ r.protocol || 'unknown' }}</span>
         </span>
+        @if (cache(); as c) {
+          <span class="flex gap-2 items-baseline">
+            <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">Cache</span>
+            <span class="text-sm font-medium" data-test="cache-verdict">
+              {{ c.kind }} <span class="text-content-muted">({{ (c.cachedFraction * 100).toFixed(0) }}% cached)</span>
+            </span>
+          </span>
+        }
         <span class="flex gap-2 items-baseline">
           <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">Requests</span>
           <span class="text-sm font-medium">{{ r.requestCount }}</span>

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
@@ -9,8 +9,8 @@ import { createBasicStoreModule, STORE_TEST_PROVIDERS, CoreTestingModule } from 
 
 import { CurrentUserPermissionsService } from '../../../core/permissions/current-user-permissions.service';
 import { TabNavService } from '../../../tab-nav.service';
-import { LoadReport, reportToJson, reportToMarkdown } from '../diagnostics-data/load-performance';
-import { DiagnosticPerformancePageComponent } from './diagnostic-performance-page.component';
+import { LoadReport, buildLoadReport, reportToJson, reportToMarkdown } from '../diagnostics-data/load-performance';
+import { DiagnosticPerformancePageComponent, resetSavedLoadReport } from './diagnostic-performance-page.component';
 
 const { fixedReport } = vi.hoisted(() => {
   const fixedReport: LoadReport = {
@@ -48,6 +48,8 @@ describe('DiagnosticPerformancePageComponent', () => {
   let writeText: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    resetSavedLoadReport();
+    vi.mocked(buildLoadReport).mockClear();
     writeText = vi.fn(async () => undefined);
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText },
@@ -109,10 +111,32 @@ describe('DiagnosticPerformancePageComponent', () => {
     expect(writeText).toHaveBeenCalledWith(reportToMarkdown(fixedReport));
   });
 
-  it('drains the resource-timing buffer after measuring', async () => {
-    const clear = vi.spyOn(performance, 'clearResourceTimings');
-    await component.measure();
-    expect(clear).toHaveBeenCalled();
+  it('shows the cold/warm cache verdict for the load', () => {
+    const verdict = (fixture.nativeElement as HTMLElement)
+      .querySelector('[data-test="cache-verdict"]')?.textContent ?? '';
+    // fixedReport has 1 of 2 resources cached — the warm boundary.
+    expect(verdict).toContain('warm');
+    expect(verdict).toContain('50% cached');
+  });
+
+  it('re-displays the saved report instead of re-measuring on re-entry', async () => {
+    expect(vi.mocked(buildLoadReport)).toHaveBeenCalledTimes(1);
+
+    const second = TestBed.createComponent(DiagnosticPerformancePageComponent);
+    second.detectChanges();
+    await second.whenStable();
+
+    expect(vi.mocked(buildLoadReport)).toHaveBeenCalledTimes(1);
+    expect(second.componentInstance.report()).toEqual(fixedReport);
+  });
+
+  it('wires the reload button to a document reload', () => {
+    const reload = vi.spyOn(component, 'reload').mockImplementation(() => undefined);
+    const button = (fixture.nativeElement as HTMLElement)
+      .querySelector<HTMLButtonElement>('[data-test="reload-measure"]');
+    expect(button?.textContent).toContain('Reload & measure');
+    button?.click();
+    expect(reload).toHaveBeenCalled();
   });
 
   it('copies the JSON report to the clipboard', async () => {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.ts
@@ -9,6 +9,7 @@ import {
   LoadReport,
   ResourceRow,
   buildLoadReport,
+  classifyCache,
   reportToJson,
   reportToMarkdown,
 } from '../diagnostics-data/load-performance';
@@ -16,6 +17,16 @@ import { BytesBarComponent } from './bytes-bar.component';
 import { ResourceWaterfallComponent } from './resource-waterfall.component';
 
 const TOP_RESOURCE_COUNT = 20;
+
+// The initial-load report is immutable for a browsing session, so it survives
+// route changes here and re-displays when the user returns to this tab. A
+// hard reload resets module state and yields a fresh measurement.
+let savedReport: LoadReport | null = null;
+
+/** Test hook: clear the session-persisted report between specs. */
+export function resetSavedLoadReport(): void {
+  savedReport = null;
+}
 
 @Component({
   selector: 'app-diagnostic-performance-page',
@@ -50,15 +61,30 @@ export class DiagnosticPerformancePageComponent implements OnInit {
     this.destroyRef.onDestroy(() => clearTimeout(this.copiedTimer));
   }
 
+  /** Cold/warm verdict for the displayed report. */
+  cache = computed(() => {
+    const r = this.report();
+    return r ? classifyCache(r.resources) : null;
+  });
+
   ngOnInit() {
-    this.measure();
+    if (savedReport) {
+      this.report.set(savedReport);
+    } else {
+      this.measure();
+    }
   }
 
   async measure() {
-    this.report.set(await buildLoadReport());
-    // Drain the buffer so the next "Measure again" reports only resources
-    // fetched since this measurement, not everything since page load.
-    performance.clearResourceTimings();
+    const report = await buildLoadReport();
+    savedReport = report;
+    this.report.set(report);
+  }
+
+  /** A fresh measurement needs a fresh document load; the new report is
+   *  collected automatically when this page re-initialises after it. */
+  reload(): void {
+    location.reload();
   }
 
   ms(value: number | null): string {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
@@ -1,12 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
 
-import { ResourceRow } from '../diagnostics-data/load-performance';
+import { LoadReport, ResourceRow } from '../diagnostics-data/load-performance';
 import {
+  ResourceWaterfallComponent,
+  WATERFALL_GROUP_GAP_MS,
   WATERFALL_ROW_CAP,
   axisTicks,
   basename,
-  capRows,
   formatTick,
+  groupRows,
   milestoneLines,
   spanPercent,
   toPercent,
@@ -63,24 +67,52 @@ describe('spanPercent', () => {
   });
 });
 
-describe('capRows', () => {
-  it('returns rows ordered by start time', () => {
-    const rows = capRows([row({ startMs: 30 }), row({ startMs: 10 }), row({ startMs: 20 })]);
-    expect(rows.map(r => r.startMs)).toEqual([10, 20, 30]);
+describe('groupRows', () => {
+  it('returns no groups for no resources', () => {
+    expect(groupRows([])).toEqual([]);
   });
 
-  it('caps at the first N rows by start time', () => {
-    const many = Array.from({ length: WATERFALL_ROW_CAP + 5 }, (_, i) => row({ startMs: i }));
-    const rows = capRows(many.reverse());
-    expect(rows.length).toBe(WATERFALL_ROW_CAP);
-    expect(rows[0].startMs).toBe(0);
-    expect(rows[rows.length - 1].startMs).toBe(WATERFALL_ROW_CAP - 1);
+  it('clusters resources starting within the gap of the group anchor', () => {
+    const groups = groupRows([row({ startMs: 0 }), row({ startMs: 10 }), row({ startMs: 20 })], 25);
+    expect(groups.length).toBe(1);
+    expect(groups[0].rows.length).toBe(3);
+  });
+
+  it('starts a new group past the gap boundary, keeping the boundary inclusive', () => {
+    const groups = groupRows([row({ startMs: 0 }), row({ startMs: 25 }), row({ startMs: 26 })], 25);
+    expect(groups.map(g => g.rows.length)).toEqual([2, 1]);
+    expect(groups[1].startMs).toBe(26);
+  });
+
+  it('measures the gap from the group anchor, not the previous member', () => {
+    // 0, 20, 40: 40 is within 25ms of 20 but not of the anchor 0.
+    const groups = groupRows([row({ startMs: 0 }), row({ startMs: 20 }), row({ startMs: 40 })], 25);
+    expect(groups.map(g => g.rows.length)).toEqual([2, 1]);
+  });
+
+  it('orders groups by start time regardless of input order', () => {
+    const groups = groupRows([row({ startMs: 100 }), row({ startMs: 0 })], 25);
+    expect(groups.map(g => g.startMs)).toEqual([0, 100]);
+  });
+
+  it('aggregates span end and transfer bytes over members', () => {
+    const groups = groupRows([
+      row({ startMs: 0, durationMs: 50, transferBytes: 100 }),
+      row({ startMs: 10, durationMs: 10, transferBytes: 200 }),
+    ], 25);
+    expect(groups[0].endMs).toBe(50);
+    expect(groups[0].totalTransferBytes).toBe(300);
   });
 
   it('does not mutate its input', () => {
     const input = [row({ startMs: 2 }), row({ startMs: 1 })];
-    capRows(input);
+    groupRows(input);
     expect(input[0].startMs).toBe(2);
+  });
+
+  it('uses the exported gap by default', () => {
+    const groups = groupRows([row({ startMs: 0 }), row({ startMs: WATERFALL_GROUP_GAP_MS })]);
+    expect(groups.length).toBe(1);
   });
 });
 
@@ -147,5 +179,101 @@ describe('basename', () => {
 
   it('falls back to the path itself when there is no segment', () => {
     expect(basename('/')).toBe('/');
+  });
+});
+
+const reportWith = (resources: ResourceRow[]): LoadReport => ({
+  collectedAt: '2026-07-04T00:00:00.000Z',
+  topology: 'local/other',
+  requestId: null,
+  protocol: 'h2',
+  responseStartMs: 12,
+  domContentLoadedMs: 300,
+  loadEventMs: 500,
+  firstContentfulPaintMs: 250,
+  lcpMs: null,
+  lcpElement: null,
+  requestCount: resources.length,
+  totalTransferBytes: resources.reduce((n, r) => n + r.transferBytes, 0),
+  resources,
+});
+
+/** One resource per group: starts spaced past the gap so nothing clusters. */
+const spacedResources = (count: number): ResourceRow[] =>
+  Array.from({ length: count }, (_, i) =>
+    row({ path: `/chunk-${i}.js`, startMs: i * (WATERFALL_GROUP_GAP_MS + 1) * 2 }));
+
+describe('ResourceWaterfallComponent', () => {
+  let fixture: ComponentFixture<ResourceWaterfallComponent>;
+
+  const render = (report: LoadReport) => {
+    fixture.componentRef.setInput('report', report);
+    fixture.detectChanges();
+  };
+  const el = () => fixture.nativeElement as HTMLElement;
+  const query = <T extends HTMLElement>(selector: string) => el().querySelector<T>(selector);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResourceWaterfallComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ResourceWaterfallComponent);
+  });
+
+  it('summarises resources and groups in the banner', () => {
+    render(reportWith(spacedResources(3)));
+    expect(query('[data-test="waterfall-summary"]')?.textContent)
+      .toMatch(/Showing 3 of 3 resources\s+in 3 of 3 groups/);
+  });
+
+  it('hides paging controls when the groups fit one page', () => {
+    render(reportWith(spacedResources(3)));
+    expect(query('[data-test="waterfall-next"]')).toBeNull();
+  });
+
+  it('pages group lines past the row cap', () => {
+    render(reportWith(spacedResources(WATERFALL_ROW_CAP + 5)));
+    const prev = query<HTMLButtonElement>('[data-test="waterfall-prev"]');
+    const next = query<HTMLButtonElement>('[data-test="waterfall-next"]');
+    expect(prev?.disabled).toBe(true);
+    expect(el().textContent).toContain(`Showing ${WATERFALL_ROW_CAP} of ${WATERFALL_ROW_CAP + 5} resources`);
+
+    next?.click();
+    fixture.detectChanges();
+    expect(el().textContent).toContain(`Showing 5 of ${WATERFALL_ROW_CAP + 5} resources`);
+    expect(query<HTMLButtonElement>('[data-test="waterfall-next"]')?.disabled).toBe(true);
+    expect(query<HTMLButtonElement>('[data-test="waterfall-prev"]')?.disabled).toBe(false);
+  });
+
+  it('collapses a start-time burst into one line and expands it on click', () => {
+    render(reportWith([
+      row({ path: '/a.js', startMs: 0 }),
+      row({ path: '/b.js', startMs: 5 }),
+      row({ path: '/late.js', startMs: 500 }),
+    ]));
+    expect(el().textContent).toContain('2 resources');
+    expect(el().textContent).not.toContain('b.js');
+
+    query<HTMLButtonElement>('[data-test="waterfall-group"]')?.click();
+    fixture.detectChanges();
+    expect(el().textContent).toContain('a.js');
+    expect(el().textContent).toContain('b.js');
+
+    query<HTMLButtonElement>('[data-test="waterfall-group"]')?.click();
+    fixture.detectChanges();
+    expect(el().textContent).not.toContain('b.js');
+  });
+
+  it('resets to the first page when a new report arrives', async () => {
+    render(reportWith(spacedResources(WATERFALL_ROW_CAP + 5)));
+    query<HTMLButtonElement>('[data-test="waterfall-next"]')?.click();
+    fixture.detectChanges();
+    expect(el().textContent).toContain('page 2 / 2');
+
+    render(reportWith(spacedResources(WATERFALL_ROW_CAP + 5)));
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(el().textContent).toContain('page 1 / 2');
   });
 });

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
@@ -11,6 +11,7 @@ import {
   basename,
   formatTick,
   groupRows,
+  mergeMilestoneLabels,
   milestoneLines,
   spanPercent,
   toPercent,
@@ -39,6 +40,41 @@ describe('waterfallScaleMax', () => {
 
   it('never returns zero, so percent math stays finite', () => {
     expect(waterfallScaleMax(0, [])).toBeGreaterThan(0);
+  });
+
+  it('extends past the load event to cover a late milestone like LCP', () => {
+    const milestones = [{ label: 'LCP', title: 'Largest contentful paint', ms: 248 }];
+    expect(waterfallScaleMax(167, [row({ startMs: 180, durationMs: 20 })], milestones)).toBe(248);
+  });
+});
+
+describe('mergeMilestoneLabels', () => {
+  const line = (label: string, ms: number) => ({ label, title: `${label} long name`, ms });
+
+  it('merges labels that would overprint into one line', () => {
+    const merged = mergeMilestoneLabels([line('FCP', 240), line('LCP', 243)], 250);
+    expect(merged.length).toBe(1);
+    expect(merged[0].label).toBe('FCP · LCP');
+    expect(merged[0].title).toBe('FCP long name — 240 ms\nLCP long name — 243 ms');
+  });
+
+  it('keeps well-separated labels apart, with the time folded into the title', () => {
+    const merged = mergeMilestoneLabels([line('DCL', 100), line('Load', 500)], 1000);
+    expect(merged.map(m => m.label)).toEqual(['DCL', 'Load']);
+    expect(merged[0].title).toBe('DCL long name — 100 ms');
+  });
+
+  it('chains a cluster of close labels into a single merged line', () => {
+    const merged = mergeMilestoneLabels([line('DCL', 100), line('FCP', 101), line('LCP', 102)], 1000);
+    expect(merged.length).toBe(1);
+    expect(merged[0].label).toBe('DCL · FCP · LCP');
+  });
+
+  it('does not mutate its input', () => {
+    const input = [line('FCP', 240), line('LCP', 248)];
+    mergeMilestoneLabels(input, 250);
+    expect(input[0].label).toBe('FCP');
+    expect(input[0].title).toBe('FCP long name');
   });
 });
 

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
@@ -29,13 +29,40 @@ export interface MilestoneLine {
   ms: number;
 }
 
-/** Scale end: whichever finishes last, the load event or the last response end. */
+/** Scale end: whichever finishes last — the load event, the last response end,
+ *  or the latest milestone (LCP can land after both; clamping it to the edge
+ *  overprints its label into unreadable fragments). */
 export function waterfallScaleMax(
   loadEventMs: number,
   resources: Pick<ResourceRow, 'startMs' | 'durationMs'>[],
+  milestones: MilestoneLine[] = [],
 ): number {
   const lastEnd = resources.reduce((max, r) => Math.max(max, r.startMs + r.durationMs), 0);
-  return Math.max(loadEventMs, lastEnd, 1);
+  const lastMilestone = milestones.reduce((max, m) => Math.max(max, m.ms), 0);
+  return Math.max(loadEventMs, lastEnd, lastMilestone, 1);
+}
+
+/** Merge milestone labels that would overprint (closer than minGapPercent on
+ *  the scale) into one combined label, e.g. "FCP · LCP". Titles come back
+ *  fully formed, one "name — time" line per merged milestone. */
+export function mergeMilestoneLabels(
+  lines: MilestoneLine[],
+  scaleMaxMs: number,
+  minGapPercent = 2,
+): MilestoneLine[] {
+  const sorted = [...lines].sort((a, b) => a.ms - b.ms);
+  const merged: MilestoneLine[] = [];
+  for (const line of sorted) {
+    const last = merged[merged.length - 1];
+    const titled = `${line.title} — ${formatTick(line.ms)}`;
+    if (last && toPercent(line.ms, scaleMaxMs) - toPercent(last.ms, scaleMaxMs) < minGapPercent) {
+      last.label = `${last.label} · ${line.label}`;
+      last.title = `${last.title}\n${titled}`;
+    } else {
+      merged.push({ ...line, title: titled });
+    }
+  }
+  return merged;
 }
 
 /** Map a millisecond offset onto the 0-100 percent range of the scale. */
@@ -166,14 +193,17 @@ export function basename(path: string): string {
         </div>
       </div>
 
-      <!-- Milestone labels -->
+      <!-- Milestone labels (merged where they would overprint) -->
       <div class="flex h-6">
         <div class="w-56 shrink-0"></div>
         <div class="relative flex-1 min-w-0">
-          @for (m of milestones(); track m.label) {
+          @for (m of labelMilestones(); track m.label) {
             <span
-              class="absolute top-0.5 pl-1 text-[10px] leading-none text-content-muted whitespace-nowrap cursor-help"
-              [title]="m.title + ' — ' + formatTick(m.ms)"
+              class="absolute top-0.5 text-[10px] leading-none text-content-muted whitespace-nowrap cursor-help"
+              [class.pl-1]="toPercent(m.ms, scaleMax()) <= 90"
+              [class.pr-1]="toPercent(m.ms, scaleMax()) > 90"
+              [style.transform]="toPercent(m.ms, scaleMax()) > 90 ? 'translateX(-100%)' : null"
+              [title]="m.title"
               [style.left.%]="toPercent(m.ms, scaleMax())">{{ m.label }}</span>
           }
         </div>
@@ -257,8 +287,10 @@ export class ResourceWaterfallComponent {
   pagedResourceCount = computed(() => this.pagedGroups().reduce((n, g) => n + g.rows.length, 0));
   expanded = signal<ReadonlySet<string>>(new Set());
 
-  scaleMax = computed(() => waterfallScaleMax(this.report().loadEventMs, this.report().resources));
   milestones = computed(() => milestoneLines(this.report()));
+  scaleMax = computed(() => waterfallScaleMax(this.report().loadEventMs, this.report().resources, this.milestones()));
+  /** Labels merged where they would overprint; the dashed lines still draw per milestone. */
+  labelMilestones = computed(() => mergeMilestoneLabels(this.milestones(), this.scaleMax()));
   ticks = computed(() => axisTicks(this.scaleMax()));
 
   toPercent = toPercent;

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
@@ -1,10 +1,27 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, input, signal } from '@angular/core';
 
 import { formatBytes } from '../diagnostics-data/entity-footprint';
 import { LoadReport, ResourceRow } from '../diagnostics-data/load-performance';
 
-/** Cap the waterfall at the first N resources by start time for readability. */
+/** Group lines per waterfall page. */
 export const WATERFALL_ROW_CAP = 40;
+
+/**
+ * Resources whose start times fall within this window of a group's first
+ * member collapse into one expandable line. Parallel fetch bursts (lazy
+ * chunks, fonts, API fan-outs) start within a few ms of each other; widen
+ * this if real loads still produce more group lines than pages can hold.
+ */
+export const WATERFALL_GROUP_GAP_MS = 25;
+
+/** A start-time cluster of resources rendered as one expandable line. */
+export interface WaterfallGroup {
+  key: string;
+  startMs: number;
+  endMs: number;
+  totalTransferBytes: number;
+  rows: ResourceRow[];
+}
 
 export interface MilestoneLine {
   label: string;
@@ -32,9 +49,28 @@ export function spanPercent(startMs: number, durationMs: number, scaleMaxMs: num
   return toPercent(startMs + durationMs, scaleMaxMs) - toPercent(startMs, scaleMaxMs);
 }
 
-/** First N rows by start time. */
-export function capRows(resources: ResourceRow[], cap: number = WATERFALL_ROW_CAP): ResourceRow[] {
-  return [...resources].sort((a, b) => a.startMs - b.startMs).slice(0, cap);
+/** Greedy start-time clustering over rows sorted by start: a resource joins
+ *  the current group while its start is within gapMs of the group's anchor. */
+export function groupRows(resources: ResourceRow[], gapMs: number = WATERFALL_GROUP_GAP_MS): WaterfallGroup[] {
+  const sorted = [...resources].sort((a, b) => a.startMs - b.startMs);
+  const groups: WaterfallGroup[] = [];
+  for (const r of sorted) {
+    const current = groups[groups.length - 1];
+    if (current && r.startMs - current.startMs <= gapMs) {
+      current.rows.push(r);
+      current.endMs = Math.max(current.endMs, r.startMs + r.durationMs);
+      current.totalTransferBytes += r.transferBytes;
+    } else {
+      groups.push({
+        key: `${r.startMs}:${r.path}`,
+        startMs: r.startMs,
+        endMs: r.startMs + r.durationMs,
+        totalTransferBytes: r.transferBytes,
+        rows: [r],
+      });
+    }
+  }
+  return groups;
 }
 
 /** Milestone lines to draw; null milestones are skipped. */
@@ -91,11 +127,23 @@ export function basename(path: string): string {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @if (rows().length < report().requestCount) {
-      <div class="pb-1 text-xs text-content-muted">
-        Showing {{ rows().length }} of {{ report().requestCount }} resources
-      </div>
-    }
+    <div class="flex items-center gap-3 pb-1 text-xs text-content-muted">
+      <span data-test="waterfall-summary">
+        Showing {{ pagedResourceCount() }} of {{ report().requestCount }} resources
+        in {{ pagedGroups().length }} of {{ groups().length }} groups
+      </span>
+      @if (pageCount() > 1) {
+        <button
+          type="button" data-test="waterfall-prev"
+          class="px-1.5 py-0.5 rounded border border-content-border hover:bg-content-secondary disabled:opacity-40 disabled:hover:bg-transparent"
+          [disabled]="safePage() === 0" (click)="prevPage()">Prev</button>
+        <span>page {{ safePage() + 1 }} / {{ pageCount() }}</span>
+        <button
+          type="button" data-test="waterfall-next"
+          class="px-1.5 py-0.5 rounded border border-content-border hover:bg-content-secondary disabled:opacity-40 disabled:hover:bg-transparent"
+          [disabled]="safePage() === pageCount() - 1" (click)="nextPage()">Next</button>
+      }
+    </div>
     <div class="relative">
       <!-- Milestone lines span the header, rows and axis; offset past the label column. -->
       <div class="absolute inset-y-0 left-56 right-0 pointer-events-none" aria-hidden="true">
@@ -131,18 +179,52 @@ export function basename(path: string): string {
         </div>
       </div>
 
-      <!-- One row per resource -->
-      @for (r of rows(); track r.path + r.startMs) {
-        <div class="flex h-5 items-stretch hover:bg-content-secondary transition-colors" [title]="barTitle(r)">
-          <div class="w-56 shrink-0 pr-2 text-xs leading-5 text-content-muted truncate">{{ basename(r.path) }}</div>
-          <div class="relative flex-1 min-w-0">
-            <div
-              class="absolute top-1/2 -translate-y-1/2 h-2.5 rounded bg-[#2a78d6] dark:bg-[#3987e5]"
-              style="min-width: 2px"
-              [style.left.%]="toPercent(r.startMs, scaleMax())"
-              [style.width.%]="spanPercent(r.startMs, r.durationMs, scaleMax())"></div>
+      <!-- One line per group: single-member groups render as plain resource
+           rows; multi-member groups render a summary line that expands. -->
+      @for (g of pagedGroups(); track g.key) {
+        @if (g.rows.length === 1) {
+          <div class="flex h-5 items-stretch hover:bg-content-secondary transition-colors" [title]="barTitle(g.rows[0])">
+            <div class="w-56 shrink-0 pr-2 text-xs leading-5 text-content-muted truncate">{{ basename(g.rows[0].path) }}</div>
+            <div class="relative flex-1 min-w-0">
+              <div
+                class="absolute top-1/2 -translate-y-1/2 h-2.5 rounded bg-[#2a78d6] dark:bg-[#3987e5]"
+                style="min-width: 2px"
+                [style.left.%]="toPercent(g.rows[0].startMs, scaleMax())"
+                [style.width.%]="spanPercent(g.rows[0].startMs, g.rows[0].durationMs, scaleMax())"></div>
+            </div>
           </div>
-        </div>
+        } @else {
+          <button
+            type="button" data-test="waterfall-group"
+            class="flex h-5 w-full items-stretch text-left hover:bg-content-secondary transition-colors cursor-pointer"
+            [title]="groupTitle(g)" (click)="toggle(g.key)">
+            <span class="w-56 shrink-0 pr-2 text-xs leading-5 text-content-muted truncate">
+              <span class="inline-block w-3" aria-hidden="true">{{ expanded().has(g.key) ? '▾' : '▸' }}</span>
+              {{ g.rows.length }} resources · {{ basename(g.rows[0].path) }}
+            </span>
+            <span class="relative flex-1 min-w-0">
+              <span
+                class="absolute top-1/2 -translate-y-1/2 h-2.5 rounded bg-[#2a78d6] dark:bg-[#3987e5] opacity-70"
+                style="min-width: 2px"
+                [style.left.%]="toPercent(g.startMs, scaleMax())"
+                [style.width.%]="spanPercent(g.startMs, g.endMs - g.startMs, scaleMax())"></span>
+            </span>
+          </button>
+          @if (expanded().has(g.key)) {
+            @for (r of g.rows; track r.path + r.startMs) {
+              <div class="flex h-5 items-stretch hover:bg-content-secondary transition-colors" [title]="barTitle(r)">
+                <div class="w-56 shrink-0 pl-3 pr-2 text-xs leading-5 text-content-muted truncate">{{ basename(r.path) }}</div>
+                <div class="relative flex-1 min-w-0">
+                  <div
+                    class="absolute top-1/2 -translate-y-1/2 h-2.5 rounded bg-[#2a78d6] dark:bg-[#3987e5]"
+                    style="min-width: 2px"
+                    [style.left.%]="toPercent(r.startMs, scaleMax())"
+                    [style.width.%]="spanPercent(r.startMs, r.durationMs, scaleMax())"></div>
+                </div>
+              </div>
+            }
+          }
+        }
       }
 
       <!-- Bottom axis -->
@@ -166,7 +248,15 @@ export function basename(path: string): string {
 export class ResourceWaterfallComponent {
   report = input.required<LoadReport>();
 
-  rows = computed(() => capRows(this.report().resources));
+  groups = computed(() => groupRows(this.report().resources));
+  page = signal(0);
+  pageCount = computed(() => Math.max(1, Math.ceil(this.groups().length / WATERFALL_ROW_CAP)));
+  safePage = computed(() => Math.min(this.page(), this.pageCount() - 1));
+  pagedGroups = computed(() =>
+    this.groups().slice(this.safePage() * WATERFALL_ROW_CAP, (this.safePage() + 1) * WATERFALL_ROW_CAP));
+  pagedResourceCount = computed(() => this.pagedGroups().reduce((n, g) => n + g.rows.length, 0));
+  expanded = signal<ReadonlySet<string>>(new Set());
+
   scaleMax = computed(() => waterfallScaleMax(this.report().loadEventMs, this.report().resources));
   milestones = computed(() => milestoneLines(this.report()));
   ticks = computed(() => axisTicks(this.scaleMax()));
@@ -176,6 +266,33 @@ export class ResourceWaterfallComponent {
   formatTick = formatTick;
   basename = basename;
 
+  constructor() {
+    // A fresh report (Measure again) restarts on the first page, all collapsed.
+    effect(() => {
+      this.report();
+      this.page.set(0);
+      this.expanded.set(new Set());
+    });
+  }
+
+  prevPage(): void {
+    this.page.set(Math.max(0, this.safePage() - 1));
+  }
+
+  nextPage(): void {
+    this.page.set(Math.min(this.pageCount() - 1, this.safePage() + 1));
+  }
+
+  toggle(key: string): void {
+    const next = new Set(this.expanded());
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    this.expanded.set(next);
+  }
+
   barTitle(r: ResourceRow): string {
     return [
       r.path,
@@ -183,6 +300,16 @@ export class ResourceWaterfallComponent {
       `duration: ${r.durationMs.toFixed(0)} ms`,
       `transfer: ${formatBytes(r.transferBytes)}`,
       `cached: ${r.cached ? 'yes' : 'no'}`,
+    ].join('\n');
+  }
+
+  groupTitle(g: WaterfallGroup): string {
+    return [
+      `${g.rows.length} resources starting within ${WATERFALL_GROUP_GAP_MS} ms`,
+      `start: ${g.startMs.toFixed(0)} ms`,
+      `span: ${(g.endMs - g.startMs).toFixed(0)} ms`,
+      `transfer: ${formatBytes(g.totalTransferBytes)}`,
+      'click to expand',
     ].join('\n');
   }
 }

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  classifyCache,
   collectResources,
   detectTopology,
   buildLoadReport,
@@ -202,5 +203,31 @@ describe('buildLoadReport', () => {
     expect(typeof r.requestCount).toBe('number');
     expect(typeof r.totalTransferBytes).toBe('number');
     expect(Array.isArray(r.resources)).toBe(true);
+  });
+});
+
+describe('classifyCache', () => {
+  const res = (cached: boolean) => ({
+    path: '/x.js', startMs: 0, durationMs: 1, transferBytes: 1,
+    decodedBytes: 1, protocol: 'h2', cached,
+  });
+
+  it('calls an uncached load cold', () => {
+    expect(classifyCache([res(false), res(false), res(false)]))
+      .toEqual({ kind: 'cold', cachedFraction: 0 });
+  });
+
+  it('calls a mostly-cached load warm', () => {
+    const verdict = classifyCache([res(true), res(true), res(false)]);
+    expect(verdict.kind).toBe('warm');
+    expect(verdict.cachedFraction).toBeCloseTo(2 / 3);
+  });
+
+  it('puts the boundary at half cached', () => {
+    expect(classifyCache([res(true), res(false)]).kind).toBe('warm');
+  });
+
+  it('treats an empty resource list as cold', () => {
+    expect(classifyCache([]).kind).toBe('cold');
   });
 });

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
@@ -14,6 +14,24 @@ export interface ResourceRow {
   cached: boolean;
 }
 
+export interface CacheVerdict {
+  kind: 'cold' | 'warm';
+  cachedFraction: number;
+}
+
+/**
+ * Classify a load as cold (empty/bypassed HTTP cache) or warm (primed cache)
+ * from the fraction of resources served from cache. A genuinely cold load has
+ * near-zero cached entries; a warm one serves most static assets from cache,
+ * so the halfway mark separates them cleanly.
+ */
+export function classifyCache(resources: ResourceRow[]): CacheVerdict {
+  const cachedFraction = resources.length
+    ? resources.filter(r => r.cached).length / resources.length
+    : 0;
+  return { kind: cachedFraction >= 0.5 ? 'warm' : 'cold', cachedFraction };
+}
+
 export interface LoadReport {
   collectedAt: string;
   topology: 'cf-pushed' | 'local/other';


### PR DESCRIPTION
## What

Two related extensions to the diagnostics load-performance page.

### Waterfall grouping + paging

The waterfall truncated at the first 40 resources by start time. The full resource list was already captured (timing buffer holds 500) and exported via copy-as-JSON, but the display made everything past row 40 unreachable.

- Resources whose start times fall within 25 ms of a group anchor collapse into one expandable line (parallel fetch bursts — lazy chunks, fonts, API fan-outs — start within a few ms of each other). Single-member groups render exactly as before.
- A group line shows count, first member name, and a bar spanning the group's start to its last response end; clicking expands the member rows inline.
- Group lines page at 40 per page with Prev/Next controls; the page resets when a new report arrives.

On a dev-serve load this turns 'first 40 of 290 resources' into '290 of 290 resources in 7 groups', with every resource reachable through expansion.

### Persist the load report; reload to re-measure

Tab switches destroyed and recreated the perf page, which silently re-measured against a drained resource buffer — producing a chimera of hard-load milestones plus background API calls plotted on the original page-load clock (and a 30-second axis). Now:

- The initial-load report is measured once per browsing session, kept, and re-displayed on tab re-entry.
- 'Measure again' becomes 'Reload & measure': a fresh measurement needs a fresh document load (warm, cache primed). A cold measurement can't be triggered from JS, so the scope note explains the hard-reload path.
- The summary labels each report cold/warm from the fraction of cached resources.
- The diagnostics e2e spec (from #5568) is updated to match: the measure-again test becomes two tests — report persistence across tab switches, and reload-and-measure collecting a fresh report.

### Milestone labels stay readable

The scale ignored milestones, so an LCP later than the load event and last response end clamped to the right edge — its label overprinted FCP's and clipped at the container, rendering fragments like 'EC' that appear in no legend. The scale now covers the latest milestone, labels near the right edge right-align instead of clipping, and labels that would still overprint merge into one combined line ('FCP · LCP') whose tooltip lists each milestone with its time.

## Testing

- Unit: grouping edge cases (gap boundary, anchor-based clustering, aggregation), paging math, expansion toggle, page-reset on new report, report persistence, reload wiring, cache classification — about suite 122 green.
- Diagnostics e2e: 8/8 green including the two new tests.
- Full lint/test gate green.
- Live-verified on a local dev stack: grouping, expand/collapse, persistence across tab switches, reload & measure producing a fresh report.

Refs #5391
