### PR TITLE
fix(profile): fetch the user profile on first subscription

### DIFF
--- a/src/frontend/packages/core/src/core/user-profile.service.spec.ts
+++ b/src/frontend/packages/core/src/core/user-profile.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SessionData, UserProfileInfo } from '@stratosui/store';
+import { UserProfileDataService } from '@stratosui/store';
+import { BehaviorSubject, of } from 'rxjs';
+import { first } from 'rxjs/operators';
+
+import { AuthSignalService } from './signals/auth-signal.service';
+import { UserProfileService } from './user-profile.service';
+
+const SESSION: SessionData = {
+  valid: true,
+  user: { guid: 'user-1', name: 'admin', admin: true, scopes: [] },
+} as SessionData;
+
+const PROFILE = { id: 'user-1', userName: 'admin', emails: [] } as unknown as UserProfileInfo;
+
+describe('UserProfileService', () => {
+  let profile$: BehaviorSubject<UserProfileInfo | null>;
+  let dataStub: {
+    profile$: BehaviorSubject<UserProfileInfo | null>;
+    fetching$: BehaviorSubject<boolean>;
+    error$: BehaviorSubject<boolean>;
+    fetch: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    profile$ = new BehaviorSubject<UserProfileInfo | null>(null);
+    dataStub = {
+      profile$,
+      fetching$: new BehaviorSubject<boolean>(false),
+      error$: new BehaviorSubject<boolean>(false),
+      fetch: vi.fn().mockImplementation(() => profile$.next(PROFILE)),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: AuthSignalService, useValue: { sessionData: signal<SessionData | null>(SESSION) } },
+        { provide: UserProfileDataService, useValue: dataStub },
+        UserProfileService,
+      ],
+    });
+  });
+
+  it('fetches the profile on first subscription to userProfile$', async () => {
+    const service = TestBed.inject(UserProfileService);
+    const profile = await new Promise<UserProfileInfo>(resolve =>
+      service.userProfile$.pipe(first()).subscribe(resolve)
+    );
+    expect(dataStub.fetch).toHaveBeenCalledWith('user-1');
+    expect(profile.id).toBe('user-1');
+  });
+
+  it('does not re-fetch on subsequent subscriptions', async () => {
+    const service = TestBed.inject(UserProfileService);
+    await new Promise(resolve => service.userProfile$.pipe(first()).subscribe(resolve));
+    await new Promise(resolve => service.userProfile$.pipe(first()).subscribe(resolve));
+    expect(dataStub.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchUserProfile still forces a fetch (explicit refresh)', async () => {
+    const service = TestBed.inject(UserProfileService);
+    await new Promise(resolve => service.userProfile$.pipe(first()).subscribe(resolve));
+    service.fetchUserProfile();
+    expect(dataStub.fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/frontend/packages/core/src/core/user-profile.service.ts
+++ b/src/frontend/packages/core/src/core/user-profile.service.ts
@@ -9,7 +9,7 @@ import {
   UserProfileInfo,
   UserProfileInfoEmail,
   UserProfileInfoUpdates } from '@stratosui/store';
-import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { combineLatest, defer, Observable, of as observableOf } from 'rxjs';
 import { take, filter, map } from 'rxjs/operators';
 
 import { AuthSignalService } from './signals/auth-signal.service';
@@ -31,6 +31,8 @@ export class UserProfileService {
 
   private userGuid$: Observable<string>;
 
+  private fetchStarted = false;
+
   constructor() {
     // Source the user GUID from the signal-native auth projection. The
     // upstream pipe order matches the legacy implementation: wait for
@@ -44,8 +46,16 @@ export class UserProfileService {
 
     // Read the profile off the signal-native UserProfileDataService (replaces
     // the ngrx `userProfile` EntityService). Same emission shape as before:
-    // only emit a populated profile.
-    this.userProfile$ = this.userProfileData.profile$.pipe(
+    // only emit a populated profile. The legacy EntityService's
+    // `waitForEntity$` auto-fetched on first subscribe; the signal store is
+    // passive, so re-establish that here — without it, consumers that never
+    // call fetchUserProfile() (profile page, page header) wait forever.
+    this.userProfile$ = defer(() => {
+      if (!this.fetchStarted) {
+        this.fetchUserProfile();
+      }
+      return this.userProfileData.profile$;
+    }).pipe(
       filter((data): data is UserProfileInfo => !!data && !!data.id)
     );
     this.isFetching$ = this.userProfileData.fetching$;
@@ -62,6 +72,7 @@ export class UserProfileService {
   }
 
   fetchUserProfile() {
+    this.fetchStarted = true;
     // Once we have the user's guid, fetch their profile
     this.userGuid$.pipe(take(1)).subscribe(userGuid => {
       if (userGuid) { this.userProfileData.fetch(userGuid); }


### PR DESCRIPTION
## Problem

The `/user-profile` page renders only its header — no summary card, no Local Settings, and no theme toggle (#5572). The page-header user menu has the same silent gap.

## Root cause

The signal migration replaced the `userProfile` ngrx EntityService with a passive `UserProfileDataService`. The legacy `waitForEntity$` auto-fetched on first subscribe; the new `profile$` emits nothing until someone calls `fetchUserProfile()` — and only the edit-profile page does. Every other consumer of `userProfile$` waited on a stream that never emitted, so the profile page body (which is gated on `userProfile$ | async`) never rendered. The theme toggle markup itself was present all along.

## Fix

Restore the auto-fetch semantics in the `UserProfileService` facade: `userProfile$` is now wrapped in `defer()` so the first subscription triggers the fetch, once per session. `fetchUserProfile()` remains public for explicit refreshes (edit page).

## Verification

- New `user-profile.service.spec.ts`: fetch-on-first-subscribe, no re-fetch on later subscriptions, explicit refresh still forces a fetch (red before the fix, green after)
- Branding e2e spec (`e2e/tests/core/branding.spec.ts`): 6/6 passing, including the previously failing `profile settings shows theme toggle buttons`
- Full lint + unit gate green

Closes #5572