### PR TITLE
Publish documentation website to GitHub Pages

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,0 +1,67 @@
+name: Deploy Website
+
+# Publishes the documentation website (website/ rendering docs/) to GitHub
+# Pages on every develop push that touches it. Until the
+# stratos.cloudfoundry.org custom domain is set up (CFF/LF infra ticket),
+# the site lives at https://cloudfoundry.github.io/stratos/ — hence the
+# SITE_URL/SITE_BASE_URL overrides below; once the CNAME lands, change them
+# to https://stratos.cloudfoundry.org and /.
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'docs/**'
+      - 'website/**'
+      - '.github/workflows/website-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One Pages deployment at a time; don't cancel a running deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '24'
+  BUN_VERSION: '1.3.14'
+
+jobs:
+  build:
+    name: Build Website
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install dependencies
+        run: cd website && bun install --frozen-lockfile
+      - name: Build website
+        run: cd website && bun run build
+        env:
+          # Owner-derived so the same workflow deploys to a fork's Pages
+          # (e.g. for previewing) as well as cloudfoundry.github.io.
+          SITE_URL: https://${{ github.repository_owner }}.github.io
+          SITE_BASE_URL: /${{ github.event.repository.name }}/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/README.md
+++ b/website/README.md
@@ -31,3 +31,21 @@ diagrams.
 The sidebar is curated in `sidebars.js` — new pages must be added
 there to appear in the site navigation. Landing-page and other
 site-only content lives under `src/pages`, never in `docs/`.
+
+## Deployment
+
+`.github/workflows/website-deploy.yml` publishes the site to GitHub
+Pages on every `develop` push touching `docs/` or `website/`
+(requires Pages to be enabled on the repo with source "GitHub
+Actions"). It builds with `SITE_URL`/`SITE_BASE_URL` set for
+`cloudfoundry.github.io/stratos/`; switch those to
+`https://stratos.cloudfoundry.org` and `/` once the custom domain
+CNAME exists.
+
+The built site can also be pushed to any Cloud Foundry as a static
+app:
+
+```bash
+make build website
+cf push -f website/manifest.yml
+```

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,8 +9,10 @@ const config = {
   tagline: 'Open-Source Multi-Cluster UI for Cloud Foundry and Kubernetes',
   favicon: 'img/favicon.ico',
 
-  url: 'https://stratos.app',
-  baseUrl: '/',
+  // Overridable so the GitHub Pages workflow can build for
+  // cloudfoundry.github.io/stratos/ until the custom domain lands.
+  url: process.env.SITE_URL || 'https://stratos.app',
+  baseUrl: process.env.SITE_BASE_URL || '/',
 
   organizationName: 'cloudfoundry',
   projectName: 'stratos',

--- a/website/manifest.yml
+++ b/website/manifest.yml
@@ -1,0 +1,6 @@
+applications:
+  - name: stratos-docs
+    memory: 64M
+    path: build
+    buildpacks:
+      - staticfile_buildpack


### PR DESCRIPTION
Adds the publishing leg of the docs/website work merged in #5583.

- New `website-deploy.yml` workflow: builds the Docusaurus site and deploys it to GitHub Pages on every `develop` push touching `docs/` or `website/` (plus manual dispatch). Uses the official upload/deploy-pages actions; node/bun versions match `pr.yml`.
- Until the `stratos.cloudfoundry.org` custom domain exists, the site is built for project Pages (`<owner>.github.io/stratos/`). `docusaurus.config.js` gains `SITE_URL`/`SITE_BASE_URL` env overrides (defaults unchanged); the workflow derives them from the repository owner, so the same workflow also deploys fork previews. Once the CNAME lands, set them to `https://stratos.cloudfoundry.org` and `/`.
- `website/manifest.yml`: the built site can also be pushed to any Cloud Foundry as a staticfile app (`make build website && cf push -f website/manifest.yml`).
- README documents both deploy paths.

Requires a repo admin to enable Pages (Settings → Pages → source "GitHub Actions") before the deploy job succeeds. Verified end to end on a fork: the workflow run deploys and the site renders correctly under the `/stratos/` base path.