### PR TITLE
fix(build): generate backend plugins before every build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,13 @@ $(call register, stamp, frontend)
 
 # ── Backend ───────────────────────────────────────────────────
 
+# extra_plugins.go is generated from plugin-config.yaml (gitignored), so a
+# fresh checkout compiles a plugin-less jetstream unless generation runs
+# first. Internal prerequisite of every backend build; hidden from help.
+.PHONY: $(_HIDE)gen-plugins
+$(_HIDE)gen-plugins:
+	cd src/jetstream && go generate ./...
+
 define build.backend
 	@if [ -n "$(PLATFORM)" ]; then \
 		echo "Building backend for $($(_HIDE)CURRENT_PLATFORM)..."; \
@@ -281,7 +288,7 @@ define build.backend
 		echo "All platform binaries built: $($(_HIDE)BIN_DIR)/"; \
 	fi
 endef
-$(call register, build, backend)
+$(call register, build, backend, $(_HIDE)gen-plugins)
 
 define test.backend
 	@echo "Running backend tests..."
@@ -530,14 +537,13 @@ define build.korifi
 	@command -v zig > /dev/null 2>&1 || (echo "zig not installed — required for the static cgo cross-compile. Install: brew install zig" >&2 && exit 1)
 	@echo "Building static backend for $($(_HIDE)CURRENT_PLATFORM) (Korifi)..."
 	@mkdir -p $($(_HIDE)BIN_DIR)
-	cd src/jetstream && go generate ./...
 	cd src/jetstream && CGO_ENABLED=1 GOOS=linux GOARCH=$($(_HIDE)TARGET_ARCH) \
 		CC="zig cc -target $(if $(filter arm64,$($(_HIDE)TARGET_ARCH)),aarch64,x86_64)-linux-musl" \
 		go build -ldflags "$($(_HIDE)GO_LDFLAGS) -linkmode external -extldflags -static" \
 		-o ../../$($(_HIDE)BIN_DIR)/jetstream
 	@echo "Backend built (static): $($(_HIDE)BIN_DIR)/jetstream"
 endef
-$(call register, build, korifi)
+$(call register, build, korifi, $(_HIDE)gen-plugins)
 
 define release.korifi
 	@chmod +x build/release-cf.sh

--- a/Makefile
+++ b/Makefile
@@ -782,4 +782,6 @@ include deprecated.mk
 
 # ── Site-specific overrides ──────────────────────────────────
 $(_HIDE)SITE := site
--include $($(_HIDE)SITE).mk
+# $(wildcard) so make 3.81 (macOS) stays silent when the file is absent —
+# bare -include still prints a spurious "No rule to make target" there.
+-include $(wildcard $($(_HIDE)SITE).mk)

--- a/build/cross-compile.sh
+++ b/build/cross-compile.sh
@@ -3,6 +3,12 @@
 
 set -euo pipefail
 
+# Must run from the repo root (paths below are root-relative).
+if [ ! -f Makefile ] || [ ! -d src/jetstream ]; then
+  echo "error: run from the repository root (where the Makefile lives)" >&2
+  exit 1
+fi
+
 VERSION=${1:-$(node -p "require('./package.json').version")}
 BUILD_DATE=${2:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
 GIT_COMMIT=${3:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}


### PR DESCRIPTION
## What

Two build-system fixes:

1. **Plugin generation runs before every backend build.** `extra_plugins.go` is generated from `plugin-config.yaml` and gitignored, so a fresh checkout compiled a plugin-less jetstream: no cloudfoundry plugin, `Unknown endpoint type "cf"` warnings in the log, and a silently empty endpoints page in the UI (the cf group never reaches `/pp/v1/info`, while `/api/v1/endpoints` still returns DB rows). Only the korifi target and `cross-compile.sh` ran the generator. The step is now an internal `gen-plugins` prerequisite shared by `build backend` and `build korifi` (`dev backend` inherits it via its delegated build), and `cross-compile.sh` gains a repo-root guard since its paths are root-relative.

2. **Silence spurious `site.mk` include noise on make 3.81.** macOS's bundled GNU Make 3.81 prints `No rule to make target 'site.mk'. Stop.` for a missing `-include`'d file and then continues anyway; newer make is silent. Wrapping the include in `$(wildcard)` keeps 3.81 quiet with no behavior change when a `site.mk` is present.

## Verification

- `make -n build backend PLATFORM=…`, `make -n build korifi`, and the cross-compile branch all show generation running first
- Cold-build test: deleted `extra_plugins.go`, ran `make build backend PLATFORM=darwin/arm64` — file regenerated, resulting binary contains the cloudfoundry plugin
- `site.mk` A/B: message gone when absent, include still honored when present
- `make help` unchanged (gen-plugins is an internal hidden target)