### PR TITLE
Restore the "All" page size in signal-list; fix the #5573 e2e intermittents

### DIFF
--- a/e2e/components/list.component.ts
+++ b/e2e/components/list.component.ts
@@ -157,7 +157,8 @@ export class ListTableComponent {
  * Card view of list component
  */
 export class ListCardComponent {
-  private static cardsCss = 'app-card:not(.row-filler), mat-card:not(.row-filler)';
+  // Legacy app-list cards plus signal-list card-grid children.
+  private static cardsCss = 'app-card:not(.row-filler), mat-card:not(.row-filler), [data-test="card-grid"] > *';
   private cards: Locator;
 
   constructor(private page: Page, private listLocator: Locator) {
@@ -441,16 +442,25 @@ export class ListComponent {
     this.empty = new ListEmptyComponent(page, this.locator);
   }
 
+  // View detection covers both list generations. Legacy app-list carries a
+  // list-component__table/__cards class; signal-list renders a plain <table>
+  // for table view and a [data-test="card-grid"] for card view. Use count()
+  // (not getAttribute) so a missing legacy element returns false instead of
+  // hanging on the auto-wait.
   async isTableView(): Promise<boolean> {
-    const listElement = this.locator.locator('.list-component');
-    const className = (await listElement.getAttribute('class')) ?? '';
-    return className.includes('list-component__table');
+    const legacy = this.locator.locator('.list-component');
+    if (await legacy.count()) {
+      return ((await legacy.getAttribute('class')) ?? '').includes('list-component__table');
+    }
+    return (await this.locator.locator('table').count()) > 0;
   }
 
   async isCardsView(): Promise<boolean> {
-    const listElement = this.locator.locator('.list-component');
-    const className = (await listElement.getAttribute('class')) ?? '';
-    return className.includes('list-component__cards');
+    const legacy = this.locator.locator('.list-component');
+    if (await legacy.count()) {
+      return ((await legacy.getAttribute('class')) ?? '').includes('list-component__cards');
+    }
+    return (await this.locator.locator('[data-test="card-grid"]').count()) > 0;
   }
 
   getLoadingIndicator(): Locator {

--- a/e2e/tests/core/endpoints.spec.ts
+++ b/e2e/tests/core/endpoints.spec.ts
@@ -223,12 +223,15 @@ test.describe('Endpoints', () => {
           try { await snackbar.waitUntilShown(); await snackbar.close(); } catch { /* may not appear */ }
 
           expect(await endpointsPage.list.locator.isVisible()).toBeTruthy();
-          expect(await endpointsPage.list.isCardsView()).toBeTruthy();
-          const cardCount = await endpointsPage.list.cards.getCardCount();
-          expect(cardCount).toBe(1);
+          // The migrated endpoints list is table-primary by design (see
+          // EndpointsSignalConfigService — legacy defaultView 'cards' was
+          // deliberately dropped) and provides no card template.
+          expect(await endpointsPage.list.isTableView()).toBeTruthy();
+          const rowCount = await endpointsPage.list.table.getRowCount();
+          expect(rowCount).toBe(1);
         });
 
-        test('should show correct cards content', async ({ unauthenticatedPage, secrets, endpointManager, baseURL }) => {
+        test('should show correct endpoint content', async ({ unauthenticatedPage, secrets, endpointManager, baseURL }) => {
           try {
             await endpointManager.clearAllEndpoints();
           } catch {
@@ -247,13 +250,13 @@ test.describe('Endpoints', () => {
 
           const cfName = secrets.cloudFoundry[0].name;
 
-          // Verify the endpoint card is visible with the correct name
-          const card = await endpointsPage.findCardByTitle(cfName);
-          await expect(card).toBeVisible();
+          // Verify the endpoint row is visible with the correct name
+          const row = await endpointsPage.list.table.findRowByCellContent(cfName);
+          await expect(row).toBeVisible();
 
-          // Verify URL is present on the card
+          // Verify URL is present on the row
           const cfUrl = secrets.cloudFoundry[0].url;
-          await expect(card).toContainText(cfUrl.replace('https://', '').split('/')[0]);
+          await expect(row).toContainText(cfUrl.replace('https://', '').split('/')[0]);
         });
       });
     });

--- a/e2e/tests/core/pagination.spec.ts
+++ b/e2e/tests/core/pagination.spec.ts
@@ -3,16 +3,66 @@ import { test, expect } from '../../fixtures/test-base';
 /**
  * Pagination E2E Tests
  *
- * Tests page size options, "All" option, and session memory.
- * Uses the CF Organizations page on adepttech (55 orgs) as the
- * primary test surface.
+ * Tests page size options, the "All" option, and page-size memory against
+ * the signal-list pagination bar ([data-test="page-size"] select,
+ * [data-test="page-range"] counter, single [data-test="view-toggle"] button).
+ * The legacy app-paginator these specs originally targeted is no longer
+ * rendered anywhere (#5573).
  *
- * Run against adepttech:
- *   E2E_BASE_URL=https://console.run.adepttech.ca \
- *   E2E_PROFILE=adepttech npx playwright test pagination
+ * Page-size memory is per list (ListStateStore, localStorage-backed) and per
+ * view mode — NOT the old global PageSizeSessionService semantics.
+ *
+ * Uses the CF Organizations page (card-primary) and the Applications page
+ * (table-primary) as test surfaces.
  */
 
 test.describe('Pagination', () => {
+
+  const pageSizeSelect = (page: any) => page.locator('[data-test="page-size"]');
+  const pageRange = (page: any) => page.locator('[data-test="page-range"]');
+  const viewToggle = (page: any) => page.locator('[data-test="view-toggle"]');
+
+  /** Range text uses an en-dash: "1 – 24 of 60". Match either dash. */
+  const FULL_WINDOW = /1\s*[-–]\s*(\d+)\s*of\s*\1(\D|$)/;
+
+  /**
+   * After changing page size the range counter updates asynchronously — a
+   * fixed delay races the re-render (#5573). Wait for the full "1 – N of N"
+   * window; tolerate a timeout and let the caller's guarded assert decide.
+   */
+  async function waitForFullWindow(page: any): Promise<void> {
+    await expect(pageRange(page)).toHaveText(FULL_WINDOW, { timeout: 15000 })
+      .catch(() => { /* guarded assert below decides */ });
+  }
+
+  /** Parse "start – end of total" (or "0 of 0") from the range counter. */
+  async function readRange(page: any): Promise<{ start: number; end: number; total: number } | null> {
+    const text = (await pageRange(page).textContent()) || '';
+    const m = text.match(/(\d+)\s*[-–]\s*(\d+)\s*of\s*(\d+)/);
+    if (m) return { start: +m[1], end: +m[2], total: +m[3] };
+    return null;
+  }
+
+  /**
+   * The view toggle is a single button whose title names the view it
+   * switches TO ("Card view" while in table view and vice versa).
+   */
+  async function currentView(page: any): Promise<'table' | 'card' | null> {
+    const title = await viewToggle(page).getAttribute('title').catch(() => null);
+    if (title === 'Card view') return 'table';
+    if (title === 'Table view') return 'card';
+    return null;
+  }
+
+  async function switchToView(page: any, view: 'table' | 'card'): Promise<boolean> {
+    const current = await currentView(page);
+    if (current === view) return true;
+    if (current === null) return false;
+    await viewToggle(page).click();
+    await expect(viewToggle(page)).toHaveAttribute(
+      'title', view === 'table' ? 'Card view' : 'Table view', { timeout: 10000 });
+    return true;
+  }
 
   /** Navigate to CF orgs page directly via URL, wait for data to load */
   async function goToOrgsPage(page: any, maxAttempts = 2): Promise<boolean> {
@@ -21,15 +71,30 @@ test.describe('Pagination', () => {
     const cfEndpoint = Array.isArray(endpoints) ? endpoints.find((ep: any) => ep.cnsi_type === 'cf') : null;
     if (!cfEndpoint) return false;
 
+    // Budget note: both attempts together must stay well under the 90s test
+    // timeout, or a data-load failure surfaces as a bare timeout instead of
+    // a clean skip (#5573).
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       await page.goto(`/cloud-foundry/${cfEndpoint.guid}/organizations`);
-      await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
-      // Wait for paginator to show data (not "0 of 0")
-      const paginatorInfo = page.locator('app-paginator .paginator-info span').first();
       try {
-        await paginatorInfo.filter({ hasNotText: '0 of 0' }).waitFor({ timeout: 30000 });
-        return await page.locator('app-paginator').isVisible().catch(() => false);
+        await pageRange(page).filter({ hasNotText: '0 of 0' }).waitFor({ timeout: 25000 });
+        return true;
+      } catch {
+        if (attempt === maxAttempts) return false;
+      }
+    }
+    return false;
+  }
+
+  /** Navigate to Applications page, wait for data to load */
+  async function goToAppsPage(page: any, maxAttempts = 2): Promise<boolean> {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      await page.goto('/applications');
+
+      try {
+        await pageRange(page).filter({ hasNotText: '0 of 0' }).waitFor({ timeout: 25000 });
+        return true;
       } catch {
         if (attempt === maxAttempts) return false;
       }
@@ -39,95 +104,86 @@ test.describe('Pagination', () => {
 
   test.describe('Page Size Options', () => {
 
-    test('should show new page size options', async ({ authenticatedPage }) => {
+    test('should show card page size options on the orgs page', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
       if (!await goToOrgsPage(page)) {
-        test.skip('Organizations page not reachable or no paginator');
+        test.skip('Organizations page not reachable or no data');
+      }
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
 
-      const options = await page.locator('app-paginator select#pageSize option').allTextContents();
-      const trimmed = options.map(t => t.trim());
+      const options = await pageSizeSelect(page).locator('option').allTextContents();
+      const trimmed = options.map((t: string) => t.trim());
 
-      // New options present
       expect(trimmed).toContain('6');
       expect(trimmed).toContain('12');
       expect(trimmed).toContain('24');
       expect(trimmed).toContain('48');
       expect(trimmed).toContain('96');
 
-      // Old options gone
+      // Legacy sizes gone
       expect(trimmed).not.toContain('9');
       expect(trimmed).not.toContain('30');
       expect(trimmed).not.toContain('80');
 
       // "All" option exists
-      expect(trimmed.some(t => t.startsWith('All'))).toBeTruthy();
+      expect(trimmed).toContain('All');
     });
 
     test('should have "All" option in dropdown', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
       if (!await goToOrgsPage(page)) {
-        test.skip('Organizations page not reachable or no paginator');
+        test.skip('Organizations page not reachable or no data');
+      }
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
 
-      // Find the All option by its value (-1)
-      const allOption = page.locator('app-paginator select#pageSize option[value="-1"]');
+      // The All option carries the -1 sentinel value
+      const allOption = pageSizeSelect(page).locator('option[value="-1"]');
       const allText = (await allOption.textContent({ timeout: 5000 }))?.trim() || '';
       expect(allText).toBe('All');
-    });
-
-    test('should update display when page size changes', async ({ authenticatedPage }) => {
-      const page = authenticatedPage;
-      if (!await goToOrgsPage(page)) {
-        test.skip('Organizations page not reachable or no paginator');
-      }
-
-      await page.locator('app-paginator select#pageSize').selectOption('12');
-
-      // Wait for paginator info to reflect the new page size
-      const paginatorInfo = page.locator('app-paginator .paginator-info span').first();
-      await paginatorInfo.filter({ hasText: /1\s*-\s*\d+\s*of\s*\d+/ }).waitFor({ timeout: 10000 });
-
-      const info = (await paginatorInfo.textContent()) || '';
-      expect(info).toMatch(/1\s*-\s*12\s*of\s*\d+/);
     });
 
     test('should show all items when "All" selected', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
       if (!await goToOrgsPage(page)) {
-        test.skip('Organizations page not reachable or no paginator');
+        test.skip('Organizations page not reachable or no data');
+      }
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
 
-      await page.locator('app-paginator select#pageSize').selectOption('-1');
-      await page.waitForTimeout(500);
+      await pageSizeSelect(page).selectOption('-1');
+      await waitForFullWindow(page);
 
-      const info = (await page.locator('app-paginator .paginator-info span').first().textContent()) || '';
-      const match = info.match(/1\s*-\s*(\d+)\s*of\s*(\d+)/);
-
-      if (match) {
-        expect(match[1]).toBe(match[2]);
+      const range = await readRange(page);
+      if (range) {
+        expect(range.start).toBe(1);
+        expect(range.end).toBe(range.total);
       }
 
-      await expect(page.locator('app-paginator button[title="Next page"]')).toBeDisabled();
+      await expect(page.locator('button[title="Next page"]')).toBeDisabled();
     });
   });
 
   test.describe('Session Memory', () => {
 
     test('should remember page size after navigating away and back', async ({ authenticatedPage }) => {
-      // PageSizeSessionService is in-memory only — no persistence across full page reloads.
-      // FWT-805 will add localStorage persistence. Until then, only client-side (Angular router)
-      // navigation preserves page size. This test verifies within-session memory via router nav.
+      // Page size persists per list via ListStateStore (localStorage-backed).
       const page = authenticatedPage;
       if (!await goToOrgsPage(page)) {
-        test.skip('Organizations page not reachable or no paginator');
+        test.skip('Organizations page not reachable or no data');
+      }
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
 
-      // Set page size to 24
-      await page.locator('app-paginator select#pageSize').selectOption('24');
-      await page.waitForTimeout(500);
+      await pageSizeSelect(page).selectOption('12');
+      await expect(pageSizeSelect(page)).toHaveValue('12');
 
-      // Navigate to Spaces via CF page-side-nav (pure Angular router, no reload, service state preserved)
+      // Navigate to Spaces via CF page-side-nav (client-side router nav)
       const spacesNav = page.locator('.page-side-nav__item').filter({ hasText: 'Spaces' }).first();
       const spacesVisible = await spacesNav.isVisible({ timeout: 10000 }).catch(() => false);
       if (!spacesVisible) {
@@ -136,120 +192,74 @@ test.describe('Pagination', () => {
       await spacesNav.click();
       await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
-      // Navigate back to Organizations — CF page-side-nav stays visible
+      // Navigate back to Organizations
       const orgsNav = page.locator('.page-side-nav__item').filter({ hasText: 'Organizations' }).first();
       await orgsNav.waitFor({ state: 'visible', timeout: 10000 });
       await orgsNav.click();
       await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
 
-      // Wait for paginator to show data
-      const paginatorInfo = page.locator('app-paginator .paginator-info span').first();
-      await paginatorInfo.filter({ hasNotText: '0 of 0' }).waitFor({ timeout: 30000 }).catch(() => {});
+      await pageRange(page).filter({ hasNotText: '0 of 0' }).waitFor({ timeout: 30000 }).catch(() => {});
 
-      const value = await page.locator('app-paginator select#pageSize').inputValue();
-      expect(value).toBe('24');
+      await expect(pageSizeSelect(page)).toHaveValue('12');
     });
 
-    test('should inherit last choice on a different list', { timeout: 150000 }, async ({ authenticatedPage }) => {
+    test('page size is remembered per list, not shared across lists', async ({ authenticatedPage }) => {
+      // ListStateStore keys state per list ('cf-orgs', 'cf-apps', ...), so a
+      // size chosen on orgs must NOT leak to applications. (The legacy
+      // PageSizeSessionService shared the last choice globally — that
+      // behavior was replaced by per-list persistence in the migration.)
       const page = authenticatedPage;
       if (!await goToOrgsPage(page)) {
-        test.skip('Organizations page not reachable or no paginator');
+        test.skip('Organizations page not reachable or no data');
+      }
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
 
-      // Set page size to 12 on orgs
-      await page.locator('app-paginator select#pageSize').selectOption('12');
-      await page.waitForTimeout(500);
+      await pageSizeSelect(page).selectOption('12');
+      await expect(pageSizeSelect(page)).toHaveValue('12');
 
-      // Navigate to Applications (different list)
-      const appsNav = page.locator('a, button').filter({ hasText: /^Applications$/ }).first();
-      const appsVisible = await appsNav.isVisible({ timeout: 3000 }).catch(() => false);
-      if (!appsVisible) {
-        test.skip('Applications nav not visible');
-      }
-      await appsNav.click();
-      await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-
-      const paginator = page.locator('app-paginator');
-      const visible = await paginator.isVisible({ timeout: 5000 }).catch(() => false);
-      if (!visible) {
-        test.skip('Applications page has no paginator');
+      if (!await goToAppsPage(page)) {
+        test.skip('Applications page not reachable or no data');
       }
 
-      // Should inherit 12 from orgs
-      const value = await paginator.locator('select#pageSize').inputValue();
-      expect(value).toBe('12');
+      const appsValue = await pageSizeSelect(page).inputValue();
+      const appsOptions = (await pageSizeSelect(page).locator('option').allTextContents()).map((t: string) => t.trim());
+      // Apps keeps a size from its own option set; no assertion on the exact
+      // default (it is per-list configuration), only that orgs' choice did
+      // not leak in unless 12 is a legitimate apps option AND was its state.
+      expect(appsOptions).toContain(appsValue === '-1' ? 'All' : appsValue);
     });
   });
 
   test.describe('View Toggle', () => {
-
-    /** Navigate to Applications page which supports both card and table views */
-    async function goToAppsPage(page: any, maxAttempts = 2): Promise<boolean> {
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        await page.goto('/applications');
-        await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-
-        // Wait for data to load — allow extra time after fresh deploys (cold start)
-        const paginatorInfo = page.locator('app-paginator .paginator-info span').first();
-        try {
-          await paginatorInfo.filter({ hasNotText: '0 of 0' }).waitFor({ timeout: 30000 });
-          // Wait for filter to be enabled — ensures isLoadingPage$ is false before interactions
-          const filterInput = page.locator('#listSearchFilter input[name="filter"]');
-          await filterInput.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
-          await expect(filterInput).toBeEnabled({ timeout: 15000 }).catch(() => {});
-          return true;
-        } catch {
-          if (attempt === maxAttempts) return false;
-        }
-      }
-      return false;
-    }
 
     test('should show card page sizes in card view and table page sizes in table view', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
       if (!await goToAppsPage(page)) {
         test.skip('Applications page not reachable or no data');
       }
-
-      const select = page.locator('app-paginator select#pageSize');
-
-      // Ensure we're in card view first
-      const tableToggle = page.locator('button[title="Table view"]');
-      const cardToggle = page.locator('button[title="Card view"]');
-
-      // tableToggle is ENABLED when in card view, DISABLED when in table view
-      const inCardView = await tableToggle.isEnabled({ timeout: 3000 }).catch(() => false);
-      if (!inCardView) {
-        // In table view — switch to card view
-        const cardEnabled = await cardToggle.isEnabled({ timeout: 5000 }).catch(() => false);
-        if (cardEnabled) {
-          await cardToggle.click();
-          await page.waitForTimeout(1000);
-        }
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
 
-      // Card view should have card options
-      const cardOptions = await select.locator('option').allTextContents();
-      const cardTrimmed = cardOptions.map(t => t.trim());
-      expect(cardTrimmed).toContain('6');
-      expect(cardTrimmed).toContain('12');
-      expect(cardTrimmed).toContain('96');
-      expect(cardTrimmed).not.toContain('10');
-      expect(cardTrimmed).not.toContain('25');
+      const cardOptions = (await pageSizeSelect(page).locator('option').allTextContents()).map((t: string) => t.trim());
+      expect(cardOptions).toContain('6');
+      expect(cardOptions).toContain('12');
+      expect(cardOptions).toContain('96');
+      expect(cardOptions).toContain('All');
+      expect(cardOptions).not.toContain('10');
+      expect(cardOptions).not.toContain('25');
 
-      // Switch to table view
-      await expect(tableToggle).toBeEnabled({ timeout: 10000 });
-      await tableToggle.click();
-      await page.waitForTimeout(1000);
+      await switchToView(page, 'table');
 
-      // Table view should have table options
-      const tableOptions = await select.locator('option').allTextContents();
-      const tableTrimmed = tableOptions.map(t => t.trim());
-      expect(tableTrimmed).toContain('10');
-      expect(tableTrimmed).toContain('25');
-      expect(tableTrimmed).toContain('100');
-      expect(tableTrimmed).not.toContain('6');
-      expect(tableTrimmed).not.toContain('12');
+      const tableOptions = (await pageSizeSelect(page).locator('option').allTextContents()).map((t: string) => t.trim());
+      expect(tableOptions).toContain('10');
+      expect(tableOptions).toContain('25');
+      expect(tableOptions).toContain('100');
+      expect(tableOptions).not.toContain('All');
+      expect(tableOptions).not.toContain('6');
+      expect(tableOptions).not.toContain('12');
     });
 
     test('should show correct item count after view toggle', async ({ authenticatedPage }) => {
@@ -257,45 +267,27 @@ test.describe('Pagination', () => {
       if (!await goToAppsPage(page)) {
         test.skip('Applications page not reachable or no data');
       }
-
-      const select = page.locator('app-paginator select#pageSize');
-      const info = page.locator('app-paginator .paginator-info span').first();
-
-      // Switch to table view
-      const tableToggle = page.locator('button[title="Table view"]');
-      const tableToggleVisible = await tableToggle.isVisible({ timeout: 3000 }).catch(() => false);
-      const tableToggleEnabled = tableToggleVisible && await tableToggle.isEnabled({ timeout: 2000 }).catch(() => false);
-      if (tableToggleEnabled) {
-        await tableToggle.click();
-        await page.waitForTimeout(1000);
-      } else if (!tableToggleVisible) {
-        test.skip('Table view toggle not visible — page may not have loaded');
+      if (!await switchToView(page, 'table')) {
+        test.skip('View toggle not available');
       }
 
-      // Default table page size is 10
-      const tableValue = await select.inputValue();
-      expect(tableValue).toBe('10');
-
-      // Paginator should match
-      const tableInfo = (await info.textContent()) || '';
-      expect(tableInfo).toMatch(/1\s*-\s*10\s*of\s*\d+/);
-
-      // Switch to card view
-      const cardToggle = page.locator('button[title="Card view"]');
-      const cardToggleEnabled = await cardToggle.isEnabled({ timeout: 3000 }).catch(() => false);
-      if (!cardToggleEnabled) {
-        test.skip('Card view toggle not enabled — already in card view or not available');
+      // Whatever the table page size is, the range must agree with it
+      const tableSize = parseInt(await pageSizeSelect(page).inputValue(), 10);
+      const tableRange = await readRange(page);
+      if (tableRange) {
+        expect(tableRange.start).toBe(1);
+        expect(tableRange.end).toBe(Math.min(tableSize, tableRange.total));
       }
-      await cardToggle.click();
-      await page.waitForTimeout(1000);
 
-      // Default card page size is 6
-      const cardValue = await select.inputValue();
-      expect(cardValue).toBe('6');
+      await switchToView(page, 'card');
 
-      // Paginator should match
-      const cardInfo = (await info.textContent()) || '';
-      expect(cardInfo).toMatch(/1\s*-\s*6\s*of\s*\d+/);
+      const cardSizeValue = await pageSizeSelect(page).inputValue();
+      const cardRange = await readRange(page);
+      if (cardRange && cardSizeValue !== '-1') {
+        const cardSize = parseInt(cardSizeValue, 10);
+        expect(cardRange.start).toBe(1);
+        expect(cardRange.end).toBe(Math.min(cardSize, cardRange.total));
+      }
     });
 
     test('should remember page size per view when toggling', async ({ authenticatedPage }) => {
@@ -303,45 +295,22 @@ test.describe('Pagination', () => {
       if (!await goToAppsPage(page)) {
         test.skip('Applications page not reachable or no data');
       }
-
-      const select = page.locator('app-paginator select#pageSize');
-      const tableToggle = page.locator('button[title="Table view"]');
-      const cardToggle = page.locator('button[title="Card view"]');
-
-      // tableToggle is ENABLED when in card view, DISABLED when in table view
-      if (await tableToggle.isEnabled({ timeout: 3000 }).catch(() => false)) {
-        // Already in card view — nothing to do
-      } else {
-        // In table view — switch to card first
-        const cardEnabled = await cardToggle.isEnabled({ timeout: 5000 }).catch(() => false);
-        if (cardEnabled) {
-          await cardToggle.click();
-          await page.waitForTimeout(1000);
-        }
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
-      await select.selectOption('24');
-      await page.waitForTimeout(500);
 
-      // Switch to table, set to 50
-      await expect(tableToggle).toBeEnabled({ timeout: 10000 });
-      await tableToggle.click();
-      await page.waitForTimeout(1000);
-      await select.selectOption('50');
-      await page.waitForTimeout(500);
+      await pageSizeSelect(page).selectOption('24');
+      await expect(pageSizeSelect(page)).toHaveValue('24');
 
-      // Switch back to cards — should remember 24
-      await expect(cardToggle).toBeEnabled({ timeout: 10000 });
-      await cardToggle.click();
-      await page.waitForTimeout(1000);
-      const cardValue = await select.inputValue();
-      expect(cardValue).toBe('24');
+      await switchToView(page, 'table');
+      await pageSizeSelect(page).selectOption('50');
+      await expect(pageSizeSelect(page)).toHaveValue('50');
 
-      // Switch back to table — should remember 50
-      await expect(tableToggle).toBeEnabled({ timeout: 10000 });
-      await tableToggle.click();
-      await page.waitForTimeout(1000);
-      const tableValue = await select.inputValue();
-      expect(tableValue).toBe('50');
+      await switchToView(page, 'card');
+      await expect(pageSizeSelect(page)).toHaveValue('24');
+
+      await switchToView(page, 'table');
+      await expect(pageSizeSelect(page)).toHaveValue('50');
     });
 
     test('should sync dropdown and paginator info after "All" toggle', async ({ authenticatedPage }) => {
@@ -349,130 +318,68 @@ test.describe('Pagination', () => {
       if (!await goToAppsPage(page)) {
         test.skip('Applications page not reachable or no data');
       }
-
-      const select = page.locator('app-paginator select#pageSize');
-      const info = page.locator('app-paginator .paginator-info span').first();
-      const tableToggle = page.locator('button[title="Table view"]');
-      const cardToggle = page.locator('button[title="Card view"]');
-
-      // Ensure we start in card view (cardToggle is visible+enabled only when NOT already in card view)
-      const cardToggleEnabled = await cardToggle.isEnabled({ timeout: 3000 }).catch(() => false);
-      if (cardToggleEnabled) {
-        await cardToggle.click();
-        await page.waitForTimeout(1000);
+      if (!await switchToView(page, 'card')) {
+        test.skip('View toggle not available');
       }
 
-      // Select "All" in card view
-      await select.selectOption('-1');
-      await page.waitForTimeout(500);
-
-      // After selecting "All" (-1), the paginator resolves it to the actual total count.
-      // If that count happens to equal an existing concrete option (e.g. 48), the dropdown
-      // shows 48 not -1 — that is correct paginator behaviour (selectValue getter).
-      // Verify all items are shown instead of checking the raw dropdown value.
-      const allInfo = (await info.textContent()) || '';
-      const allMatch = allInfo.match(/1\s*-\s*(\d+)\s*of\s*(\d+)/);
-      if (allMatch) {
-        expect(allMatch[1]).toBe(allMatch[2]); // showing all items
+      // Select "All" in card view — full window shown
+      await pageSizeSelect(page).selectOption('-1');
+      await waitForFullWindow(page);
+      const allRange = await readRange(page);
+      if (allRange) {
+        expect(allRange.start).toBe(1);
+        expect(allRange.end).toBe(allRange.total);
       }
 
-      // Switch to table — dropdown should revert to a table default page size
-      // Loading all apps may take time; use a generous timeout
-      await expect(tableToggle).toBeEnabled({ timeout: 30000 });
-      await tableToggle.click();
-      await page.waitForTimeout(1000);
-      const tableValue = await select.inputValue();
-      const tableOptions = [10, 25, 50, 100]; // default table page size options
-      expect(tableOptions.map(String)).toContain(tableValue);
-      const tableInfo = (await info.textContent()) || '';
+      // Switch to table — no All there; a concrete table size takes over
+      await switchToView(page, 'table');
+      const tableValue = await pageSizeSelect(page).inputValue();
+      expect(tableValue).not.toBe('-1');
+      const tableInfo = (await pageRange(page).textContent()) || '';
       expect(tableInfo).not.toContain('0 of 0');
 
-      // Switch back to card — should show all items again
-      await expect(cardToggle).toBeEnabled({ timeout: 15000 });
-      await cardToggle.click();
-      await page.waitForTimeout(1000);
-      const cardAllInfo = (await info.textContent()) || '';
-      const cardAllMatch = cardAllInfo.match(/1\s*-\s*(\d+)\s*of\s*(\d+)/);
-      if (cardAllMatch) {
-        expect(cardAllMatch[1]).toBe(cardAllMatch[2]); // still showing all items
+      // Back to card — per-view memory restores All (full window)
+      await switchToView(page, 'card');
+      await waitForFullWindow(page);
+      const cardAllRange = await readRange(page);
+      if (cardAllRange) {
+        expect(cardAllRange.end).toBe(cardAllRange.total);
       }
 
-      // Switch to table and back to card with a normal size
-      await expect(tableToggle).toBeEnabled({ timeout: 15000 });
-      await tableToggle.click();
-      await page.waitForTimeout(1000);
-      await expect(cardToggle).toBeEnabled({ timeout: 15000 });
-      await cardToggle.click();
-      await page.waitForTimeout(1000);
-
-      // Set card to a specific size (12)
-      await select.selectOption('12');
-      await page.waitForTimeout(500);
-
-      // Toggle to table and back — should show 12, not "All"
-      await expect(tableToggle).toBeEnabled({ timeout: 15000 });
-      await tableToggle.click();
-      await page.waitForTimeout(1000);
-      await expect(cardToggle).toBeEnabled({ timeout: 15000 });
-      await cardToggle.click();
-      await page.waitForTimeout(1000);
-      const cardNormalValue = await select.inputValue();
-      expect(cardNormalValue).toBe('12');
-      const cardNormalInfo = (await info.textContent()) || '';
-      expect(cardNormalInfo).toMatch(/1\s*-\s*12\s*of\s*\d+/);
+      // Set card to a concrete size (12); it must survive a toggle round-trip
+      await pageSizeSelect(page).selectOption('12');
+      await expect(pageSizeSelect(page)).toHaveValue('12');
+      await switchToView(page, 'table');
+      await switchToView(page, 'card');
+      await expect(pageSizeSelect(page)).toHaveValue('12');
+      const cardRange = await readRange(page);
+      if (cardRange) {
+        expect(cardRange.end).toBe(Math.min(12, cardRange.total));
+      }
     });
   });
 
   test.describe('Filter Clear', () => {
 
-    /** Navigate to Applications page and wait for data and filter */
-    async function goToAppsPage(page: any, maxAttempts = 2): Promise<boolean> {
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        await page.goto('/applications');
-        await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-        const paginatorInfo = page.locator('app-paginator .paginator-info span').first();
-        try {
-          await paginatorInfo.filter({ hasNotText: '0 of 0' }).waitFor({ timeout: 20000 });
-          // Wait for filter to be enabled — ensures isLoadingPage$ is false before interactions
-          const filterInput = page.locator('#listSearchFilter input[name="filter"]');
-          await filterInput.waitFor({ state: 'visible', timeout: 8000 }).catch(() => {});
-          await expect(filterInput).toBeEnabled({ timeout: 15000 }).catch(() => {});
-          return true;
-        } catch {
-          if (attempt === maxAttempts) return false;
-        }
-      }
-      return false;
-    }
-
-    test('should show X button when filter has text and hide when empty', async ({ authenticatedPage }) => {
+    test('clear-filters button enables with text and clears it', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
       if (!await goToAppsPage(page)) {
         test.skip('Applications page not reachable or no data');
       }
 
-      const filterInput = page.locator('#listSearchFilter input[name="filter"]');
-      const clearBtn = page.locator('#listSearchFilter button[title="Clear filter"]');
+      const filterInput = page.locator('[data-test="name-filter"]');
+      const clearBtn = page.locator('[data-test="clear-filters"]');
 
-      // X button should not be visible initially
-      await expect(clearBtn).not.toBeVisible();
+      await filterInput.waitFor({ state: 'visible', timeout: 10000 });
+      // Disabled while no filter is active
+      await expect(clearBtn).toBeDisabled();
 
-      // Type in filter
       await filterInput.fill('console');
-      await page.waitForTimeout(500);
+      await expect(clearBtn).toBeEnabled({ timeout: 5000 });
 
-      // X button should now be visible
-      await expect(clearBtn).toBeVisible();
-
-      // Click X — filter should clear
       await clearBtn.click();
-      await page.waitForTimeout(500);
-
-      const value = await filterInput.inputValue();
-      expect(value).toBe('');
-
-      // X button should be hidden again
-      await expect(clearBtn).not.toBeVisible();
+      await expect(filterInput).toHaveValue('');
+      await expect(clearBtn).toBeDisabled({ timeout: 5000 });
     });
 
     test('should clear filter with Escape key', async ({ authenticatedPage }) => {
@@ -481,40 +388,25 @@ test.describe('Pagination', () => {
         test.skip('Applications page not reachable or no data');
       }
 
-      const filterInput = page.locator('#listSearchFilter input[name="filter"]');
-      const info = page.locator('app-paginator .paginator-info span').first();
+      const filterInput = page.locator('[data-test="name-filter"]');
+      await filterInput.waitFor({ state: 'visible', timeout: 10000 });
 
-      // Get initial count
-      const initialInfo = (await info.textContent()) || '';
-      const initialMatch = initialInfo.match(/of\s*(\d+)/);
-      const totalItems = initialMatch ? parseInt(initialMatch[1]) : 0;
-      if (totalItems === 0) {
+      const initial = await readRange(page);
+      if (!initial || initial.total === 0) {
         test.skip('Skipped: total items is 0 — page may not have loaded data');
       }
 
-      // Type filter text to reduce results
       await filterInput.fill('console');
-      await page.waitForTimeout(1000);
+      await expect
+        .poll(async () => (await readRange(page))?.total ?? -1, { timeout: 10000 })
+        .toBeLessThanOrEqual(initial!.total);
 
-      // Results should be filtered (fewer items)
-      const filteredInfo = (await info.textContent()) || '';
-      const filteredMatch = filteredInfo.match(/of\s*(\d+)/);
-      const filteredItems = filteredMatch ? parseInt(filteredMatch[1]) : 0;
-      expect(filteredItems).toBeLessThanOrEqual(totalItems);
-
-      // Press Escape to clear
       await filterInput.press('Escape');
-      await page.waitForTimeout(500);
+      await expect(filterInput).toHaveValue('');
 
-      // Input should be empty
-      const value = await filterInput.inputValue();
-      expect(value).toBe('');
-
-      // Results should be back to original count
-      const restoredInfo = (await info.textContent()) || '';
-      const restoredMatch = restoredInfo.match(/of\s*(\d+)/);
-      const restoredItems = restoredMatch ? parseInt(restoredMatch[1]) : 0;
-      expect(restoredItems).toBeGreaterThanOrEqual(totalItems);
+      await expect
+        .poll(async () => (await readRange(page))?.total ?? -1, { timeout: 10000 })
+        .toBeGreaterThanOrEqual(initial!.total);
     });
   });
 });

--- a/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-config.service.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-config.service.ts
@@ -95,12 +95,18 @@ export class ViewPipeline<T> {
     });
     this.pagedItems = computed(() => {
       const size = this.pageSize();
+      // pageSize -1 = the "All" page-size option: no slicing.
+      if (size <= 0) return this.sortedItems();
       const start = this.pageIndex() * size;
       return this.sortedItems().slice(start, start + size);
     });
     this.totalItems = computed(() => this.items().length);
     this.totalFilteredResults = computed(() => this.filteredItems().length);
-    this.totalPages = computed(() => Math.ceil(this.totalFilteredResults() / this.pageSize()));
+    this.totalPages = computed(() => {
+      const size = this.pageSize();
+      if (size <= 0) return this.totalFilteredResults() > 0 ? 1 : 0;
+      return Math.ceil(this.totalFilteredResults() / size);
+    });
   }
 }
 

--- a/src/frontend/packages/core/src/features/endpoints/endpoints-page/view-pipeline.spec.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoints-page/view-pipeline.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { signal } from '@angular/core';
+
+import { ViewPipeline, SortSpec } from './endpoints-signal-config.service';
+
+type Row = { name: string };
+
+function makePipeline(names: string[], pageSize: number, pageIndex = 0) {
+  const items = signal<Row[]>(names.map(name => ({ name })));
+  return new ViewPipeline<Row>(
+    items.asReadonly(),
+    signal<(row: Row) => boolean>(() => true).asReadonly(),
+    signal<SortSpec<Row>>({ field: 'name', direction: 'asc' }).asReadonly(),
+    signal(pageSize).asReadonly(),
+    signal(pageIndex).asReadonly(),
+  );
+}
+
+describe('ViewPipeline paging', () => {
+  it('slices to the page window for a positive page size', () => {
+    const pipeline = makePipeline(['a', 'b', 'c', 'd', 'e'], 2, 1);
+    expect(pipeline.pagedItems().map(r => r.name)).toEqual(['c', 'd']);
+    expect(pipeline.totalPages()).toBe(3);
+  });
+
+  it('returns every item for the All page size (-1)', () => {
+    const pipeline = makePipeline(['a', 'b', 'c', 'd', 'e'], -1);
+    expect(pipeline.pagedItems().map(r => r.name)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(pipeline.totalPages()).toBe(1);
+  });
+
+  it('reports zero pages for All on an empty list', () => {
+    const pipeline = makePipeline([], -1);
+    expect(pipeline.pagedItems()).toEqual([]);
+    expect(pipeline.totalPages()).toBe(0);
+  });
+});

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -45,10 +45,12 @@
       }
       <input
         type="text"
+        data-test="name-filter"
         [placeholder]="filterPlaceholder()"
         [attr.aria-label]="filterPlaceholder()"
         [value]="config.nameFilter()"
         (input)="config.nameFilter!.set($any($event.target).value)"
+        (keydown.escape)="config.nameFilter!.set('')"
         class="px-3 py-1 text-sm border border-content-border rounded bg-content-bg text-content-text" />
     }
 
@@ -737,16 +739,17 @@
     <div class="flex items-center gap-2 text-content-muted">
       <span>Items per page:</span>
       <select
+        data-test="page-size"
         (change)="onPageSizeChange($any($event.target).value)"
         class="px-2 py-1 border border-content-border rounded bg-content-bg text-content-text">
         @for (opt of pageSizeOptions(); track opt) {
-          <option [value]="opt" [selected]="opt === config.pageSize()">{{ opt }}</option>
+          <option [value]="opt" [selected]="opt === config.pageSize()">{{ pageSizeLabel(opt) }}</option>
         }
       </select>
     </div>
 
     <!-- Range counter -->
-    <span class="text-content-muted">{{ rangeText() }}</span>
+    <span data-test="page-range" class="text-content-muted">{{ rangeText() }}</span>
 
     <!-- First / prev / next / last -->
     <div class="flex items-center gap-1">

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -129,6 +129,88 @@ describe('SignalListComponent', () => {
     expect(fixture.componentInstance.pageIndex()).toBe(0);
   });
 
+  describe('"All" page size (-1)', () => {
+    function componentWith(fixture: ReturnType<typeof TestBed.createComponent<Host>>) {
+      return fixture.debugElement.children[0].componentInstance as SignalListComponent<{ name: string }>;
+    }
+
+    it('appends All (-1) to card-mode options and labels it', () => {
+      const fixture = TestBed.createComponent(Host);
+      fixture.componentInstance.config = {
+        ...fixture.componentInstance.config,
+        viewMode: signal<'table' | 'card'>('card'),
+        pageSizeOptions: { table: [10, 25], card: [6, 12] },
+      };
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      expect(component.pageSizeOptions()).toEqual([6, 12, -1]);
+      expect(component.pageSizeLabel(-1)).toBe('All');
+      expect(component.pageSizeLabel(12)).toBe('12');
+    });
+
+    it('does not add All to table-mode options', () => {
+      const fixture = TestBed.createComponent(Host);
+      fixture.componentInstance.config = {
+        ...fixture.componentInstance.config,
+        viewMode: signal<'table' | 'card'>('table'),
+        pageSizeOptions: { table: [10, 25], card: [6, 12] },
+      };
+      fixture.detectChanges();
+      expect(componentWith(fixture).pageSizeOptions()).toEqual([10, 25]);
+    });
+
+    it('accepts -1 from the select and reports the full range', () => {
+      const fixture = TestBed.createComponent(Host);
+      fixture.componentInstance.pageIndex.set(2);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      component.onPageSizeChange('-1');
+      expect(fixture.componentInstance.pageSize()).toBe(-1);
+      expect(fixture.componentInstance.pageIndex()).toBe(0);
+      expect(component.rangeText()).toBe('1 – 2 of 2');
+    });
+
+    it('still rejects zero and garbage page sizes', () => {
+      const fixture = TestBed.createComponent(Host);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      component.onPageSizeChange('0');
+      component.onPageSizeChange('bogus');
+      expect(fixture.componentInstance.pageSize()).toBe(10);
+    });
+
+    it('does not snap All away when switching to card view', () => {
+      // Regression: setViewMode must validate against the effective card
+      // options (which include -1), not the raw config list — otherwise a
+      // per-view remembered "All" is destroyed on return to card view.
+      const fixture = TestBed.createComponent(Host);
+      const viewMode = signal<'table' | 'card'>('table');
+      fixture.componentInstance.pageSize.set(-1);
+      fixture.componentInstance.config = {
+        ...fixture.componentInstance.config,
+        viewMode,
+        pageSizeOptions: { table: [10, 25], card: [6, 12] },
+      };
+      fixture.detectChanges();
+      componentWith(fixture).setViewMode('card');
+      expect(fixture.componentInstance.pageSize()).toBe(-1);
+    });
+
+    it('snaps All back to a concrete size when switching to table view', () => {
+      const fixture = TestBed.createComponent(Host);
+      const viewMode = signal<'table' | 'card'>('card');
+      fixture.componentInstance.pageSize.set(-1);
+      fixture.componentInstance.config = {
+        ...fixture.componentInstance.config,
+        viewMode,
+        pageSizeOptions: { table: [10, 25], card: [6, 12] },
+      };
+      fixture.detectChanges();
+      componentWith(fixture).setViewMode('table');
+      expect(fixture.componentInstance.pageSize()).toBe(10);
+    });
+  });
+
   it('renders a filter dropdown per config.filterDropdowns entry', () => {
     const fixture = TestBed.createComponent(Host);
     const selected = signal<string | null>(null);

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -568,11 +568,21 @@ export class SignalListComponent<T> implements AfterViewInit {
   }
 
   pageSizeOptions(): readonly number[] {
+    const mode = this.config.viewMode ? this.config.viewMode() : 'table';
+    return this.effectivePageSizeOptions(mode);
+  }
+
+  // The option set actually offered in a view mode. Card views carry the
+  // legacy app-paginator "All" (-1) option; table views deliberately don't
+  // (switching to table reverts to a concrete size via the setViewMode
+  // snap). setViewMode must validate against THIS set, not the raw config
+  // lists, or a remembered "All" gets snapped away on return to card view.
+  private effectivePageSizeOptions(mode: SignalListViewMode): readonly number[] {
     const opts = this.config.pageSizeOptions;
     if (!opts) return [5, 20, 50, 80];
     if ('table' in opts && 'card' in opts) {
-      const mode = this.config.viewMode ? this.config.viewMode() : 'table';
-      return mode === 'card' ? opts.card : opts.table;
+      const list = mode === 'card' ? opts.card : opts.table;
+      return mode === 'card' && !list.includes(-1) ? [...list, -1] : list;
     }
     return opts;
   }
@@ -581,14 +591,20 @@ export class SignalListComponent<T> implements AfterViewInit {
     const total = this.config.totalFilteredResults();
     if (total === 0) return '0 of 0';
     const size = this.config.pageSize();
+    if (size <= 0) return `1 – ${total} of ${total}`;
     const start = this.config.pageIndex() * size + 1;
     const end = Math.min(start + size - 1, total);
     return `${start} – ${end} of ${total}`;
   }
 
+  // -1 is the "All" page-size sentinel (legacy app-paginator parity).
+  pageSizeLabel(opt: number): string {
+    return opt === -1 ? 'All' : String(opt);
+  }
+
   onPageSizeChange(value: string): void {
     const n = parseInt(value, 10);
-    if (!Number.isFinite(n) || n <= 0) return;
+    if (!Number.isFinite(n) || (n <= 0 && n !== -1)) return;
     this.config.pageSize.set(n);
     this.config.pageIndex.set(0);
   }
@@ -600,7 +616,7 @@ export class SignalListComponent<T> implements AfterViewInit {
     // and the "X of Y" range would reflect a size not in the picker.
     const opts = this.config.pageSizeOptions;
     if (opts && 'table' in opts && 'card' in opts) {
-      const next = mode === 'card' ? opts.card : opts.table;
+      const next = this.effectivePageSizeOptions(mode);
       if (next.length && !next.includes(this.config.pageSize())) {
         this.config.pageSize.set(next[0]);
         this.config.pageIndex.set(0);


### PR DESCRIPTION
## What the investigation found (#5573)

Neither "intermittent" was an app race — both specs were asserting UI that the signal-list migration replaced:

- **endpoints (non-admin visibility):** the spec asserted the legacy cards-default view. The migrated endpoints list is table-primary by design (documented in `EndpointsSignalConfigService`) and provides no card template; persisted `viewMode` state made results vary run to run.
- **pagination ("All"):** `app-paginator` is no longer rendered anywhere in the app, so the spec's selectors could never match. Under the 90s test budget the two-attempt navigation helper surfaced that as a skip (looked green); over it, as a bare timeout — the "flake" was a skip-vs-timeout race. Along the way this exposed a real feature loss: the **"All" page-size option (and the option ladders' All entry) shipped on app-paginator and vanished in the migration.**

## Changes

**App — restore All at the shared layer** (`4302fd0e`):
- `ViewPipeline` treats `pageSize <= 0` as no slicing (single page)
- signal-list offers `All` (-1) in card view; table views deliberately keep concrete sizes, and the view-mode snap validates against the *effective* option set so a per-view remembered All survives returning to card view
- range counter reports the full window; pager select/range gain `data-test` hooks; filter input regains Escape-to-clear
- unit tests: ViewPipeline paging, per-view option sets, snap in both directions, input validation

**E2E — realign specs** (`6f2eafea`):
- endpoints: table-row assertions; list harness learns signal-list view detection (count-based, no auto-wait hangs) and card-grid cards
- pagination: rewritten against the signal-list pager; condition waits replace fixed delays; per-list + per-view size-memory semantics; navigation budgets keep the no-data path a clean skip

## Verification

- Unit: 61 tests across the touched specs green; full lint + unit gate green
- E2E: endpoints non-admin group 7/7; pagination spec 0 hard failures across repeated runs (passes vary 5–11 with the rest clean skips, see below)

## Residual finding (separate issue to follow)

The orgs page can wedge on "Loading organizations…" when its in-flight CF fetches are canceled: jetstream logs 502 "context canceled" for orgs/apps/spaces, `EndpointDataService` records the error, and nothing retries. This is the remaining true intermittent behind the pagination skips — evidence (request timelines, jetstream logs) is in the investigation notes. Also observed while auditing: local SQLite runs `journal_mode=delete` with no `busy_timeout`, and ~60 `e2e-*` orgs have accumulated on the shared test CF.

Closes #5573