### PR TITLE
Add deploy vocabulary for the documentation website

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -6,10 +6,15 @@ name: Deploy Website
 # the site lives at https://cloudfoundry.github.io/stratos/ — hence the
 # SITE_URL/SITE_BASE_URL overrides below; once the CNAME lands, change them
 # to https://stratos.cloudfoundry.org and /.
+# The pages-preview branch is a fork-preview trigger: `make deploy website
+# pages` force-pushes HEAD there on a fork, and this workflow publishes the
+# fork's Pages site. The job-level guard below keeps that path fork-only —
+# the upstream site can only ever publish from develop.
 on:
   push:
     branches:
       - develop
+      - pages-preview
     paths:
       - 'docs/**'
       - 'website/**'
@@ -33,6 +38,8 @@ env:
 jobs:
   build:
     name: Build Website
+    # pages-preview deploys are fork-only; upstream publishes from develop.
+    if: github.ref != 'refs/heads/pages-preview' || github.repository_owner != 'cloudfoundry'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,13 @@ endif
 $(_HIDE)WANT_CF     :=
 $(_HIDE)WANT_KORIFI :=
 $(_HIDE)WANT_GITHUB :=
+$(_HIDE)WANT_PAGES  :=
 
 ifneq ($(filter cf,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_CF := yes
+endif
+ifneq ($(filter pages,$(MAKECMDGOALS)),)
+  $(_HIDE)WANT_PAGES := yes
 endif
 ifneq ($(filter korifi,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_KORIFI := yes
@@ -218,8 +222,8 @@ endif
 
 # No-op targets so modifiers don't error
 # Note: lint has its own standalone recipe — not listed here.
-.PHONY: frontend backend website booklets cf korifi github dist version e2e actions gate tests coverage summary dependabot
-frontend backend website booklets cf korifi github dist version e2e actions gate tests coverage summary dependabot:
+.PHONY: frontend backend website booklets cf korifi github pages dist version e2e actions gate tests coverage summary dependabot
+frontend backend website booklets cf korifi github pages dist version e2e actions gate tests coverage summary dependabot:
 	@:
 
 # No-op targets for bump modifiers (consumed by BUMP_MOD filter).
@@ -559,6 +563,81 @@ define release.github
 endef
 $(call register, release, github)
 
+# ── Deploy (documentation website) ───────────────────────────
+# Grammar: make deploy website <destination> — the component says what is
+# deployed, the destination says where. Destinations here are mechanisms
+# with no environment baked in; site-specific values live in site.mk.
+#
+#   make deploy website pages   Push HEAD to your fork's pages-preview
+#                               branch; the Deploy Website workflow builds
+#                               and publishes your fork's Pages site.
+#                               One-time fork setup: see README.
+#   make deploy website cf      cf push the built site to the current
+#                               cf target (cf login / cf target first).
+#   make build deploy website cf    Build locally, then push.
+#
+# App deployment (the zip from `make release cf`) is site-specific —
+# site.mk redefines deploy.cf to add it (see site.mk.example).
+
+# Remote the pages-preview branch is pushed to. `origin` is right when
+# your clone's origin is your fork; override in site.mk otherwise.
+PAGES_REMOTE ?= origin
+
+# Destination words for `deploy website`. site.mk appends custom ones
+# (WEBSITE_DEPLOY_DESTS += mysite) so the usage guard stays accurate.
+WEBSITE_DEPLOY_DESTS := pages cf
+
+# Plain --force: pages-preview is a disposable deploy trigger that never
+# holds work, and --force-with-lease fails without a remote-tracking ref.
+define deploy.pages
+	@git remote get-url $(PAGES_REMOTE) >/dev/null 2>&1 || \
+		{ echo "ERROR: remote '$(PAGES_REMOTE)' not found — set PAGES_REMOTE to your fork remote (site.mk or make line)." >&2; exit 1; }
+	@echo "Pushing HEAD to $(PAGES_REMOTE)/pages-preview (GitHub Pages preview)..."
+	git push --force $(PAGES_REMOTE) HEAD:refs/heads/pages-preview
+	@echo "The fork's 'Deploy Website' workflow now builds and publishes the site."
+endef
+$(call register, deploy, pages)
+
+define deploy.cf
+	@if [ -n "$($(_HIDE)WANT_WEBSITE)" ]; then \
+		echo "Deploying documentation website to CF..."; \
+		cf target 2>/dev/null | grep -qE "org:.+" || \
+			{ echo "ERROR: no CF target / not logged in. Run 'cf login' then 'cf target -o ORG -s SPACE'." >&2; exit 1; }; \
+		[ -d website/build ] || \
+			{ echo "ERROR: website/build not found. Run 'make build website' first." >&2; exit 1; }; \
+		cf push -f website/manifest.yml; \
+	else \
+		$(MAKE) --no-print-directory $(_HIDE)deploy.cf.app; \
+	fi
+endef
+$(call register, deploy, cf)
+
+# App deploys carry site knowledge; site.mk redefines this recipe variable
+# (define deploy.cf.app ... endef) to enable them — see site.mk.example.
+define deploy.cf.app
+	@echo "ERROR: app deployment to CF is site-specific — see site.mk.example." >&2
+	@exit 1
+endef
+$(call register_always, deploy, cf.app)
+
+# Bare `make deploy website` (no destination word) → usage, not a no-op.
+define deploy.website
+	@if [ -z "$(filter $(WEBSITE_DEPLOY_DESTS),$(MAKECMDGOALS))" ]; then \
+		echo "Usage: make deploy website <destination>" >&2; \
+		echo "Destinations: $(WEBSITE_DEPLOY_DESTS)" >&2; \
+		exit 1; \
+	fi
+endef
+$(call register, deploy, website)
+
+# Bare `make deploy` → usage.
+define deploy.usage
+	@echo "Usage: make deploy website <destination>"
+	@echo "Destinations: $(WEBSITE_DEPLOY_DESTS)"
+	@echo "App deployment is site-specific — see site.mk.example."
+endef
+$(call register_always, deploy, usage)
+
 # ══════════════════════════════════════════════════════════════
 # Verb wiring — declare each verb after all objects are registered.
 # ══════════════════════════════════════════════════════════════
@@ -584,10 +663,12 @@ endif
 # These modifiers affect build behavior through variables (e.g.,
 # cf forces PLATFORM=linux/amd64) rather than via a registered recipe.
 $(call allow, build, cf)
+$(call allow, build, pages)
 
 $(call declare_verb, build)
 $(call declare_verb, test)
 $(call declare_verb, release)
+$(call declare_verb_default, deploy, $(_HIDE)deploy.usage)
 $(call declare_verb, stamp)
 $(call declare_verb, check)
 $(call declare_verb, audit)
@@ -719,6 +800,11 @@ help:
 	@echo "  make release cf           CF-pushable zip only"
 	@echo "  make release korifi       Korifi-pushable zip (Paketo procfile manifest)"
 	@echo "  make release github       GitHub release archives only"
+	@echo ""
+	@echo "Deploy (documentation website):"
+	@echo "  make deploy website pages Push preview to your fork's GitHub Pages"
+	@echo "  make deploy website cf    cf push built website to current CF target"
+	@echo "  make build deploy website cf  Build website, then cf push it"
 	@echo ""
 	@echo "Setup:"
 	@echo "  make install              Install dependencies (bun install)"

--- a/actions.mk
+++ b/actions.mk
@@ -22,6 +22,7 @@ $(_HIDE)FLAG_booklets    := $($(_HIDE)WANT_BOOKLETS)
 $(_HIDE)FLAG_cf          := $($(_HIDE)WANT_CF)
 $(_HIDE)FLAG_korifi      := $($(_HIDE)WANT_KORIFI)
 $(_HIDE)FLAG_github      := $($(_HIDE)WANT_GITHUB)
+$(_HIDE)FLAG_pages       := $($(_HIDE)WANT_PAGES)
 $(_HIDE)FLAG_e2e         := $($(_HIDE)WANT_E2E)
 $(_HIDE)FLAG_dist        := $($(_HIDE)WANT_CLEAN_DIST)
 $(_HIDE)FLAG_version     := $($(_HIDE)WANT_VERSION)
@@ -34,7 +35,7 @@ $(_HIDE)FLAG_summary     := $($(_HIDE)WANT_SUMMARY)
 $(_HIDE)FLAG_dependabot  := $($(_HIDE)WANT_DEPENDABOT)
 
 # Known modifiers — the set checked during validation in declare_verb
-$(_HIDE)KNOWN_MODS := frontend backend website booklets cf korifi github e2e dist version actions lint gate tests coverage summary dependabot
+$(_HIDE)KNOWN_MODS := frontend backend website booklets cf korifi github pages e2e dist version actions lint gate tests coverage summary dependabot
 
 # Known verbs — populated by declare_verb, checked for collisions
 $(_HIDE)KNOWN_VERBS :=

--- a/site.mk.example
+++ b/site.mk.example
@@ -5,6 +5,15 @@
 #
 # All variables and targets from the main Makefile are available.
 # Targets defined here extend (not replace) the main Makefile.
+# Do not put secrets in this file — the deploy targets deliberately
+# take credentials from tool state (cf login, git remotes), not variables.
+#
+# Three extension patterns, each shown below:
+#   1. Parameter override — set a variable the Makefile consumes.
+#   2. Recipe override — redefine a recipe variable (define NAME ... endef);
+#      the already-registered target picks up the new body. Do NOT call
+#      register again — that would duplicate the rule and make will warn.
+#   3. New destination — add a modifier word for `deploy website`.
 
 # ── Site Help ─────────────────────────────────────────────────
 # This target is called by 'make help' when site.mk exists.
@@ -12,27 +21,48 @@
 $(_HIDE)site-help:
 	@echo ""
 	@echo "Site-specific:"
-	@echo "  make build release deploy cf  Build, package, and push to current CF target"
-	@echo "  make deploy cf                Push existing CF zip to current CF target"
+	@echo "  make deploy cf                Push existing app CF zip to current CF target"
+	@echo "  make build release deploy cf  Build, package, and push app to current CF target"
 
-# ── Deploy ───────────────────────────────────────────────────
-# Deploy to Cloud Foundry. Requires cf CLI authenticated and targeted.
+# ── 1. Parameter override: fork remote for Pages previews ────
+# `make deploy website pages` pushes to the `origin` remote by default,
+# which is correct when your clone's origin is your fork. If your fork
+# is a differently named remote, set it here:
 #
-# Usage:
-#   make deploy cf                Push existing CF zip
-#   make build release deploy cf  Build, package, and push
+# PAGES_REMOTE = my-fork
 
-define deploy.cf
-	@echo "Deploying to CF..."
+# ── 2. Recipe override: enable app deploys to CF ─────────────
+# The committed Makefile only deploys the documentation website; app
+# deployment (the zip from `make release cf`) is site-specific and errors
+# by default. Redefine deploy.cf.app to enable it:
+
+define deploy.cf.app
+	@echo "Deploying app to CF..."
 	@cf target | grep -E "org:|space:" || \
-		(echo "ERROR: No CF target set. Run 'cf target -o ORG -s SPACE' first."; exit 1)
+		{ echo "ERROR: No CF target set. Run 'cf target -o ORG -s SPACE' first." >&2; exit 1; }
 	@ZIP=$$(ls -t $($(_HIDE)DIST_DIR)/stratos-cf-*.zip 2>/dev/null | head -1); \
 	if [ -z "$$ZIP" ]; then \
-		echo "ERROR: No CF zip found. Run 'make build release cf' first."; exit 1; \
+		echo "ERROR: No CF zip found. Run 'make build release cf' first." >&2; exit 1; \
 	fi; \
 	echo "Deploying $$ZIP..."; \
 	cf push -f $($(_HIDE)DIST_DIR)/cf-package/manifest.yml -p "$$ZIP"
 endef
-$(call register, deploy, cf)
 
-$(call declare_verb, deploy)
+# ── 3. New destination for `deploy website` ──────────────────
+# Operators publishing the site to their own infrastructure add a
+# destination word: flag + no-op target + recipe + register. Uncomment
+# and adapt. Adding the word to WEBSITE_DEPLOY_DESTS keeps the
+# `make deploy website` usage message accurate.
+#
+# WEBSITE_DEPLOY_DESTS += mysite
+# $(_HIDE)FLAG_mysite := $(filter mysite,$(MAKECMDGOALS))
+# .PHONY: mysite
+# mysite:
+#	@:
+#
+# define deploy.mysite
+#	@[ -d website/build ] || \
+#		{ echo "ERROR: website/build not found. Run 'make build website' first." >&2; exit 1; }
+#	rsync -a --delete website/build/ deploy@docs.example.internal:/srv/docs/
+# endef
+# $(call register, deploy, mysite)

--- a/website/README.md
+++ b/website/README.md
@@ -42,10 +42,38 @@ Actions"). It builds with `SITE_URL`/`SITE_BASE_URL` set for
 `https://stratos.cloudfoundry.org` and `/` once the custom domain
 CNAME exists.
 
-The built site can also be pushed to any Cloud Foundry as a static
-app:
+Deploy targets follow the Makefile's verb + modifier grammar — the
+component says what is deployed, the destination says where:
 
 ```bash
-make build website
-cf push -f website/manifest.yml
+make deploy website pages       # preview on your fork's GitHub Pages
+make deploy website cf          # cf push to your current cf target
+make build deploy website cf    # build locally, then push
 ```
+
+`deploy website cf` pushes `website/manifest.yml` as a static app to
+whatever `cf target` points at (log in and target first — no
+environment is baked into the Makefile). Site-specific destinations
+can be added from `site.mk`; see `site.mk.example`.
+
+### Fork previews (`deploy website pages`)
+
+`make deploy website pages` force-pushes `HEAD` to the
+`pages-preview` branch of your fork (`PAGES_REMOTE`, default
+`origin`; override in `site.mk` if your fork is a differently named
+remote). The deploy workflow triggers on that branch, builds with
+your fork's Pages URL, and publishes to
+`https://<you>.github.io/stratos/`. The workflow guards this path to
+forks only — the upstream site publishes exclusively from `develop`.
+
+One-time fork setup:
+
+1. Enable Pages with the "GitHub Actions" source:
+   `gh api -X POST repos/<you>/stratos/pages -f build_type=workflow`
+2. The first deploy auto-creates a `github-pages` deployment
+   environment restricted to the default branch. Allow the preview
+   branch:
+   `gh api -X POST repos/<you>/stratos/environments/github-pages/deployment-branch-policies -f name=pages-preview`
+
+The branch is a disposable deploy trigger — it never holds unique
+work and is always force-pushed.


### PR DESCRIPTION
Closes #5594

Adds deploy vocabulary for the documentation website to the build system. The grammar is two-axis, consistent with the existing verb + modifier pattern: the component says what is deployed, the destination says where.

```
make deploy website pages      push a preview to your fork's GitHub Pages
make deploy website cf         cf push the built site to your current cf target
make build deploy website cf   build, then push
make deploy website            usage error listing the destinations
```

The split follows one rule: mechanism is committed, parameters are site-local (`site.mk`, gitignored).

- `PAGES_REMOTE ?= origin` — correct when your clone's origin is your fork; override in site.mk otherwise.
- `deploy website cf` targets whatever `cf target` points at; no org/space/API in the Makefile.
- App deployment (the zip from `make release cf`) stays site-specific: the committed `deploy cf` errors and points at `site.mk.example`, which shows how a site enables it by redefining the `deploy.cf.app` recipe variable. The example also shows how an operator adds a custom destination word for their own infrastructure.

## Workflow change

`website-deploy.yml` now also triggers on `pages-preview` pushes, with a job-level guard (`github.repository_owner != 'cloudfoundry'`) so that path runs on forks only — the upstream site can only ever publish from develop. With the trigger committed, `deploy website pages` is a single force-push of HEAD to the fork's `pages-preview` branch; the previous approach needed a hand-maintained fork-only branch carrying an extra commit just to add itself to the trigger.

One-time fork setup (enable Pages with the Actions source, allow `pages-preview` in the `github-pages` environment) is documented in `website/README.md`.

## Verified

- `make -n` matrix over all sentences, with no site.mk, with site.mk.example copied in as site.mk, and with a site.mk overriding `PAGES_REMOTE` and `deploy.cf.app` — correct dispatch and no make warnings in every combination.
- End to end from this branch: `make deploy website pages` pushed HEAD to the fork, the workflow triggered natively off the committed `pages-preview` trigger, the fork guard passed, and the preview published (run 28899641277, site 200).
- The upstream no-op side of the guard is the review ask: a `pages-preview` push to cloudfoundry/stratos must skip both jobs.
