### PR TITLE
fix: keep severity color on the message strip only

### DIFF
--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -703,7 +703,7 @@
               </tr>
             }
             @if (hasRowMessage(row) || rowStateBusy(row)) {
-              <tr data-test="row-message" [class]="rowStateRowClass(row)">
+              <tr data-test="row-message" [class]="rowStateMessageClass(row)">
                 <td [attr.colspan]="totalColumnCount()" class="px-3 pb-2 pt-0 text-sm">
                   <div class="flex items-start gap-2">
                     @if (rowStateBusy(row)) {

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -998,22 +998,26 @@ describe('SignalListComponent rowState', () => {
     expect(msgs[0].textContent).toContain('name taken');
   });
 
-  it('tints the row by severity and uses the warning icon for warning state', () => {
+  it('tints the message strip (not the data row) and uses the warning icon for warning state', () => {
     const fixture = TestBed.createComponent(RowStateHost);
     fixture.detectChanges();
     const rows = fixture.nativeElement.querySelectorAll('[data-test="row"]');
-    expect(rows[0].className).toContain('border-warning-300');
-    const icon = fixture.nativeElement.querySelector('[data-test="row-message"] .material-icons');
+    expect(rows[0].className).not.toContain('border-warning-300');
+    const msg = fixture.nativeElement.querySelector('[data-test="row-message"]');
+    expect(msg.className).toContain('border-warning-300');
+    const icon = msg.querySelector('.material-icons');
     expect(icon.textContent).toContain('warning');
   });
 
-  it('uses the info icon for info state and red tint for error', () => {
+  it('uses the info icon for info state and red tint on the error message strip', () => {
     const fixture = TestBed.createComponent(RowStateHost);
     fixture.componentInstance.states['one'].set({ info: true, message: 'just connecting' });
     fixture.componentInstance.states['two'].set({ error: true, message: 'bad' });
     fixture.detectChanges();
     const rows = fixture.nativeElement.querySelectorAll('[data-test="row"]');
-    expect(rows[1].className).toContain('border-danger-300');
+    expect(rows[1].className).not.toContain('border-danger-300');
+    const msgs = fixture.nativeElement.querySelectorAll('[data-test="row-message"]');
+    expect(msgs[1].className).toContain('border-danger-300');
     const icons = fixture.nativeElement.querySelectorAll('[data-test="row-message"] .material-icons');
     expect(icons[0].textContent).toContain('info');
     expect(icons[1].textContent).toContain('warning'); // error → warning glyph

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -909,18 +909,27 @@ export class SignalListComponent<T> implements AfterViewInit {
     return this.config.rowState?.(row)?.() ?? null;
   }
 
-  // Tailwind tint for the row <tr>, by severity precedence
-  // error → warning → info, then highlighted. blocked/deleting/disabled rows
-  // also dim and go non-interactive (cf. v4.9.2 table-row), the per-row
-  // feedback for multiline/bulk operations.
+  // Data rows stay neutral surfaces — severity colors belong to the message
+  // strip only (tinting a whole data row fights the theme). Rows keep the
+  // functional treatments: highlight, and dim/non-interactive for
+  // blocked/deleting/disabled (cf. v4.9.2 table-row).
   rowStateRowClass(row: T): string {
+    const s = this.rowStateOf(row);
+    if (!s) return '';
+    const dim = (s.blocked || s.deleting || s.disabled) ? ' opacity-60 pointer-events-none' : '';
+    if (s.highlighted) return 'bg-accent/5' + dim;
+    return dim.trim();
+  }
+
+  // Tailwind tint for the row's message strip, by severity precedence
+  // error → warning → info.
+  rowStateMessageClass(row: T): string {
     const s = this.rowStateOf(row);
     if (!s) return '';
     const dim = (s.blocked || s.deleting || s.disabled) ? ' opacity-60 pointer-events-none' : '';
     if (s.error)   return 'bg-danger-50 dark:bg-danger-900/30 border-l-2 border-danger-300 dark:border-danger-700' + dim;
     if (s.warning) return 'bg-warning-50 dark:bg-warning-900/30 border-l-2 border-warning-300 dark:border-warning-700' + dim;
     if (s.info)    return 'bg-info-50 dark:bg-info-900/30 border-l-2 border-info-300 dark:border-info-700' + dim;
-    if (s.highlighted) return 'bg-accent/5' + dim;
     return dim.trim();
   }
 


### PR DESCRIPTION
Follow-up to #5592 — this commit was pushed seconds after the merge, so it rides separately.

Signal-list rows with a warning/info/error state tinted the entire data row. The convention is that only the message strip carries the status color while data rows stay neutral surfaces (also keeps them theme-clean). Rows keep the functional treatments: highlight, and dim/non-interactive for blocked/deleting/disabled. Verified live on the kubeconfig import wizard (the only warning/info rowState consumer); signal-list specs updated.