### PR TITLE
fix: endpoint card copy button + kubeconfig import wizard

### DIFF
--- a/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.html
@@ -1,6 +1,9 @@
 <app-list-sub-nav title="Total Endpoints" [count]="totalEndpoints" [addAction]="addAction"></app-list-sub-nav>
 @if (listConfig(); as config) {
   <app-signal-list [config]="config" class="flex-1 min-h-0">
+    <ng-template #cardTemplate let-row>
+      <app-endpoint-card [row]="$any(row)" [actionMenu]="cardMenuFor($any(row))"></app-endpoint-card>
+    </ng-template>
     <ng-template appSignalListCell="address" let-row>
       <app-table-cell-endpoint-address [row]="row"></app-table-cell-endpoint-address>
     </ng-template>

--- a/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 
 import {
   EndpointModel,
+  MenuItem,
   UserFavorite,
   UserFavoriteManager,
   entityCatalog,
@@ -26,6 +27,8 @@ import {
   SignalListRowAction,
 } from '../../../shared/components/signal-list/signal-list.component';
 import { SignalListCellTemplateDirective } from '../../../shared/components/signal-list/signal-list-cell-template.directive';
+import { EndpointCardComponent } from '../../../shared/components/endpoint-list/endpoint-card/endpoint-card.component';
+import { EndpointListHelper } from '../../../shared/components/endpoint-list/endpoint-list.helpers';
 import { TableCellEndpointAddressComponent } from '../../../shared/components/endpoint-list/table-cell-endpoint-address/table-cell-endpoint-address.component';
 import { SnackBarService } from '../../../shared/services/snackbar.service';
 import { TailwindDialogService } from '../../../shared/services/tailwind-dialog.service';
@@ -44,11 +47,13 @@ import { EndpointsSignalConfigService } from './endpoints-signal-config.service'
   host: { class: 'flex flex-col flex-1 min-h-0' },
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [EndpointListHelper],
   imports: [
     CommonModule,
     ListSubNavComponent,
     SignalListComponent,
     SignalListCellTemplateDirective,
+    EndpointCardComponent,
     TableCellEndpointAddressComponent,
   ],
 })
@@ -241,6 +246,15 @@ export class EndpointsSignalListComponent {
     this.endpointsConfig.registerSortExtractor('admin', adminLabel);
     this.endpointsConfig.registerSortExtractor('user', userLabel);
   }
+
+  // Card view projects the rich endpoint card; the kebab actions are the
+  // same ones the table rows use, adapted to the meta-card's MenuItem shape.
+  cardMenuFor = (ep: EndpointModel): MenuItem[] =>
+    this.buildEndpointActions(ep).map(a => ({
+      label: a.label,
+      icon: a.icon,
+      action: () => a.invoke(ep),
+    }));
 
   private toggleEndpointFavorite(ep: EndpointModel): void {
     if (!ep.guid || !ep.cnsi_type) {

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
@@ -2,7 +2,7 @@
 </app-page-header-events>
 <app-meta-card class="endpoint-card" [routerLink]="endpointLink" [appDisableRouterLink]="!endpointLink"
   [ngClass]="{'endpoint-card--no-link': !endpointLink, 'endpoint-card--disconnected': connectionStatus === 'disconnected', 'endpoint-card--checking': connectionStatus === 'checking'}"
-  [favorite]="favorite" [status$]="cardStatus$" [statusIcon]="false" [statusBackground]="true">
+  [favorite]="favorite" [actionMenu]="actionMenu" [status$]="cardStatus$" [statusIcon]="false" [statusBackground]="true">
   <app-meta-card-title>
     <div class="endpoint-card__title">
       @if (!!endpointCatalogEntity && endpointCatalogEntity.definition.logoUrl) {

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
@@ -2,7 +2,7 @@
 </app-page-header-events>
 <app-meta-card class="endpoint-card" [routerLink]="endpointLink" [appDisableRouterLink]="!endpointLink"
   [ngClass]="{'endpoint-card--no-link': !endpointLink, 'endpoint-card--disconnected': connectionStatus === 'disconnected', 'endpoint-card--checking': connectionStatus === 'checking'}"
-  [favorite]="favorite" [actionMenu]="cardMenu" [status$]="cardStatus$" [statusIcon]="false" [statusBackground]="true">
+  [favorite]="favorite" [status$]="cardStatus$" [statusIcon]="false" [statusBackground]="true">
   <app-meta-card-title>
     <div class="endpoint-card__title">
       @if (!!endpointCatalogEntity && endpointCatalogEntity.definition.logoUrl) {
@@ -25,8 +25,6 @@
           -->
         </div>
       </div>
-      <app-copy-to-clipboard #copyToClipboard class="endpoint-card__hidden" [text]="address" tooltip="Copy to clipboard"
-      [showSuccessText]="false"></app-copy-to-clipboard>
     </div>
   </app-meta-card-title>
   <app-meta-card-item>
@@ -49,6 +47,8 @@
     <app-meta-card-value>
       <div class="endpoint-card__address">
         <div class="endpoint-card__address__value">{{ address }}</div>
+        <app-copy-to-clipboard class="ml-0.5 w-fit inline-flex" [compact]="true" [text]="address"
+        tooltip="Copy to clipboard" [showSuccessText]="false"></app-copy-to-clipboard>
         @if (isDuplicate$ | async) {
           <span class="material-icons text-warning-shade-600 dark:text-warning-shade-300 ml-1 text-[20px] leading-none"
             matTooltip="Another endpoint is registered at this URL">warning</span>

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.scss
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.scss
@@ -99,14 +99,6 @@
       color: var(--content-muted, #64748b);
     }
   }
-
-  &__hidden {
-    height: 0;
-    opacity: 0;
-    pointer-events: none;
-    width: 0;
-    position: absolute;
-  }
 }
 
 /* Responsive adjustments */

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.ts
@@ -1,13 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ComponentRef, Input, OnDestroy, OnInit, ViewChild, ViewContainerRef, ChangeDetectorRef, inject } from '@angular/core';
 import { CustomTooltipDirective } from '../../custom-tooltip/custom-tooltip.directive';
-import { Router, RouterModule } from '@angular/router';
+import { RouterModule } from '@angular/router';
 import { toObservable } from '@angular/core/rxjs-interop';
 import {
   EndpointModel,
   entityCatalog,
   getFullEndpointApiUrl,
-  MenuItem,
   StratosCatalogEndpointEntity,
   StratosStatus,
   UserFavoriteEndpoint,
@@ -63,7 +62,6 @@ import { DisableRouterLinkDirective } from '../../../../core/disable-router-link
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EndpointCardComponent extends CardCell<EndpointModel> implements OnInit, OnDestroy {
-  private router = inject(Router);
   private endpointsSignal = inject(EndpointsSignalService);
   private endpoints$ = toObservable(this.endpointsSignal.endpoints);
   private endpointListHelper = inject(EndpointListHelper);
@@ -77,7 +75,6 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
   public favorite: UserFavoriteEndpoint | null = null;
   public address!: string;
   public isDuplicate$!: Observable<boolean>;
-  public cardMenu!: MenuItem[];
   public endpointCatalogEntity?: StratosCatalogEndpointEntity;
   public hasDetails = true;
   public endpointLink: string | null = null;
@@ -99,8 +96,6 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
     this.endpointDetails = content;
     this.updateInnerComponent();
   }
-
-  @ViewChild('copyToClipboard') copyToClipboard!: CopyToClipboardComponent;
 
   @Input()
   set row(row: EndpointModel) {
@@ -127,10 +122,10 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
   }
   // V2 BaseEndpointsDataSource was deleted in W12 — the kubernetes
   // card consumer never bound [dataSource] and the V2 endpoints list
-  // (only other consumer) was the only path that did. Card menu +
-  // cardStatus$ are now driven by direct consumer template bindings
-  // when needed, not the data-source narrowing the V2 list-config
-  // pipeline used to inject.
+  // (only other consumer) was the only path that did. cardStatus$ is
+  // now driven by direct consumer template bindings when needed, not
+  // the data-source narrowing the V2 list-config pipeline used to
+  // inject.
 
   constructor() {
     super();
@@ -184,11 +179,6 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
       this.component.row = this.row;
       this.componentRef.changeDetectorRef.detectChanges();
     }
-  }
-
-  editEndpoint() {
-    const routerLink = `/endpoints/edit/${this.row.guid}`;
-    this.router.navigate(routerLink.split('/'));
   }
 
   /**

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.ts
@@ -7,6 +7,7 @@ import {
   EndpointModel,
   entityCatalog,
   getFullEndpointApiUrl,
+  MenuItem,
   StratosCatalogEndpointEntity,
   StratosStatus,
   UserFavoriteEndpoint,
@@ -89,6 +90,11 @@ export class EndpointCardComponent extends CardCell<EndpointModel> implements On
   public viewCreator$!: Observable<boolean>;
 
   private componentRef!: ComponentRef<EndpointListDetailsComponent>;
+
+  // Optional per-endpoint kebab menu, rendered by the meta-card header.
+  // Consumers that suppress it (e.g. the kubernetes endpoints page) simply
+  // leave it unset.
+  @Input() actionMenu: MenuItem[] | null = null;
 
   @Input() component: EndpointListDetailsComponent | null = null;
   private endpointDetails!: ViewContainerRef;

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-import/kube-config-import.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-import/kube-config-import.component.ts
@@ -1,8 +1,7 @@
 import { ChangeDetectionStrategy, Component, EnvironmentInjector, Injector, OnDestroy, Signal, WritableSignal, computed, inject, signal } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 
 import { UntypedFormBuilder } from '@angular/forms';
-import { Observable, of as observableOf, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, of as observableOf, Subscription } from 'rxjs';
 import { filter, map, startWith, take } from 'rxjs/operators';
 
 import { EndpointsDataService } from '@stratosui/store';
@@ -46,18 +45,27 @@ const CONNECT_ACTION = 'Connect endpoint';
  */
 function createSignalWrapper<T>(initialValue: T) {
   const _signal = signal<T>(initialValue);
+  // asObservable() must be callable outside injection contexts (wrappers are
+  // created and read during import execution, from step event handlers), so
+  // it is backed by a BehaviorSubject kept in sync on every write instead of
+  // a lazy toObservable(), which throws NG0203 there.
+  const _subject = new BehaviorSubject<T>(initialValue);
+  const write = (value: T) => {
+    _signal.set(value);
+    _subject.next(value);
+  };
   const wrapper = Object.assign(
     // Make it callable like a signal
     () => _signal(),
     {
       // WritableSignal methods
-      set: (value: T) => _signal.set(value),
-      update: (fn: (value: T) => T) => _signal.update(fn),
+      set: write,
+      update: (fn: (value: T) => T) => write(fn(_signal())),
       asReadonly: () => _signal.asReadonly(),
       // BehaviorSubject compatibility methods
-      next: (value: T) => _signal.set(value),
+      next: write,
       getValue: () => _signal(),
-      asObservable: () => toObservable(_signal),
+      asObservable: () => _subject.asObservable(),
     }
   );
   return wrapper as WritableSignal<T> & {

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-selection.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-selection.component.html
@@ -8,14 +8,19 @@
               class="flex-1 min-w-0 px-2 py-1 text-sm border border-content-border rounded bg-content-bg text-content-text"
               [value]="editRowName()"
               (click)="$event.stopPropagation()"
-              (input)="editRowName.set($any($event.target).value)" />
+              (input)="editRowName.set($any($event.target).value)"
+              (blur)="saveEdit(row)"
+              (keyup.enter)="saveEdit(row)"
+              (keyup.escape)="cancelEdit()" />
             <button id="kube-config-name-edit-done" type="button" title="Save"
               class="inline-flex items-center justify-center p-0.5 text-success hover:text-success/80"
+              (mousedown)="$event.preventDefault()"
               (click)="$event.stopPropagation(); saveEdit(row)">
               <span class="material-icons text-base leading-none">done</span>
             </button>
             <button id="kube-config-name-edit-cancel" type="button" title="Cancel"
               class="inline-flex items-center justify-center p-0.5 text-content-muted hover:text-content-text"
+              (mousedown)="$event.preventDefault()"
               (click)="$event.stopPropagation(); cancelEdit()">
               <span class="material-icons text-base leading-none">clear</span>
             </button>

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { EndpointsService } from '../../../../core/src/core/endpoints.service';
+import { KubeConfigHelper } from './kube-config.helper';
+import { KubeConfigFileCluster } from './kube-config.types';
+
+// A minimal kubeconfig with one cluster/user/context pair. parse() runs
+// checkValidity() from outside any injection context, which is exactly how
+// the file-input handler calls it in the wizard (NG0203 regression cover).
+const kubeConfigYaml = (name: string, server: string) => `
+apiVersion: v1
+kind: Config
+current-context: ${name}
+clusters:
+- name: ${name}
+  cluster:
+    server: ${server}
+contexts:
+- name: ${name}
+  context:
+    cluster: ${name}
+    user: admin@${name}
+users:
+- name: admin@${name}
+  user:
+    client-certificate-data: Y2VydA==
+    client-key-data: a2V5
+`;
+
+const endpoint = (name: string, host: string) => ({
+  name,
+  guid: `guid-${name}`,
+  api_endpoint: { Scheme: 'https', Host: host, Path: '' },
+});
+
+describe('KubeConfigHelper', () => {
+  let helper: KubeConfigHelper;
+  let clusters: KubeConfigFileCluster[];
+
+  const setup = (endpoints: object[]) => {
+    TestBed.configureTestingModule({
+      providers: [
+        KubeConfigHelper,
+        { provide: EndpointsService, useValue: { endpoints$: of(Object.fromEntries(endpoints.map((e, i) => [i, e]))) } },
+      ],
+    });
+    helper = TestBed.inject(KubeConfigHelper);
+    helper.clustersChanged = () => { /* noop */ };
+    clusters = [];
+    helper.clusters$.subscribe(c => clusters = c);
+  };
+
+  it('parses a config and marks the cluster valid when nothing conflicts', () => {
+    setup([]);
+    helper.parse(kubeConfigYaml('fresh', 'https://1.2.3.4:6443')).subscribe();
+    expect(clusters.length).toBe(1);
+    expect(clusters[0]._invalid).toBeFalsy();
+  });
+
+  it('warns but does not block when the URL is already registered under a different name', () => {
+    setup([endpoint('other-name', '1.2.3.4:6443')]);
+    helper.parse(kubeConfigYaml('fresh', 'https://1.2.3.4:6443')).subscribe();
+    expect(clusters[0]._invalid).toBeFalsy();
+    expect(clusters[0]._state.getValue().message).toBe('An endpoint with this URL already exists');
+    expect(clusters[0]._state.getValue().warning).toBe(true);
+  });
+
+  it('marks connect-only when name and URL match an existing endpoint', () => {
+    setup([endpoint('fresh', '1.2.3.4:6443')]);
+    helper.parse(kubeConfigYaml('fresh', 'https://1.2.3.4:6443')).subscribe();
+    expect(clusters[0]._invalid).toBeFalsy();
+    expect(clusters[0]._guid).toBe('guid-fresh');
+    expect(clusters[0]._state.getValue().info).toBe(true);
+  });
+
+  it('blocks when the name is taken by an endpoint with a different URL', () => {
+    setup([endpoint('fresh', '5.6.7.8:6443')]);
+    helper.parse(kubeConfigYaml('fresh', 'https://1.2.3.4:6443')).subscribe();
+    expect(clusters[0]._invalid).toBe(true);
+    expect(clusters[0]._state.getValue().message).toBe('An endpoint with this name already exists');
+  });
+});

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.spec.ts
@@ -62,7 +62,7 @@ describe('KubeConfigHelper', () => {
     setup([endpoint('other-name', '1.2.3.4:6443')]);
     helper.parse(kubeConfigYaml('fresh', 'https://1.2.3.4:6443')).subscribe();
     expect(clusters[0]._invalid).toBeFalsy();
-    expect(clusters[0]._state.getValue().message).toBe('An endpoint with this URL already exists');
+    expect(clusters[0]._state.getValue().message).toBe('Another endpoint is already registered at this URL — importing will register this as an additional endpoint.');
     expect(clusters[0]._state.getValue().warning).toBe(true);
   });
 
@@ -82,7 +82,7 @@ describe('KubeConfigHelper', () => {
     helper.update(clusters[0]);
     expect(clusters[0]._guid).toBe('');
     expect(clusters[0]._invalid).toBeFalsy();
-    expect(clusters[0]._state.getValue().message).toBe('An endpoint with this URL already exists');
+    expect(clusters[0]._state.getValue().message).toBe('Another endpoint is already registered at this URL — importing will register this as an additional endpoint.');
   });
 
   it('blocks when the name is taken by an endpoint with a different URL', () => {

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.spec.ts
@@ -74,6 +74,17 @@ describe('KubeConfigHelper', () => {
     expect(clusters[0]._state.getValue().info).toBe(true);
   });
 
+  it('clears connect-only when the cluster is renamed away from the collision', () => {
+    setup([endpoint('fresh', '1.2.3.4:6443')]);
+    helper.parse(kubeConfigYaml('fresh', 'https://1.2.3.4:6443')).subscribe();
+    expect(clusters[0]._guid).toBe('guid-fresh');
+    clusters[0].name = 'fresh-2';
+    helper.update(clusters[0]);
+    expect(clusters[0]._guid).toBe('');
+    expect(clusters[0]._invalid).toBeFalsy();
+    expect(clusters[0]._state.getValue().message).toBe('An endpoint with this URL already exists');
+  });
+
   it('blocks when the name is taken by an endpoint with a different URL', () => {
     setup([endpoint('fresh', '5.6.7.8:6443')]);
     helper.parse(kubeConfigYaml('fresh', 'https://1.2.3.4:6443')).subscribe();

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.ts
@@ -1,7 +1,6 @@
 import { Injectable, signal, WritableSignal, inject } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import * as yaml from 'js-yaml';
-import { combineLatest, Observable, of } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
 import { filter, map, take, tap } from 'rxjs/operators';
 
 import { EndpointsService } from '../../../../core/src/core/endpoints.service';
@@ -18,18 +17,27 @@ import { KubeConfigFile, KubeConfigFileCluster } from './kube-config.types';
  */
 function createSignalWrapper<T>(initialValue: T) {
   const _signal = signal<T>(initialValue);
+  // asObservable() must be callable outside injection contexts (wrappers are
+  // created and read from event handlers, e.g. the file-input parse), so it
+  // is backed by a BehaviorSubject kept in sync on every write instead of a
+  // lazy toObservable(), which throws NG0203 there.
+  const _subject = new BehaviorSubject<T>(initialValue);
+  const write = (value: T) => {
+    _signal.set(value);
+    _subject.next(value);
+  };
   const wrapper = Object.assign(
     // Make it callable like a signal
     () => _signal(),
     {
       // WritableSignal methods
-      set: (value: T) => _signal.set(value),
-      update: (fn: (value: T) => T) => _signal.update(fn),
+      set: write,
+      update: (fn: (value: T) => T) => write(fn(_signal())),
       asReadonly: () => _signal.asReadonly(),
       // BehaviorSubject compatibility methods
-      next: (value: T) => _signal.set(value),
+      next: write,
       getValue: () => _signal(),
-      asObservable: () => toObservable(_signal),
+      asObservable: () => _subject.asObservable(),
     }
   );
   return wrapper as WritableSignal<T> & {
@@ -171,9 +179,11 @@ export class KubeConfigHelper {
         cluster._state.next({ message: 'An endpoint with this name already exists', warning: true });
       }
     } else {
-      // Check endpoint url is not registered with a different name
+      // A registered endpoint already uses this URL under a different name.
+      // Duplicate URLs are allowed (the endpoints list surfaces them with a
+      // warning icon), so inform the user but don't block the import.
       if (endpoints.find(item => getFullEndpointApiUrl(item) === cluster.cluster.server)) {
-        cluster._invalid = true;
+        reset = false;
         cluster._state.next({ message: 'An endpoint with this URL already exists', warning: true });
       }
     }

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.ts
@@ -161,6 +161,11 @@ export class KubeConfigHelper {
 
   private validate(endpoints: EndpointModel[], cluster: KubeConfigFileCluster, clusters: KubeConfigFileCluster[] | null) {
     cluster._invalid = false;
+    // Recompute connect-only from scratch: a stale _guid from a previous
+    // pass would otherwise pin the cluster to connect-only after the user
+    // renames it away from the collision (import skips registration when
+    // _guid is set).
+    cluster._guid = '';
     let reset = true;
 
     const found = endpoints.find(item => item.name === cluster.name);

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config.helper.ts
@@ -174,7 +174,7 @@ export class KubeConfigHelper {
       if (getFullEndpointApiUrl(found) === cluster.cluster.server && !!cluster._user && !!found.guid) {
         cluster._guid = found.guid;
         cluster._state.next({
-          message: 'This endpoint will be connected and not registered (endpoint is already registered)',
+          message: 'This endpoint is already registered — importing will connect it, not register a new one. Rename it to register a separate endpoint.',
           info: true
         });
         reset = false;
@@ -189,7 +189,10 @@ export class KubeConfigHelper {
       // warning icon), so inform the user but don't block the import.
       if (endpoints.find(item => getFullEndpointApiUrl(item) === cluster.cluster.server)) {
         reset = false;
-        cluster._state.next({ message: 'An endpoint with this URL already exists', warning: true });
+        cluster._state.next({
+          message: 'Another endpoint is already registered at this URL — importing will register this as an additional endpoint.',
+          warning: true
+        });
       }
     }
 

--- a/src/jetstream/repository/cnsis/pgsql_cnsis.go
+++ b/src/jetstream/repository/cnsis/pgsql_cnsis.go
@@ -37,10 +37,10 @@ var saveCNSI = `INSERT INTO cnsis (guid, name, cnsi_type, api_endpoint, auth_end
 var deleteCNSI = `DELETE FROM cnsis WHERE guid = $1`
 
 // Update some of the endpoint metadata
-var updateCNSI = `UPDATE cnsis SET name = $1, skip_ssl_validation = $2, sso_allowed = $3, client_id = $4, client_secret = $5, ca_cert = $6 WHERE guid = $7`
+var updateCNSI = `UPDATE cnsis SET name = $1, skip_ssl_validation = $2, sso_allowed = $3, client_id = $4, client_secret = $5, ca_cert = $6, last_updated = CURRENT_TIMESTAMP WHERE guid = $7`
 
 // Update the metadata
-var updateCNSIMetadata = `UPDATE cnsis SET meta_data = $1 WHERE guid = $2`
+var updateCNSIMetadata = `UPDATE cnsis SET meta_data = $1, last_updated = CURRENT_TIMESTAMP WHERE guid = $2`
 
 var countCNSI = `SELECT COUNT(*) FROM cnsis WHERE guid=$1`
 

--- a/src/jetstream/repository/tokens/pgsql_tokens.go
+++ b/src/jetstream/repository/tokens/pgsql_tokens.go
@@ -24,7 +24,7 @@ var insertAuthToken = `INSERT INTO tokens (cnsi_guid, token_guid, user_guid, tok
 									VALUES ('STRATOS', $1, $2, $3, $4, $5, $6)`
 
 var updateAuthToken = `UPDATE tokens
-									SET auth_token = $1, refresh_token = $2, token_expiry = $3
+									SET auth_token = $1, refresh_token = $2, token_expiry = $3, last_updated = CURRENT_TIMESTAMP
 									WHERE cnsi_guid = 'STRATOS' AND user_guid = $4 AND token_type = $5`
 
 var getToken = `SELECT token_guid, auth_token, refresh_token, token_expiry, disconnected, auth_type, meta_data, user_guid, linked_token, enabled
@@ -59,7 +59,7 @@ var insertCNSIToken = `INSERT INTO tokens (token_guid, cnsi_guid, user_guid, tok
 										VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
 
 var updateCNSIToken = `UPDATE tokens
-										SET auth_token = $1, refresh_token = $2, token_expiry = $3, disconnected = $4, meta_data = $5, linked_token = $6
+										SET auth_token = $1, refresh_token = $2, token_expiry = $3, disconnected = $4, meta_data = $5, linked_token = $6, last_updated = CURRENT_TIMESTAMP
 										WHERE cnsi_guid = $7 AND user_guid = $8 AND token_type = $9 AND auth_type = $10`
 var deleteCNSIToken = `DELETE FROM tokens
 										WHERE token_type = 'cnsi' AND cnsi_guid = $1 AND user_guid = $2`
@@ -67,7 +67,7 @@ var deleteCNSITokens = `DELETE FROM tokens
 											WHERE token_type = 'cnsi' AND cnsi_guid = $1`
 
 var updateToken = `UPDATE tokens
-										SET auth_token = $1, refresh_token = $2, token_expiry = $3
+										SET auth_token = $1, refresh_token = $2, token_expiry = $3, last_updated = CURRENT_TIMESTAMP
 										WHERE token_guid = $4 AND user_guid = $5`
 
 // PgsqlTokenRepository is a PostgreSQL-backed token repository


### PR DESCRIPTION
## Endpoint card (fixes #5585)

The card carried a permanently hidden copy-to-clipboard component whose only caller was removed in #5356. Replaced with a compact copy button beside the address, matching the table view's address cell. The dead `cardMenu` binding, orphaned `editEndpoint()` handler, and hidden-component CSS are gone. The button's click-stop from #5552 keeps the card's routerLink from firing on copy — verified live: copy succeeds without navigating, card click still navigates.

## Rich endpoint card restored on the endpoints page (fixes #5593)

The V2→V3 signal-list cutover replaced the endpoints page card view with the generic key-value card. The rich `EndpointCardComponent` is now projected through the signal-list `cardTemplate` slot, the same pattern the kubernetes endpoints page uses. The card gains an optional `actionMenu` input feeding the meta-card kebab, and the endpoints page maps its existing row actions (connect/disconnect/edit/unregister) into it — card view keeps the same actions as table view, matching the 4.9.x card surface. Consumers that leave `actionMenu` unset (kubernetes page) keep the kebab hidden. Verified live in both themes: logo/title/details render, kebab shows the right actions per connection state, favorites toggle, copy and navigation behave.

## Kubeconfig import wizard

Parsing any kubeconfig crashed with NG0203: the signal wrapper's `asObservable()` lazily called `toObservable()` outside an injection context, so the cluster table never rendered and Next stayed disabled; import execution had the same latent crash. `asObservable()` is now backed by a BehaviorSubject synced on every write, in both wrapper copies.

The wizard also hard-blocked clusters whose URL was already registered under a different name. Duplicate URLs are allowed (and warning-flagged) everywhere else, so the wizard now warns but leaves the row selectable.

## Inline rename in the wizard

Renaming a cluster never escaped connect-only: `validate()` set `_guid` on a name match but never cleared it, so the import silently reconnected the old endpoint instead of registering the new name. `_guid` is now recomputed on every validation pass. The name edit also only committed via its confirm button — typing a name and pressing Next silently discarded it. It now commits on blur and Enter (Escape cancels). Collision messages now state their consequence and the correction path (rename registers a separate endpoint; duplicate URL registers an additional one).

All wizard paths were verified live end-to-end: clean import, connect-only reimport, duplicate-URL import, and rename-away-from-collision (registers and connects under the new name). A helper spec covers the validity paths and doubles as NG0203 regression coverage.

