### PR TITLE
Classify CF errors correctly and retry transient list failures

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-organization-spaces-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-organization-spaces-signal.component.ts
@@ -114,7 +114,7 @@ export class CloudFoundryOrganizationSpacesSignalComponent {
       pageIndex: this.spacesConfig.pageIndex,
       pageSize: this.spacesConfig.pageSize,
       isAnyLoading: computed(() => !this.spacesConfig.hasLoadedOnce()),
-      errorsByCnsi: signal(new Map()),
+      errorsByCnsi: this.spacesConfig.errorsByCnsi,
       columns: [
         {
           header: 'Name', key: 'name', sortField: 'name',
@@ -155,6 +155,7 @@ export class CloudFoundryOrganizationSpacesSignalComponent {
       emptyMessage: 'There are no spaces in this organization',
       emptyFilterMessage: 'No spaces match the current filters',
       loadingMessage: 'Loading spaces…',
+      errorMessage: 'Failed to load spaces — the endpoint may be temporarily unreachable',
       pageSizeOptions: {
         table: [10, 25, 50, 100],
         card: [6, 12, 24, 48, 96],

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cloud-foundry-organizations-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cloud-foundry-organizations-signal.component.ts
@@ -137,7 +137,7 @@ export class CloudFoundryOrganizationsSignalComponent {
       pageIndex: this.orgsConfig.pageIndex,
       pageSize: this.orgsConfig.pageSize,
       isAnyLoading: computed(() => !this.orgsConfig.hasLoadedOnce()),
-      errorsByCnsi: signal(new Map()),
+      errorsByCnsi: this.orgsConfig.errorsByCnsi,
       columns: [
         {
           header: 'Name', key: 'name', sortField: 'name',
@@ -190,6 +190,7 @@ export class CloudFoundryOrganizationsSignalComponent {
       emptyMessage: 'There are no organizations',
       emptyFilterMessage: 'No organizations match the current filters',
       loadingMessage: 'Loading organizations…',
+      errorMessage: 'Failed to load organizations — the endpoint may be temporarily unreachable',
       pageSizeOptions: {
         table: [10, 25, 50, 100],
         card: [6, 12, 24, 48, 96],

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/drain-pages.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/drain-pages.ts
@@ -1,0 +1,77 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { from, Observable, of, timer } from 'rxjs';
+import { map, mergeMap, reduce, retry, switchMap } from 'rxjs/operators';
+
+// Shared page-drain for Stratos-shape list endpoints, used by
+// EndpointDataService and CfUsersPagedDataService. Page 1 inline, pages
+// 2..N in parallel (concurrency=4). Reads totalPages from the
+// StratosPagedResponse pagination meta (stratos_paging.go:68). Reduces to
+// a single {resources, totalResults, totalPages} envelope so the caller
+// can populate count signals from page-1 metadata without an extra fetch.
+// Tolerates both StratosPagedResponse and the older flat-envelope shape
+// (totalResults at the top level) — the backend PR #5337 era still has
+// handlers in transition.
+
+export interface DrainedPages<T> {
+  resources: T[];
+  totalResults: number;
+  totalPages: number;
+}
+
+// Statuses that indicate a transient transport/gateway failure rather
+// than a real CF answer: 0 = network error / connection refused,
+// 502/503/504 = gateway-layer failures. Anything else only counts as
+// transient when Jetstream explicitly classified it (reason header).
+const TRANSIENT_STATUSES = new Set([0, 502, 503, 504]);
+
+// Same cadence as the backend's listWithRouterFlapRetry (2x, 500ms/1s) —
+// long enough for a gorouter route-table flap or a rolling restart to
+// pass, short enough that a genuinely-down endpoint fails in ~1.5s extra.
+const RETRY_DELAYS_MS = [500, 1000];
+
+// The machine-readable classification Jetstream's native-CF error
+// middleware sets (native_errors.go). 'unreachable' means a router-level
+// or origin availability failure — worth a brief retry regardless of the
+// mapped status code.
+const STRATOS_ERROR_REASON_HEADER = 'X-Stratos-Error-Reason';
+
+function isTransientCfError(err: unknown): boolean {
+  return err instanceof HttpErrorResponse &&
+    (TRANSIENT_STATUSES.has(err.status) ||
+      err.headers?.get(STRATOS_ERROR_REASON_HEADER) === 'unreachable');
+}
+
+export function drainCfPages<T>(http: HttpClient, urlBase: string): Observable<DrainedPages<T>> {
+  const perPage = 500;
+  type Paged<U> = { resources: U[]; totalResults?: number; pagination?: { totalResults?: number; totalPages?: number } };
+  const totalResultsOf = <U>(r: Paged<U>): number => r.pagination?.totalResults ?? r.totalResults ?? r.resources.length;
+  // Per-page retry (not whole-drain): a transient failure on page 7 of 12
+  // re-fetches only page 7. Non-transient errors rethrow immediately and
+  // fail the drain as before.
+  const fetchPage = (page: number) =>
+    http.get<Paged<T>>(`${urlBase}?per_page=${perPage}&page=${page}`).pipe(
+      retry({
+        count: RETRY_DELAYS_MS.length,
+        delay: (err, retryCount) => {
+          if (!isTransientCfError(err)) { throw err; }
+          return timer(RETRY_DELAYS_MS[retryCount - 1]);
+        },
+      }),
+    );
+  return fetchPage(1).pipe(
+    switchMap(firstResp => {
+      const totalResults = totalResultsOf(firstResp);
+      const totalPages = firstResp.pagination?.totalPages ?? 1;
+      const firstResources = firstResp.resources;
+      if (totalPages <= 1) {
+        return of({ resources: firstResources, totalResults, totalPages });
+      }
+      const remainingPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
+      return from(remainingPages).pipe(
+        mergeMap(p => fetchPage(p).pipe(map(r => r.resources)), 4 /* concurrency */),
+        reduce((acc, resources) => [...acc, ...resources], [...firstResources]),
+        map(allResources => ({ resources: allResources, totalResults, totalPages })),
+      );
+    }),
+  );
+}

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
@@ -727,6 +727,18 @@ describe('EndpointDataService', () => {
       expect(service.apps()).toHaveLength(1);
     });
 
+    it('a successful drain clears the slice errors recorded by an earlier failure', async () => {
+      const failed = firstValueFrom(service.loadOrgs());
+      httpMock.expectOne(ORGS_FULL_URL).flush('boom', { status: 500, statusText: 'Server Error' });
+      await failed;
+      expect(service.errors().some(e => e.resource === 'orgs-full')).toBeTruthy();
+
+      const retried = firstValueFrom(service.loadOrgs());
+      httpMock.expectOne(ORGS_FULL_URL).flush(orgPage);
+      await retried;
+      expect(service.errors().some(e => e.resource === 'orgs-full')).toBeFalsy();
+    });
+
     it('load() with a failed sub-request does not stamp lastFetched (cache stays cold)', async () => {
       const p = firstValueFrom(service.load());
       httpMock.expectOne(ORGS_URL).flush('x', { status: 500, statusText: 'Server Error' });

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
 import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
@@ -644,6 +645,95 @@ describe('EndpointDataService', () => {
       service.removeServiceInstance('si-a');
       expect(service.serviceInstances()).toEqual([]);
       expect(service.serviceInstancesCount()).toBe(0);
+    });
+  });
+
+  describe('transient retry + cold cache on failure (#5577)', () => {
+    afterEach(() => vi.useRealTimers());
+
+    const orgPage = { resources: [{ guid: 'o1', name: 'Org One', cnsiGuid: 'test-cnsi-guid' }], pagination: { totalResults: 1, totalPages: 1 } };
+    const emptyPage = { resources: [], pagination: { totalResults: 0, totalPages: 1 } };
+
+    it('loadOrgs() retries a transient 502 page fetch (500ms backoff) and succeeds', async () => {
+      vi.useFakeTimers();
+      const done = firstValueFrom(service.loadOrgs());
+      httpMock.expectOne(ORGS_FULL_URL).flush('bad gateway', { status: 502, statusText: 'Bad Gateway' });
+      await vi.advanceTimersByTimeAsync(500);
+      httpMock.expectOne(ORGS_FULL_URL).flush(orgPage);
+      await done;
+      expect(service.orgs()).toHaveLength(1);
+      expect(service.orgsLastFetched()).not.toBeNull();
+      expect(service.errors()).toEqual([]);
+    });
+
+    it('loadOrgs() does NOT retry a non-transient 404', async () => {
+      const done = firstValueFrom(service.loadOrgs());
+      httpMock.expectOne(ORGS_FULL_URL).flush('not found', { status: 404, statusText: 'Not Found' });
+      await done;
+      httpMock.expectNone(ORGS_FULL_URL);
+      expect(service.errors().some(e => e.resource === 'orgs-full')).toBeTruthy();
+      expect(service.orgsLastFetched()).toBeNull();
+    });
+
+    it('loadOrgs() gives up after 2 retries; cache stays cold and the stale flag survives', async () => {
+      vi.useFakeTimers();
+      service.markStale('orgs');
+      const done = firstValueFrom(service.loadOrgs());
+      httpMock.expectOne(ORGS_FULL_URL).flush('x', { status: 503, statusText: 'Service Unavailable' });
+      await vi.advanceTimersByTimeAsync(500);
+      httpMock.expectOne(ORGS_FULL_URL).flush('x', { status: 503, statusText: 'Service Unavailable' });
+      await vi.advanceTimersByTimeAsync(1000);
+      httpMock.expectOne(ORGS_FULL_URL).flush('x', { status: 503, statusText: 'Service Unavailable' });
+      await done;
+      expect(service.orgsLastFetched()).toBeNull();
+      expect(service.orgsStale()).toBeTruthy();
+      expect(service.errors().some(e => e.resource === 'orgs-full')).toBeTruthy();
+      // Cache is still cold — the next read refetches instead of serving the failure.
+      const again = firstValueFrom(service.loadOrgs());
+      httpMock.expectOne(ORGS_FULL_URL).flush(orgPage);
+      await again;
+      expect(service.orgsLastFetched()).not.toBeNull();
+      expect(service.orgsStale()).toBeFalsy();
+    });
+
+    it('retries when Jetstream classifies the failure unreachable, regardless of status', async () => {
+      vi.useFakeTimers();
+      const done = firstValueFrom(service.loadSpaces());
+      httpMock.expectOne(SPACES_FULL_URL).flush('route flap', {
+        status: 404, statusText: 'Not Found', headers: { 'X-Stratos-Error-Reason': 'unreachable' },
+      });
+      await vi.advanceTimersByTimeAsync(500);
+      httpMock.expectOne(SPACES_FULL_URL).flush(emptyPage);
+      await done;
+      expect(service.spacesLastFetched()).not.toBeNull();
+    });
+
+    it('loadDetails() partial failure: only the failed domain refetches on the next call', async () => {
+      const first = firstValueFrom(service.loadDetails());
+      httpMock.expectOne(ORGS_FULL_URL).flush(orgPage);
+      httpMock.expectOne(SPACES_FULL_URL).flush({ resources: [{ guid: 's1', name: 'Sp', cnsiGuid: 'test-cnsi-guid' }], pagination: { totalResults: 1, totalPages: 1 } });
+      // 500 is a real CF answer, not transient — no retry.
+      httpMock.expectOne(APPS_FULL_URL).flush('boom', { status: 500, statusText: 'Server Error' });
+      await first;
+      expect(service.appsLastFetched()).toBeNull();
+      expect(service.orgsLastFetched()).not.toBeNull();
+
+      const second = firstValueFrom(service.loadDetails());
+      httpMock.expectNone(ORGS_FULL_URL);
+      httpMock.expectNone(SPACES_FULL_URL);
+      httpMock.expectOne(APPS_FULL_URL).flush({ resources: [{ guid: 'a1', name: 'App', cnsiGuid: 'test-cnsi-guid', state: 'STARTED' }], pagination: { totalResults: 1, totalPages: 1 } });
+      await second;
+      expect(service.appsLastFetched()).not.toBeNull();
+      expect(service.apps()).toHaveLength(1);
+    });
+
+    it('load() with a failed sub-request does not stamp lastFetched (cache stays cold)', async () => {
+      const p = firstValueFrom(service.load());
+      httpMock.expectOne(ORGS_URL).flush('x', { status: 500, statusText: 'Server Error' });
+      httpMock.expectOne(APPS_URL).flush({ resources: [], totalResults: 0 });
+      httpMock.expectOne(ROUTES_URL).flush({ totalResults: 0 });
+      await p;
+      expect(service.lastFetched()).toBeNull();
     });
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
@@ -308,6 +308,7 @@ export class EndpointDataService {
         this._orgCount.set(resp.totalResults);
         this._orgsLastFetched.set(new Date());
         this._orgsStale.set(false);
+        this.clearErrors('orgs-full');
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('orgs-full', err); return of(undefined as void); }),
@@ -340,6 +341,7 @@ export class EndpointDataService {
         this._appCount.set(resp.totalResults);
         this._appsLastFetched.set(new Date());
         this._appsStale.set(false);
+        this.clearErrors('apps-full');
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('apps-full', err); return of(undefined as void); }),
@@ -374,6 +376,7 @@ export class EndpointDataService {
         this._spaces.set(resp.resources);
         this._spacesLastFetched.set(new Date());
         this._spacesStale.set(false);
+        this.clearErrors('spaces-full');
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('spaces-full', err); return of(undefined as void); }),
@@ -510,6 +513,7 @@ export class EndpointDataService {
         this._orgCount.set(resp.totalResults);
         this._orgsLastFetched.set(new Date());
         this._orgsStale.set(false);
+        this.clearErrors('orgs-full');
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('orgs-full', err); return of(undefined as void); }),
@@ -530,6 +534,7 @@ export class EndpointDataService {
         this._appCount.set(resp.totalResults);
         this._appsLastFetched.set(new Date());
         this._appsStale.set(false);
+        this.clearErrors('apps-full');
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('apps-full', err); return of(undefined as void); }),
@@ -549,6 +554,7 @@ export class EndpointDataService {
         this._spaces.set(resp.resources);
         this._spacesLastFetched.set(new Date());
         this._spacesStale.set(false);
+        this.clearErrors('spaces-full');
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('spaces-full', err); return of(undefined as void); }),
@@ -725,6 +731,16 @@ export class EndpointDataService {
       spaces: this._spaces(),
       routeCount: this._routeCount(),
     };
+  }
+
+  // Drop recorded errors for one resource slice. Called from the drain
+  // success paths so a recovered slice stops reporting its old failure —
+  // without this a failed-then-retried drain leaves a stale error that the
+  // list error surfaces keep rendering forever.
+  private clearErrors(resource: string): void {
+    this._errors.update(errors => errors.some(e => e.resource === resource)
+      ? errors.filter(e => e.resource !== resource)
+      : errors);
   }
 
   private addError(resource: string, err: unknown): void {

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
@@ -1,9 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { signal, Signal } from '@angular/core';
-import { EMPTY, firstValueFrom, from, merge, Observable, of, ReplaySubject } from 'rxjs';
-import { catchError, finalize, map, mergeMap, reduce, shareReplay, switchMap, tap, timeout } from 'rxjs/operators';
+import { EMPTY, firstValueFrom, merge, Observable, of, ReplaySubject } from 'rxjs';
+import { catchError, finalize, map, shareReplay, tap, timeout } from 'rxjs/operators';
 import { cascadeFor, CascadeKey, EntityKind } from '../data-sources/cascade-registry';
 import { StratosDiagnostics } from '../diagnostics/stratos-diagnostics.service';
+import { drainCfPages } from './drain-pages';
 import { EndpointDataShim } from './endpoint-data.shim';
 import {
   StApp,
@@ -182,10 +183,14 @@ export class EndpointDataService {
     this._isLoading.set(true);
     this._errors.set([]);
 
+    // Freshness stamps only on full success: a failed sub-request must not
+    // stamp _lastFetched, or the warm-cache short-circuit serves the broken
+    // counts until something else busts the cache.
+    let anyFailed = false;
     this._inFlightLoad = merge(
       this.http.get<{ resources: StOrg[]; totalResults: number }>(`/pp/v1/cf/orgs/${this.guid}?return=counts`).pipe(
         tap(resp => this._orgCount.set(resp.totalResults)),
-        catchError(err => { this.addError('orgs', err); return EMPTY; }),
+        catchError(err => { this.addError('orgs', err); anyFailed = true; return EMPTY; }),
       ),
       this.http.get<{ resources: StApp[]; totalResults: number }>(`/pp/v1/cf/apps/${this.guid}?return=recent`).pipe(
         tap(resp => {
@@ -193,23 +198,30 @@ export class EndpointDataService {
           this._recentApps.set(resp.resources);
           this._appCount.set(resp.totalResults);
         }),
-        catchError(err => { this.addError('apps', err); return EMPTY; }),
+        catchError(err => { this.addError('apps', err); anyFailed = true; return EMPTY; }),
       ),
       // ?return=counts hits the backend per_page=1 fast path — without it
       // we fall through to the full route list + ListDestinations path,
       // which delays the home-card route count behind the apps fetch.
       this.http.get<{ totalResults: number }>(`/pp/v1/cf/routes/${this.guid}?return=counts`).pipe(
-        tap(resp => this._routeCount.set(resp.totalResults)),
-        catchError(err => { this.addError('routes', err); return EMPTY; }),
+        tap(resp => {
+          this._routeCount.set(resp.totalResults);
+          // Route count has just been refetched — clear the cascade stale flag.
+          this._routesStale.set(false);
+        }),
+        catchError(err => { this.addError('routes', err); anyFailed = true; return EMPTY; }),
       ),
     ).pipe(
       timeout(60_000),
       map(() => undefined),
+      // A timeout (or any merged-stream error) is a failure too — it must
+      // not stamp the cache either.
+      tap({ error: () => { anyFailed = true; } }),
       finalize(() => {
         this._isLoading.set(false);
-        this._lastFetched.set(new Date());
-        // Route count has just been refetched — clear the cascade stale flag.
-        this._routesStale.set(false);
+        if (!anyFailed) {
+          this._lastFetched.set(new Date());
+        }
         // Shim write-through is intentionally NOT called here. Counts + recent
         // apps populate service signals for the home card directly; the NGRX
         // pagination store only needs the full lists, which loadDetails()
@@ -235,8 +247,13 @@ export class EndpointDataService {
   // fires the apps + spaces drains.
   loadDetails(): Observable<void> {
     this.diagnostics?.emitCounter('service-call-count', { service: 'EndpointDataService', method: 'loadDetails' });
+    // Warm-cache gate keys off the three per-domain stamps (each set only on
+    // a successful drain), NOT the orchestrator's own _detailsLastFetched —
+    // otherwise a partial failure (orgs ok, apps drain failed) would cache-hit
+    // here forever and the failed domain would never refetch.
     const anyStale = this._orgsStale() || this._appsStale() || this._spacesStale();
-    if (!anyStale && this._detailsLastFetched() !== null && this._orgs().length > 0) {
+    const allFetched = this._orgsLastFetched() !== null && this._appsLastFetched() !== null && this._spacesLastFetched() !== null;
+    if (!anyStale && allFetched && this._orgs().length > 0) {
       this.diagnostics?.emitCounter('cache-hit', { service: 'EndpointDataService', method: 'loadDetails' });
       return of(undefined);
     }
@@ -266,10 +283,10 @@ export class EndpointDataService {
   }
 
   // loadOrgs() drains /pp/v1/cf/orgs/{guid} (paginated, page-1 inline +
-  // pages 2..N parallel via drainPages). Independent cache + in-flight
+  // pages 2..N parallel via drainCfPages). Independent cache + in-flight
   // guard so consumers that only read orgs() don't pay the cost of the
-  // apps + spaces drains. 500 per page; see drainPages for the
-  // pagination strategy comment.
+  // apps + spaces drains. 500 per page; see drain-pages.ts for the
+  // pagination + transient-retry strategy.
   loadOrgs(): Observable<void> {
     this.diagnostics?.emitCounter('service-call-count', { service: 'EndpointDataService', method: 'loadOrgs' });
     if (!this._orgsStale() && this._orgsLastFetched() !== null && this._orgs().length > 0) {
@@ -282,17 +299,20 @@ export class EndpointDataService {
     }
     this.diagnostics?.emitCounter('cache-miss', { service: 'EndpointDataService', method: 'loadOrgs' });
     this._isLoadingOrgs.set(true);
-    this._inFlightLoadOrgs = this.drainPages<StOrg>(`/pp/v1/cf/orgs/${this.guid}`).pipe(
+    this._inFlightLoadOrgs = drainCfPages<StOrg>(this.http, `/pp/v1/cf/orgs/${this.guid}`).pipe(
+      // Freshness stamp + stale-clear live on the success path, not in
+      // finalize — a failed drain must leave the cache cold and the stale
+      // flag set so the next read retries instead of serving the failure.
       tap(resp => {
         this._orgs.set(resp.resources);
         this._orgCount.set(resp.totalResults);
+        this._orgsLastFetched.set(new Date());
+        this._orgsStale.set(false);
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('orgs-full', err); return of(undefined as void); }),
       finalize(() => {
         this._isLoadingOrgs.set(false);
-        this._orgsLastFetched.set(new Date());
-        this._orgsStale.set(false);
         this._inFlightLoadOrgs = null;
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
@@ -313,17 +333,18 @@ export class EndpointDataService {
     }
     this.diagnostics?.emitCounter('cache-miss', { service: 'EndpointDataService', method: 'loadApps' });
     this._isLoadingApps.set(true);
-    this._inFlightLoadApps = this.drainPages<StApp>(`/pp/v1/cf/apps/${this.guid}`).pipe(
+    this._inFlightLoadApps = drainCfPages<StApp>(this.http, `/pp/v1/cf/apps/${this.guid}`).pipe(
+      // Stamp on success only — see loadOrgs.
       tap(resp => {
         this._apps.set(resp.resources);
         this._appCount.set(resp.totalResults);
+        this._appsLastFetched.set(new Date());
+        this._appsStale.set(false);
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('apps-full', err); return of(undefined as void); }),
       finalize(() => {
         this._isLoadingApps.set(false);
-        this._appsLastFetched.set(new Date());
-        this._appsStale.set(false);
         this._inFlightLoadApps = null;
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
@@ -347,14 +368,17 @@ export class EndpointDataService {
     }
     this.diagnostics?.emitCounter('cache-miss', { service: 'EndpointDataService', method: 'loadSpaces' });
     this._isLoadingSpaces.set(true);
-    this._inFlightLoadSpaces = this.drainPages<StSpace>(`/pp/v1/cf/spaces/${this.guid}`).pipe(
-      tap(resp => this._spaces.set(resp.resources)),
+    this._inFlightLoadSpaces = drainCfPages<StSpace>(this.http, `/pp/v1/cf/spaces/${this.guid}`).pipe(
+      // Stamp on success only — see loadOrgs.
+      tap(resp => {
+        this._spaces.set(resp.resources);
+        this._spacesLastFetched.set(new Date());
+        this._spacesStale.set(false);
+      }),
       map(() => undefined as void),
       catchError(err => { this.addError('spaces-full', err); return of(undefined as void); }),
       finalize(() => {
         this._isLoadingSpaces.set(false);
-        this._spacesLastFetched.set(new Date());
-        this._spacesStale.set(false);
         this._inFlightLoadSpaces = null;
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
@@ -479,17 +503,18 @@ export class EndpointDataService {
   refreshOrgs(): Observable<void> {
     this.diagnostics?.emitCounter('service-call-count', { service: 'EndpointDataService', method: 'refreshOrgs' });
     this._isLoadingOrgs.set(true);
-    return this.drainPages<StOrg>(`/pp/v1/cf/orgs/${this.guid}`).pipe(
+    return drainCfPages<StOrg>(this.http, `/pp/v1/cf/orgs/${this.guid}`).pipe(
+      // Stamp on success only — see loadOrgs.
       tap(resp => {
         this._orgs.set(resp.resources);
         this._orgCount.set(resp.totalResults);
+        this._orgsLastFetched.set(new Date());
+        this._orgsStale.set(false);
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('orgs-full', err); return of(undefined as void); }),
       finalize(() => {
         this._isLoadingOrgs.set(false);
-        this._orgsLastFetched.set(new Date());
-        this._orgsStale.set(false);
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
     ) as Observable<void>;
@@ -498,17 +523,18 @@ export class EndpointDataService {
   refreshApps(): Observable<void> {
     this.diagnostics?.emitCounter('service-call-count', { service: 'EndpointDataService', method: 'refreshApps' });
     this._isLoadingApps.set(true);
-    return this.drainPages<StApp>(`/pp/v1/cf/apps/${this.guid}`).pipe(
+    return drainCfPages<StApp>(this.http, `/pp/v1/cf/apps/${this.guid}`).pipe(
+      // Stamp on success only — see loadOrgs.
       tap(resp => {
         this._apps.set(resp.resources);
         this._appCount.set(resp.totalResults);
+        this._appsLastFetched.set(new Date());
+        this._appsStale.set(false);
       }),
       map(() => undefined as void),
       catchError(err => { this.addError('apps-full', err); return of(undefined as void); }),
       finalize(() => {
         this._isLoadingApps.set(false);
-        this._appsLastFetched.set(new Date());
-        this._appsStale.set(false);
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
     ) as Observable<void>;
@@ -517,14 +543,17 @@ export class EndpointDataService {
   refreshSpaces(): Observable<void> {
     this.diagnostics?.emitCounter('service-call-count', { service: 'EndpointDataService', method: 'refreshSpaces' });
     this._isLoadingSpaces.set(true);
-    return this.drainPages<StSpace>(`/pp/v1/cf/spaces/${this.guid}`).pipe(
-      tap(resp => this._spaces.set(resp.resources)),
+    return drainCfPages<StSpace>(this.http, `/pp/v1/cf/spaces/${this.guid}`).pipe(
+      // Stamp on success only — see loadOrgs.
+      tap(resp => {
+        this._spaces.set(resp.resources);
+        this._spacesLastFetched.set(new Date());
+        this._spacesStale.set(false);
+      }),
       map(() => undefined as void),
       catchError(err => { this.addError('spaces-full', err); return of(undefined as void); }),
       finalize(() => {
         this._isLoadingSpaces.set(false);
-        this._spacesLastFetched.set(new Date());
-        this._spacesStale.set(false);
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
     ) as Observable<void>;
@@ -550,38 +579,6 @@ export class EndpointDataService {
   }
 
   // -----------------------------------------------------------------------
-
-  // Drain all pages for a Stratos-shape list endpoint. Page 1 inline,
-  // pages 2..N in parallel (concurrency=4). Reads totalPages from the
-  // StratosPagedResponse pagination meta (stratos_paging.go:68). Reduces
-  // to a single {resources, totalResults, totalPages} envelope so the
-  // caller can populate count signals from page-1 metadata without an
-  // extra fetch. Tolerates both StratosPagedResponse and the older
-  // flat-envelope shape (totalResults at the top level) — the backend
-  // PR #5337 era still has handlers in transition.
-  private drainPages<T>(urlBase: string): Observable<{ resources: T[]; totalResults: number; totalPages: number }> {
-    const perPage = 500;
-    type Paged<U> = { resources: U[]; totalResults?: number; pagination?: { totalResults?: number; totalPages?: number } };
-    const totalResultsOf = <U>(r: Paged<U>): number => r.pagination?.totalResults ?? r.totalResults ?? r.resources.length;
-    const fetchPage = (page: number) =>
-      this.http.get<Paged<T>>(`${urlBase}?per_page=${perPage}&page=${page}`);
-    return fetchPage(1).pipe(
-      switchMap(firstResp => {
-        const totalResults = totalResultsOf(firstResp);
-        const totalPages = firstResp.pagination?.totalPages ?? 1;
-        const firstResources = firstResp.resources;
-        if (totalPages <= 1) {
-          return of({ resources: firstResources, totalResults, totalPages });
-        }
-        const remainingPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
-        return from(remainingPages).pipe(
-          mergeMap(p => fetchPage(p).pipe(map(r => r.resources)), 4 /* concurrency */),
-          reduce((acc, resources) => [...acc, ...resources], [...firstResources]),
-          map(allResources => ({ resources: allResources, totalResults, totalPages })),
-        );
-      }),
-    );
-  }
 
   // loadServicesCounts() fetches the four cnsi-scoped services-domain counts
   // in parallel via the existing `?return=counts` convention. Used by the

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-users-paged-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-users-paged-data.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { firstValueFrom } from 'rxjs';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CfUsersPagedDataService } from './cf-users-paged-data.service';
 
 const CNSI = 'cf1';
@@ -97,5 +97,35 @@ describe('CfUsersPagedDataService', () => {
     const detail = firstValueFrom(svc.getUser('cf2', 'z'));
     http.expectOne(`/pp/v1/cf/users/cf2/z`).flush(mkUser('z'));
     expect(await detail).toMatchObject({ guid: 'z' });
+  });
+
+  describe('transient retry + cold cache on failure (#5577)', () => {
+    afterEach(() => vi.useRealTimers());
+
+    it('a failed drain does not stamp lastFetched or clear stale — next read refetches', async () => {
+      svc.markStale(CNSI);
+      const p = firstValueFrom(svc.loadUsers(CNSI));
+      http.expectOne(P1).flush('boom', { status: 500, statusText: 'Server Error' });
+      await p;
+      expect(svc.lastFetched(CNSI)()).toBeNull();
+      expect(svc.errorsByCnsi()(CNSI)).toBeTruthy();
+
+      const again = firstValueFrom(svc.loadUsers(CNSI));
+      http.expectOne(P1).flush({ resources: [mkUser('a')], pagination: { totalResults: 1, totalPages: 1 } });
+      await again;
+      expect(svc.lastFetched(CNSI)()).not.toBeNull();
+      expect(svc.errorsByCnsi()(CNSI)).toBeFalsy();
+    });
+
+    it('retries a transient 502 page fetch via the shared drain helper', async () => {
+      vi.useFakeTimers();
+      const p = firstValueFrom(svc.loadUsers(CNSI));
+      http.expectOne(P1).flush('bad gateway', { status: 502, statusText: 'Bad Gateway' });
+      await vi.advanceTimersByTimeAsync(500);
+      http.expectOne(P1).flush({ resources: [mkUser('a')], pagination: { totalResults: 1, totalPages: 1 } });
+      await p;
+      expect(svc.usersSignal(CNSI)().map(u => u.guid)).toEqual(['a']);
+      expect(svc.lastFetched(CNSI)()).not.toBeNull();
+    });
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-users-paged-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cf-users-paged-data.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Signal, WritableSignal, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, from, of } from 'rxjs';
-import { catchError, finalize, map, mergeMap, reduce, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, finalize, map, shareReplay, tap } from 'rxjs/operators';
+import { drainCfPages } from '../../services/endpoint-data/drain-pages';
 import { StUser, StUserOrgRole, StUserSpaceRole } from '../../services/endpoint-data/stratos-types';
 
 interface CfUsersCnsiState {
@@ -14,8 +15,8 @@ interface CfUsersCnsiState {
 }
 
 // Signal-native, per-CNSI source of truth for CF users. Drains the
-// server-paged native endpoint into an in-memory StUser[] (mirrors
-// EndpointDataService.drainPages), and exposes signals + Observable
+// server-paged native endpoint into an in-memory StUser[] (shared
+// drainCfPages helper), and exposes signals + Observable
 // bridges for the read-only list pages and the role/remove/invite wizards.
 // Replaces the ngrx pagination path that lived in CfUserService.
 @Injectable({ providedIn: 'root' })
@@ -70,14 +71,21 @@ export class CfUsersPagedDataService {
     }
     if (s.inFlight) { return s.inFlight; }
     s.isLoading.set(true);
-    s.inFlight = this.drainPages(`/pp/v1/cf/users/${cnsi}`).pipe(
-      tap(resp => { s.allUsers.set(resp.resources); s.count.set(resp.totalResults); this.clearError(cnsi); }),
+    s.inFlight = drainCfPages<StUser>(this.http, `/pp/v1/cf/users/${cnsi}`).pipe(
+      // Freshness stamp + stale-clear on the success path only — a failed
+      // drain leaves the cache cold so the next read retries instead of
+      // serving the failure as fresh.
+      tap(resp => {
+        s.allUsers.set(resp.resources);
+        s.count.set(resp.totalResults);
+        s.lastFetched.set(new Date());
+        s.stale.set(false);
+        this.clearError(cnsi);
+      }),
       map(() => undefined as void),
       catchError(err => { this.setError(cnsi, err); return of(undefined as void); }),
       finalize(() => {
         s.isLoading.set(false);
-        s.lastFetched.set(new Date());
-        s.stale.set(false);
         s.inFlight = null;
       }),
       shareReplay({ bufferSize: 1, refCount: false }),
@@ -106,27 +114,6 @@ export class CfUsersPagedDataService {
     this._errorsByCnsi.update(m => { if (!m.has(cnsi)) { return m; } const n = new Map(m); n.delete(cnsi); return n; });
   }
 
-  // Mirror of EndpointDataService.drainPages (private there). per_page=500,
-  // page 1 inline, pages 2..N fanned out at concurrency 4.
-  private drainPages(urlBase: string): Observable<{ resources: StUser[]; totalResults: number; totalPages: number }> {
-    const perPage = 500;
-    type Paged = { resources: StUser[]; totalResults?: number; pagination?: { totalResults?: number; totalPages?: number } };
-    const totalResultsOf = (r: Paged) => r.pagination?.totalResults ?? r.totalResults ?? r.resources.length;
-    const fetchPage = (page: number) => this.http.get<Paged>(`${urlBase}?per_page=${perPage}&page=${page}`);
-    return fetchPage(1).pipe(
-      switchMap(first => {
-        const totalResults = totalResultsOf(first);
-        const totalPages = first.pagination?.totalPages ?? 1;
-        if (totalPages <= 1) { return of({ resources: first.resources, totalResults, totalPages }); }
-        const rest = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
-        return from(rest).pipe(
-          mergeMap(p => fetchPage(p).pipe(map(r => r.resources)), 4),
-          reduce((acc, res) => [...acc, ...res], [...first.resources]),
-          map(all => ({ resources: all, totalResults, totalPages })),
-        );
-      }),
-    );
-  }
 }
 
 function patchUserRoles(user: StUser, orgGuid: string, spaceGuid: string | undefined, role: string, add: boolean): StUser {

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/org/cf-orgs-signal-config.service.ts
@@ -77,6 +77,20 @@ export class CfOrgsSignalConfigService {
   private readonly _hasLoadedOnce = signal(false);
   readonly hasLoadedOnce: Signal<boolean> = this._hasLoadedOnce.asReadonly();
 
+  // Orgs-slice failures for the signal-list error surfaces (top strip +
+  // failed-load empty state with Retry). Keyed by the active cnsi; empties
+  // when a later drain succeeds (EndpointDataService clears the slice's
+  // errors on success).
+  readonly errorsByCnsi: Signal<Map<string, unknown>> = computed(() => {
+    const out = new Map<string, unknown>();
+    const errs = this.orgsErrors();
+    if (errs.length > 0) out.set(this.cnsiGuid, errs[errs.length - 1]);
+    return out;
+  });
+
+  private readonly orgsErrors = computed(() =>
+    (this.endpointDataService()?.errors() ?? []).filter(e => e.resource === 'orgs-full' || e.resource === 'orgs'));
+
   initialize(cnsiGuid: string): void {
     this.cnsiGuid = cnsiGuid;
     const ds = this.registry.acquire(cnsiGuid);
@@ -115,7 +129,14 @@ export class CfOrgsSignalConfigService {
       this.loadedOnceEffect = effect(() => {
         const cur = this.endpointDataService();
         if (!cur) return;
-        if (cur.orgs().length > 0) this._hasLoadedOnce.set(true);
+        // Loaded = rows arrived, OR the drain completed successfully with
+        // zero rows (lastFetched stamps on success only), OR it failed and
+        // recorded an error. All three must release the loading state —
+        // gating on rows alone left a failed drain spinning on "Loading
+        // organizations…" forever (#5577).
+        if (cur.orgs().length > 0 || cur.orgsLastFetched() !== null || this.orgsErrors().length > 0) {
+          this._hasLoadedOnce.set(true);
+        }
       });
     });
     this.destroyRef.onDestroy(() => {

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/space/cf-spaces-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/space/cf-spaces-signal-config.service.ts
@@ -78,6 +78,12 @@ export class CfSpacesSignalConfigService {
   private readonly _hasLoadedOnce = signal(false);
   readonly hasLoadedOnce: Signal<boolean> = this._hasLoadedOnce.asReadonly();
 
+  // Last drain failure keyed by cnsi, for the signal-list error surfaces
+  // (top strip + failed-load empty state with Retry). Cleared on the next
+  // successful drain.
+  private readonly _errorsByCnsi: WritableSignal<Map<string, unknown>> = signal(new Map());
+  readonly errorsByCnsi: Signal<Map<string, unknown>> = this._errorsByCnsi.asReadonly();
+
   initialize(cnsiGuid: string, orgGuid: string): void {
     // If the active scope is changing (revisiting the page for a different
     // org under the same singleton), drop the previous payload so the
@@ -181,13 +187,13 @@ export class CfSpacesSignalConfigService {
       // row, so the wire payload is self-describing — no stamping needed.
       this._orgSpaces.set(out);
       this._hasLoadedOnce.set(true);
-    } catch {
-      // Swallow — the empty list and "no spaces" message communicate the
-      // failure. A future enhancement could surface a StError; for now
-      // the symptom is identical to a legitimately empty org and the
-      // Refresh button retries.
+      this._errorsByCnsi.set(new Map());
+    } catch (err) {
+      // Surface the failure so the list renders the failed-load state with
+      // a Retry affordance instead of a misleading "no spaces" (#5577).
       if (epoch === this.fetchEpoch) {
         this._hasLoadedOnce.set(true);
+        this._errorsByCnsi.set(new Map([[this.cnsiGuid, err]]));
       }
     }
   }

--- a/src/frontend/packages/core/src/features/about/about.routes.ts
+++ b/src/frontend/packages/core/src/features/about/about.routes.ts
@@ -3,6 +3,7 @@ import { Routes } from '@angular/router';
 import { AboutPageComponent } from './about-page/about-page.component';
 import { DiagnosticCountsPageComponent } from './diagnostic-counts-page/diagnostic-counts-page.component';
 import { DiagnosticPerformancePageComponent } from './diagnostic-performance-page/diagnostic-performance-page.component';
+import { DiagnosticProbesPageComponent } from './diagnostic-probes-page/diagnostic-probes-page.component';
 import { DiagnosticsBaseComponent } from './diagnostics-base/diagnostics-base.component';
 import { DiagnosticsPageComponent } from './diagnostics-page/diagnostics-page.component';
 import { EulaPageComponent } from './eula-page/eula-page.component';
@@ -24,6 +25,7 @@ export const ABOUT_ROUTES: Routes = [
       { path: 'overview', component: DiagnosticsPageComponent },
       { path: 'counts', component: DiagnosticCountsPageComponent },
       { path: 'performance', component: DiagnosticPerformancePageComponent },
+      { path: 'probes', component: DiagnosticProbesPageComponent },
     ]
   }
 ];

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.html
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.html
@@ -26,12 +26,18 @@
     <!-- Scope note -->
     <app-card>
       <div class="px-4 py-3 text-sm text-content-muted">
-        These numbers reflect this browsing session's initial page load and stay put
-        as you move around the app. Reload &amp; measure captures a fresh warm
-        (cached) load; for a cold load, hard-reload the browser with the cache
-        bypassed (&#8984;&#8679;R in Chrome/Firefox on macOS, Ctrl+Shift+R elsewhere).
-        Numbers are cleanest when this page is opened soon after the app loads &mdash;
-        background requests made before the first visit are included.
+        The milestone numbers reflect this browsing session's initial page load and
+        stay put as you move around the app. The waterfall and byte totals keep
+        accumulating: every fetch since the page loaded is recorded, including lazy
+        route chunks loaded as you navigate, so the timeline grows (and its scale
+        stretches from ms to s) the longer the session runs &mdash; check
+        &ldquo;Initial load only&rdquo; on the waterfall to compare like with like.
+        Recording stops silently after 500 resources. Reload &amp; measure captures
+        a fresh warm (cached) load; for a cold load, hard-reload the browser with
+        the cache bypassed (&#8984;&#8679;R in Chrome/Firefox on macOS,
+        Ctrl+Shift+R elsewhere). Numbers are cleanest when this page is opened soon
+        after the app loads &mdash; background requests made before the first visit
+        are included.
       </div>
     </app-card>
 

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
@@ -119,14 +119,16 @@ describe('DiagnosticPerformancePageComponent', () => {
     expect(verdict).toContain('50% cached');
   });
 
-  it('re-displays the saved report instead of re-measuring on re-entry', async () => {
+  it('re-displays the saved report immediately and re-measures on re-entry', async () => {
     expect(vi.mocked(buildLoadReport)).toHaveBeenCalledTimes(1);
 
     const second = TestBed.createComponent(DiagnosticPerformancePageComponent);
     second.detectChanges();
+    // The saved report shows before the fresh measurement resolves.
+    expect(second.componentInstance.report()).toEqual(fixedReport);
     await second.whenStable();
 
-    expect(vi.mocked(buildLoadReport)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(buildLoadReport)).toHaveBeenCalledTimes(2);
     expect(second.componentInstance.report()).toEqual(fixedReport);
   });
 

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.ts
@@ -18,9 +18,11 @@ import { ResourceWaterfallComponent } from './resource-waterfall.component';
 
 const TOP_RESOURCE_COUNT = 20;
 
-// The initial-load report is immutable for a browsing session, so it survives
-// route changes here and re-displays when the user returns to this tab. A
-// hard reload resets module state and yields a fresh measurement.
+// The last report survives route changes so returning to this tab shows data
+// immediately instead of waiting out the ~500ms paint-observer window. Each
+// visit still re-measures in the background: the milestone numbers come out
+// identical (same navigation), but the waterfall picks up resources fetched
+// since the last look. A hard reload resets module state entirely.
 let savedReport: LoadReport | null = null;
 
 /** Test hook: clear the session-persisted report between specs. */
@@ -70,9 +72,8 @@ export class DiagnosticPerformancePageComponent implements OnInit {
   ngOnInit() {
     if (savedReport) {
       this.report.set(savedReport);
-    } else {
-      this.measure();
     }
+    this.measure();
   }
 
   async measure() {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
@@ -11,11 +11,15 @@ import {
   basename,
   formatTick,
   groupRows,
+  initialLoadResources,
   mergeMilestoneLabels,
   milestoneLines,
   spanPercent,
+  rowLabel,
   toPercent,
   waterfallScaleMax,
+  windowPercent,
+  windowTicks,
 } from './resource-waterfall.component';
 
 const row = (over: Partial<ResourceRow> = {}): ResourceRow => ({
@@ -149,6 +153,63 @@ describe('groupRows', () => {
   it('uses the exported gap by default', () => {
     const groups = groupRows([row({ startMs: 0 }), row({ startMs: WATERFALL_GROUP_GAP_MS })]);
     expect(groups.length).toBe(1);
+  });
+});
+
+describe('rowLabel', () => {
+  it('keeps a file basename bare', () => {
+    expect(rowLabel('/assets/js/main.abc123.js')).toBe('main.abc123.js');
+  });
+
+  it('prefixes an extensionless basename with its parent segment', () => {
+    expect(rowLabel('/@vite/client')).toBe('@vite/client');
+    expect(rowLabel('/pp/v1/proxy/apps/df29d654')).toBe('apps/df29d654');
+  });
+
+  it('leaves a single extensionless segment bare', () => {
+    expect(rowLabel('/info')).toBe('info');
+  });
+});
+
+describe('windowPercent', () => {
+  it('maps ms linearly onto 0-100 within the window', () => {
+    expect(windowPercent(1500, { startMs: 1000, endMs: 2000 })).toBe(50);
+  });
+
+  it('clamps values outside the window', () => {
+    expect(windowPercent(500, { startMs: 1000, endMs: 2000 })).toBe(0);
+    expect(windowPercent(2500, { startMs: 1000, endMs: 2000 })).toBe(100);
+  });
+
+  it('returns 0 for an empty window', () => {
+    expect(windowPercent(1000, { startMs: 1000, endMs: 1000 })).toBe(0);
+  });
+});
+
+describe('windowTicks', () => {
+  it('matches axisTicks for a zero-based window', () => {
+    expect(windowTicks({ startMs: 0, endMs: 1000 })).toEqual(axisTicks(1000));
+  });
+
+  it('emits round-number ticks inside a shifted window, excluding the start edge', () => {
+    expect(windowTicks({ startMs: 1000, endMs: 2000 }))
+      .toEqual([1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000]);
+  });
+
+  it('returns nothing for an empty window', () => {
+    expect(windowTicks({ startMs: 1000, endMs: 1000 })).toEqual([]);
+  });
+});
+
+describe('initialLoadResources', () => {
+  it('drops resources starting after the load event, keeping the boundary inclusive', () => {
+    const rows = [row({ startMs: 100 }), row({ startMs: 500 }), row({ startMs: 501 })];
+    expect(initialLoadResources(rows, 500).map(r => r.startMs)).toEqual([100, 500]);
+  });
+
+  it('filters nothing when the load event is unknown', () => {
+    const rows = [row({ startMs: 100 }), row({ startMs: 9999 })];
+    expect(initialLoadResources(rows, 0)).toEqual(rows);
   });
 });
 

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
@@ -29,6 +29,19 @@ export interface MilestoneLine {
   ms: number;
 }
 
+/** The time range the waterfall currently displays (brush zoom). */
+export interface ViewWindow {
+  startMs: number;
+  endMs: number;
+}
+
+/** Map a millisecond offset onto the 0-100 percent range of a view window. */
+export function windowPercent(ms: number, w: ViewWindow): number {
+  const span = w.endMs - w.startMs;
+  if (span <= 0) { return 0; }
+  return Math.min(100, Math.max(0, ((ms - w.startMs) / span) * 100));
+}
+
 /** Scale end: whichever finishes last — the load event, the last response end,
  *  or the latest milestone (LCP can land after both; clamping it to the edge
  *  overprints its label into unreadable fragments). */
@@ -49,13 +62,15 @@ export function mergeMilestoneLabels(
   lines: MilestoneLine[],
   scaleMaxMs: number,
   minGapPercent = 2,
+  startMs = 0,
 ): MilestoneLine[] {
+  const window: ViewWindow = { startMs, endMs: scaleMaxMs };
   const sorted = [...lines].sort((a, b) => a.ms - b.ms);
   const merged: MilestoneLine[] = [];
   for (const line of sorted) {
     const last = merged[merged.length - 1];
     const titled = `${line.title} — ${formatTick(line.ms)}`;
-    if (last && toPercent(line.ms, scaleMaxMs) - toPercent(last.ms, scaleMaxMs) < minGapPercent) {
+    if (last && windowPercent(line.ms, window) - windowPercent(last.ms, window) < minGapPercent) {
       last.label = `${last.label} · ${line.label}`;
       last.title = `${last.title}\n${titled}`;
     } else {
@@ -100,6 +115,13 @@ export function groupRows(resources: ResourceRow[], gapMs: number = WATERFALL_GR
   return groups;
 }
 
+/** Resources that started before the load event; everything when the load
+ *  event is unknown (0) — a filter that hides all rows helps nobody. */
+export function initialLoadResources(resources: ResourceRow[], loadEventMs: number): ResourceRow[] {
+  if (loadEventMs <= 0) { return resources; }
+  return resources.filter(r => r.startMs <= loadEventMs);
+}
+
 /** Milestone lines to draw; null milestones are skipped. */
 export function milestoneLines(report: {
   domContentLoadedMs: number | null;
@@ -118,35 +140,51 @@ export function milestoneLines(report: {
     .map(([label, title, ms]) => ({ label, title, ms }));
 }
 
-/** 4-10 evenly spaced round-number ticks (1/2/2.5/5 x 10^k steps) up to the scale end. */
-export function axisTicks(scaleMaxMs: number): number[] {
-  if (scaleMaxMs <= 0) { return []; }
-  const pow = Math.pow(10, Math.floor(Math.log10(scaleMaxMs / 4)));
+/** 4-10 evenly spaced round-number ticks (1/2/2.5/5 x 10^k steps) across a window. */
+export function windowTicks(w: ViewWindow): number[] {
+  const span = w.endMs - w.startMs;
+  if (span <= 0) { return []; }
+  const pow = Math.pow(10, Math.floor(Math.log10(span / 4)));
   let step = 10 * pow;
   for (const m of [1, 2, 2.5, 5]) {
-    if (Math.floor(scaleMaxMs / (m * pow)) <= 10) {
+    if (Math.floor(span / (m * pow)) <= 10) {
       step = m * pow;
       break;
     }
   }
   const ticks: number[] = [];
-  for (let t = step; t <= scaleMaxMs; t += step) {
-    ticks.push(t);
+  for (let t = Math.ceil(w.startMs / step) * step; t <= w.endMs; t += step) {
+    if (t > w.startMs) { ticks.push(t); }
   }
   return ticks;
 }
 
-/** Tick label: ms below one second, seconds (trimmed) above. */
+/** windowTicks from zero up to the scale end. */
+export function axisTicks(scaleMaxMs: number): number[] {
+  return windowTicks({ startMs: 0, endMs: scaleMaxMs });
+}
+
+/** Tick label: ms below one second, seconds (trimmed, up to 2 decimals when zoomed) above. */
 export function formatTick(ms: number): string {
   if (ms < 1000) { return `${Math.round(ms)} ms`; }
-  const s = ms / 1000;
-  return `${Number.isInteger(s) ? s : s.toFixed(1)} s`;
+  return `${parseFloat((ms / 1000).toFixed(2))} s`;
 }
 
 /** Last path segment, ignoring a trailing slash; the path itself when empty. */
 export function basename(path: string): string {
   const segment = path.split('/').filter(Boolean).pop();
   return segment ?? path;
+}
+
+/** Row label: the basename, prefixed with its parent segment when the basename
+ *  has no extension — bare segments like "client", "component" or a guid say
+ *  nothing without the context of where they live. */
+export function rowLabel(path: string): string {
+  const segments = path.split('/').filter(Boolean);
+  const last = segments.pop();
+  if (last === undefined) { return path; }
+  const parent = segments.pop();
+  return last.includes('.') || parent === undefined ? last : `${parent}/${last}`;
 }
 
 @Component({
@@ -159,6 +197,19 @@ export function basename(path: string): string {
         Showing {{ pagedResourceCount() }} of {{ report().requestCount }} resources
         in {{ pagedGroups().length }} of {{ groups().length }} groups
       </span>
+      <label class="flex items-center gap-1.5 cursor-pointer select-none">
+        <input
+          type="checkbox" data-test="waterfall-initial-only"
+          [checked]="initialOnly()" (change)="initialOnly.set($any($event.target).checked)">
+        Initial load only
+      </label>
+      @if (viewWindow(); as w) {
+        <span data-test="waterfall-zoom-range">{{ formatTick(w.startMs) }} &ndash; {{ formatTick(w.endMs) }}</span>
+        <button
+          type="button" data-test="waterfall-zoom-reset"
+          class="px-1.5 py-0.5 rounded border border-content-border hover:bg-content-secondary"
+          (click)="resetZoom()">Reset zoom</button>
+      }
       @if (pageCount() > 1) {
         <button
           type="button" data-test="waterfall-prev"
@@ -174,21 +225,34 @@ export function basename(path: string): string {
     <div class="relative">
       <!-- Milestone lines span the header, rows and axis; offset past the label column. -->
       <div class="absolute inset-y-0 left-56 right-0 pointer-events-none" aria-hidden="true">
-        @for (m of milestones(); track m.label) {
+        @for (m of visibleMilestones(); track m.label) {
           <div
             class="absolute inset-y-0 w-0 border-l border-dashed border-content-muted opacity-60"
-            [style.left.%]="toPercent(m.ms, scaleMax())"></div>
+            [style.left.%]="pct(m.ms)"></div>
+        }
+        @if (brushRect(); as b) {
+          <div
+            class="absolute inset-y-0 bg-[#2a78d6]/15 border-x border-[#2a78d6]/50"
+            [style.left.%]="b.left" [style.width.%]="b.width"></div>
         }
       </div>
 
-      <!-- Top axis -->
+      <!-- Top axis: also the brush surface — drag along it to zoom. -->
       <div class="flex h-5">
         <div class="w-56 shrink-0"></div>
-        <div class="relative flex-1 min-w-0 border-b border-content-border">
+        <div
+          class="relative flex-1 min-w-0 border-b border-content-border cursor-crosshair touch-none"
+          data-test="waterfall-brush"
+          title="Drag to zoom to a time range; double-click to reset"
+          (pointerdown)="onBrushStart($event)"
+          (pointermove)="onBrushMove($event)"
+          (pointerup)="onBrushEnd()"
+          (pointercancel)="brush.set(null)"
+          (dblclick)="resetZoom()">
           @for (t of ticks(); track t) {
             <span
-              class="absolute bottom-1 -translate-x-1/2 text-[10px] leading-none text-content-muted whitespace-nowrap"
-              [style.left.%]="toPercent(t, scaleMax())">{{ formatTick(t) }}</span>
+              class="absolute bottom-1 -translate-x-1/2 text-[10px] leading-none text-content-muted whitespace-nowrap pointer-events-none"
+              [style.left.%]="pct(t)">{{ formatTick(t) }}</span>
           }
         </div>
       </div>
@@ -200,11 +264,11 @@ export function basename(path: string): string {
           @for (m of labelMilestones(); track m.label) {
             <span
               class="absolute top-0.5 text-[10px] leading-none text-content-muted whitespace-nowrap cursor-help"
-              [class.pl-1]="toPercent(m.ms, scaleMax()) <= 90"
-              [class.pr-1]="toPercent(m.ms, scaleMax()) > 90"
-              [style.transform]="toPercent(m.ms, scaleMax()) > 90 ? 'translateX(-100%)' : null"
+              [class.pl-1]="pct(m.ms) <= 90"
+              [class.pr-1]="pct(m.ms) > 90"
+              [style.transform]="pct(m.ms) > 90 ? 'translateX(-100%)' : null"
               [title]="m.title"
-              [style.left.%]="toPercent(m.ms, scaleMax())">{{ m.label }}</span>
+              [style.left.%]="pct(m.ms)">{{ m.label }}</span>
           }
         </div>
       </div>
@@ -214,13 +278,13 @@ export function basename(path: string): string {
       @for (g of pagedGroups(); track g.key) {
         @if (g.rows.length === 1) {
           <div class="flex h-5 items-stretch hover:bg-content-secondary transition-colors" [title]="barTitle(g.rows[0])">
-            <div class="w-56 shrink-0 pr-2 text-xs leading-5 text-content-muted truncate">{{ basename(g.rows[0].path) }}</div>
+            <div class="w-56 shrink-0 pr-2 text-xs leading-5 text-content-muted truncate">{{ rowLabel(g.rows[0].path) }}</div>
             <div class="relative flex-1 min-w-0">
               <div
                 class="absolute top-1/2 -translate-y-1/2 h-2.5 rounded bg-[#2a78d6] dark:bg-[#3987e5]"
                 style="min-width: 2px"
-                [style.left.%]="toPercent(g.rows[0].startMs, scaleMax())"
-                [style.width.%]="spanPercent(g.rows[0].startMs, g.rows[0].durationMs, scaleMax())"></div>
+                [style.left.%]="pct(g.rows[0].startMs)"
+                [style.width.%]="spanPct(g.rows[0].startMs, g.rows[0].durationMs)"></div>
             </div>
           </div>
         } @else {
@@ -230,26 +294,26 @@ export function basename(path: string): string {
             [title]="groupTitle(g)" (click)="toggle(g.key)">
             <span class="w-56 shrink-0 pr-2 text-xs leading-5 text-content-muted truncate">
               <span class="inline-block w-3" aria-hidden="true">{{ expanded().has(g.key) ? '▾' : '▸' }}</span>
-              {{ g.rows.length }} resources · {{ basename(g.rows[0].path) }}
+              {{ g.rows.length }} resources · {{ rowLabel(g.rows[0].path) }}
             </span>
             <span class="relative flex-1 min-w-0">
               <span
                 class="absolute top-1/2 -translate-y-1/2 h-2.5 rounded bg-[#2a78d6] dark:bg-[#3987e5] opacity-70"
                 style="min-width: 2px"
-                [style.left.%]="toPercent(g.startMs, scaleMax())"
-                [style.width.%]="spanPercent(g.startMs, g.endMs - g.startMs, scaleMax())"></span>
+                [style.left.%]="pct(g.startMs)"
+                [style.width.%]="spanPct(g.startMs, g.endMs - g.startMs)"></span>
             </span>
           </button>
           @if (expanded().has(g.key)) {
             @for (r of g.rows; track r.path + r.startMs) {
               <div class="flex h-5 items-stretch hover:bg-content-secondary transition-colors" [title]="barTitle(r)">
-                <div class="w-56 shrink-0 pl-3 pr-2 text-xs leading-5 text-content-muted truncate">{{ basename(r.path) }}</div>
+                <div class="w-56 shrink-0 pl-3 pr-2 text-xs leading-5 text-content-muted truncate">{{ rowLabel(r.path) }}</div>
                 <div class="relative flex-1 min-w-0">
                   <div
                     class="absolute top-1/2 -translate-y-1/2 h-2.5 rounded bg-[#2a78d6] dark:bg-[#3987e5]"
                     style="min-width: 2px"
-                    [style.left.%]="toPercent(r.startMs, scaleMax())"
-                    [style.width.%]="spanPercent(r.startMs, r.durationMs, scaleMax())"></div>
+                    [style.left.%]="pct(r.startMs)"
+                    [style.width.%]="spanPct(r.startMs, r.durationMs)"></div>
                 </div>
               </div>
             }
@@ -264,7 +328,7 @@ export function basename(path: string): string {
           @for (t of ticks(); track t) {
             <span
               class="absolute top-1 -translate-x-1/2 text-[10px] leading-none text-content-muted whitespace-nowrap"
-              [style.left.%]="toPercent(t, scaleMax())">{{ formatTick(t) }}</span>
+              [style.left.%]="pct(t)">{{ formatTick(t) }}</span>
           }
         </div>
       </div>
@@ -272,39 +336,120 @@ export function basename(path: string): string {
     <div class="pt-2 text-[11px] text-content-muted">
       Dashed lines mark page milestones: DCL = DOM content loaded, Load = load event,
       FCP = first contentful paint, LCP = largest contentful paint (hover a label for its time).
+      Drag along the top axis to zoom to a time range; drag again to drill deeper,
+      double-click the axis (or Reset zoom) to zoom back out.
     </div>
   `,
 })
 export class ResourceWaterfallComponent {
   report = input.required<LoadReport>();
 
-  groups = computed(() => groupRows(this.report().resources));
+  /** Hide fetches that started after the load event (lazy route chunks from
+   *  post-load navigation) so the scale stays comparable between looks. */
+  initialOnly = signal(false);
+  visibleResources = computed(() =>
+    this.initialOnly() ? initialLoadResources(this.report().resources, this.report().loadEventMs) : this.report().resources);
+
+  groups = computed(() => groupRows(this.visibleResources()));
+  milestones = computed(() => milestoneLines(this.report()));
+  scaleMax = computed(() => waterfallScaleMax(this.report().loadEventMs, this.visibleResources(), this.milestones()));
+
+  /** Brush zoom: null = full scale. */
+  viewWindow = signal<ViewWindow | null>(null);
+  view = computed<ViewWindow>(() => this.viewWindow() ?? { startMs: 0, endMs: this.scaleMax() });
+  /** In-progress drag selection, in percent of the current view. */
+  brush = signal<{ fromPct: number, toPct: number } | null>(null);
+  brushRect = computed(() => {
+    const b = this.brush();
+    if (!b) { return null; }
+    return { left: Math.min(b.fromPct, b.toPct), width: Math.abs(b.toPct - b.fromPct) };
+  });
+
+  /** Groups intersecting the view window; bars are clipped at the edges. */
+  windowGroups = computed(() => {
+    const v = this.view();
+    return this.groups().filter(g => g.endMs >= v.startMs && g.startMs <= v.endMs);
+  });
   page = signal(0);
-  pageCount = computed(() => Math.max(1, Math.ceil(this.groups().length / WATERFALL_ROW_CAP)));
+  pageCount = computed(() => Math.max(1, Math.ceil(this.windowGroups().length / WATERFALL_ROW_CAP)));
   safePage = computed(() => Math.min(this.page(), this.pageCount() - 1));
   pagedGroups = computed(() =>
-    this.groups().slice(this.safePage() * WATERFALL_ROW_CAP, (this.safePage() + 1) * WATERFALL_ROW_CAP));
+    this.windowGroups().slice(this.safePage() * WATERFALL_ROW_CAP, (this.safePage() + 1) * WATERFALL_ROW_CAP));
   pagedResourceCount = computed(() => this.pagedGroups().reduce((n, g) => n + g.rows.length, 0));
   expanded = signal<ReadonlySet<string>>(new Set());
 
-  milestones = computed(() => milestoneLines(this.report()));
-  scaleMax = computed(() => waterfallScaleMax(this.report().loadEventMs, this.report().resources, this.milestones()));
+  visibleMilestones = computed(() => {
+    const v = this.view();
+    return this.milestones().filter(m => m.ms >= v.startMs && m.ms <= v.endMs);
+  });
   /** Labels merged where they would overprint; the dashed lines still draw per milestone. */
-  labelMilestones = computed(() => mergeMilestoneLabels(this.milestones(), this.scaleMax()));
-  ticks = computed(() => axisTicks(this.scaleMax()));
+  labelMilestones = computed(() => {
+    const v = this.view();
+    return mergeMilestoneLabels(this.visibleMilestones(), v.endMs, 2, v.startMs);
+  });
+  ticks = computed(() => windowTicks(this.view()));
 
-  toPercent = toPercent;
-  spanPercent = spanPercent;
   formatTick = formatTick;
   basename = basename;
+  rowLabel = rowLabel;
 
   constructor() {
-    // A fresh report (Measure again) restarts on the first page, all collapsed.
+    // A fresh report (Measure again) restarts on the first page, all collapsed, unzoomed.
     effect(() => {
       this.report();
       this.page.set(0);
       this.expanded.set(new Set());
+      this.viewWindow.set(null);
     });
+  }
+
+  pct(ms: number): number {
+    return windowPercent(ms, this.view());
+  }
+
+  spanPct(startMs: number, durationMs: number): number {
+    const v = this.view();
+    return windowPercent(startMs + durationMs, v) - windowPercent(startMs, v);
+  }
+
+  private brushPct(e: PointerEvent): number {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    if (rect.width <= 0) { return 0; }
+    return Math.min(100, Math.max(0, ((e.clientX - rect.left) / rect.width) * 100));
+  }
+
+  onBrushStart(e: PointerEvent): void {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    const pct = this.brushPct(e);
+    this.brush.set({ fromPct: pct, toPct: pct });
+  }
+
+  onBrushMove(e: PointerEvent): void {
+    const b = this.brush();
+    if (!b) { return; }
+    this.brush.set({ ...b, toPct: this.brushPct(e) });
+  }
+
+  onBrushEnd(): void {
+    const b = this.brush();
+    this.brush.set(null);
+    if (!b) { return; }
+    const lo = Math.min(b.fromPct, b.toPct);
+    const hi = Math.max(b.fromPct, b.toPct);
+    if (hi - lo < 1) { return; } // a click, not a drag
+    const v = this.view();
+    const span = v.endMs - v.startMs;
+    this.viewWindow.set({
+      startMs: v.startMs + (lo / 100) * span,
+      endMs: v.startMs + (hi / 100) * span,
+    });
+    this.page.set(0);
+  }
+
+  resetZoom(): void {
+    this.viewWindow.set(null);
+    this.brush.set(null);
+    this.page.set(0);
   }
 
   prevPage(): void {
@@ -337,6 +482,7 @@ export class ResourceWaterfallComponent {
 
   groupTitle(g: WaterfallGroup): string {
     return [
+      g.rows[0].path,
       `${g.rows.length} resources starting within ${WATERFALL_GROUP_GAP_MS} ms`,
       `start: ${g.startMs.toFixed(0)} ms`,
       `span: ${(g.endMs - g.startMs).toFixed(0)} ms`,

--- a/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.html
+++ b/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.html
@@ -1,0 +1,76 @@
+<div class="p-4 space-y-4">
+  <div class="text-sm text-content-muted max-w-3xl">
+    Measures each Cloud Foundry endpoint's effective URI-length ceiling — the minimum across every proxy
+    hop between Stratos and the CF API. Guid-list filters wider than this ceiling are rejected with
+    HTTP 414 and silently drop counts. Probes run only when you click the button
+    (~10 unauthenticated requests); nothing probes automatically.
+  </div>
+
+  @if (!hasEndpoints()) {
+    <div data-test="probes-empty" class="text-content-muted">No Cloud Foundry endpoints registered.</div>
+  }
+
+  @for (ep of cfEndpoints(); track ep.guid) {
+    <div data-test="probe-row" class="border border-content-border rounded p-4 space-y-2">
+      <div class="flex items-center gap-3">
+        <div class="font-semibold">{{ ep.name }}</div>
+        <div class="text-sm text-content-muted">{{ address(ep) }}</div>
+        <div class="flex-1"></div>
+        <button type="button" data-test="probe-run"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded font-semibold text-sm bg-primary text-white hover:bg-primary/90 transition-all duration-150 disabled:opacity-50"
+                [disabled]="stateFor(ep.guid).running"
+                (click)="probe(ep.guid)">
+          @if (stateFor(ep.guid).running) {
+            <div class="spinner !h-4 !w-4 !border-2"></div>
+            Probing…
+          } @else {
+            <span class="material-icons text-base leading-none">network_check</span>
+            Probe URI limit
+          }
+        </button>
+      </div>
+
+      @if (stateFor(ep.guid).error; as err) {
+        <div data-test="probe-error" class="text-sm text-danger">{{ err }}</div>
+      }
+
+      @if (stateFor(ep.guid).result; as r) {
+        <div data-test="probe-result" class="text-sm space-y-1">
+          <div>
+            Chain accepts <span class="font-semibold">{{ r.probedLimitBytes | number }}</span> bytes
+            @if (r.cappedAtMax) { <span class="text-content-muted">(at least — search capped)</span> }
+            <span class="text-content-muted">({{ r.probeRequests }} probe requests)</span>
+          </div>
+          <div>
+            Configured budget: <span class="font-mono">STRATOS_CF_GUID_CHUNK={{ r.adaptive ? 'auto' : r.configuredChunk }}</span>
+            → {{ r.configuredBytes | number }} bytes per request
+            @if (r.adaptive && r.effectiveChunk !== r.configuredChunk) {
+              <span class="text-content-muted">(adapted to {{ r.effectiveChunk }} at runtime)</span>
+            }
+          </div>
+          @switch (verdict(r)) {
+            @case ('lower') {
+              <div data-test="probe-verdict-lower" class="text-danger">
+                <span class="material-icons text-base leading-none align-text-bottom">warning</span>
+                Configured budget exceeds what this chain accepts — set
+                <span class="font-mono">STRATOS_CF_GUID_CHUNK={{ r.recommendedChunk }}</span> or lower.
+              </div>
+            }
+            @case ('headroom') {
+              <div data-test="probe-verdict-headroom" class="text-content-muted">
+                Headroom available: <span class="font-mono">STRATOS_CF_GUID_CHUNK={{ r.recommendedChunk }}</span>
+                would use this chain's ceiling.
+              </div>
+            }
+            @case ('ok') {
+              <div data-test="probe-verdict-ok" class="text-success">
+                <span class="material-icons text-base leading-none align-text-bottom">check_circle</span>
+                Configured budget fits this chain.
+              </div>
+            }
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.html
+++ b/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.html
@@ -1,4 +1,8 @@
 <div class="p-4 space-y-4">
+  <div data-test="poc-notice"
+    class="px-3 py-2 text-sm rounded border border-warning-shade-300 bg-warning-shade-100 text-warning-shade-700 dark:border-warning-shade-700 dark:bg-warning-shade-900/30 dark:text-warning-shade-300">
+    Proof of concept &mdash; this page and its metrics are exploratory and may change or be removed.
+  </div>
   <div class="text-sm text-content-muted max-w-3xl">
     Measures each Cloud Foundry endpoint's effective URI-length ceiling — the minimum across every proxy
     hop between Stratos and the CF API. Guid-list filters wider than this ceiling are rejected with

--- a/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EndpointsDataService } from '@stratosui/store';
+
+import { DiagnosticProbesPageComponent } from './diagnostic-probes-page.component';
+
+const SYSTEM_INFO_URL = '/pp/v1/info';
+const PROBE_URL = '/pp/v1/cf/diag/urilimit/cf-1';
+
+const systemInfo = {
+  version: { proxy_version: 'test', database_version: 1 },
+  user: { guid: 'u1', name: 'admin', admin: true },
+  endpoints: {
+    cf: {
+      'cf-1': {
+        guid: 'cf-1', name: 'cf-one', cnsi_type: 'cf',
+        api_endpoint: { Scheme: 'https', Host: 'api.example.com' },
+        user: { guid: 'u1', name: 'admin', admin: true },
+        system_shared_token: false, sso_allowed: false, metricsAvailable: false,
+        creator: { name: 'admin', admin: true, system: false },
+      },
+    },
+  },
+};
+
+const probeResult = {
+  probedLimitBytes: 8064, cappedAtMax: false,
+  configuredChunk: 150, effectiveChunk: 150, configuredBytes: 5850,
+  adaptive: false, recommendedChunk: 200, probeRequests: 11,
+};
+
+describe('DiagnosticProbesPageComponent', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        EndpointsDataService,
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  async function createHydrated() {
+    const svc = TestBed.inject(EndpointsDataService);
+    const p = svc.getAll();
+    httpMock.expectOne(SYSTEM_INFO_URL).flush(systemInfo);
+    await p;
+    const fixture = TestBed.createComponent(DiagnosticProbesPageComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders a probe row per CF endpoint with a run button', async () => {
+    const fixture = await createHydrated();
+    const rows = fixture.nativeElement.querySelectorAll('[data-test="probe-row"]');
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('cf-one');
+    expect(rows[0].textContent).toContain('https://api.example.com');
+    expect(fixture.nativeElement.querySelector('[data-test="probe-run"]')).not.toBeNull();
+  });
+
+  it('probe click calls the backend and renders probed-vs-configured with headroom verdict', async () => {
+    const fixture = await createHydrated();
+    const done = fixture.componentInstance.probe('cf-1');
+    httpMock.expectOne(PROBE_URL).flush(probeResult);
+    await done;
+    fixture.detectChanges();
+    const result = fixture.nativeElement.querySelector('[data-test="probe-result"]');
+    expect(result).not.toBeNull();
+    expect(result.textContent).toContain('8,064');
+    expect(result.textContent).toContain('STRATOS_CF_GUID_CHUNK=150');
+    expect(fixture.nativeElement.querySelector('[data-test="probe-verdict-headroom"]')?.textContent)
+      .toContain('STRATOS_CF_GUID_CHUNK=200');
+  });
+
+  it('warns to lower the setting when the configured budget exceeds the probed ceiling', async () => {
+    const fixture = await createHydrated();
+    const done = fixture.componentInstance.probe('cf-1');
+    httpMock.expectOne(PROBE_URL).flush({ ...probeResult, probedLimitBytes: 4096, recommendedChunk: 78 });
+    await done;
+    fixture.detectChanges();
+    const verdict = fixture.nativeElement.querySelector('[data-test="probe-verdict-lower"]');
+    expect(verdict).not.toBeNull();
+    expect(verdict.textContent).toContain('STRATOS_CF_GUID_CHUNK=78');
+  });
+
+  it('surfaces a probe failure without wedging the button', async () => {
+    const fixture = await createHydrated();
+    const done = fixture.componentInstance.probe('cf-1');
+    httpMock.expectOne(PROBE_URL).flush({ detail: 'probe failed: endpoint unreachable' }, { status: 502, statusText: 'Bad Gateway' });
+    await done;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-test="probe-error"]')).not.toBeNull();
+    expect(fixture.componentInstance.stateFor('cf-1').running).toBe(false);
+  });
+});

--- a/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, Component, Signal, WritableSignal, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { EndpointModel, EndpointsDataService } from '@stratosui/store';
+
+// Result DTO from GET /pp/v1/cf/diag/urilimit/:cnsiGuid (#5579).
+interface URILimitProbeResult {
+  probedLimitBytes: number;
+  cappedAtMax: boolean;
+  configuredChunk: number;
+  effectiveChunk: number;
+  configuredBytes: number;
+  adaptive: boolean;
+  recommendedChunk: number;
+  probeRequests: number;
+}
+
+interface ProbeState {
+  running: boolean;
+  result?: URILimitProbeResult;
+  error?: string;
+}
+
+// Operator-triggered probe of each CF endpoint's composite URI-length
+// ceiling. The limit is the min across every hop in the endpoint's proxy
+// chain and cannot be derived from configuration — only measured. Nothing
+// here runs automatically ("no churn to endpoints"): each probe is a
+// button click issuing ~10 unauthenticated requests via the backend.
+@Component({
+  selector: 'app-diagnostic-probes-page',
+  templateUrl: './diagnostic-probes-page.component.html',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DiagnosticProbesPageComponent {
+  private readonly http = inject(HttpClient);
+  private readonly endpoints = inject(EndpointsDataService);
+
+  readonly cfEndpoints: Signal<EndpointModel[]> = this.endpoints.endpointsByType('cf');
+  private readonly states: WritableSignal<Map<string, ProbeState>> = signal(new Map());
+
+  readonly hasEndpoints = computed(() => this.cfEndpoints().length > 0);
+
+  constructor() {
+    // Hydrate the endpoint list when landing on this tab directly.
+    void this.endpoints.whenReady();
+  }
+
+  stateFor(guid: string): ProbeState {
+    return this.states().get(guid) ?? { running: false };
+  }
+
+  address(ep: EndpointModel): string {
+    const api = ep.api_endpoint;
+    if (!api) { return ''; }
+    return `${api.Scheme}://${api.Host}`;
+  }
+
+  // The probed ceiling is only comfortably used when the configured chunk
+  // fits under it with the same reserve the backend recommendation uses.
+  verdict(r: URILimitProbeResult): 'ok' | 'lower' | 'headroom' {
+    if (r.configuredChunk > r.recommendedChunk) { return 'lower'; }
+    if (r.recommendedChunk > r.configuredChunk * 1.2) { return 'headroom'; }
+    return 'ok';
+  }
+
+  async probe(guid: string): Promise<void> {
+    this.patch(guid, { running: true, result: undefined, error: undefined });
+    try {
+      const result = await firstValueFrom(
+        this.http.get<URILimitProbeResult>(`/pp/v1/cf/diag/urilimit/${guid}`));
+      this.patch(guid, { running: false, result });
+    } catch (e: any) {
+      const detail = e?.error?.detail ?? e?.message ?? 'probe failed';
+      this.patch(guid, { running: false, error: String(detail) });
+    }
+  }
+
+  private patch(guid: string, state: ProbeState): void {
+    this.states.update(m => {
+      const next = new Map(m);
+      next.set(guid, state);
+      return next;
+    });
+  }
+}

--- a/src/frontend/packages/core/src/features/about/diagnostics-base/diagnostics-base.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-base/diagnostics-base.component.spec.ts
@@ -46,6 +46,6 @@ describe('DiagnosticsBaseComponent', () => {
   });
 
   it('defines the diagnostics tab links', () => {
-    expect(component.tabLinks.map(t => t.link)).toEqual(['overview', 'counts', 'performance']);
+    expect(component.tabLinks.map(t => t.link)).toEqual(['overview', 'counts', 'performance', 'probes']);
   });
 });

--- a/src/frontend/packages/core/src/features/about/diagnostics-base/diagnostics-base.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-base/diagnostics-base.component.ts
@@ -23,5 +23,6 @@ export class DiagnosticsBaseComponent {
     { link: 'overview', label: 'Overview', icon: 'build' },
     { link: 'counts', label: 'Entity Counts', icon: 'storage' },
     { link: 'performance', label: 'Load Performance', icon: 'speed' },
+    { link: 'probes', label: 'Endpoint Probes', icon: 'network_check' },
   ];
 }

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -223,6 +223,22 @@
           <span class="text-lg">{{ config.loadingMessage ?? 'Loading…' }}</span>
         </div>
       </div>
+    } @else if (config.totalFilteredResults() === 0 && config.errorsByCnsi().size > 0) {
+      <!-- Failed-load state: the drain errored and automatic retries are
+           exhausted. Offer an in-page Retry (same handler as the toolbar
+           refresh) instead of a misleading "no items" (#5577). -->
+      <div data-test="empty-error" class="flex flex-col items-center justify-center h-full gap-3 text-content-muted">
+        <span class="material-icons text-6xl opacity-30 text-danger">error_outline</span>
+        <span class="text-base">{{ config.errorMessage ?? 'Failed to load — the endpoint may be temporarily unreachable' }}</span>
+        @if (config.onRefresh) {
+          <button type="button" data-test="empty-error-retry"
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded font-semibold text-sm bg-primary text-white hover:bg-primary/90 transition-all duration-150"
+                  (click)="invokeRefresh()">
+            <span class="material-icons text-base leading-none">refresh</span>
+            Retry
+          </button>
+        }
+      </div>
     } @else if (config.totalFilteredResults() === 0) {
       @if (hasActiveFilter()) {
         <div data-test="empty-filtered" class="flex flex-col items-center justify-center h-full gap-3 text-content-muted">

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -119,6 +119,41 @@ describe('SignalListComponent', () => {
     expect(empty.textContent).toContain('There are no items');
   });
 
+  it('renders the failed-load state with a working Retry button when empty and errored (#5577)', async () => {
+    const onRefresh = vi.fn();
+    const fixture = TestBed.createComponent(Host);
+    fixture.componentInstance.config = {
+      ...fixture.componentInstance.config,
+      totalFilteredResults: signal(0).asReadonly(),
+      errorsByCnsi: signal(new Map<string, unknown>([['cnsi-1', new Error('boom')]])).asReadonly(),
+      errorMessage: 'Failed to load organizations',
+      onRefresh,
+    };
+    fixture.detectChanges();
+    // Failed-load state replaces the plain empty state...
+    expect(fixture.nativeElement.querySelector('[data-test="empty"]')).toBeNull();
+    const errorState = fixture.nativeElement.querySelector('[data-test="empty-error"]');
+    expect(errorState).not.toBeNull();
+    expect(errorState.textContent).toContain('Failed to load organizations');
+    // ...and its Retry button drives the same refresh handler as the toolbar.
+    const retry = fixture.nativeElement.querySelector('[data-test="empty-error-retry"]');
+    expect(retry).not.toBeNull();
+    retry.click();
+    await fixture.whenStable();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers the plain empty state when empty without errors', () => {
+    const fixture = TestBed.createComponent(Host);
+    fixture.componentInstance.config = {
+      ...fixture.componentInstance.config,
+      totalFilteredResults: signal(0).asReadonly(),
+    };
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-test="empty-error"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-test="empty"]')).not.toBeNull();
+  });
+
   it('resets pageIndex to 0 when page size changes', () => {
     const fixture = TestBed.createComponent(Host);
     fixture.componentInstance.pageIndex.set(3);

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -357,6 +357,12 @@ export interface SignalListConfig<T> {
   // the UI distinguish "no apps here" from "your filters match nothing".
   readonly emptyFilterMessage?: string;
   readonly loadingMessage?: string;
+  // Shown in the failed-load empty state (0 rows AND errorsByCnsi
+  // non-empty). That state also renders a Retry button wired to onRefresh,
+  // so a transient failure that exhausted the automatic retries has an
+  // in-page recovery affordance instead of an empty list until
+  // re-navigation (#5577).
+  readonly errorMessage?: string;
   readonly nameFilter?: WritableSignal<string>;
   // Column keys (see SignalListColumn.key / header fallback) eligible for
   // the text-filter. When 2+ entries are provided AND filterField is

--- a/src/frontend/packages/store/src/services/endpoints-data.service.spec.ts
+++ b/src/frontend/packages/store/src/services/endpoints-data.service.spec.ts
@@ -167,6 +167,29 @@ describe('EndpointsDataService', () => {
     expect(svc.disconnectedSignal()).toHaveLength(1);
   });
 
+  it('update() sends the endpoint id in the form body (backend correlation contract)', async () => {
+    const p = svc.getAll();
+    httpMock.expectOne(SYSTEM_INFO_URL).flush(makeSystemInfo());
+    await p;
+
+    const updatePromise = svc.update('cf-1', {
+      endpointType: 'cf', name: 'cf-one-renamed', skipSSL: true, setClientInfo: false,
+      clientID: '', clientSecret: '', allowSSO: false, caCert: '',
+    });
+    const req = httpMock.expectOne('/api/v1/endpoints/cf-1');
+    expect(req.request.method).toBe('POST');
+    const body = req.request.body as FormData;
+    expect(body.get('id')).toBe('cf-1');
+    expect(body.get('name')).toBe('cf-one-renamed');
+    req.flush({ guid: 'cf-1' });
+    // update() re-fetches the endpoint list on success (async callback —
+    // yield a macrotask so the GET is issued before we expect it)
+    await new Promise(resolve => setTimeout(resolve));
+    httpMock.expectOne(SYSTEM_INFO_URL).flush(makeSystemInfo());
+    const state = await updatePromise;
+    expect(state.error).toBe(false);
+  });
+
   it('clearDisconnected resets the delta queue', async () => {
     const p = svc.getAll();
     httpMock.expectOne(SYSTEM_INFO_URL).flush(makeSystemInfo());

--- a/src/frontend/packages/store/src/services/endpoints-data.service.ts
+++ b/src/frontend/packages/store/src/services/endpoints-data.service.ts
@@ -412,6 +412,11 @@ export class EndpointsDataService {
 
   async update(guid: string, opts: EndpointUpdateOptions): Promise<ActionState> {
     const body = new FormData();
+    // The backend requires the id in the body (UpdateEndpointParams) and
+    // uses it to correlate parallel operations; older backends never read
+    // the :id in the URL path. The migration dropped this field, which made
+    // every endpoint edit fail with 400 "Missing target endpoint".
+    body.set('id', guid);
     body.set('name', opts.name);
     body.set('skipSSL', String(opts.skipSSL));
     body.set('setClientInfo', String(opts.setClientInfo));

--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -508,7 +508,12 @@ type RegisterEndpointParams struct {
 }
 
 type UpdateEndpointParams struct {
-	ID            string `json:"id" form:"id" query:"id"`
+	// param:"id" binds the :id from the route path (POST /endpoints/:id) —
+	// the resource being POSTed to is the resource being updated. The
+	// form/json/query bindings remain because clients also send the id in
+	// the body to correlate parallel operations; a body id, when present,
+	// overrides the path value (echo binds path params before the body).
+	ID            string `json:"id" form:"id" query:"id" param:"id"`
 	Name          string `json:"name" form:"name" query:"name"`
 	SkipSSL       string `json:"skipSSL" form:"skipSSL" query:"skipSSL"`
 	SetClientInfo string `json:"setClientInfo" form:"setClientInfo" query:"setClientInfo"`

--- a/src/jetstream/cnsi_test.go
+++ b/src/jetstream/cnsi_test.go
@@ -789,3 +789,53 @@ func TestListCNSIsWithUserEndpointsEnabled(t *testing.T) {
 		})
 	})
 }
+
+// Regression for the migrated endpoint-edit flow: the frontend PUTs the
+// endpoint id only in the URL path (POST /pp/v1/endpoints/:id). Before
+// UpdateEndpointParams gained the param:"id" tag, Bind left params.ID
+// empty and every update failed with the shadow 400 "Missing target
+// endpoint" before reaching the endpoint lookup.
+func TestUpdateEndpointBindsPathID(t *testing.T) {
+	t.Parallel()
+
+	req := setupMockReq("POST", "", map[string]string{"name": "renamed"})
+	_, _, ctx, pp, db, _ := setupHTTPTest(req)
+	defer db.Close()
+
+	ctx.SetParamNames("id")
+	ctx.SetParamValues(mockCNSIGUID)
+
+	err := pp.updateEndpoint(ctx)
+	if err == nil {
+		t.Fatal("expected the endpoint lookup to fail (no DB rows mocked)")
+	}
+	if strings.Contains(err.Error(), "Missing target endpoint") {
+		t.Errorf("update rejected before the lookup — path :id was not bound: %v", err)
+	}
+	// The lookup error names the guid it searched for — proves the path id
+	// travelled through Bind into the handler.
+	if !strings.Contains(err.Error(), mockCNSIGUID) {
+		t.Errorf("expected lookup error to reference the path id %q, got: %v", mockCNSIGUID, err)
+	}
+}
+
+// A body id, when present, still wins over the path id — clients send it to
+// correlate parallel operations and that contract is preserved.
+func TestUpdateEndpointBodyIDOverridesPath(t *testing.T) {
+	t.Parallel()
+
+	req := setupMockReq("POST", "", map[string]string{"id": "body-id", "name": "renamed"})
+	_, _, ctx, _, db, _ := setupHTTPTest(req)
+	defer db.Close()
+
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("path-id")
+
+	params := new(api.UpdateEndpointParams)
+	if err := ctx.Bind(params); err != nil {
+		t.Fatalf("bind failed: %v", err)
+	}
+	if params.ID != "body-id" {
+		t.Errorf("expected body id to override path id, got %q", params.ID)
+	}
+}

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
@@ -128,24 +128,30 @@ func fetchWebProcessesForApps(ctx echo.Context, cfClient capi.Client, appGUIDs [
 	}
 
 	processes := make(map[string]capi.Process, len(appGUIDs))
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["app_guids"] = appGUIDs
-		params.Filters["types"] = []string{"web"}
+	// Chunked — see native_guid_chunks.go / #5579.
+	cerr := forEachGuidChunk("app_guids", appGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["app_guids"] = chunk
+			params.Filters["types"] = []string{"web"}
 
-		raw, err := cfClient.Processes().List(ctx.Request().Context(), params)
-		if err != nil {
-			return nil, err
-		}
-		for _, p := range raw.Resources {
-			if p.Relationships != nil && p.Relationships.App != nil {
-				processes[relationshipGUID(*p.Relationships.App)] = p
+			raw, err := cfClient.Processes().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
+			}
+			for _, p := range raw.Resources {
+				if p.Relationships != nil && p.Relationships.App != nil {
+					processes[relationshipGUID(*p.Relationships.App)] = p
+				}
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
 			}
 		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if cerr != nil {
+		return nil, cerr
 	}
 	return processes, nil
 }
@@ -160,21 +166,27 @@ func fetchSpacesByGUIDs(ctx echo.Context, cfClient capi.Client, spaceGUIDs []str
 		return map[string]capi.Space{}, nil
 	}
 	spaces := make(map[string]capi.Space, len(spaceGUIDs))
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["guids"] = spaceGUIDs
+	// Chunked — see native_guid_chunks.go / #5579.
+	cerr := forEachGuidChunk("guids", spaceGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["guids"] = chunk
 
-		raw, err := cfClient.Spaces().List(ctx.Request().Context(), params)
-		if err != nil {
-			return nil, err
+			raw, err := cfClient.Spaces().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
+			}
+			for _, s := range raw.Resources {
+				spaces[s.GUID] = s
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
+			}
 		}
-		for _, s := range raw.Resources {
-			spaces[s.GUID] = s
-		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if cerr != nil {
+		return nil, cerr
 	}
 	return spaces, nil
 }
@@ -189,21 +201,27 @@ func fetchOrgsByGUIDs(ctx echo.Context, cfClient capi.Client, orgGUIDs []string)
 		return map[string]capi.Organization{}, nil
 	}
 	orgs := make(map[string]capi.Organization, len(orgGUIDs))
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["guids"] = orgGUIDs
+	// Chunked — see native_guid_chunks.go / #5579.
+	cerr := forEachGuidChunk("guids", orgGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["guids"] = chunk
 
-		raw, err := cfClient.Organizations().List(ctx.Request().Context(), params)
-		if err != nil {
-			return nil, err
+			raw, err := cfClient.Organizations().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
+			}
+			for _, o := range raw.Resources {
+				orgs[o.GUID] = o
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
+			}
 		}
-		for _, o := range raw.Resources {
-			orgs[o.GUID] = o
-		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if cerr != nil {
+		return nil, cerr
 	}
 	return orgs, nil
 }
@@ -230,31 +248,37 @@ func fetchRoutesForApps(ctx echo.Context, cfClient capi.Client, appGUIDs []strin
 	}
 
 	out := make(map[string][]StAppRoute, len(appGUIDs))
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["app_guids"] = appGUIDs
+	// Chunked — see native_guid_chunks.go / #5579.
+	cerr := forEachGuidChunk("app_guids", appGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["app_guids"] = chunk
 
-		raw, err := cfClient.Routes().List(ctx.Request().Context(), params)
-		if err != nil {
-			return nil, err
-		}
-		for _, r := range raw.Resources {
-			ar := StAppRoute{GUID: r.GUID, URL: r.URL}
-			for _, d := range r.Destinations {
-				appGUID := d.App.GUID
-				if appGUID == "" {
-					continue
+			raw, err := cfClient.Routes().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
+			}
+			for _, r := range raw.Resources {
+				ar := StAppRoute{GUID: r.GUID, URL: r.URL}
+				for _, d := range r.Destinations {
+					appGUID := d.App.GUID
+					if appGUID == "" {
+						continue
+					}
+					if _, ok := wanted[appGUID]; !ok {
+						continue
+					}
+					out[appGUID] = append(out[appGUID], ar)
 				}
-				if _, ok := wanted[appGUID]; !ok {
-					continue
-				}
-				out[appGUID] = append(out[appGUID], ar)
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
 			}
 		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if cerr != nil {
+		return nil, cerr
 	}
 	return out, nil
 }

--- a/src/jetstream/plugins/cloudfoundry/native_errors.go
+++ b/src/jetstream/plugins/cloudfoundry/native_errors.go
@@ -116,6 +116,13 @@ func classifyNativeErrors(next echo.HandlerFunc) echo.HandlerFunc {
 			log.Debugf("[diag drain] client-abort cnsi=%s path=%s err=%v", cnsiGUID, ctx.Path(), err)
 			return echo.NewHTTPError(statusClientClosedRequest, "client closed request")
 		}
+		// A 414 that escaped the chunked internal drains means a pass-through
+		// guid filter (width = whatever the frontend sent) exceeded the
+		// platform's URI ceiling — make it operator-visible (#5579).
+		if upstreamStatusOf(err) == 414 {
+			log.Warnf("request %s rejected upstream with 414 Request-URI Too Large — a guid filter exceeds what the platform chain accepts; re-run the endpoint probe on the diagnostics page and lower %s (currently %d)",
+				ctx.Path(), guidChunkEnv, guidChunkSize())
+		}
 		return nativeCFError(ctx, cnsiGUID, err)
 	}
 }

--- a/src/jetstream/plugins/cloudfoundry/native_errors.go
+++ b/src/jetstream/plugins/cloudfoundry/native_errors.go
@@ -12,12 +12,25 @@ import (
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
 	"github.com/fivetwenty-io/capi/v3/pkg/capi"
 	"github.com/labstack/echo/v4"
+	log "github.com/sirupsen/logrus"
 )
 
 // capiStatusRe matches the "(status NNN)" fragment capi.MapHTTPError embeds in
 // its error messages. capi sentinel errors don't expose the numeric HTTP
 // status via a field, so this is the only way to recover it for display.
 var capiStatusRe = regexp.MustCompile(`\(status (\d{3})\)`)
+
+// gorouterRouteMissingRe matches the body gorouter returns when the platform's
+// route table has no entry for the CF API host ("404 Not Found: Requested
+// route ('api.example.com') does not exist."). It reaches us as a capi 404,
+// but it is a router-level availability failure — the CF API itself was never
+// consulted — so it must not be confused with a CAPI resource 404.
+var gorouterRouteMissingRe = regexp.MustCompile(`Requested route \('[^']*'\) does not exist`)
+
+// isRouterRouteMissing reports whether err is the gorouter route-flap 404.
+func isRouterRouteMissing(err error) bool {
+	return err != nil && gorouterRouteMissingRe.MatchString(err.Error())
+}
 
 // stratosErrorReasonHeader carries the machine-readable failure classification
 // to the frontend. Present only for the called-out reasons (unreachable,
@@ -95,7 +108,40 @@ func classifyNativeErrors(next echo.HandlerFunc) echo.HandlerFunc {
 		if cnsiGUID == "" {
 			return err
 		}
+		// Client abandoned the request (page navigation cancels in-flight
+		// fetches — routine). Not a gateway failure: log quietly at debug
+		// and answer 499-style instead of polluting logs/metrics with 502s.
+		// The response never reaches the client anyway.
+		if reqErr := ctx.Request().Context().Err(); errors.Is(reqErr, context.Canceled) {
+			log.Debugf("[diag drain] client-abort cnsi=%s path=%s err=%v", cnsiGUID, ctx.Path(), err)
+			return echo.NewHTTPError(statusClientClosedRequest, "client closed request")
+		}
 		return nativeCFError(ctx, cnsiGUID, err)
+	}
+}
+
+// statusClientClosedRequest is nginx's non-standard 499 "client closed
+// request" — the conventional status for a request the client abandoned.
+const statusClientClosedRequest = 499
+
+// diagFailKind classifies a failed CAPI call in a parallel drain for the
+// [diag drain] logs, so one real failure that cancels its errgroup siblings
+// reads as 1 primary + N collateral instead of N+1 independent failures:
+//   - "primary": a real upstream failure (not a cancellation)
+//   - "client_abort": canceled because the browser dropped the request
+//   - "collateral": canceled because a sibling in the same errgroup failed
+//
+// parent is the request-scoped context from before the errgroup wrap.
+func diagFailKind(parent context.Context, err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case !errors.Is(err, context.Canceled):
+		return "primary"
+	case parent.Err() != nil:
+		return "client_abort"
+	default:
+		return "collateral"
 	}
 }
 
@@ -170,6 +216,13 @@ func classifyCfError(err error) cfErrorReason {
 		default:
 			return reasonUnclassified
 		}
+	}
+
+	// gorouter route-flap: a 404 from the platform router, not from CAPI.
+	// The API route was missing from the route table, so the endpoint was
+	// effectively unreachable regardless of the 404 status.
+	if isRouterRouteMissing(err) {
+		return reasonUnreachable
 	}
 
 	// capi CF-API call path: sentinels mapped by capi.MapHTTPError.

--- a/src/jetstream/plugins/cloudfoundry/native_errors_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_errors_test.go
@@ -53,6 +53,9 @@ func TestClassifyCfError(t *testing.T) {
 		{"capi 404 not found", fmt.Errorf("get failed: %w", capi.ErrNotFound), reasonUnclassified},
 		{"capi 422 unprocessable", fmt.Errorf("create failed: %w", capi.ErrUnprocessable), reasonUnclassified},
 
+		// --- gorouter route-flap: platform router lost the API route ---
+		{"gorouter route missing", errors.New("listing organizations: capi: resource not found (status 404): 404 Not Found: Requested route ('api.sys.example.com') does not exist."), reasonUnreachable},
+
 		// --- transport-level errors (no HTTP response at all) ---
 		{"net error", fakeNetError{}, reasonUnreachable},
 		{"net error wrapped", fmt.Errorf("doing request: %w", fakeNetError{timeout: true}), reasonUnreachable},
@@ -127,6 +130,23 @@ func TestClassifyNativeErrorsMiddleware(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("client-abort answers 499, not a shaped 502", func(t *testing.T) {
+		reqCtx, cancel := context.WithCancel(context.Background())
+		req := httptest.NewRequest(http.MethodGet, "/cf/orgs/cnsi-9", nil).WithContext(reqCtx)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("cnsiGuid")
+		c.SetParamValues("cnsi-9")
+		err := classifyNativeErrors(func(ctx echo.Context) error {
+			cancel() // browser navigates away mid-handler
+			return fmt.Errorf("executing request: %w", context.Canceled)
+		})(c)
+		he, ok := err.(*echo.HTTPError)
+		require.True(t, ok)
+		assert.Equal(t, statusClientClosedRequest, he.Code)
+		assert.Empty(t, c.Response().Header().Get(stratosErrorReasonHeader))
+	})
+
 	t.Run("raw error without cnsiGuid passes through untouched", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/no-cnsi", nil)
 		rec := httptest.NewRecorder()
@@ -134,6 +154,68 @@ func TestClassifyNativeErrorsMiddleware(t *testing.T) {
 		raw := errors.New("boom")
 		err := classifyNativeErrors(func(ctx echo.Context) error { return raw })(c)
 		assert.Same(t, raw, err)
+	})
+}
+
+func TestDiagFailKind(t *testing.T) {
+	live := context.Background()
+	dead, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.Equal(t, "", diagFailKind(live, nil))
+	assert.Equal(t, "primary", diagFailKind(live, errors.New("real upstream failure")))
+	assert.Equal(t, "primary", diagFailKind(dead, errors.New("real upstream failure")))
+	assert.Equal(t, "collateral", diagFailKind(live, fmt.Errorf("giving up: %w", context.Canceled)))
+	assert.Equal(t, "client_abort", diagFailKind(dead, fmt.Errorf("giving up: %w", context.Canceled)))
+}
+
+func TestListWithRouterFlapRetry(t *testing.T) {
+	routerFlap := errors.New("capi: resource not found (status 404): 404 Not Found: Requested route ('api.sys.example.com') does not exist.")
+
+	t.Run("retries router flap then succeeds", func(t *testing.T) {
+		calls := 0
+		got, err := listWithRouterFlapRetry(context.Background(), "test", func() (int, error) {
+			calls++
+			if calls == 1 {
+				return 0, routerFlap
+			}
+			return 42, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 42, got)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("gives up after the retry budget", func(t *testing.T) {
+		calls := 0
+		_, err := listWithRouterFlapRetry(context.Background(), "test", func() (int, error) {
+			calls++
+			return 0, routerFlap
+		})
+		assert.ErrorIs(t, err, routerFlap)
+		assert.Equal(t, routerFlapRetries+1, calls)
+	})
+
+	t.Run("does not retry other errors", func(t *testing.T) {
+		calls := 0
+		_, err := listWithRouterFlapRetry(context.Background(), "test", func() (int, error) {
+			calls++
+			return 0, errors.New("capi: resource not found (status 404): org does not exist")
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("does not retry when the context is done", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		_, err := listWithRouterFlapRetry(ctx, "test", func() (int, error) {
+			calls++
+			return 0, routerFlap
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 1, calls)
 	})
 }
 

--- a/src/jetstream/plugins/cloudfoundry/native_guid_chunks.go
+++ b/src/jetstream/plugins/cloudfoundry/native_guid_chunks.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -74,6 +75,28 @@ func chunkGuids(guids []string) [][]string {
 	return chunks
 }
 
+// guidChunkFloor bounds the adaptive halving: below this width, chunking
+// is not the problem (a 10-guid filter is ~400 bytes) and the 414 must
+// have another cause — stop retrying and surface the error.
+const guidChunkFloor = 10
+
+// adaptedChunkSize is the width adaptive mode derived from runtime 414s
+// (0 = never adapted). Process-wide, not per-endpoint: when multiple
+// registered CFs sit behind different chains, the tightest one wins —
+// conservative by construction.
+var adaptedChunkSize atomic.Int64
+
+// effectiveGuidChunkSize is the width new drains start from: the adapted
+// width when adaptive mode has learned one, otherwise the configured size.
+func effectiveGuidChunkSize() int {
+	if guidChunkAdaptive() {
+		if a := adaptedChunkSize.Load(); a > 0 {
+			return int(a)
+		}
+	}
+	return guidChunkSize()
+}
+
 // forEachGuidChunk runs fn once per chunk of guids and stops on the first
 // error. fn accumulates into captured state (a counts map, a resource
 // slice), so results merge naturally across chunks.
@@ -83,12 +106,34 @@ func chunkGuids(guids []string) [][]string {
 // (config reloads are hot; enterprise middleboxes appear). The WARN is
 // unconditional so a stale-high setting is self-announcing instead of
 // silently dropping counts again. filterKey only labels the log line.
+//
+// Fixed mode (default): WARN and stop — a human re-runs the diagnostics
+// probe and adjusts the knob deliberately. Adaptive mode
+// (STRATOS_CF_GUID_CHUNK=auto): halve the width and retry the same slice,
+// re-deriving the budget from the live failure instead of paging a human;
+// the learned width persists for later drains (see #5579 addendum 2).
 func forEachGuidChunk(filterKey string, guids []string, fn func(chunk []string) error) error {
-	for _, chunk := range chunkGuids(guids) {
+	size := effectiveGuidChunkSize()
+	for start := 0; start < len(guids); {
+		end := start + size
+		if end > len(guids) {
+			end = len(guids)
+		}
+		chunk := guids[start:end]
 		if err := fn(chunk); err != nil {
 			warnOnURITooLarge(err, filterKey, len(chunk))
+			if upstreamStatusOf(err) == 414 && guidChunkAdaptive() && size > guidChunkFloor {
+				size = size / 2
+				if size < guidChunkFloor {
+					size = guidChunkFloor
+				}
+				adaptedChunkSize.Store(int64(size))
+				log.Warnf("%s=auto: adapted guid chunk width to %d after a 414 and retrying", guidChunkEnv, size)
+				continue // retry the same slice at the reduced width
+			}
 			return err
 		}
+		start = end
 	}
 	return nil
 }

--- a/src/jetstream/plugins/cloudfoundry/native_guid_chunks.go
+++ b/src/jetstream/plugins/cloudfoundry/native_guid_chunks.go
@@ -1,0 +1,104 @@
+// src/jetstream/plugins/cloudfoundry/native_guid_chunks.go
+package cloudfoundry
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// CF v3 list requests take guid-list filters (space_guids=, guids=,
+// user_guids=, ...). Nothing in the API bounds how wide those lists may be,
+// but the request line traverses a chain of proxies (deployment edge nginx,
+// gorouter, CC nginx, puma) and the effective URI ceiling is the minimum
+// across every hop — commonly 8KB, unmeasurable from config alone because
+// middleboxes (VPNs, corporate proxies) also participate. A 500-guid filter
+// is ~19.5KB encoded and the platform answers 414; the enrichment callers
+// treat errors as lazy-non-fatal, so the UI silently loses counts (#5579).
+//
+// Fix: every unbounded guid-list call site runs through forEachGuidChunk,
+// which splits the list into chunks sized well under every default limit
+// observed in the wild. Precedent: the cf CLI hit the same bug
+// (cloudfoundry/cli#2220) and batches at a fixed 200.
+
+// guidChunkDefault is the chunk width used when STRATOS_CF_GUID_CHUNK is
+// unset. 150 guids ≈ 5.7KB encoded (36-byte guid + %2C separator) — enough
+// headroom under an 8KB chain for the path, remaining query params, and
+// headers that share nginx's large_client_header_buffers.
+const guidChunkDefault = 150
+
+// guidChunkEnv is the operator knob. Accepts a positive integer (fixed
+// chunk width) or "auto" (adaptive: on a runtime 414 the backend may
+// re-probe the endpoint's composite limit and retry — see #5579 addendum 2).
+const guidChunkEnv = "STRATOS_CF_GUID_CHUNK"
+
+var guidChunkSetting = os.Getenv(guidChunkEnv)
+
+// guidChunkAdaptive reports whether the operator opted into adaptive mode.
+func guidChunkAdaptive() bool {
+	return strings.EqualFold(strings.TrimSpace(guidChunkSetting), "auto")
+}
+
+// guidChunkSize returns the configured fixed chunk width. In adaptive mode
+// (or when the knob is unset/invalid) this is the default; the adaptive
+// path only departs from it after a runtime 414 triggers a re-probe.
+func guidChunkSize() int {
+	s := strings.TrimSpace(guidChunkSetting)
+	if s == "" || guidChunkAdaptive() {
+		return guidChunkDefault
+	}
+	if v, err := strconv.Atoi(s); err == nil && v > 0 {
+		return v
+	}
+	log.Warnf("%s=%q is not a positive integer or \"auto\"; using default %d", guidChunkEnv, guidChunkSetting, guidChunkDefault)
+	return guidChunkDefault
+}
+
+// chunkGuids splits guids into slices of at most guidChunkSize() elements.
+// A nil/empty input yields no chunks.
+func chunkGuids(guids []string) [][]string {
+	size := guidChunkSize()
+	if len(guids) == 0 {
+		return nil
+	}
+	chunks := make([][]string, 0, (len(guids)+size-1)/size)
+	for start := 0; start < len(guids); start += size {
+		end := start + size
+		if end > len(guids) {
+			end = len(guids)
+		}
+		chunks = append(chunks, guids[start:end])
+	}
+	return chunks
+}
+
+// forEachGuidChunk runs fn once per chunk of guids and stops on the first
+// error. fn accumulates into captured state (a counts map, a resource
+// slice), so results merge naturally across chunks.
+//
+// A 414 from fn means the configured chunk width exceeds what this
+// platform's proxy chain accepts *right now* — chains shrink unannounced
+// (config reloads are hot; enterprise middleboxes appear). The WARN is
+// unconditional so a stale-high setting is self-announcing instead of
+// silently dropping counts again. filterKey only labels the log line.
+func forEachGuidChunk(filterKey string, guids []string, fn func(chunk []string) error) error {
+	for _, chunk := range chunkGuids(guids) {
+		if err := fn(chunk); err != nil {
+			warnOnURITooLarge(err, filterKey, len(chunk))
+			return err
+		}
+	}
+	return nil
+}
+
+// warnOnURITooLarge emits the operator-facing WARN when a guid-filter
+// request bounced off the platform's URI-length ceiling.
+func warnOnURITooLarge(err error, filterKey string, chunkLen int) {
+	if upstreamStatusOf(err) != 414 {
+		return
+	}
+	log.Warnf("guid-filter request (%s, %d guids) rejected with 414: configured %s (%d) exceeds what the platform chain accepts — re-run the endpoint probe on the diagnostics page and lower the setting",
+		filterKey, chunkLen, guidChunkEnv, guidChunkSize())
+}

--- a/src/jetstream/plugins/cloudfoundry/native_guid_chunks_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_guid_chunks_test.go
@@ -114,3 +114,66 @@ func TestGuidChunkSizeKnobParsing(t *testing.T) {
 		}
 	}
 }
+
+func TestForEachGuidChunkAdaptiveHalvesOn414(t *testing.T) {
+	// Not parallel — mutates the package-level setting + adapted width.
+	orig := guidChunkSetting
+	defer func() {
+		guidChunkSetting = orig
+		adaptedChunkSize.Store(0)
+	}()
+	guidChunkSetting = "auto"
+	adaptedChunkSize.Store(0)
+
+	err414 := errors.New("capi: request failed (status 414): Request-URI Too Large")
+
+	// The chain accepts <=80 guids: reject wider chunks with 414.
+	var widths []int
+	err := forEachGuidChunk("space_guids", mkGuids(300), func(chunk []string) error {
+		widths = append(widths, len(chunk))
+		if len(chunk) > 80 {
+			return err414
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("adaptive mode should have ridden through the 414s, got: %v", err)
+	}
+	// 150 fails → 75 passes; every guid still covered exactly once.
+	covered := 0
+	for _, w := range widths {
+		if w <= 80 {
+			covered += w
+		}
+	}
+	if covered != 300 {
+		t.Errorf("adaptive retries should cover all 300 guids, covered %d (widths: %v)", covered, widths)
+	}
+	if adaptedChunkSize.Load() != 75 {
+		t.Errorf("expected adapted width 75, got %d", adaptedChunkSize.Load())
+	}
+	// A later drain starts at the learned width.
+	if got := effectiveGuidChunkSize(); got != 75 {
+		t.Errorf("effectiveGuidChunkSize() = %d, want the adapted 75", got)
+	}
+}
+
+func TestForEachGuidChunkFixedModeStopsOn414(t *testing.T) {
+	// Not parallel — asserts against the default (fixed) mode.
+	orig := guidChunkSetting
+	defer func() { guidChunkSetting = orig }()
+	guidChunkSetting = ""
+
+	err414 := errors.New("capi: request failed (status 414): Request-URI Too Large")
+	calls := 0
+	err := forEachGuidChunk("space_guids", mkGuids(300), func(chunk []string) error {
+		calls++
+		return err414
+	})
+	if !errors.Is(err, err414) {
+		t.Errorf("fixed mode must propagate the 414, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("fixed mode must not retry, got %d calls", calls)
+	}
+}

--- a/src/jetstream/plugins/cloudfoundry/native_guid_chunks_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_guid_chunks_test.go
@@ -1,0 +1,116 @@
+package cloudfoundry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func mkGuids(n int) []string {
+	guids := make([]string, n)
+	for i := range guids {
+		guids[i] = fmt.Sprintf("guid-%04d", i)
+	}
+	return guids
+}
+
+func TestChunkGuids(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		n          int
+		wantChunks int
+		wantLast   int
+	}{
+		{0, 0, 0},
+		{1, 1, 1},
+		{guidChunkDefault, 1, guidChunkDefault},
+		{guidChunkDefault + 1, 2, 1},
+		{500, 4, 500 - 3*guidChunkDefault},
+	}
+	for _, c := range cases {
+		chunks := chunkGuids(mkGuids(c.n))
+		if len(chunks) != c.wantChunks {
+			t.Errorf("chunkGuids(%d): got %d chunks, want %d", c.n, len(chunks), c.wantChunks)
+			continue
+		}
+		total := 0
+		for i, ch := range chunks {
+			if len(ch) > guidChunkDefault {
+				t.Errorf("chunkGuids(%d): chunk %d has %d guids (> %d)", c.n, i, len(ch), guidChunkDefault)
+			}
+			total += len(ch)
+		}
+		if total != c.n {
+			t.Errorf("chunkGuids(%d): chunks cover %d guids, want all %d", c.n, total, c.n)
+		}
+		if c.wantChunks > 0 && len(chunks[len(chunks)-1]) != c.wantLast {
+			t.Errorf("chunkGuids(%d): last chunk has %d guids, want %d", c.n, len(chunks[len(chunks)-1]), c.wantLast)
+		}
+	}
+}
+
+func TestForEachGuidChunkMergesAndStopsOnError(t *testing.T) {
+	t.Parallel()
+
+	// All chunks visited, in order, covering every guid exactly once.
+	seen := []string{}
+	calls := 0
+	err := forEachGuidChunk("space_guids", mkGuids(320), func(chunk []string) error {
+		calls++
+		seen = append(seen, chunk...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 || len(seen) != 320 {
+		t.Errorf("expected 3 calls covering 320 guids, got %d calls / %d guids", calls, len(seen))
+	}
+	if seen[0] != "guid-0000" || seen[319] != "guid-0319" {
+		t.Errorf("chunk order not preserved: first=%s last=%s", seen[0], seen[319])
+	}
+
+	// First error stops the iteration and propagates.
+	boom := errors.New("boom")
+	calls = 0
+	err = forEachGuidChunk("space_guids", mkGuids(320), func(chunk []string) error {
+		calls++
+		return boom
+	})
+	if !errors.Is(err, boom) {
+		t.Errorf("expected the fn error to propagate, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected iteration to stop after the first error, got %d calls", calls)
+	}
+}
+
+func TestGuidChunkSizeKnobParsing(t *testing.T) {
+	// Not parallel — mutates the package-level setting.
+	orig := guidChunkSetting
+	defer func() { guidChunkSetting = orig }()
+
+	cases := []struct {
+		setting  string
+		want     int
+		adaptive bool
+	}{
+		{"", guidChunkDefault, false},
+		{"200", 200, false},
+		{"auto", guidChunkDefault, true},
+		{"AUTO", guidChunkDefault, true},
+		{"nonsense", guidChunkDefault, false},
+		{"-5", guidChunkDefault, false},
+		{"0", guidChunkDefault, false},
+	}
+	for _, c := range cases {
+		guidChunkSetting = c.setting
+		if got := guidChunkSize(); got != c.want {
+			t.Errorf("guidChunkSize() with %q = %d, want %d", c.setting, got, c.want)
+		}
+		if got := guidChunkAdaptive(); got != c.adaptive {
+			t.Errorf("guidChunkAdaptive() with %q = %v, want %v", c.setting, got, c.adaptive)
+		}
+	}
+}

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -142,6 +142,37 @@ func callWithCapiRetry[T any](
 	return res, opErr
 }
 
+// routerFlapRetries and routerFlapBackoff bound the retry loop in
+// listWithRouterFlapRetry. 2 retries at 500ms/1s covers the observed
+// transient window without holding a user-facing request much past a second.
+const routerFlapRetries = 2
+const routerFlapBackoff = 500 * time.Millisecond
+
+// listWithRouterFlapRetry runs a CAPI list read, retrying when the failure is
+// the gorouter route-flap 404 ("Requested route ... does not exist" — the
+// platform router transiently lost the CF API route, so the request never
+// reached CAPI). retryablehttp inside capi won't retry it: it's a clean 404
+// response, and 404 is a don't-retry status. Reads are idempotent so a short
+// retry here is safe; writes must NOT use this wrapper.
+func listWithRouterFlapRetry[T any](ctx context.Context, op string, fn func() (T, error)) (T, error) {
+	var res T
+	var err error
+	wait := routerFlapBackoff
+	for attempt := 0; ; attempt++ {
+		res, err = fn()
+		if err == nil || attempt >= routerFlapRetries || !isRouterRouteMissing(err) || ctx.Err() != nil {
+			return res, err
+		}
+		log.Warnf("[diag drain] router-flap retry op=%s attempt=%d wait=%s err=%v", op, attempt+1, wait, err)
+		select {
+		case <-ctx.Done():
+			return res, err
+		case <-time.After(wait):
+		}
+		wait *= 2
+	}
+}
+
 // normaliseStringMap ensures nil maps are returned as empty maps (not null in JSON).
 func normaliseStringMap(m map[string]string) map[string]string {
 	if m == nil {
@@ -360,7 +391,9 @@ func (c *CloudFoundrySpecification) getNativeOrgs(ctx echo.Context) error {
 
 	if ctx.QueryParam("return") == "counts" {
 		params := capi.NewQueryParams().WithPerPage(1)
-		raw, err := cfClient.Organizations().List(ctx.Request().Context(), params)
+		raw, err := listWithRouterFlapRetry(ctx.Request().Context(), "orgs.counts", func() (*capi.ListResponse[capi.Organization], error) {
+			return cfClient.Organizations().List(ctx.Request().Context(), params)
+		})
 		if err != nil {
 			return err
 		}
@@ -386,7 +419,9 @@ func (c *CloudFoundrySpecification) getNativeOrgs(ctx echo.Context) error {
 		}
 	}
 
-	raw, lerr := cfClient.Organizations().List(ctx.Request().Context(), params)
+	raw, lerr := listWithRouterFlapRetry(ctx.Request().Context(), "orgs.page", func() (*capi.ListResponse[capi.Organization], error) {
+		return cfClient.Organizations().List(ctx.Request().Context(), params)
+	})
 	if lerr != nil {
 		return lerr
 	}
@@ -425,11 +460,17 @@ func (c *CloudFoundrySpecification) getNativeOrgs(ctx echo.Context) error {
 	eg.Go(func() error {
 		sc, sm, err := fetchSpacesForOrgs(egCtx, cfClient, orgGUIDs)
 		spaceCounts, spaceToOrg = sc, sm
+		if err != nil {
+			log.Warnf("[diag drain] op=orgs.relations.spaces fail_kind=%s err=%v", diagFailKind(ctx.Request().Context(), err), err)
+		}
 		return err
 	})
 	eg.Go(func() error {
 		a, err := drainAppsForOrgs(egCtx, cfClient, orgGUIDs)
 		rawApps = a
+		if err != nil {
+			log.Warnf("[diag drain] op=orgs.relations.apps fail_kind=%s err=%v", diagFailKind(ctx.Request().Context(), err), err)
+		}
 		return err
 	})
 	_ = eg.Wait() // lazy-non-fatal: partial counts beat blocking the row payload
@@ -494,7 +535,9 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 				params = params.WithFilter("space_guids", spaces...)
 			}
 		}
-		raw, err := cfClient.Apps().List(ctx.Request().Context(), params)
+		raw, err := listWithRouterFlapRetry(ctx.Request().Context(), "apps.counts", func() (*capi.ListResponse[capi.App], error) {
+			return cfClient.Apps().List(ctx.Request().Context(), params)
+		})
 		if err != nil {
 			return err
 		}
@@ -506,7 +549,9 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 
 	case "recent":
 		params := capi.NewQueryParams().WithPerPage(10).WithOrderBy("-updated_at")
-		raw, err := cfClient.Apps().List(ctx.Request().Context(), params)
+		raw, err := listWithRouterFlapRetry(ctx.Request().Context(), "apps.recent", func() (*capi.ListResponse[capi.App], error) {
+			return cfClient.Apps().List(ctx.Request().Context(), params)
+		})
 		if err != nil {
 			return err
 		}
@@ -553,7 +598,9 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 		}
 	}
 
-	raw, lerr := cfClient.Apps().List(ctx.Request().Context(), params)
+	raw, lerr := listWithRouterFlapRetry(ctx.Request().Context(), "apps.page", func() (*capi.ListResponse[capi.App], error) {
+		return cfClient.Apps().List(ctx.Request().Context(), params)
+	})
 	if lerr != nil {
 		return lerr
 	}
@@ -675,7 +722,9 @@ func (c *CloudFoundrySpecification) getNativeSpaces(ctx echo.Context) (err error
 	if ctx.QueryParam("return") == "counts" {
 		params := capi.NewQueryParams().WithPerPage(1)
 		cStart := time.Now()
-		raw, lerr := cfClient.Spaces().List(ctx.Request().Context(), params)
+		raw, lerr := listWithRouterFlapRetry(ctx.Request().Context(), "spaces.counts", func() (*capi.ListResponse[capi.Space], error) {
+			return cfClient.Spaces().List(ctx.Request().Context(), params)
+		})
 		cRows, cTotal := -1, -1
 		if raw != nil {
 			cRows = len(raw.Resources)
@@ -730,7 +779,9 @@ func (c *CloudFoundrySpecification) getNativeSpaces(ctx echo.Context) (err error
 	}
 
 	pStart := time.Now()
-	raw, lerr := cfClient.Spaces().List(ctx.Request().Context(), params)
+	raw, lerr := listWithRouterFlapRetry(ctx.Request().Context(), "spaces.page", func() (*capi.ListResponse[capi.Space], error) {
+		return cfClient.Spaces().List(ctx.Request().Context(), params)
+	})
 	pRows, pTotal := -1, -1
 	if raw != nil {
 		pRows = len(raw.Resources)
@@ -798,7 +849,9 @@ func listAllRoutes(ctx context.Context, cfClient capi.Client, spaceGUIDs string)
 
 	firstParams := withRouteFilters(capi.NewQueryParams().WithPerPage(fullPagePerRequest))
 	firstParams.Page = 1
-	first, err := cfClient.Routes().List(ctx, firstParams)
+	first, err := listWithRouterFlapRetry(ctx, "routes.page1", func() (*capi.ListResponse[capi.Route], error) {
+		return cfClient.Routes().List(ctx, firstParams)
+	})
 	if err != nil {
 		return nil, 0, err
 	}
@@ -818,8 +871,11 @@ func listAllRoutes(ctx context.Context, cfClient capi.Client, spaceGUIDs string)
 		g.Go(func() error {
 			params := withRouteFilters(capi.NewQueryParams().WithPerPage(fullPagePerRequest))
 			params.Page = p
-			raw, err := cfClient.Routes().List(gctx, params)
+			raw, err := listWithRouterFlapRetry(gctx, "routes.pageN", func() (*capi.ListResponse[capi.Route], error) {
+				return cfClient.Routes().List(gctx, params)
+			})
 			if err != nil {
+				log.Warnf("[diag drain] op=routes.pageN page=%d fail_kind=%s err=%v", p, diagFailKind(ctx, err), err)
 				return err
 			}
 			pageResources[p] = raw.Resources
@@ -890,7 +946,9 @@ func (c *CloudFoundrySpecification) getNativeRouteCount(ctx echo.Context) error 
 				params = params.WithFilter("space_guids", spaces...)
 			}
 		}
-		raw, err := cfClient.Routes().List(ctx.Request().Context(), params)
+		raw, err := listWithRouterFlapRetry(ctx.Request().Context(), "routes.counts", func() (*capi.ListResponse[capi.Route], error) {
+			return cfClient.Routes().List(ctx.Request().Context(), params)
+		})
 		if err != nil {
 			return err
 		}
@@ -1007,7 +1065,9 @@ func (c *CloudFoundrySpecification) getNativeOrgSpaces(ctx echo.Context) error {
 		params := capi.NewQueryParams().
 			WithPerPage(1).
 			WithFilter("organization_guids", orgGUID)
-		raw, lerr := cfClient.Spaces().List(ctx.Request().Context(), params)
+		raw, lerr := listWithRouterFlapRetry(ctx.Request().Context(), "orgSpaces.counts", func() (*capi.ListResponse[capi.Space], error) {
+			return cfClient.Spaces().List(ctx.Request().Context(), params)
+		})
 		if lerr != nil {
 			return lerr
 		}
@@ -1022,7 +1082,9 @@ func (c *CloudFoundrySpecification) getNativeOrgSpaces(ctx echo.Context) error {
 		capi.NewQueryParams().WithFilter("organization_guids", orgGUID),
 		perPage, page, present,
 	)
-	raw, lerr := cfClient.Spaces().List(ctx.Request().Context(), params)
+	raw, lerr := listWithRouterFlapRetry(ctx.Request().Context(), "orgSpaces.page", func() (*capi.ListResponse[capi.Space], error) {
+		return cfClient.Spaces().List(ctx.Request().Context(), params)
+	})
 	if lerr != nil {
 		return lerr
 	}

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -522,30 +522,44 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 		// V2 ngrx-pagination count helper. Mirrors the filter names CF v3 uses
 		// on /v3/apps and the same comma-split convention as the list-path
 		// space_guids filter below.
-		params := capi.NewQueryParams().WithPerPage(1)
-		if rawOrgs := ctx.QueryParam("organization_guids"); rawOrgs != "" {
-			orgs := splitNonEmpty(rawOrgs, ",")
-			if len(orgs) > 0 {
-				params = params.WithFilter("organization_guids", orgs...)
+		//
+		// The guid scoping is chunked (an org's full space list can exceed
+		// the platform's URI ceiling — #5579); counts sum across chunks
+		// since the guid sets are disjoint. Consumers read only
+		// totalResults, so Resources stays empty.
+		orgScope := splitNonEmpty(ctx.QueryParam("organization_guids"), ",")
+		spaceScope := splitNonEmpty(ctx.QueryParam("space_guids"), ",")
+		total := 0
+		runCount := func(orgChunk, spaceChunk []string) error {
+			params := capi.NewQueryParams().WithPerPage(1)
+			if len(orgChunk) > 0 {
+				params = params.WithFilter("organization_guids", orgChunk...)
 			}
-		}
-		if rawSpaces := ctx.QueryParam("space_guids"); rawSpaces != "" {
-			spaces := splitNonEmpty(rawSpaces, ",")
-			if len(spaces) > 0 {
-				params = params.WithFilter("space_guids", spaces...)
+			if len(spaceChunk) > 0 {
+				params = params.WithFilter("space_guids", spaceChunk...)
 			}
+			raw, err := listWithRouterFlapRetry(ctx.Request().Context(), "apps.counts", func() (*capi.ListResponse[capi.App], error) {
+				return cfClient.Apps().List(ctx.Request().Context(), params)
+			})
+			if err != nil {
+				return err
+			}
+			total += raw.Pagination.TotalResults
+			return nil
 		}
-		raw, err := listWithRouterFlapRetry(ctx.Request().Context(), "apps.counts", func() (*capi.ListResponse[capi.App], error) {
-			return cfClient.Apps().List(ctx.Request().Context(), params)
-		})
+		var err error
+		switch {
+		case len(spaceScope) > 0:
+			err = forEachGuidChunk("space_guids", spaceScope, func(chunk []string) error { return runCount(orgScope, chunk) })
+		case len(orgScope) > 0:
+			err = forEachGuidChunk("organization_guids", orgScope, func(chunk []string) error { return runCount(chunk, nil) })
+		default:
+			err = runCount(nil, nil)
+		}
 		if err != nil {
 			return err
 		}
-		apps := make([]StApp, 0, len(raw.Resources))
-		for _, r := range raw.Resources {
-			apps = append(apps, toStApp(r, cnsiGUID))
-		}
-		return ctx.JSON(http.StatusOK, StAppsResponse{Resources: apps, TotalResults: raw.Pagination.TotalResults})
+		return ctx.JSON(http.StatusOK, StAppsResponse{Resources: []StApp{}, TotalResults: total})
 
 	case "recent":
 		params := capi.NewQueryParams().WithPerPage(10).WithOrderBy("-updated_at")

--- a/src/jetstream/plugins/cloudfoundry/native_orgs_relations.go
+++ b/src/jetstream/plugins/cloudfoundry/native_orgs_relations.go
@@ -22,27 +22,33 @@ func fetchSpacesForOrgs(ctx context.Context, cfClient capi.Client, orgGUIDs []st
 	if len(orgGUIDs) == 0 {
 		return counts, spaceToOrg, nil
 	}
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["organization_guids"] = orgGUIDs
+	// Chunked — see native_guid_chunks.go / #5579.
+	cerr := forEachGuidChunk("organization_guids", orgGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["organization_guids"] = chunk
 
-		raw, lerr := listWithRouterFlapRetry(ctx, "orgs.relations.spaces", func() (*capi.ListResponse[capi.Space], error) {
-			return cfClient.Spaces().List(ctx, params)
-		})
-		if lerr != nil {
-			return nil, nil, lerr
-		}
-		for _, s := range raw.Resources {
-			og := relationshipGUID(s.Relationships.Organization)
-			if og != "" {
-				counts[og]++
-				spaceToOrg[s.GUID] = og
+			raw, lerr := listWithRouterFlapRetry(ctx, "orgs.relations.spaces", func() (*capi.ListResponse[capi.Space], error) {
+				return cfClient.Spaces().List(ctx, params)
+			})
+			if lerr != nil {
+				return lerr
+			}
+			for _, s := range raw.Resources {
+				og := relationshipGUID(s.Relationships.Organization)
+				if og != "" {
+					counts[og]++
+					spaceToOrg[s.GUID] = og
+				}
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
 			}
 		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if cerr != nil {
+		return nil, nil, cerr
 	}
 	return counts, spaceToOrg, nil
 }
@@ -58,21 +64,27 @@ func drainAppsForOrgs(ctx context.Context, cfClient capi.Client, orgGUIDs []stri
 		return nil, nil
 	}
 	apps := make([]capi.App, 0)
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["organization_guids"] = orgGUIDs
+	// Chunked — see native_guid_chunks.go / #5579.
+	err := forEachGuidChunk("organization_guids", orgGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["organization_guids"] = chunk
 
-		raw, err := listWithRouterFlapRetry(ctx, "orgs.relations.apps", func() (*capi.ListResponse[capi.App], error) {
-			return cfClient.Apps().List(ctx, params)
-		})
-		if err != nil {
-			return nil, err
+			raw, lerr := listWithRouterFlapRetry(ctx, "orgs.relations.apps", func() (*capi.ListResponse[capi.App], error) {
+				return cfClient.Apps().List(ctx, params)
+			})
+			if lerr != nil {
+				return lerr
+			}
+			apps = append(apps, raw.Resources...)
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
+			}
 		}
-		apps = append(apps, raw.Resources...)
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if err != nil {
+		return nil, err
 	}
 	return apps, nil
 }

--- a/src/jetstream/plugins/cloudfoundry/native_orgs_relations.go
+++ b/src/jetstream/plugins/cloudfoundry/native_orgs_relations.go
@@ -27,7 +27,9 @@ func fetchSpacesForOrgs(ctx context.Context, cfClient capi.Client, orgGUIDs []st
 		params.Page = page
 		params.Filters["organization_guids"] = orgGUIDs
 
-		raw, lerr := cfClient.Spaces().List(ctx, params)
+		raw, lerr := listWithRouterFlapRetry(ctx, "orgs.relations.spaces", func() (*capi.ListResponse[capi.Space], error) {
+			return cfClient.Spaces().List(ctx, params)
+		})
 		if lerr != nil {
 			return nil, nil, lerr
 		}
@@ -61,7 +63,9 @@ func drainAppsForOrgs(ctx context.Context, cfClient capi.Client, orgGUIDs []stri
 		params.Page = page
 		params.Filters["organization_guids"] = orgGUIDs
 
-		raw, err := cfClient.Apps().List(ctx, params)
+		raw, err := listWithRouterFlapRetry(ctx, "orgs.relations.apps", func() (*capi.ListResponse[capi.App], error) {
+			return cfClient.Apps().List(ctx, params)
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/src/jetstream/plugins/cloudfoundry/native_routes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_routes.go
@@ -123,6 +123,9 @@ func (c *CloudFoundrySpecification) addNativeRoutes(echoGroup *echo.Group) {
 	nativeGroup.DELETE("/cf/roles/:cnsiGuid/:roleGuid", c.deleteNativeRole)
 	nativeGroup.POST("/cf/users/:cnsiGuid/associate", c.associateUser)
 	nativeGroup.GET("/cf/identity-providers/:cnsiGuid", c.getIdentityProviders)
+	// Diagnostics: operator-triggered probe of the endpoint chain's URI
+	// ceiling (#5579). Never runs automatically.
+	nativeGroup.GET("/cf/diag/urilimit/:cnsiGuid", c.probeEndpointURILimit)
 
 	// Services-domain scoped reads (slice 5: services-domain signal+V3).
 	// Path-derived filters layer on top of the existing CF-scoped handlers'

--- a/src/jetstream/plugins/cloudfoundry/native_service_brokers_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_brokers_reads.go
@@ -171,16 +171,20 @@ func batchFetchBrokerSpaces(ctx echo.Context, cfClient capi.Client, brokers []ca
 	if len(guids) == 0 {
 		return out
 	}
-	params := capi.NewQueryParams().WithPerPage(len(guids)).WithFilter("guids", guids...)
-	raw, err := cfClient.Spaces().List(ctx.Request().Context(), params)
-	if err != nil {
-		return out
-	}
-	for _, s := range raw.Resources {
-		if s.GUID != "" {
-			out[s.GUID] = s
+	// Chunked — see native_guid_chunks.go / #5579.
+	_ = forEachGuidChunk("guids", guids, func(chunk []string) error {
+		params := capi.NewQueryParams().WithPerPage(len(chunk)).WithFilter("guids", chunk...)
+		raw, err := cfClient.Spaces().List(ctx.Request().Context(), params)
+		if err != nil {
+			return err
 		}
-	}
+		for _, s := range raw.Resources {
+			if s.GUID != "" {
+				out[s.GUID] = s
+			}
+		}
+		return nil
+	})
 	return out
 }
 

--- a/src/jetstream/plugins/cloudfoundry/native_service_instances_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instances_reads.go
@@ -133,35 +133,41 @@ func fetchBoundAppsForServiceInstances(ctx echo.Context, cfClient capi.Client, s
 	if len(siGUIDs) == 0 {
 		return bound, nil
 	}
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest).WithInclude("app")
-		params.Page = page
-		params.Filters["service_instance_guids"] = siGUIDs
-		params.Filters["type"] = []string{"app"}
+	// Chunked — see native_guid_chunks.go / #5579.
+	cerr := forEachGuidChunk("service_instance_guids", siGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest).WithInclude("app")
+			params.Page = page
+			params.Filters["service_instance_guids"] = chunk
+			params.Filters["type"] = []string{"app"}
 
-		raw, err := cfClient.ServiceCredentialBindings().List(ctx.Request().Context(), params)
-		if err != nil {
-			return nil, err
-		}
-		_, appByGUID := bindingJoinsFromIncluded(raw)
-		for _, b := range raw.Resources {
-			siGUID := relationshipGUID(b.Relationships.ServiceInstance)
-			if siGUID == "" || b.Relationships.App == nil {
-				continue
+			raw, err := cfClient.ServiceCredentialBindings().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
 			}
-			appGUID := relationshipGUID(*b.Relationships.App)
-			if appGUID == "" {
-				continue
+			_, appByGUID := bindingJoinsFromIncluded(raw)
+			for _, b := range raw.Resources {
+				siGUID := relationshipGUID(b.Relationships.ServiceInstance)
+				if siGUID == "" || b.Relationships.App == nil {
+					continue
+				}
+				appGUID := relationshipGUID(*b.Relationships.App)
+				if appGUID == "" {
+					continue
+				}
+				ref := StAppRef{GUID: appGUID}
+				if app, ok := appByGUID[appGUID]; ok {
+					ref.Name = app.Name
+				}
+				bound[siGUID] = append(bound[siGUID], ref)
 			}
-			ref := StAppRef{GUID: appGUID}
-			if app, ok := appByGUID[appGUID]; ok {
-				ref.Name = app.Name
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
 			}
-			bound[siGUID] = append(bound[siGUID], ref)
 		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if cerr != nil {
+		return nil, cerr
 	}
 	return bound, nil
 }

--- a/src/jetstream/plugins/cloudfoundry/native_service_offerings_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_offerings_reads.go
@@ -279,14 +279,20 @@ func drainBrokersForOfferings(ctx echo.Context, cfClient capi.Client, offerings 
 	for g := range brokerGUIDSet {
 		brokerGUIDs = append(brokerGUIDs, g)
 	}
-	brokerParams := capi.NewQueryParams().
-		WithPerPage(len(brokerGUIDs)).
-		WithFilter("guids", brokerGUIDs...)
-	if raw, berr := cfClient.ServiceBrokers().List(ctx.Request().Context(), brokerParams); berr == nil {
+	// Chunked — see native_guid_chunks.go / #5579.
+	_ = forEachGuidChunk("guids", brokerGUIDs, func(chunk []string) error {
+		brokerParams := capi.NewQueryParams().
+			WithPerPage(len(chunk)).
+			WithFilter("guids", chunk...)
+		raw, berr := cfClient.ServiceBrokers().List(ctx.Request().Context(), brokerParams)
+		if berr != nil {
+			return berr
+		}
 		for _, b := range raw.Resources {
 			brokerByGUID[b.GUID] = b
 		}
-	}
+		return nil
+	})
 	return brokerByGUID
 }
 

--- a/src/jetstream/plugins/cloudfoundry/native_service_plans_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_plans_reads.go
@@ -406,16 +406,20 @@ func batchFetchBrokersForOfferings(ctx echo.Context, cfClient capi.Client, offer
 	if len(guids) == 0 {
 		return out
 	}
-	params := capi.NewQueryParams().WithPerPage(len(guids)).WithFilter("guids", guids...)
-	raw, err := cfClient.ServiceBrokers().List(ctx.Request().Context(), params)
-	if err != nil {
-		return out
-	}
-	for _, b := range raw.Resources {
-		if b.GUID != "" {
-			out[b.GUID] = b
+	// Chunked — see native_guid_chunks.go / #5579.
+	_ = forEachGuidChunk("guids", guids, func(chunk []string) error {
+		params := capi.NewQueryParams().WithPerPage(len(chunk)).WithFilter("guids", chunk...)
+		raw, err := cfClient.ServiceBrokers().List(ctx.Request().Context(), params)
+		if err != nil {
+			return err
 		}
-	}
+		for _, b := range raw.Resources {
+			if b.GUID != "" {
+				out[b.GUID] = b
+			}
+		}
+		return nil
+	})
 	return out
 }
 

--- a/src/jetstream/plugins/cloudfoundry/native_spaces_relations.go
+++ b/src/jetstream/plugins/cloudfoundry/native_spaces_relations.go
@@ -17,24 +17,31 @@ func fetchAppCountsForSpaces(ctx echo.Context, cfClient capi.Client, spaceGUIDs 
 	if len(spaceGUIDs) == 0 {
 		return counts, nil
 	}
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["space_guids"] = spaceGUIDs
+	// Chunked: a full 500-space page ≈ 19.5KB of space_guids= blows the
+	// platform's URI ceiling (414) — see native_guid_chunks.go / #5579.
+	err := forEachGuidChunk("space_guids", spaceGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["space_guids"] = chunk
 
-		raw, err := cfClient.Apps().List(ctx.Request().Context(), params)
-		if err != nil {
-			return nil, err
-		}
-		for _, a := range raw.Resources {
-			sg := relationshipGUID(a.Relationships.Space)
-			if sg != "" {
-				counts[sg]++
+			raw, err := cfClient.Apps().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
+			}
+			for _, a := range raw.Resources {
+				sg := relationshipGUID(a.Relationships.Space)
+				if sg != "" {
+					counts[sg]++
+				}
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
 			}
 		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if err != nil {
+		return nil, err
 	}
 	return counts, nil
 }
@@ -49,24 +56,30 @@ func fetchRouteCountsForSpaces(ctx echo.Context, cfClient capi.Client, spaceGUID
 	if len(spaceGUIDs) == 0 {
 		return counts, nil
 	}
-	for page := 1; ; page++ {
-		params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
-		params.Page = page
-		params.Filters["space_guids"] = spaceGUIDs
+	// Chunked — see fetchAppCountsForSpaces.
+	err := forEachGuidChunk("space_guids", spaceGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["space_guids"] = chunk
 
-		raw, err := cfClient.Routes().List(ctx.Request().Context(), params)
-		if err != nil {
-			return nil, err
-		}
-		for _, r := range raw.Resources {
-			sg := relationshipGUID(r.Relationships.Space)
-			if sg != "" {
-				counts[sg]++
+			raw, err := cfClient.Routes().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
+			}
+			for _, r := range raw.Resources {
+				sg := relationshipGUID(r.Relationships.Space)
+				if sg != "" {
+					counts[sg]++
+				}
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
 			}
 		}
-		if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
-			break
-		}
+	})
+	if err != nil {
+		return nil, err
 	}
 	return counts, nil
 }

--- a/src/jetstream/plugins/cloudfoundry/native_uri_probe.go
+++ b/src/jetstream/plugins/cloudfoundry/native_uri_probe.go
@@ -1,0 +1,159 @@
+// src/jetstream/plugins/cloudfoundry/native_uri_probe.go
+package cloudfoundry
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	log "github.com/sirupsen/logrus"
+)
+
+// Operator-triggered probe of an endpoint's composite URI-length ceiling
+// (#5579). The limit cannot be derived from configuration — it is the min
+// across every hop in the chain (edge proxy, gorouter, CC nginx, puma,
+// plus whatever middleboxes the deployment inserts) — so the only reliable
+// measurement is empirical. The probe works unauthenticated: a request
+// that passes every hop's length check reaches CC and draws a CF-shaped
+// 401; one that doesn't draws 414. No automatic probing anywhere — this
+// runs only when an operator clicks the button on the diagnostics page.
+
+const (
+	// probeLoBytes is assumed-safe: every chain in the wild accepts 2KB.
+	probeLoBytes = 2048
+	// probeHiBytes caps the search; gorouter's own ceiling is ~1MB but
+	// chunk sizing gains nothing above 128KB.
+	probeHiBytes = 131072
+	// probeGranularityBytes stops the bisection — finer resolution does
+	// not change the recommended chunk meaningfully.
+	probeGranularityBytes = 256
+	// guidFilterBytesPerGuid: a 36-byte guid plus an encoded comma.
+	guidFilterBytesPerGuid = 39
+	// probeReserveBytes is held back from the probed limit for the path,
+	// other query params, and safety margin when deriving the recommended
+	// chunk width.
+	probeReserveBytes = 1024
+)
+
+// StURILimitProbe is the probe result DTO for the diagnostics page.
+type StURILimitProbe struct {
+	// ProbedLimitBytes is the measured composite request-target ceiling.
+	// When the chain accepted even probeHiBytes, this reports probeHiBytes
+	// and CappedAtMax is true.
+	ProbedLimitBytes int  `json:"probedLimitBytes"`
+	CappedAtMax      bool `json:"cappedAtMax"`
+	// ConfiguredChunk / ConfiguredBytes describe the active setting and
+	// the request width it produces; EffectiveChunk differs from
+	// ConfiguredChunk only in adaptive mode after a runtime 414 adapted it.
+	ConfiguredChunk int  `json:"configuredChunk"`
+	EffectiveChunk  int  `json:"effectiveChunk"`
+	ConfiguredBytes int  `json:"configuredBytes"`
+	Adaptive        bool `json:"adaptive"`
+	// RecommendedChunk is the width that would use the probed ceiling
+	// (minus reserve). Matches ConfiguredChunk when the setting already
+	// fits; lower when the configured budget silently overshoots.
+	RecommendedChunk int `json:"recommendedChunk"`
+	Requests         int `json:"probeRequests"`
+}
+
+// probeURILimit bisects the endpoint's request-target ceiling between
+// probeLoBytes and probeHiBytes. Returns the largest length that passed,
+// whether the search was capped at probeHiBytes, and how many requests it
+// took.
+func probeURILimit(httpClient *http.Client, apiBase string, doProbe func(client *http.Client, base string, targetLen int) (bool, error)) (limit int, capped bool, requests int, err error) {
+	lo, hi := probeLoBytes, probeHiBytes
+
+	ok, err := doProbe(httpClient, apiBase, lo)
+	requests++
+	if err != nil {
+		return 0, false, requests, err
+	}
+	if !ok {
+		// Even the floor bounced — report the floor as "less than".
+		return 0, false, requests, fmt.Errorf("endpoint rejected even a %d-byte request-target with 414", lo)
+	}
+
+	ok, err = doProbe(httpClient, apiBase, hi)
+	requests++
+	if err != nil {
+		return 0, false, requests, err
+	}
+	if ok {
+		return hi, true, requests, nil
+	}
+
+	for hi-lo > probeGranularityBytes {
+		mid := (lo + hi) / 2
+		ok, err = doProbe(httpClient, apiBase, mid)
+		requests++
+		if err != nil {
+			return 0, false, requests, err
+		}
+		if ok {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return lo, false, requests, nil
+}
+
+// probeURITargetLen issues one unauthenticated GET whose request-target
+// (path + query) is exactly targetLen bytes. Any HTTP answer other than
+// 414 means every hop accepted the length (unauthenticated requests that
+// reach CC draw 401); 414 means some hop rejected it.
+func probeURITargetLen(client *http.Client, apiBase string, targetLen int) (bool, error) {
+	base := strings.TrimSuffix(apiBase, "/")
+	path := "/v3/organizations"
+	prefix := path + "?guids="
+	fill := targetLen - len(prefix)
+	if fill < 1 {
+		fill = 1
+	}
+	u := base + prefix + strings.Repeat("a", fill)
+	resp, err := client.Get(u)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode != http.StatusRequestURITooLong, nil
+}
+
+// probeEndpointURILimit handles GET /pp/v1/cf/diag/urilimit/:cnsiGuid —
+// the diagnostics-page button. Reports probed vs configured and the
+// recommended STRATOS_CF_GUID_CHUNK for this endpoint's chain.
+func (c *CloudFoundrySpecification) probeEndpointURILimit(ctx echo.Context) error {
+	cnsiGUID := ctx.Param("cnsiGuid")
+	record, err := c.nativeProxy().GetCNSIRecord(cnsiGUID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, "endpoint not found")
+	}
+
+	httpClient := c.nativeProxy().GetHttpClient(record.SkipSSLValidation, record.CACert)
+	limit, capped, requests, perr := probeURILimit(&httpClient, record.APIEndpoint.String(), probeURITargetLen)
+	if perr != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, "probe failed: "+perr.Error())
+	}
+
+	configured := guidChunkSize()
+	effective := effectiveGuidChunkSize()
+	recommended := (limit - probeReserveBytes) / guidFilterBytesPerGuid
+	if recommended < 1 {
+		recommended = 1
+	}
+
+	result := StURILimitProbe{
+		ProbedLimitBytes: limit,
+		CappedAtMax:      capped,
+		ConfiguredChunk:  configured,
+		EffectiveChunk:   effective,
+		ConfiguredBytes:  configured * guidFilterBytesPerGuid,
+		Adaptive:         guidChunkAdaptive(),
+		RecommendedChunk: recommended,
+		Requests:         requests,
+	}
+	log.Infof("URI-limit probe cnsi=%s: chain accepts %d bytes (capped=%v, %d requests); configured %s=%d uses %d bytes; recommended %d",
+		cnsiGUID, limit, capped, requests, guidChunkEnv, configured, result.ConfiguredBytes, recommended)
+	return ctx.JSON(http.StatusOK, result)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_uri_probe_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_uri_probe_test.go
@@ -1,0 +1,45 @@
+package cloudfoundry
+
+import (
+	"net/http"
+	"testing"
+)
+
+// fakeChain simulates a proxy chain with a fixed request-target ceiling.
+func fakeChain(limit int) func(*http.Client, string, int) (bool, error) {
+	return func(_ *http.Client, _ string, targetLen int) (bool, error) {
+		return targetLen <= limit, nil
+	}
+}
+
+func TestProbeURILimitBisect(t *testing.T) {
+	t.Parallel()
+
+	// An 8KB chain (the common default) — probed limit must land within
+	// one granularity step below the true ceiling, never above it.
+	limit, capped, requests, err := probeURILimit(nil, "https://api.example.com", fakeChain(8192))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capped {
+		t.Error("8KB chain must not report capped")
+	}
+	if limit > 8192 || limit < 8192-probeGranularityBytes {
+		t.Errorf("probed limit %d outside (%d, %d]", limit, 8192-probeGranularityBytes, 8192)
+	}
+	if requests > 15 {
+		t.Errorf("bisect took %d requests, expected a handful", requests)
+	}
+
+	// A chain accepting everything caps at the search maximum.
+	limit, capped, _, err = probeURILimit(nil, "https://api.example.com", fakeChain(1<<20))
+	if err != nil || !capped || limit != probeHiBytes {
+		t.Errorf("wide-open chain: want capped at %d, got limit=%d capped=%v err=%v", probeHiBytes, limit, capped, err)
+	}
+
+	// A chain tighter than the floor is an explicit error, not a bogus 0.
+	_, _, _, err = probeURILimit(nil, "https://api.example.com", fakeChain(1024))
+	if err == nil {
+		t.Error("sub-floor chain must error")
+	}
+}

--- a/src/jetstream/plugins/cloudfoundry/native_users_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_users_reads.go
@@ -245,7 +245,30 @@ func listRolesForUsers(ctx context.Context, cfClient capi.Client, userGUIDs []st
 	if len(userGUIDs) == 0 {
 		return nil, nil, nil
 	}
+	// Chunked: every user on the CF lands in this filter (14 users ≈ 1.3KB
+	// already) — see native_guid_chunks.go / #5579.
+	var all []capi.Role
+	spaces := make(map[string]includedSpace)
+	err := forEachGuidChunk("user_guids", userGUIDs, func(chunk []string) error {
+		roles, sp, cerr := listRolesForUserChunk(ctx, cfClient, chunk)
+		if cerr != nil {
+			return cerr
+		}
+		all = append(all, roles...)
+		for k, v := range sp {
+			spaces[k] = v
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return all, spaces, nil
+}
 
+// listRolesForUserChunk is the single-chunk body of listRolesForUsers —
+// the paged, bounded-parallel drain for one guid-filter chunk.
+func listRolesForUserChunk(ctx context.Context, cfClient capi.Client, userGUIDs []string) ([]capi.Role, map[string]includedSpace, error) {
 	const perPage = 500
 	const maxConcurrency = 6
 

--- a/src/jetstream/repository/cnsis/pgsql_cnsis.go
+++ b/src/jetstream/repository/cnsis/pgsql_cnsis.go
@@ -388,7 +388,10 @@ func (p *PostgresCNSIRepository) Update(endpoint api.CNSIRecord, encryptionKey [
 		return err
 	}
 
-	result, err := p.db.Exec(updateCNSI, endpoint.Name, endpoint.SkipSSLValidation, endpoint.SSOAllowed, endpoint.ClientId, cipherTextClientSecret, endpoint.GUID, endpoint.CACert)
+	// Arg order must match updateCNSI: ... ca_cert = $6 WHERE guid = $7.
+	// These were swapped once (guid landed in ca_cert, WHERE matched the
+	// cert) and every update failed with "no rows were updated".
+	result, err := p.db.Exec(updateCNSI, endpoint.Name, endpoint.SkipSSLValidation, endpoint.SSOAllowed, endpoint.ClientId, cipherTextClientSecret, endpoint.CACert, endpoint.GUID)
 	if err != nil {
 		msg := "Unable to UPDATE endpoint: %v"
 		log.Debugf(msg, err)

--- a/src/jetstream/repository/cnsis/pgsql_cnsis_test.go
+++ b/src/jetstream/repository/cnsis/pgsql_cnsis_test.go
@@ -798,3 +798,45 @@ func TestPgSQLCNSIs(t *testing.T) {
 	})
 
 }
+
+// Pins the positional arg order of the endpoint UPDATE against the SQL
+// (`... ca_cert = $6 WHERE guid = $7`). The GUID and CA cert were swapped
+// once: WHERE guid matched the cert value, so every endpoint update failed
+// with "no rows were updated" (and a matching row would have had its
+// ca_cert overwritten with the guid).
+func TestPgSQLCNSIsUpdateArgOrder(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	repository, err := NewPostgresCNSIRepository(db)
+	if err != nil {
+		t.Fatalf("unexpected error creating repository: %v", err)
+	}
+
+	endpoint := api.CNSIRecord{
+		GUID:              "some-guid",
+		Name:              "renamed",
+		SkipSSLValidation: true,
+		SSOAllowed:        false,
+		ClientId:          "cf",
+		ClientSecret:      "",
+		CACert:            "ca-pem",
+	}
+	encryptionKey := make([]byte, 32)
+
+	mock.ExpectExec(`UPDATE cnsis`).
+		WithArgs("renamed", true, false, "cf", sqlmock.AnyArg(), "ca-pem", "some-guid").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repository.Update(endpoint, encryptionKey); err != nil {
+		t.Errorf("unexpected error from Update: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %s", err)
+	}
+}


### PR DESCRIPTION
CF error classification, transient-failure recovery, and guid-filter chunking. Found and fixed together because each layer was discovered while verifying the previous one (#5577 → #5579 → endpoint-update repair).

## Error classification (jetstream)

- `context.Canceled` from a dropped client request answers 499 instead of a shaped 502 — page navigation is routine, not a gateway failure. Parallel-drain failures are tagged primary / collateral / client_abort in the `[diag drain]` logs so one errgroup cancel cascade no longer reads as N independent failures.
- A gorouter route-flap 404 ("Requested route ... does not exist") classifies as `unreachable` instead of unclassified, and list reads retry it briefly (2x, 500ms/1s) since retryablehttp treats the clean 404 as don't-retry.

## Transient-failure recovery (frontend)

- Shared `drainCfPages` helper (replaces the duplicated drains in `EndpointDataService` / `CfUsersPagedDataService`) retries transient page fetches — status 0/502/503/504 or `X-Stratos-Error-Reason: unreachable` — 2x with 500ms/1s backoff, per page.
- Freshness stamps and stale-flag clears moved from `finalize` to the success path, so a failed load leaves the cache cold and the next read refetches instead of serving the failure as fresh. `loadDetails` warm-cache gating keys off the three per-domain stamps, closing a partial-failure hole.
- Retry affordance: when a drain fails and no rows are showing, signal-list renders a failed-load state with a Retry button instead of a misleading "there are no items" — and the orgs page no longer spins on "Loading organizations…" forever after a failed drain. Recovered slices clear their recorded errors.

## Guid-filter chunking (#5579)

Jetstream built CF v3 list requests with unbounded guid-list filters; a 500-row page produces a ~19.5KB query string that the platform chain rejects with 414 (composite ceiling is the min across every hop, commonly 8KB), and enrichment callers swallowed the error — counts silently vanished (80 observed 414s in one browsing pass).

- `forEachGuidChunk` splits guid lists at every unbounded call site (spaces/orgs relations, apps summary enrichment, users roles, service resolution, apps `return=counts` scoping) into chunks of `STRATOS_CF_GUID_CHUNK` (default 150 ≈ 5.7KB; cf CLI precedent batches at 200 — cloudfoundry/cli#2220).
- Runtime 414s WARN unconditionally, naming the knob and the diagnostics probe — a chain that shrinks after deployment is self-announcing. `STRATOS_CF_GUID_CHUNK=auto` (opt-in) additionally halves the width and retries from the live failure.
- Operator-triggered probe (`GET /pp/v1/cf/diag/urilimit/:cnsiGuid` + a Diagnostics > Endpoint Probes tab) bisects an endpoint's composite ceiling with ~10 unauthenticated requests and reports probed vs configured with a recommended setting. Nothing probes automatically.
- Paged pass-through filters (client-controlled `?guids=`, bounded by visible rows) are deliberately not split server-side — splitting would change client pagination semantics; they get the middleware 414 WARN.

## Endpoint update repair

Endpoint edits failed at three layers: the migrated frontend dropped the `id` form field the backend requires; `UpdateEndpointParams` never bound the `:id` route param; and the repository UPDATE had guid and ca_cert swapped in its arg list (`WHERE guid` matched the cert — "no rows were updated", with silent ca_cert corruption on a hypothetical match). All three fixed and pinned by tests.

## Verification

Unit: new Go tests (chunking, adaptive mode, probe bisect, update binding, SQL arg order) + frontend specs (retry, cold-cache, error self-heal, retry affordance, probe page). Live against a 4-endpoint duplicated-URL rig: probe measured the chain's real 8,096-byte ceiling (11 requests, recommendation 181 vs configured 150); the previously-414ing spaces enrichment now runs clean (0 x 414); endpoint rename works end-to-end.

Closes #5577
Closes #5579