### PR TITLE
Korifi build and release targets (not usable until Korifi auth lands)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,24 +98,30 @@ endif
 
 # Default: frontend + backend when none specified (unless e2e),
 # but only for verbs that use these modifiers (not clean/dump).
+# korifi counts as a build modifier here (make build korifi = static
+# backend only), so it must suppress the default like the others.
 ifneq ($(filter build test dev stamp,$(MAKECMDGOALS)),)
-ifeq ($($(_HIDE)WANT_FRONTEND)$($(_HIDE)WANT_BACKEND)$($(_HIDE)WANT_E2E)$($(_HIDE)WANT_WEBSITE),)
+ifeq ($($(_HIDE)WANT_FRONTEND)$($(_HIDE)WANT_BACKEND)$($(_HIDE)WANT_E2E)$($(_HIDE)WANT_WEBSITE)$(filter korifi,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_FRONTEND := yes
   $(_HIDE)WANT_BACKEND  := yes
 endif
 endif
 
 $(_HIDE)WANT_CF     :=
+$(_HIDE)WANT_KORIFI :=
 $(_HIDE)WANT_GITHUB :=
 
 ifneq ($(filter cf,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_CF := yes
 endif
+ifneq ($(filter korifi,$(MAKECMDGOALS)),)
+  $(_HIDE)WANT_KORIFI := yes
+endif
 ifneq ($(filter github,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_GITHUB := yes
 endif
 ifneq ($(filter release,$(MAKECMDGOALS)),)
-ifeq ($($(_HIDE)WANT_CF)$($(_HIDE)WANT_GITHUB),)
+ifeq ($($(_HIDE)WANT_CF)$($(_HIDE)WANT_KORIFI)$($(_HIDE)WANT_GITHUB),)
   $(_HIDE)WANT_CF     := yes
   $(_HIDE)WANT_GITHUB := yes
 endif
@@ -146,6 +152,19 @@ ifeq ($($(_HIDE)WANT_CF),yes)
     $(_HIDE)TARGET_ARCH := amd64
     $(_HIDE)GO_ENV      := GOOS=linux GOARCH=amd64
     $(_HIDE)CURRENT_PLATFORM := linux/amd64
+  endif
+endif
+
+# korifi modifier targets linux at the host arch unless PLATFORM is set
+# (a local kind cluster runs the host arch; real clusters override,
+# e.g. make build korifi PLATFORM=linux/amd64)
+ifeq ($($(_HIDE)WANT_KORIFI),yes)
+  ifndef PLATFORM
+    PLATFORM := linux/$($(_HIDE)HOST_ARCH)
+    $(_HIDE)TARGET_OS   := linux
+    $(_HIDE)TARGET_ARCH := $($(_HIDE)HOST_ARCH)
+    $(_HIDE)GO_ENV      := GOOS=linux GOARCH=$($(_HIDE)HOST_ARCH)
+    $(_HIDE)CURRENT_PLATFORM := linux/$($(_HIDE)HOST_ARCH)
   endif
 endif
 
@@ -195,8 +214,8 @@ endif
 
 # No-op targets so modifiers don't error
 # Note: lint has its own standalone recipe — not listed here.
-.PHONY: frontend backend website cf github dist version e2e actions gate tests coverage summary dependabot
-frontend backend website cf github dist version e2e actions gate tests coverage summary dependabot:
+.PHONY: frontend backend website cf korifi github dist version e2e actions gate tests coverage summary dependabot
+frontend backend website cf korifi github dist version e2e actions gate tests coverage summary dependabot:
 	@:
 
 # No-op targets for bump modifiers (consumed by BUMP_MOD filter).
@@ -482,6 +501,32 @@ define release.cf
 endef
 $(call register, release, cf)
 
+# ── Korifi ────────────────────────────────────────────────────
+# Korifi runs droplets on the Paketo jammy run image, which has no
+# glibc loader at the paths a dynamically linked cgo binary expects,
+# and the sqlite driver needs cgo — so the binary must be a static
+# cgo build (zig/musl). Korifi also has no binary_buildpack; the
+# package manifest uses paketo-buildpacks/procfile instead.
+
+define build.korifi
+	@command -v zig > /dev/null 2>&1 || (echo "zig not installed — required for the static cgo cross-compile. Install: brew install zig" >&2 && exit 1)
+	@echo "Building static backend for $($(_HIDE)CURRENT_PLATFORM) (Korifi)..."
+	@mkdir -p $($(_HIDE)BIN_DIR)
+	cd src/jetstream && go generate ./...
+	cd src/jetstream && CGO_ENABLED=1 GOOS=linux GOARCH=$($(_HIDE)TARGET_ARCH) \
+		CC="zig cc -target $(if $(filter arm64,$($(_HIDE)TARGET_ARCH)),aarch64,x86_64)-linux-musl" \
+		go build -ldflags "$($(_HIDE)GO_LDFLAGS) -linkmode external -extldflags -static" \
+		-o ../../$($(_HIDE)BIN_DIR)/jetstream
+	@echo "Backend built (static): $($(_HIDE)BIN_DIR)/jetstream"
+endef
+$(call register, build, korifi)
+
+define release.korifi
+	@chmod +x build/release-cf.sh
+	@./build/release-cf.sh "$($(_HIDE)SEMVER_VERSION)" korifi
+endef
+$(call register, release, korifi)
+
 # ── GitHub release ────────────────────────────────────────────
 
 define release.github
@@ -506,7 +551,7 @@ $(_HIDE)finalize-and-reexec:
 	@./build/version-bump.sh bump release
 	@echo "Re-running: $(MAKE) $(MAKECMDGOALS)"
 	@$(MAKE) FINAL= $(MAKECMDGOALS)
-$(filter-out frontend backend cf github dist version e2e actions lint gate tests coverage,$(MAKECMDGOALS)): $(_HIDE)finalize-and-reexec ; @:
+$(filter-out frontend backend cf korifi github dist version e2e actions lint gate tests coverage,$(MAKECMDGOALS)): $(_HIDE)finalize-and-reexec ; @:
 else ifneq ($(FINAL),)
 $(error Unknown FINAL value '$(FINAL)' — supported: strip)
 endif
@@ -545,7 +590,7 @@ endif
 # make clean dist      — above + node_modules
 
 define clean.release
-	rm -rf $($(_HIDE)DIST_DIR)/release $($(_HIDE)DIST_DIR)/cf-package $($(_HIDE)DIST_DIR)/install $($(_HIDE)DIST_DIR)/stratos-cf-*.zip
+	rm -rf $($(_HIDE)DIST_DIR)/release $($(_HIDE)DIST_DIR)/cf-package $($(_HIDE)DIST_DIR)/korifi-package $($(_HIDE)DIST_DIR)/install $($(_HIDE)DIST_DIR)/stratos-cf-*.zip $($(_HIDE)DIST_DIR)/stratos-korifi-*.zip
 endef
 
 define clean.dist
@@ -628,6 +673,7 @@ help:
 	@echo "  make build frontend       Build frontend only"
 	@echo "  make build backend        Cross-compile all backend platforms"
 	@echo "  make build backend PLATFORM=linux/amd64  Build single platform"
+	@echo "  make build korifi         Static cgo backend for Korifi (linux/host-arch)"
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test                 Run all tests"
@@ -647,6 +693,7 @@ help:
 	@echo "Release:"
 	@echo "  make release              Create CF zip + GitHub archives"
 	@echo "  make release cf           CF-pushable zip only"
+	@echo "  make release korifi       Korifi-pushable zip (Paketo procfile manifest)"
 	@echo "  make release github       GitHub release archives only"
 	@echo ""
 	@echo "Setup:"

--- a/actions.mk
+++ b/actions.mk
@@ -19,6 +19,7 @@ $(_HIDE)FLAG_frontend    := $($(_HIDE)WANT_FRONTEND)
 $(_HIDE)FLAG_backend     := $($(_HIDE)WANT_BACKEND)
 $(_HIDE)FLAG_website     := $($(_HIDE)WANT_WEBSITE)
 $(_HIDE)FLAG_cf          := $($(_HIDE)WANT_CF)
+$(_HIDE)FLAG_korifi      := $($(_HIDE)WANT_KORIFI)
 $(_HIDE)FLAG_github      := $($(_HIDE)WANT_GITHUB)
 $(_HIDE)FLAG_e2e         := $($(_HIDE)WANT_E2E)
 $(_HIDE)FLAG_dist        := $($(_HIDE)WANT_CLEAN_DIST)
@@ -32,7 +33,7 @@ $(_HIDE)FLAG_summary     := $($(_HIDE)WANT_SUMMARY)
 $(_HIDE)FLAG_dependabot  := $($(_HIDE)WANT_DEPENDABOT)
 
 # Known modifiers — the set checked during validation in declare_verb
-$(_HIDE)KNOWN_MODS := frontend backend website cf github e2e dist version actions lint gate tests coverage summary dependabot
+$(_HIDE)KNOWN_MODS := frontend backend website cf korifi github e2e dist version actions lint gate tests coverage summary dependabot
 
 # Known verbs — populated by declare_verb, checked for collisions
 $(_HIDE)KNOWN_VERBS :=

--- a/build/release-cf.sh
+++ b/build/release-cf.sh
@@ -2,7 +2,11 @@
 #
 # Stage and zip Stratos for Cloud Foundry deployment.
 #
-# Usage: ./build/release-cf.sh [VERSION]
+# Usage: ./build/release-cf.sh [VERSION] [MODE]
+#
+# MODE: cf (default) — classic CF manifest (binary_buildpack)
+#       korifi       — Korifi manifest (paketo-buildpacks/procfile;
+#                      requires a statically linked binary — make build korifi)
 #
 # Validates that required build artifacts exist before packaging.
 # Does NOT build anything — run 'make build' first.
@@ -10,12 +14,18 @@
 set -euo pipefail
 
 VERSION="${1:-$(node -p "require('./package.json').version" 2>/dev/null || echo "dev")}"
+MODE="${2:-cf}"
+
+case "${MODE}" in
+  cf|korifi) ;;
+  *) echo "ERROR: unknown mode '${MODE}' — supported: cf, korifi" >&2; exit 1 ;;
+esac
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST_DIR="${ROOT_DIR}/dist"
 BIN_DIR="${DIST_DIR}/bin"
-PKG_DIR="${DIST_DIR}/cf-package"
-ZIP_FILE="${DIST_DIR}/stratos-cf-${VERSION}.zip"
+PKG_DIR="${DIST_DIR}/${MODE}-package"
+ZIP_FILE="${DIST_DIR}/stratos-${MODE}-${VERSION}.zip"
 
 log()   { echo "-----> $1"; }
 error() { echo "ERROR: $1" >&2; }
@@ -47,6 +57,11 @@ elif ! file "${jetstream_bin}" | grep -q "ELF"; then
   error "Backend binary is not a Linux binary — CF requires a Linux ELF binary"
   error "  Current binary: $(file "${jetstream_bin}")"
   error "  Run: make build PLATFORM=linux/amd64  (or linux/arm64)"
+  fail=1
+elif [[ "${MODE}" == "korifi" ]] && ! file "${jetstream_bin}" | grep -q "statically linked"; then
+  error "Backend binary is dynamically linked — Korifi's run image cannot exec it"
+  error "  Current binary: $(file "${jetstream_bin}")"
+  error "  Run: make build korifi"
   fail=1
 fi
 
@@ -91,7 +106,38 @@ fi
 echo "web: ./jetstream" > "${PKG_DIR}/Procfile"
 
 # CF manifest
-cat > "${PKG_DIR}/manifest.yml" <<'MANIFEST'
+if [[ "${MODE}" == "korifi" ]]; then
+  # Stable per-workstation key, generated once and reused so data the
+  # console encrypted under it (endpoint tokens) survives repackaging.
+  # A shared hardcoded key would be a credential leak; a fresh key per
+  # package would orphan previously encrypted data.
+  KEY_FILE="${DIST_DIR}/.korifi-encryption-key"
+  if [[ ! -f "${KEY_FILE}" ]]; then
+    (umask 077 && openssl rand -hex 32 > "${KEY_FILE}")
+  fi
+  ENCRYPTION_KEY="$(cat "${KEY_FILE}")"
+  cat > "${PKG_DIR}/manifest.yml" <<MANIFEST
+applications:
+  - name: console
+    memory: 512M
+    disk_quota: 1024M
+    timeout: 180
+    buildpacks:
+      - paketo-buildpacks/procfile
+    health-check-type: port
+    env:
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      SESSION_STORE_EXPIRY: "240"
+      # The CF API address inferred from VCAP_APPLICATION may not be
+      # reachable from inside the cluster (on kind it is localhost).
+      # Target the Korifi API service directly; its certificate does
+      # not carry the service hostname, hence the SSL skip. Adjust
+      # both for a non-default install.
+      CF_API_URL: https://korifi-api-svc.korifi.svc.cluster.local
+      SKIP_SSL_VALIDATION: "true"
+MANIFEST
+else
+  cat > "${PKG_DIR}/manifest.yml" <<'MANIFEST'
 applications:
   - name: console
     memory: 256M
@@ -108,6 +154,7 @@ applications:
 # Force the console to use secured communication with the Cloud Foundry API endpoint
 #       CF_API_FORCE_SECURE: true
 MANIFEST
+fi
 
 # ── Create zip ────────────────────────────────────────────────
 


### PR DESCRIPTION
> [!WARNING]
> Not usable for real deployments yet. A console deployed to Korifi serves the UI but **cannot log anyone in**: Korifi has no UAA, and Stratos's CF auth assumes one (it takes Korifi's `login` root link and POSTs to a `/oauth/token` that doesn't exist). Bearer-token auth for Korifi endpoints is the subject of #5489. This PR only lands the build/packaging plumbing so that work can be developed and tested against a real Korifi.

## What

Adds a Korifi flavor of the CF release flow:

- `make build korifi` — statically linked cgo jetstream for `linux/<host-arch>` (override with `PLATFORM=linux/amd64`), built with `zig cc -target <arch>-linux-musl`. Runs `go generate ./...` first so builds from fresh worktrees don't silently drop the generated plugin registration.
- `make release korifi` — stages `dist/korifi-package/` and `stratos-korifi-<version>.zip` via a new `korifi` mode in `build/release-cf.sh`.

Existing flows are untouched: bare `make release` still means cf+github, and `make release cf` output is byte-identical.

## Why the differences from the classic cf package

- Korifi has no `binary_buildpack` (Paketo only), so the manifest uses `paketo-buildpacks/procfile` with the package's existing `Procfile`.
- Korifi runs droplets on the Paketo jammy run image, which cannot exec a dynamically linked cgo binary (no glibc loader at the expected path), and the sqlite driver needs cgo — hence the static musl build. The release script refuses a dynamically linked binary in korifi mode with a pointer to `make build korifi`.
- The CF API address jetstream infers from `VCAP_APPLICATION` may not be reachable from inside the cluster (on kind it is `localhost`, i.e. the app pod itself), so the manifest defaults `CF_API_URL` to the in-cluster `korifi-api-svc` service. See cloudfoundry/korifi#2299.
- The manifest's `ENCRYPTION_KEY` is generated at packaging time and cached in `dist/.korifi-encryption-key` (0600, gitignored, survives `make clean`) — no shared hardcoded key, and repackaging doesn't orphan data encrypted under a previous key.

## Testing

Verified end to end against Korifi v0.18.0 on kind (arm64): `make build korifi && make release korifi`, `cf push` from `dist/korifi-package/` — stages with the procfile buildpack, starts, serves the console UI, and fails login in exactly the way #5489 describes.

Two Korifi quirks hit while verifying, for the record: pushing over a crashlooping app never replaces the running droplet (filed as cloudfoundry/korifi#4378; `cf restart` recovers), and `cf delete` keeps routes, so a re-push with `default-route` needs `cf delete-route` first.

Refs #5489.
