### PR TITLE
Migrate name-uniqueness checks off the CF v2 API

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { AppInputDirective, CustomFormFieldComponent, MatLabelComponent } from '@stratosui/core';
-import { HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
+import { HttpParams, HttpRequest } from '@angular/common/http';
 import { Component, Input, OnDestroy, signal, ChangeDetectionStrategy, inject } from '@angular/core';
 import { ReactiveFormsModule, FormsModule, Validators, FormControl, FormGroup } from '@angular/forms';
 import { CustomSelectComponent, CustomOptionComponent } from '@stratosui/core';
@@ -41,7 +41,7 @@ export interface UpsPickerRow {
   alreadyBound: boolean;
 }
 
-const { proxyAPIVersion, cfAPIVersion } = environment;
+const { proxyAPIVersion } = environment;
 @Component({
   selector: 'app-specify-user-provided-details',
   templateUrl: './specify-user-provided-details.component.html',
@@ -277,19 +277,14 @@ export class SpecifyUserProvidedDetailsComponent implements OnDestroy {
 
   public getUniqueRequest = (name: string) => {
     const params = new HttpParams()
-      .set('q', 'name:' + name)
-      .append('q', 'space_guid:' + this.spaceGuid);
-    const headers = new HttpHeaders({
-      'x-cap-cnsi-list': this.cfGuid,
-      'x-cap-passthrough': 'true'
-    });
+      .set('return', 'counts')
+      .set('type', 'user-provided')
+      .set('names', name)
+      .set('space_guids', this.spaceGuid);
     return new HttpRequest(
       'GET',
-      `/pp/${proxyAPIVersion}/proxy/${cfAPIVersion}/user_provided_service_instances`,
-      {
-        headers,
-        params
-      },
+      `/pp/${proxyAPIVersion}/cf/service_instances/${this.cfGuid}`,
+      { params },
     );
   };
 

--- a/src/frontend/packages/cloud-foundry/src/shared/directives/app-name-unique.directive/app-name-unique.directive.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/directives/app-name-unique.directive/app-name-unique.directive.spec.ts
@@ -1,10 +1,13 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { FormControl } from '@angular/forms';
 import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { createBasicStoreModule } from '@stratosui/store/testing';
+import { CreateAppStateService } from '../../data-services/create-app-state.service';
 import { AppNameUniqueDirective } from './app-name-unique.directive';
 
 describe('AppNameUniqueDirective', () => {
@@ -24,5 +27,45 @@ describe('AppNameUniqueDirective', () => {
   it('should create an instance', () => {
     const directive = TestBed.runInInjectionContext(() => new AppNameUniqueDirective());
     expect(directive).toBeTruthy();
+  });
+
+  function setupValidation(name: string) {
+    TestBed.inject(CreateAppStateService).setCFDetails({ cloudFoundry: 'cf-1', org: 'org-1', space: 'space-1' });
+    const directive = TestBed.runInInjectionContext(() => new AppNameUniqueDirective());
+    directive.ngOnInit();
+    const control = new FormControl(name);
+    control.markAsDirty();
+    return firstValueFrom(directive.validate(control));
+  }
+
+  // Real 500ms debounce timer — zoneless build has no fakeAsync/tick.
+  const debounce = () => new Promise(resolve => setTimeout(resolve, 550));
+
+  it('counts apps by name via the native v3 route and flags taken names', async () => {
+    const http = TestBed.inject(HttpTestingController);
+    const result = setupValidation('my-app');
+
+    await debounce();
+    const req = http.expectOne(r =>
+      r.url === '/pp/v1/cf/apps/cf-1' &&
+      r.params.get('return') === 'counts' &&
+      r.params.get('names') === 'my-app' &&
+      r.params.get('space_guids') === 'space-1');
+    req.flush({ resources: [], totalResults: 1 });
+
+    expect(await result).toEqual({ appNameTaken: true });
+    http.verify();
+  });
+
+  it('fails open when the check request errors', async () => {
+    const http = TestBed.inject(HttpTestingController);
+    const result = setupValidation('my-app');
+
+    await debounce();
+    http.expectOne(r => r.url === '/pp/v1/cf/apps/cf-1')
+      .flush({ error: 'nope' }, { status: 500, statusText: 'Server Error' });
+
+    expect(await result).toBeNull();
+    http.verify();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/shared/directives/app-name-unique.directive/app-name-unique.directive.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/directives/app-name-unique.directive/app-name-unique.directive.ts
@@ -1,7 +1,7 @@
-import { HttpClient, HttpHeaders, HttpParams, HttpRequest, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpParams, HttpRequest, HttpResponse } from '@angular/common/http';
 import { Directive, forwardRef, Input, OnInit, inject } from '@angular/core';
 import { AbstractControl, AsyncValidator, NG_ASYNC_VALIDATORS } from '@angular/forms';
-import { Observable, of as observableOf, throwError as observableThrowError, timer as observableTimer } from 'rxjs';
+import { Observable, of as observableOf, timer as observableTimer } from 'rxjs';
 import { catchError, filter, map, switchMap, take } from 'rxjs/operators';
 
 import { environment } from '@stratosui/core';
@@ -13,7 +13,7 @@ const APP_UNIQUE_NAME_PROVIDER = {
 
 // See: https://medium.com/@kahlil/asynchronous-validation-with-angular-reactive-forms-1a392971c062
 
-const { proxyAPIVersion, cfAPIVersion } = environment;
+const { proxyAPIVersion } = environment;
 export type NameTaken<T = any> = (response: HttpResponse<T>) => boolean;
 export type UniqueValidatorRequestBuilder<T = any> = (name: string) => HttpRequest<T>;
 export class AppNameUniqueChecking {
@@ -47,7 +47,7 @@ export class AppNameUniqueDirective implements AsyncValidator, OnInit {
 
   @Input() appApplicationNameUnique!: AppNameUniqueChecking;
   @Input() appApplicationNameUniqueRequest!: UniqueValidatorRequestBuilder;
-  @Input() appApplicationNameUniqueValidator: NameTaken = (res: HttpResponse<any>) => res.body.total_results > 0;
+  @Input() appApplicationNameUniqueValidator: NameTaken = (res: HttpResponse<any>) => res.body.totalResults > 0;
 
   constructor() {
     if (!this.appApplicationNameUnique) {
@@ -73,9 +73,12 @@ export class AppNameUniqueDirective implements AsyncValidator, OnInit {
         this.appApplicationNameUnique.set(false, appNameTaken);
         return appNameTaken ? { appNameTaken } : null;
       }),
-      catchError(err => {
+      catchError(() => {
+        // Fail open: CC enforces name uniqueness at create time, so a
+        // failed convenience check must not wedge the form (an erroring
+        // async validator leaves the control PENDING forever).
         this.appApplicationNameUnique.set(false);
-        return observableThrowError(err);
+        return observableOf(null);
       }));
   }
 
@@ -91,19 +94,13 @@ export class AppNameUniqueDirective implements AsyncValidator, OnInit {
 
   private getDefaultRequest(cfGuid: string, spaceGuid: string, name: string) {
     const params = new HttpParams()
-      .set('q', 'name:' + name)
-      .append('q', 'space_guid:' + spaceGuid);
-    const headers = new HttpHeaders({
-      'x-cap-cnsi-list': cfGuid,
-      'x-cap-passthrough': 'true'
-    });
+      .set('return', 'counts')
+      .set('names', name)
+      .set('space_guids', spaceGuid);
     return new HttpRequest(
       'GET',
-      `/pp/${proxyAPIVersion}/proxy/${cfAPIVersion}/apps`,
-      {
-        headers,
-        params
-      },
+      `/pp/${proxyAPIVersion}/cf/apps/${cfGuid}`,
+      { params },
     );
   }
 

--- a/src/frontend/packages/core/src/environments/environment.desktop.ts
+++ b/src/frontend/packages/core/src/environments/environment.desktop.ts
@@ -1,9 +1,8 @@
-import { cfAPIVersion, proxyAPIVersion } from '../../../store/src/jetstream';
+import { proxyAPIVersion } from '../../../store/src/jetstream';
 
 export const environment = {
   production: true,
   proxyAPIVersion,
-  cfAPIVersion,
   showObsDebug: false,
   disablePolling: true,
   desktopMode: true,

--- a/src/frontend/packages/core/src/environments/environment.prod.ts
+++ b/src/frontend/packages/core/src/environments/environment.prod.ts
@@ -1,9 +1,8 @@
-import { cfAPIVersion, proxyAPIVersion } from '@stratosui/store';
+import { proxyAPIVersion } from '@stratosui/store';
 
 export const environment = {
   production: true,
   proxyAPIVersion,
-  cfAPIVersion,
   showObsDebug: false,
   disablePolling: true,
   desktopMode: false,

--- a/src/frontend/packages/core/src/environments/environment.ts
+++ b/src/frontend/packages/core/src/environments/environment.ts
@@ -1,4 +1,4 @@
-import { cfAPIVersion, proxyAPIVersion } from '@stratosui/store';
+import { proxyAPIVersion } from '@stratosui/store';
 
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses `environment.ts`, but if you do
@@ -8,7 +8,6 @@ import { cfAPIVersion, proxyAPIVersion } from '@stratosui/store';
 export const environment = {
   production: false,
   proxyAPIVersion,
-  cfAPIVersion,
   showObsDebug: false,
   disablePolling: false,
   desktopMode: false,

--- a/src/frontend/packages/store/src/jetstream.ts
+++ b/src/frontend/packages/store/src/jetstream.ts
@@ -3,9 +3,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 // API Version to use when making back-end API requests to Jetstraam
 export const proxyAPIVersion = 'v1';
 
-// CF API Version
-export const cfAPIVersion = 'v2';
-
 /**
  * Actual error response from stratos
  */

--- a/src/frontend/packages/store/src/public-api.ts
+++ b/src/frontend/packages/store/src/public-api.ts
@@ -88,7 +88,6 @@ export {
 export { getFavoriteInfoObservable } from './helpers/store-helpers';
 export {
   JetStreamErrorResponse,
-  cfAPIVersion,
   httpErrorResponseToSafeString,
   isHttpErrorResponse,
   proxyAPIVersion,

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
@@ -981,6 +981,49 @@ func TestGetNativeApps_LegacyReturnCountsUnchanged(t *testing.T) {
 // CloudFoundryEndpointService.fetchAppCount(orgGuid?, spaceGuid?) to
 // replace the V2 ngrx-pagination count helper without paying for a
 // full apps drain.
+func TestGetNativeApps_ReturnCountsHonorsNamesFilter(t *testing.T) {
+	var capturedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			w.Write([]byte(`{"links":{}}`))
+		case "/v3/apps":
+			capturedQuery = r.URL.RawQuery
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 1, "total_pages": 1},
+				"resources":  []map[string]interface{}{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/apps/test-cnsi?return=counts&names=my-app&space_guids=space-A", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("test-cnsi")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "test-cnsi", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getNativeApps(ctx))
+
+	var resp StAppsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, 1, resp.TotalResults)
+	assert.Contains(t, capturedQuery, "names=my-app")
+	assert.Contains(t, capturedQuery, "space_guids=space-A")
+}
+
 func TestGetNativeApps_ReturnCountsHonorsOrgGuidsFilter(t *testing.T) {
 	var capturedQuery string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -529,6 +529,10 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 		// totalResults, so Resources stays empty.
 		orgScope := splitNonEmpty(ctx.QueryParam("organization_guids"), ",")
 		spaceScope := splitNonEmpty(ctx.QueryParam("space_guids"), ",")
+		// names is an exact-match filter on /v3/apps — the app-name-unique
+		// validator asks "count of apps with this name in this space" and
+		// reads totalResults > 0.
+		nameScope := splitNonEmpty(ctx.QueryParam("names"), ",")
 		total := 0
 		runCount := func(orgChunk, spaceChunk []string) error {
 			params := capi.NewQueryParams().WithPerPage(1)
@@ -537,6 +541,9 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 			}
 			if len(spaceChunk) > 0 {
 				params = params.WithFilter("space_guids", spaceChunk...)
+			}
+			if len(nameScope) > 0 {
+				params = params.WithFilter("names", nameScope...)
 			}
 			raw, err := listWithRouterFlapRetry(ctx.Request().Context(), "apps.counts", func() (*capi.ListResponse[capi.App], error) {
 				return cfClient.Apps().List(ctx.Request().Context(), params)

--- a/src/jetstream/plugins/cloudfoundry/native_service_instances_reads.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instances_reads.go
@@ -210,6 +210,14 @@ func applyServiceInstanceFilters(ctx echo.Context, params *capi.QueryParams) *ca
 			params = params.WithFilter("organization_guids", orgGUIDs...)
 		}
 	}
+	if rawNames := ctx.QueryParam("names"); rawNames != "" {
+		// Exact-match name filter — the UPS name-unique validator counts
+		// instances with this name in a space (type=user-provided).
+		names := splitNonEmpty(rawNames, ",")
+		if len(names) > 0 {
+			params = params.WithFilter("names", names...)
+		}
+	}
 	return params
 }
 

--- a/src/jetstream/plugins/cloudfoundry/native_service_instances_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instances_reads_test.go
@@ -389,6 +389,27 @@ func TestGetNativeServiceInstances_CountsFastPath(t *testing.T) {
 	assert.Empty(t, resp.Resources)
 }
 
+func TestGetNativeServiceInstances_CountsHonorsNamesFilter(t *testing.T) {
+	srv, q := newCountsCapiServer(t, "/v3/service_instances", 1, "names", "type", "space_guids")
+	defer srv.Close()
+
+	e := echo.New()
+	ctx, rec := newServiceInstancesContext(e,
+		"/pp/v1/cf/service_instances/cnsi-1?return=counts&type=user-provided&names=my-ups&space_guids=space-A")
+	plugin := newServiceInstancesPlugin(srv.URL)
+
+	require.NoError(t, plugin.getNativeServiceInstances(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp StServiceInstancesResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, 1, resp.TotalResults)
+	assert.Equal(t, "1", q.PerPage)
+	assert.Equal(t, "my-ups", q.Filters["names"])
+	assert.Equal(t, "user-provided", q.Filters["type"])
+	assert.Equal(t, "space-A", q.Filters["space_guids"])
+}
+
 func TestGetNativeServiceInstances_PerPagePassthrough(t *testing.T) {
 	body := []byte(`{
 		"pagination": {


### PR DESCRIPTION
Follow-up to #5589. The app-name and UPS-name async validators were the frontend's last two raw CF v2 proxy calls (`/pp/v1/proxy/v2/apps` and `/pp/v1/proxy/v2/user_provided_service_instances`). v2 resource endpoints are gated by `cc.temporary_enable_v2` (default false in current capi-release), so these rode on a deprecated surface. (`/v2/info` is unaffected by that gate and remains valid on v3-only foundations — this PR doesn't touch it.)

- Both validators now use the native count paths: `/pp/v1/cf/apps/:cnsi?return=counts&names=X&space_guids=Y` and `/pp/v1/cf/service_instances/:cnsi?return=counts&type=user-provided&names=X&space_guids=Y`.
- jetstream's count branches learn the v3 exact-match `names` filter (apps `runCount` and `applyServiceInstanceFilters`), each with a forwarding test.
- The validators now fail open on request errors: Cloud Controller enforces name uniqueness at create time anyway, and an erroring async validator left the control stuck in PENDING, wedging the form.
- `cfAPIVersion` (`'v2'`) is removed from the store package, its public API and the environment files — the frontend no longer references the CF v2 API anywhere.

The directive spec gains two behavior tests (native URL + taken mapping, fail-open on error). Verified with the backend test suite and the full check gate (lint + frontend tests + production build).