### PR TITLE
feat: show starred endpoints on Home regardless of state

### DIFF
--- a/src/frontend/packages/core/src/core/dashboard-preferences.service.spec.ts
+++ b/src/frontend/packages/core/src/core/dashboard-preferences.service.spec.ts
@@ -50,38 +50,47 @@ describe('DashboardPreferencesService', () => {
   it('starts with default values when nothing is persisted', () => {
     const service = configure(makeSessionStub(username));
     flushEffects();
-    expect(service.homeShowAllEndpoints()).toBeNull();
+    expect(service.homeShowMode()).toBeNull();
     expect(service.homeLayout()).toBe(0);
   });
 
   it('hydrates from localStorage on construction when the user is known', () => {
-    localStorage.setItem(storageKey, JSON.stringify({ homeShowAllEndpoints: true, homeLayout: 3 }));
+    localStorage.setItem(storageKey, JSON.stringify({ homeShowMode: 'connected', homeLayout: 3 }));
 
     const service = configure(makeSessionStub(username));
     flushEffects();
 
-    expect(service.homeShowAllEndpoints()).toBe(true);
+    expect(service.homeShowMode()).toBe('connected');
     expect(service.homeLayout()).toBe(3);
   });
 
   it('persists changes to localStorage', () => {
     const service = configure(makeSessionStub(username));
     flushEffects();
-    service.setHomeShowAllEndpoints(true);
+    service.setHomeShowMode('connected');
     service.setHomeLayout(2);
     flushEffects();
 
     const raw = localStorage.getItem(storageKey);
     expect(raw).not.toBeNull();
-    expect(JSON.parse(raw!)).toEqual({ homeShowAllEndpoints: true, homeLayout: 2 });
+    expect(JSON.parse(raw!)).toEqual({ homeShowMode: 'connected', homeLayout: 2, homeSortDirection: 'asc' });
   });
 
   it('does not persist when the user is not yet known', () => {
     const service = configure(makeSessionStub(null));
     flushEffects();
-    service.setHomeShowAllEndpoints(true);
+    service.setHomeShowMode('connected');
     flushEffects();
 
     expect(localStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it('migrates the legacy boolean pref to a show mode', () => {
+    localStorage.setItem(storageKey, JSON.stringify({ homeShowAllEndpoints: false, homeLayout: 0 }));
+
+    const service = configure(makeSessionStub(username));
+    flushEffects();
+
+    expect(service.homeShowMode()).toBe('favorites');
   });
 });

--- a/src/frontend/packages/core/src/core/dashboard-preferences.service.ts
+++ b/src/frontend/packages/core/src/core/dashboard-preferences.service.ts
@@ -4,25 +4,39 @@ import { SessionService } from './session.service';
 
 export const DASHBOARD_PREFS_STORAGE_KEY_PREFIX = 'stratos-home-prefs-';
 
+export type HomeSortDirection = 'asc' | 'desc';
+
+// Which endpoints the Home page shows:
+// favorites = starred endpoints (directly or via starred children), any state
+// connected = every connected endpoint
+// all       = every registered endpoint, any state
+export type HomeShowMode = 'favorites' | 'connected' | 'all';
+
 interface DashboardPrefs {
-  homeShowAllEndpoints: boolean | null;
+  homeShowMode: HomeShowMode | null;
+  // Legacy boolean pref (pre three-way control); read for migration only
+  homeShowAllEndpoints?: boolean | null;
   homeLayout: number;
+  homeSortDirection: HomeSortDirection;
 }
 
 const DEFAULT_PREFS: DashboardPrefs = {
-  homeShowAllEndpoints: null,
+  homeShowMode: null,
   homeLayout: 0,
+  homeSortDirection: 'asc',
 };
 
 @Injectable({ providedIn: 'root' })
 export class DashboardPreferencesService {
   private sessionService = inject(SessionService);
 
-  private readonly _homeShowAllEndpoints: WritableSignal<boolean | null> = signal<boolean | null>(DEFAULT_PREFS.homeShowAllEndpoints);
+  private readonly _homeShowMode: WritableSignal<HomeShowMode | null> = signal<HomeShowMode | null>(DEFAULT_PREFS.homeShowMode);
   private readonly _homeLayout: WritableSignal<number> = signal<number>(DEFAULT_PREFS.homeLayout);
+  private readonly _homeSortDirection: WritableSignal<HomeSortDirection> = signal<HomeSortDirection>(DEFAULT_PREFS.homeSortDirection);
 
-  readonly homeShowAllEndpoints: Signal<boolean | null> = this._homeShowAllEndpoints.asReadonly();
+  readonly homeShowMode: Signal<HomeShowMode | null> = this._homeShowMode.asReadonly();
   readonly homeLayout: Signal<number> = this._homeLayout.asReadonly();
+  readonly homeSortDirection: Signal<HomeSortDirection> = this._homeSortDirection.asReadonly();
 
   private hydrated = false;
 
@@ -34,16 +48,23 @@ export class DashboardPreferencesService {
       }
       const stored = this.read(username);
       if (stored) {
-        this._homeShowAllEndpoints.set(stored.homeShowAllEndpoints ?? DEFAULT_PREFS.homeShowAllEndpoints);
+        // Migrate the pre-three-way boolean pref: true meant "all connected",
+        // false meant "favorites only".
+        const migrated: HomeShowMode | null = stored.homeShowMode
+          ?? (stored.homeShowAllEndpoints === true ? 'connected'
+            : stored.homeShowAllEndpoints === false ? 'favorites' : null);
+        this._homeShowMode.set(migrated);
         this._homeLayout.set(stored.homeLayout ?? DEFAULT_PREFS.homeLayout);
+        this._homeSortDirection.set(stored.homeSortDirection ?? DEFAULT_PREFS.homeSortDirection);
       }
       this.hydrated = true;
     });
 
     effect(() => {
       const next: DashboardPrefs = {
-        homeShowAllEndpoints: this._homeShowAllEndpoints(),
+        homeShowMode: this._homeShowMode(),
         homeLayout: this._homeLayout(),
+        homeSortDirection: this._homeSortDirection(),
       };
       const username = this.currentUsername();
       if (!username || !this.hydrated) {
@@ -53,12 +74,16 @@ export class DashboardPreferencesService {
     });
   }
 
-  setHomeShowAllEndpoints(value: boolean | null): void {
-    this._homeShowAllEndpoints.set(value);
+  setHomeShowMode(value: HomeShowMode | null): void {
+    this._homeShowMode.set(value);
   }
 
   setHomeLayout(layoutId: number): void {
     this._homeLayout.set(layoutId);
+  }
+
+  setHomeSortDirection(direction: HomeSortDirection): void {
+    this._homeSortDirection.set(direction);
   }
 
   private currentUsername(): string | null {

--- a/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
@@ -12,6 +12,21 @@ export function getEndpointUsername(endpoint: EndpointModel) {
   return endpoint && endpoint.user ? endpoint.user.name : '-';
 }
 
+// An endpoint is only effectively connected while its stored token is still
+// usable. An expired token must read as Disconnected rather than a broken
+// card — e.g. korifi pasted tokens have no refresh, so every session ends in
+// expiry (#5588). Expiry only matters when jetstream cannot renew: refresh-
+// capable endpoints (token_renewable) mint a fresh access token on use, so
+// their access-token expiry is harmless. token_expiry is epoch seconds;
+// 0/absent = no known expiry.
+export function isEndpointConnected(endpoint: EndpointModel): boolean {
+  if (endpoint.connectionStatus !== 'connected') {
+    return false;
+  }
+  return endpoint.token_renewable ||
+    !endpoint.token_expiry || endpoint.token_expiry * 1000 > Date.now();
+}
+
 export const DEFAULT_ENDPOINT_TYPE = 'cf';
 
 export interface EndpointIcon {

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.html
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.html
@@ -2,7 +2,7 @@
   @if (endpoint && definition) {
     <div class="card-header border-b card-header-border">
       <div class="flex items-center justify-between w-full">
-        <div class="flex items-center space-x-4 cursor-pointer" [routerLink]="link">
+        <div class="flex items-center space-x-4" [class.cursor-pointer]="!disconnected" [routerLink]="disconnected ? null : link">
           <div class="shrink-0">
             @if (definition.logoUrl) {
               <img class="h-12 w-12 object-contain" [src]="definition.logoUrl" alt="" />
@@ -40,12 +40,24 @@
     </div>
   }
   <div class="card-body p-0">
-    <div class="flex h-full" [class.flex-col]="fullView" [class.flex-row]="!fullView">
+    @if (disconnected) {
+      <div class="p-6 flex flex-col items-center justify-center text-center space-y-3">
+        <span class="material-icons text-4xl sidebar-muted-text">cloud_off</span>
+        <div class="font-medium">Disconnected</div>
+        <button class="btn btn-primary" (click)="connect()">Connect</button>
+      </div>
+    }
+    <!-- Kept in the DOM (hidden) while disconnected: the #customCard anchor is
+         a static ViewChild, and a reconnect swaps the real card back in.
+         Two layouts, chosen per endpoint via homeCard.linksBelow: the classic
+         right-hand sidebar, or a Favorites/Shortcuts strip below the content
+         (suits content-light cards like kubernetes). -->
+    <div class="flex h-full" [class.hidden]="disconnected" [class.flex-col]="fullView || linksBelow" [class.flex-row]="!fullView && !linksBelow">
       <div class="flex-1 p-6">
         <div>
           <ng-template #customCard></ng-template>
         </div>
-        @if (!showShortcutsOnSide) {
+        @if (!linksBelow && !showShortcutsOnSide) {
           <div class="mt-6">
             @if (links$ | async; as links) {
               <app-home-shortcuts [shortcuts]="links.shortcuts"></app-home-shortcuts>
@@ -53,7 +65,7 @@
           </div>
         }
       </div>
-      @if (!fullView) {
+      @if (!fullView && !linksBelow) {
         <div class="border-l sidebar-panel" [class.w-80]="!layout || layout.x <= 1" [class.w-48]="layout && layout.x === 2" [class.w-64]="layout && layout.x >= 3">
           @if (links$ | async; as links) {
             <div class="p-6">
@@ -82,6 +94,44 @@
               }
               @if (showShortcutsOnSide) {
                 <div class="mt-6">
+                  <app-home-shortcuts [shortcuts]="links.shortcuts"></app-home-shortcuts>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+      @if (!fullView && linksBelow) {
+        <div class="border-t sidebar-panel">
+          @if (links$ | async; as links) {
+            <div class="p-6 pt-2 flex flex-row gap-8">
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center justify-between mt-5 mb-2.5">
+                  <h3 class="text-sm font-medium sidebar-title">Favorites</h3>
+                  @if (hiddenFavorites > 0) {
+                    <div class="text-xs cursor-pointer sidebar-link" role="button" tabindex="0"
+                      (click)="showFavoritesPanel()"
+                      (keydown.enter)="showFavoritesPanel()"
+                      (keydown.space)="showFavoritesPanel(); $event.preventDefault()">
+                      {{hiddenFavorites}} more ...
+                    </div>
+                  }
+                </div>
+                @if (links.favs.length > 0) {
+                  <div class="space-y-3">
+                    @for (entity of links.favs; track entity) {
+                      <app-favorites-meta-card [favoriteEntity]="entity"></app-favorites-meta-card>
+                    }
+                  </div>
+                }
+                @if (links.favs.length === 0) {
+                  <div class="sidebar-muted-text">
+                    <div class="text-sm">No favorites</div>
+                  </div>
+                }
+              </div>
+              @if (links.shortcuts.length > 0) {
+                <div class="flex-1 min-w-0">
                   <app-home-shortcuts [shortcuts]="links.shortcuts"></app-home-shortcuts>
                 </div>
               }

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.spec.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.spec.ts
@@ -93,6 +93,46 @@ describe('HomePageEndpointCardComponent', () => {
     expect(component['ref']).toBeTruthy();
   });
 
+  // #5588 — disconnected endpoints render a Disconnected panel, no home card load
+  it('renders a Disconnected panel with a Connect button instead of loading the card', () => {
+    // beforeEach endpoint has no connectionStatus => not connected
+    expect(component.disconnected).toBe(true);
+    expect(component['ref']).toBeFalsy();
+    const buttons: HTMLButtonElement[] = Array.from(fixture.nativeElement.querySelectorAll('button'));
+    expect(buttons.some(b => b.textContent?.trim() === 'Connect')).toBe(true);
+    expect(fixture.nativeElement.textContent).toContain('Disconnected');
+  });
+
+  it('does not present a connected endpoint as disconnected', () => {
+    component.endpoint = { ...component.endpoint, connectionStatus: 'connected' };
+    expect(component.disconnected).toBe(false);
+  });
+
+  it('presents a connected endpoint with an expired token as disconnected', () => {
+    component.endpoint = { ...component.endpoint, connectionStatus: 'connected', token_expiry: 1 };
+    expect(component.disconnected).toBe(true);
+  });
+
+  it('ignores a future token expiry', () => {
+    component.endpoint = { ...component.endpoint, connectionStatus: 'connected', token_expiry: Math.floor(Date.now() / 1000) + 3600 };
+    expect(component.disconnected).toBe(false);
+  });
+
+  it('does not create the card twice when the endpoint input rebinds during load', () => {
+    const spy = vi.spyOn(component, 'createCard').mockResolvedValue(undefined as any);
+    component.endpoint = { ...component.endpoint, connectionStatus: 'connected' };
+    // Simulate: rebind fires while ngAfterViewInit's create is still awaiting
+    component.ngOnChanges({ endpoint: { currentValue: component.endpoint } } as any);
+    component.ngAfterViewInit();
+    component.ngOnChanges({ endpoint: { currentValue: component.endpoint } } as any);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an expired access token as alive when jetstream can refresh it', () => {
+    component.endpoint = { ...component.endpoint, connectionStatus: 'connected', token_expiry: 1, token_renewable: true };
+    expect(component.disconnected).toBe(false);
+  });
+
   it('should load component from homeCard.component() when endpoint entity provided', async () => {
     @Component({ selector: 'app-mock-card', template: '', standalone: true })
     class MockCardComponent {

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, AfterViewInit, Component, ComponentRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, ViewContainerRef, signal, inject } from '@angular/core';
+import { ChangeDetectionStrategy, AfterViewInit, Component, ComponentRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild, ViewContainerRef, signal, inject } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { RouterModule } from '@angular/router';
 import { combineLatest, Observable, of, Subscription } from 'rxjs';
@@ -13,6 +13,9 @@ import { UserFavoriteManager } from '../../../../../../store/src/user-favorite-m
 import { EntityFavoriteStarComponent } from '../../../../core/entity-favorite-star/entity-favorite-star.component';
 import { MultilineTitleComponent } from '../../../../shared/components/multiline-title/multiline-title.component';
 import { SidePanelMode, SidePanelService } from '../../../../shared/services/side-panel.service';
+import { TailwindDialogService } from '../../../../shared/services/tailwind-dialog.service';
+import { ConnectEndpointDialogComponent } from '../../../endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
+import { isEndpointConnected } from '../../../endpoints/endpoint-helpers';
 import { FavoritesSidePanelComponent } from '../favorites-side-panel/favorites-side-panel.component';
 import { FavoritesMetaCardComponent } from '../favorites-meta-card/favorites-meta-card.component';
 import { HomeShortcutsComponent } from '../home-shortcuts/home-shortcuts.component';
@@ -48,9 +51,10 @@ enum Status {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class HomePageEndpointCardComponent implements OnInit, OnDestroy, AfterViewInit {
+export class HomePageEndpointCardComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {
   private userFavoriteManager = inject(UserFavoriteManager);
   private sidePanelService = inject(SidePanelService);
+  private dialog = inject(TailwindDialogService);
 
 
 
@@ -118,6 +122,10 @@ export class HomePageEndpointCardComponent implements OnInit, OnDestroy, AfterVi
   // Should the Home Card use the whole width, or do we show the links panel as well?
   fullView = false;
 
+  // Favorites/Shortcuts placement: strip below the content (linksBelow) or
+  // the classic right-hand sidebar. Per-endpoint via homeCard.linksBelow.
+  linksBelow = false;
+
   // Does the endpoint haev entities that can be favourited
   // If not, then don't show favorites, as there can never be any
   hasFavEntities = false;
@@ -127,7 +135,36 @@ export class HomePageEndpointCardComponent implements OnInit, OnDestroy, AfterVi
     this.status$ = toObservable(this._status);
   }
 
+  // Disconnected (or token-expired) endpoints render a Disconnected panel with
+  // a connect affordance instead of loading their home card — no half-loaded
+  // or error card (#5588). unConnectable types (git etc.) are always "up".
+  get disconnected(): boolean {
+    return !this.definition?.unConnectable && !isEndpointConnected(this.endpoint);
+  }
+
   ngAfterViewInit() {
+    this.initCard();
+  }
+
+  // Set synchronously when card creation starts — `ref` is only assigned
+  // after createCard's async import resolves, so guarding on it alone lets a
+  // second initCard sneak in mid-import and append a duplicate card.
+  private cardCreated = false;
+
+  ngOnChanges(changes: SimpleChanges) {
+    // Endpoint connected while the card is on screen (e.g. via the Connect
+    // button below): create and load the real home card now.
+    if (changes['endpoint'] && !this.cardCreated && !this.disconnected) {
+      this.initCard();
+    }
+  }
+
+  private initCard() {
+    // customCard resolves in ngOnInit; the ngOnChanges path can fire earlier
+    if (this.cardCreated || this.disconnected || !this.customCard) {
+      return;
+    }
+    this.cardCreated = true;
     // Dynamically load the component for the Home Card for this endopoint
     // strict: cnsi_type is populated on every bound endpoint; '' default keeps the lookup well-formed
     const endpointEntity = entityCatalog.getEndpoint(this.endpoint.cnsi_type ?? '', this.endpoint.sub_type);
@@ -136,6 +173,23 @@ export class HomePageEndpointCardComponent implements OnInit, OnDestroy, AfterVi
     } else {
       this.createCard(undefined);
     }
+  }
+
+  public connect() {
+    // Same invocation contract as the endpoints page list
+    this.dialog.open(ConnectEndpointDialogComponent, {
+      data: {
+        name: this.endpoint.name,
+        guid: this.endpoint.guid,
+        type: this.endpoint.cnsi_type,
+        subType: this.endpoint.sub_type,
+        ssoAllowed: this.endpoint.sso_allowed,
+      },
+      disableClose: true,
+      width: '550px',
+      maxWidth: '550px',
+      panelClass: ['overflow-visible', 'p-6'],
+    });
   }
 
   ngOnInit() {
@@ -148,6 +202,7 @@ export class HomePageEndpointCardComponent implements OnInit, OnDestroy, AfterVi
       this.definition = this.entity.definition;
       this.favorite = this.userFavoriteManager.getFavoriteEndpointFromEntity(this.endpoint);
       this.fullView = this.definition?.homeCard?.fullView ?? false;
+      this.linksBelow = this.definition?.homeCard?.linksBelow ?? false;
       this.link = this.favorite ? this.favorite.getLink() : null;
       // Recompute effective layout now that definition is available
       this.computeEffectiveLayout();

--- a/src/frontend/packages/core/src/features/home/home/home-page.component.html
+++ b/src/frontend/packages/core/src/features/home/home/home-page.component.html
@@ -1,6 +1,31 @@
 <app-page-header [endpointIds$]="allEndpointIds$">
   <h1>Home</h1>
   <div class="page-header-right">
+    <div class="inline-flex items-center rounded-lg border border-content-border bg-content-bg p-1 shadow-sm"
+      role="group" aria-label="Which endpoints to show">
+      @for (mode of showModes; track mode.value) {
+        <button type="button"
+          class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors duration-200"
+          [class.bg-primary]="resolvedShowMode() === mode.value"
+          [class.text-white]="resolvedShowMode() === mode.value"
+          [class.text-content-text]="resolvedShowMode() !== mode.value"
+          [class.hover:bg-content-secondary]="resolvedShowMode() !== mode.value"
+          (click)="setShowMode(mode.value)"
+          [attr.aria-pressed]="resolvedShowMode() === mode.value">
+          {{ mode.label }}
+        </button>
+      }
+      <span class="self-stretch border-l border-content-border mx-1" aria-hidden="true"></span>
+      <button type="button" (click)="toggleSortDirection()"
+        [title]="sortDirection() === 'asc' ? 'Sorted by endpoint name, A→Z' : 'Sorted by endpoint name, Z→A'"
+        [attr.aria-label]="sortDirection() === 'asc' ? 'Sorted by endpoint name, ascending' : 'Sorted by endpoint name, descending'"
+        class="px-2 py-1.5 rounded-md text-content-muted hover:bg-content-secondary transition-colors duration-200">
+        <span class="material-icons text-base leading-5 block" [class.rotate-180]="sortDirection() === 'asc'">sort</span>
+      </button>
+    </div>
+    <!-- Divider between the endpoint controls and the layout menu, matching
+         the page header's own divider idiom -->
+    <span class="mx-2 text-content-muted opacity-40 select-none" aria-hidden="true">|</span>
     <div class="relative inline-block">
       <div class="dropdown">
         <button class="btn btn-secondary flex items-center space-x-1" [attr.aria-expanded]="false"
@@ -26,14 +51,6 @@
                   }
                 </div>
               }
-              <div class="layout-dropdown__divider"></div>
-              <button (click)="toggleShowAllEndpoints(); closeDropdown(dropdownButton)"
-                class="layout-dropdown__option">
-                <span>Show connected endpoints</span>
-                <span class="material-icons text-brand-600"
-                  [class.opacity-100]="showAllEndpoints"
-                [class.opacity-0]="!showAllEndpoints">done</span>
-            </button>
           </div>
         </div>
       </div>

--- a/src/frontend/packages/core/src/features/home/home/home-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page.component.spec.ts
@@ -8,18 +8,27 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 import { createBasicStoreModule, STORE_TEST_PROVIDERS } from '@test-framework';
-import { EntityCatalogHelper, EntityCatalogHelpers, entityCatalog, generateStratosEntities } from '@stratosui/store';
+import {
+  EndpointModel,
+  EntityCatalogHelper,
+  EntityCatalogHelpers,
+  IUserFavoritesGroups,
+  UserFavoriteManager,
+  entityCatalog,
+  generateStratosEntities,
+} from '@stratosui/store';
 
 import { CurrentUserPermissionsService } from '../../../core/permissions/current-user-permissions.service';
 import { EndpointsService } from '../../../core/endpoints.service';
 import { TabNavService } from '../../../tab-nav.service';
 import { HomePageComponent } from './home-page.component';
 
-function makeStubEndpointsService(disablePersistenceFeatures: boolean): Partial<EndpointsService> {
+function makeStubEndpointsService(disablePersistenceFeatures: boolean, endpoints: Record<string, EndpointModel> = {}): Partial<EndpointsService> {
   return {
     disablePersistenceFeatures$: of(disablePersistenceFeatures),
-    haveRegistered$: of(false),
-    connectedEndpoints$: of([]),
+    haveRegistered$: of(Object.keys(endpoints).length > 0),
+    connectedEndpoints$: of(Object.values(endpoints).filter(ep => ep.connectionStatus === 'connected')),
+    endpoints$: of(endpoints),
   } as Partial<EndpointsService>;
 }
 
@@ -31,7 +40,7 @@ describe('HomePageComponent', () => {
   let component: HomePageComponent;
   let fixture: ComponentFixture<HomePageComponent>;
 
-  async function configureTestBed(endpointsServiceStub: Partial<EndpointsService>) {
+  async function configureTestBed(endpointsServiceStub: Partial<EndpointsService>, favGroups?: IUserFavoritesGroups) {
     (entityCatalog as any).clear();
     const entities = generateStratosEntities();
     entities.forEach(entity => entityCatalog.register(entity));
@@ -51,6 +60,7 @@ describe('HomePageComponent', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         { provide: EndpointsService, useValue: endpointsServiceStub },
+        ...(favGroups ? [{ provide: UserFavoriteManager, useValue: { getAllFavorites: () => of([favGroups, []]) } }] : []),
       ]
     }).compileComponents();
 
@@ -93,4 +103,84 @@ describe('HomePageComponent', () => {
   // observables via toSignal, never triggers endpoint loading on construction),
   // so that non-behavior is now structurally guaranteed — the test had no
   // mechanism left to assert against and was removed with the store.
+
+  // #5588 — starred endpoints show regardless of connection state
+  describe('starred endpoints vs connection state', () => {
+    const downCf = {
+      guid: 'ep1',
+      name: 'down-cf',
+      cnsi_type: 'cf',
+      connectionStatus: 'disconnected',
+    } as EndpointModel;
+
+    const starredGroup = (ethereal: boolean): IUserFavoritesGroups => ({
+      ep1: { ethereal, endpoint: { endpointId: 'ep1' } as any, entitiesIds: [] },
+    });
+
+    it('starred mode shows a directly starred endpoint even when disconnected', async () => {
+      await configureTestBed(makeStubEndpointsService(false, { ep1: downCf }), starredGroup(false));
+      fixture = TestBed.createComponent(HomePageComponent);
+      component = fixture.componentInstance;
+      expect(component.endpoints().map(ep => ep.guid)).toEqual(['ep1']);
+    });
+
+    it('starred mode shows an endpoint with starred children (ethereal group) even when disconnected', async () => {
+      await configureTestBed(makeStubEndpointsService(false, { ep1: downCf }), starredGroup(true));
+      fixture = TestBed.createComponent(HomePageComponent);
+      component = fixture.componentInstance;
+      expect(component.endpoints().map(ep => ep.guid)).toEqual(['ep1']);
+    });
+
+    it('starred mode hides endpoints that are not starred at all', async () => {
+      await configureTestBed(makeStubEndpointsService(false, { ep1: downCf }), {});
+      fixture = TestBed.createComponent(HomePageComponent);
+      component = fixture.componentInstance;
+      expect(component.endpoints()).toEqual([]);
+    });
+
+    it('sorts same-type endpoints by natural name order within a group', async () => {
+      const eps: Record<string, EndpointModel> = {
+        ep10: { ...downCf, guid: 'ep10', name: 'cf10' },
+        ep2: { ...downCf, guid: 'ep2', name: 'cf2' },
+        ep1: { ...downCf, guid: 'ep1', name: 'cf1' },
+      };
+      const groups: IUserFavoritesGroups = Object.fromEntries(Object.keys(eps).map(g =>
+        [g, { ethereal: false, endpoint: { endpointId: g } as any, entitiesIds: [] }]));
+      await configureTestBed(makeStubEndpointsService(false, eps), groups);
+      fixture = TestBed.createComponent(HomePageComponent);
+      component = fixture.componentInstance;
+      expect(component.endpoints().map(ep => ep.name)).toEqual(['cf1', 'cf2', 'cf10']);
+    });
+
+    it('desc direction reverses the name tiebreak only', async () => {
+      const eps: Record<string, EndpointModel> = {
+        ep10: { ...downCf, guid: 'ep10', name: 'cf10' },
+        ep2: { ...downCf, guid: 'ep2', name: 'cf2' },
+        ep1: { ...downCf, guid: 'ep1', name: 'cf1' },
+      };
+      const groups: IUserFavoritesGroups = Object.fromEntries(Object.keys(eps).map(g =>
+        [g, { ethereal: false, endpoint: { endpointId: g } as any, entitiesIds: [] }]));
+      await configureTestBed(makeStubEndpointsService(false, eps), groups);
+      fixture = TestBed.createComponent(HomePageComponent);
+      component = fixture.componentInstance;
+      component.toggleSortDirection();
+      expect(component.endpoints().map(ep => ep.name)).toEqual(['cf10', 'cf2', 'cf1']);
+    });
+
+    it('connected mode still only shows connected endpoints', async () => {
+      await configureTestBed(makeStubEndpointsService(false, { ep1: downCf }), starredGroup(false));
+      fixture = TestBed.createComponent(HomePageComponent);
+      component = fixture.componentInstance;
+      component.setShowMode('connected');
+      expect(component.endpoints()).toEqual([]);
+    });
+
+    it('all mode shows every endpoint regardless of state or stars', async () => {
+      await configureTestBed(makeStubEndpointsService(false, { ep1: downCf }), {});
+      fixture = TestBed.createComponent(HomePageComponent);
+      component = fixture.componentInstance;
+      component.setShowMode('all');
+      expect(component.endpoints().map(ep => ep.guid)).toEqual(['ep1']);
+    });
+  });
 });

--- a/src/frontend/packages/core/src/features/home/home/home-page.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page.component.ts
@@ -11,6 +11,8 @@ import { Observable } from 'rxjs';
 import { take, filter, map, switchMap } from 'rxjs/operators';
 
 import { EndpointsService } from '../../../core/endpoints.service';
+import { HomeShowMode, HomeSortDirection } from '../../../core/dashboard-preferences.service';
+import { naturalCompare } from '../../../shared/utils/natural-sort';
 import { SessionService } from '../../../core/session.service';
 import { DashboardPreferencesService } from '../../../core/dashboard-preferences.service';
 import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
@@ -32,7 +34,7 @@ const noFavoritesMsg = (endpointCount: number, favoriteCount: number) => ({
     ? `You have ${endpointCount} endpoint${endpointCount !== 1 ? 's' : ''} and ${favoriteCount > 0 ? favoriteCount : 'none'} ha${favoriteCount === 1 ? 's' : 've'} been selected to be on your home page.`
     : 'You have no endpoints.',
   secondLine: { text: endpointCount > 0
-    ? 'Use the layout menu above to show all endpoints, or star an endpoint to add it here.'
+    ? 'Switch to "Connected" or "All" above to show more endpoints, or star an endpoint to add it here.'
     : 'Use the Endpoints view to register and connect an endpoint.' },
   icon: 'star_outline'
 });
@@ -72,24 +74,42 @@ export class HomePageComponent implements OnInit {
     this.haveRegistered() ? this.connectedEndpointsRaw() : []
   );
 
-  private sessionDefaultShowMode: Signal<boolean | null> = computed(() => {
+  // Every registered endpoint, connection state ignored — source for the
+  // starred-only view, where a starred endpoint that is down must still show
+  // (as a Disconnected card) instead of silently disappearing (#5588).
+  private allEndpointsRaw: Signal<EndpointModel[]> = toSignal(
+    this.endpointsService.endpoints$.pipe(map(eps => Object.values(eps))),
+    { initialValue: [] as EndpointModel[] }
+  );
+
+  private allEndpoints: Signal<EndpointModel[]> = computed(() =>
+    this.haveRegistered() ? this.allEndpointsRaw() : []
+  );
+
+  private sessionDefaultShowMode: Signal<HomeShowMode | null> = computed(() => {
     const c = this.sessionService.config();
-    return c ? !c.homeViewShowFavoritesOnly : null;
+    return c ? (c.homeViewShowFavoritesOnly ? 'favorites' : 'connected') : null;
   });
 
-  private resolvedShowMode: Signal<boolean> = computed(() => {
-    const a = this._showMode();
-    const b = this.prefs.homeShowAllEndpoints();
-    const c = this.sessionDefaultShowMode();
-    return (a !== null) ? a : (b !== null) ? b : (c ?? false);
-  });
+  public resolvedShowMode: Signal<HomeShowMode> = computed(() =>
+    this._showMode() ?? this.prefs.homeShowMode() ?? this.sessionDefaultShowMode() ?? 'favorites'
+  );
 
   public endpoints: Signal<EndpointModel[]> = computed(() => {
-    const showMode = this.resolvedShowMode();
-    const endpoints = this.connectedEndpoints();
+    const mode = this.resolvedShowMode();
     const fav = this.allFavorites();
     const favGroups: IUserFavoritesGroups = fav ? fav[0] : ({} as IUserFavoritesGroups);
-    const ordered = this.orderEndpoints(endpoints, favGroups, showMode);
+    if (mode === 'favorites') {
+      // Every starred endpoint (directly, or via starred child entities)
+      // regardless of connection state — a starred endpoint that is down
+      // renders as a Disconnected card rather than being hidden (#5588).
+      return this.orderEndpoints(this.allEndpoints(), favGroups, false);
+    }
+    if (mode === 'all') {
+      // Every registered endpoint, any state, favorites sorted first.
+      return this.orderEndpoints(this.allEndpoints(), favGroups, true);
+    }
+    const ordered = this.orderEndpoints(this.connectedEndpoints(), favGroups, true);
     return ordered.filter(ep => {
       // strict: cnsi_type is populated on every connected endpoint; '' default keeps the lookup well-formed
       const defn = entityCatalog.getEndpoint(ep.cnsi_type ?? '', ep.sub_type);
@@ -103,8 +123,8 @@ export class HomePageComponent implements OnInit {
   private _layout = signal<HomePageCardLayout | null>(null);
   public layout = this._layout.asReadonly();
 
-  private _showMode = signal<boolean | null>(null);
-  public showAllEndpoints = false;
+  private _showMode = signal<HomeShowMode | null>(null);
+  private persistedShowMode: HomeShowMode | null = null;
 
   public columns = 1;
 
@@ -162,16 +182,17 @@ export class HomePageComponent implements OnInit {
     // Persist resolved show-mode and refresh the noneAvailable message
     // whenever it or the endpoint list changes
     effect(() => {
-      const showMode = this.resolvedShowMode();
-      const endpoints = this.connectedEndpoints();
+      const mode = this.resolvedShowMode();
+      const registered = this.allEndpoints();
       const ordered = this.endpoints();
 
-      if (this.showAllEndpoints !== showMode) {
-        this.showAllEndpoints = showMode;
-        this.prefs.setHomeShowAllEndpoints(this.showAllEndpoints);
+      if (this.persistedShowMode !== mode) {
+        this.persistedShowMode = mode;
+        this.prefs.setHomeShowMode(mode);
       }
-      const favoriteCount = showMode ? 0 : ordered.length;
-      this.noneAvailableMsg = showMode ? noConnectedMsg : noFavoritesMsg(endpoints.length, favoriteCount);
+      this.noneAvailableMsg = mode === 'favorites'
+        ? noFavoritesMsg(registered.length, ordered.length)
+        : noConnectedMsg;
     });
 
     // Set an initial layout (the layout-init effect above will replace this once prefs hydrate)
@@ -197,8 +218,24 @@ export class HomePageComponent implements OnInit {
     }, { injector: this.injector });
   }
 
-  public toggleShowAllEndpoints() {
-    this._showMode.set(!this.showAllEndpoints);
+  // Header segmented control: Favorites | Connected | All
+  public showModes: { value: HomeShowMode, label: string }[] = [
+    { value: 'favorites', label: 'Favorites' },
+    { value: 'connected', label: 'Connected' },
+    { value: 'all', label: 'All' },
+  ];
+
+  public setShowMode(mode: HomeShowMode) {
+    this._showMode.set(mode);
+  }
+
+  // Header name-order control (signal-list card-view sort convention).
+  // Applies to the NAME tiebreak only — star grouping and type priority are
+  // fixed (decided during #5588 review).
+  public sortDirection: Signal<HomeSortDirection> = computed(() => this.prefs.homeSortDirection());
+
+  public toggleSortDirection() {
+    this.prefs.setHomeSortDirection(this.sortDirection() === 'asc' ? 'desc' : 'asc');
   }
 
   // The layout was changed
@@ -219,7 +256,7 @@ export class HomePageComponent implements OnInit {
   // 2. Endpoint that has child favourites
   // 3. Remaining endpoints
   // Within each group, sort by renderPriority (lower = first)
-  private orderEndpoints(endpoints: EndpointModel[], favorites: IUserFavoritesGroups, showMode: boolean): EndpointModel[] {
+  private orderEndpoints(endpoints: EndpointModel[], favorites: IUserFavoritesGroups, includeRest: boolean): EndpointModel[] {
     const processed: Record<string, boolean> = {};
     const directFavs: EndpointModel[] = [];
     const childFavs: EndpointModel[] = [];
@@ -251,7 +288,7 @@ export class HomePageComponent implements OnInit {
       }
     });
 
-    if (showMode) {
+    if (includeRest) {
       endpoints.forEach(ep => {
         if (ep.guid && !processed[ep.guid]) {
           processed[ep.guid] = true;
@@ -260,11 +297,15 @@ export class HomePageComponent implements OnInit {
       });
     }
 
+    const dir = this.sortDirection();
     const byPriority = (a: EndpointModel, b: EndpointModel) => {
       // strict: cnsi_type is populated on every endpoint; '' default keeps the lookup well-formed
       const pa = entityCatalog.getEndpoint(a.cnsi_type ?? '', a.sub_type)?.definition?.renderPriority ?? 1000;
       const pb = entityCatalog.getEndpoint(b.cnsi_type ?? '', b.sub_type)?.definition?.renderPriority ?? 1000;
-      return pa - pb;
+      // Same type (priority tie): natural name order, so cf1 < cf2 < cf10
+      // instead of the /pp/v1/info payload's arbitrary map order. Direction
+      // flips the name comparison only, never the group/type ordering.
+      return pa - pb || naturalCompare(a.name, b.name, false, dir);
     };
 
     return [

--- a/src/frontend/packages/core/src/features/home/home/home-shortcuts/home-shortcuts.component.scss
+++ b/src/frontend/packages/core/src/features/home/home/home-shortcuts/home-shortcuts.component.scss
@@ -10,8 +10,16 @@
     margin-bottom: 10px;
     margin-left: 12px;
 
+    // Let the text column shrink inside the flex row so titles wrap to a
+    // second line when the sidebar is genuinely too narrow, instead of
+    // overflowing the card edge.
+    > div:last-child {
+      min-width: 0;
+    }
+
     a {
       color: var(--color-primary);
+      overflow-wrap: break-word;
     }
 
     mat-icon {

--- a/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
@@ -1,5 +1,5 @@
 <app-tile-grid fit="true">
-  <app-tile-group class="ml-0 mr-4 mt-4">
+  <app-tile-group class="tile-group-3-cols tile-group-compact">
     <app-tile>
       <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/nodes" icon="apps" label="Nodes"
         labelSingular="Node" value="{{ nodeCount() }}">
@@ -14,13 +14,6 @@
       <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/resource/pod" icon="apps" label="Pods"
         labelSingular="Pod" value="{{ podCount() }}">
       </app-card-number-metric>
-    </app-tile>
-  </app-tile-group>
-  <app-tile-group class="tile-group-1-cols">
-    <app-tile>
-      <div class="px-4">
-        <app-home-shortcuts [shortcuts]="shortcuts"></app-home-shortcuts>
-      </div>
     </app-tile>
   </app-tile-group>
 </app-tile-grid>

--- a/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.scss
+++ b/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.scss
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  width: 100%;
+}

--- a/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.ts
@@ -1,27 +1,22 @@
-import { HttpClient } from '@angular/common/http';
-import { Component, Input, OnInit, Signal, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, Signal, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
-import { take } from 'rxjs/operators';
 
-import { SessionService } from '../../../../core/src/core/session.service';
 import { HomePageCardLayout } from '../../../../core/src/features/home/home.types';
-import { HomeCardShortcut } from '../../../../store/src/entity-catalog/entity-catalog.types';
 import { EndpointModel } from '../../../../store/src/types/endpoint.types';
 import { KubePodDataService } from '../../services/domain-data/kube-pod-data.service';
 import { KubeNodeDataService } from '../../services/domain-data/kube-node-data.service';
 import { KubeNamespaceDataService } from '../../services/domain-data/kube-namespace-data.service';
-import { KubernetesEndpointService } from '../services/kubernetes-endpoint.service';
 import { TileGridComponent } from '../../../../core/src/shared/components/tile/tile-grid/tile-grid.component';
 import { TileGroupComponent } from '../../../../core/src/shared/components/tile/tile-group/tile-group.component';
 import { TileComponent } from '../../../../core/src/shared/components/tile/tile/tile.component';
 import { CardNumberMetricComponent } from '../../../../core/src/shared/components/cards/card-number-metric/card-number-metric.component';
-import { HomeShortcutsComponent } from '../../../../core/src/features/home/home/home-shortcuts/home-shortcuts.component';
 
 @Component({
   selector: 'app-k8s-home-card',
   templateUrl: './kubernetes-home-card.component.html',
+  styleUrls: ['./kubernetes-home-card.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
@@ -29,11 +24,10 @@ import { HomeShortcutsComponent } from '../../../../core/src/features/home/home/
     TileGridComponent,
     TileGroupComponent,
     TileComponent,
-    CardNumberMetricComponent,
-    HomeShortcutsComponent
+    CardNumberMetricComponent
   ]
 })
-export class KubernetesHomeCardComponent implements OnInit {
+export class KubernetesHomeCardComponent {
 
   @Input() endpoint!: EndpointModel;
 
@@ -50,10 +44,6 @@ export class KubernetesHomeCardComponent implements OnInit {
     }
   }
 
-  public shortcuts!: HomeCardShortcut[];
-
-  private session = inject(SessionService);
-  private http = inject(HttpClient);
   private podData = inject(KubePodDataService);
   private nodeData = inject(KubeNodeDataService);
   private namespaceData = inject(KubeNamespaceDataService);
@@ -86,25 +76,6 @@ export class KubernetesHomeCardComponent implements OnInit {
   });
   private readonly loaded$ = toObservable(this.loaded);
 
-  ngOnInit() {
-    // strict: home cards only render for registered endpoints, which always have a guid
-    const guid = this.endpoint.guid!;
-    this.shortcuts = [
-      {
-        title: 'View Nodes',
-        link: ['/kubernetes', guid, 'nodes'],
-        icon: 'node',
-        iconFont: 'stratos-icons'
-      },
-      {
-        title: 'View Namespaces',
-        link: ['/kubernetes', guid, 'resource', 'namespace'],
-        icon: 'namespace',
-        iconFont: 'stratos-icons'
-      }
-    ];
-  }
-
   // Card is instructed to load its view by the container, whn it is visible
   load(): Observable<boolean> {
     // strict: home cards only render for registered endpoints, which always have a guid
@@ -114,31 +85,6 @@ export class KubernetesHomeCardComponent implements OnInit {
     this.guidSig.set(guid);
     void this.nodeData.refresh(guid);
     void this.namespaceData.refresh({ kubeGuid: guid });
-
-    KubernetesEndpointService.hasKubeTerminalEnabled(this.session).pipe(take(1)).subscribe(hasKubeTerminal => {
-      if (hasKubeTerminal) {
-        this.shortcuts.push(
-          {
-            title: 'Open Terminal',
-            link: ['/kubernetes', guid, 'terminal'],
-            icon: 'terminal',
-            iconFont: 'stratos-icons'
-          }
-        );
-      }
-    });
-
-    KubernetesEndpointService.kubeDashboardConfigured(this.http, this.session, guid).pipe(take(1)).subscribe(hasKubeDashboard => {
-      if (hasKubeDashboard) {
-        this.shortcuts.push(
-          {
-            title: 'View Dashboard',
-            link: ['/kubernetes', guid, 'dashboard'],
-            icon: 'dashboard'
-          }
-        );
-      }
-    });
 
     return this.loaded$;
   }

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-entity-generator.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-entity-generator.ts
@@ -17,6 +17,7 @@ import {
   StratosCatalogEntity,
 } from '../../../store/src/entity-catalog/entity-catalog-entity/entity-catalog-entity';
 import {
+  HomeCardShortcut,
   IEntityMetadata,
   IStratosEntityDefinition,
   StratosEndpointExtensionDefinition,
@@ -310,7 +311,26 @@ export class KubeEntityCatalog {
         }],
       homeCard: {
         component: () => import('./home/kubernetes-home-card.component').then(m => m.KubernetesHomeCardComponent),
-        fullView: false
+        // Definition-level like CF, so the host card renders these in the
+        // sidebar under Favorites. The old in-card conditional shortcuts
+        // (Open Terminal / View Dashboard) needed async checks this sync
+        // hook can't do; both remain reachable from the kube endpoint pages.
+        shortcuts: (endpointID: string): HomeCardShortcut[] => [
+          {
+            title: 'View Nodes',
+            link: ['/kubernetes', endpointID, 'nodes'],
+            icon: 'node',
+            iconFont: 'stratos-icons'
+          },
+          {
+            title: 'View Namespaces',
+            link: ['/kubernetes', endpointID, 'resource', 'namespace'],
+            icon: 'namespace',
+            iconFont: 'stratos-icons'
+          }
+        ],
+        fullView: false,
+        linksBelow: true
       }
     };
 

--- a/src/frontend/packages/store/src/entity-catalog/entity-catalog.types.ts
+++ b/src/frontend/packages/store/src/entity-catalog/entity-catalog.types.ts
@@ -76,6 +76,9 @@ export interface HomeCardMetadata {
   shortcuts?: (endpointID: string) => HomeCardShortcut[];
   fullView?: boolean;
   columnSpan?: number;
+  // Render Favorites/Shortcuts in a strip below the card content instead of
+  // the right-hand sidebar — suits content-light cards (e.g. kubernetes)
+  linksBelow?: boolean;
 }
 
 /**

--- a/src/frontend/packages/store/src/types/endpoint.types.ts
+++ b/src/frontend/packages/store/src/types/endpoint.types.ts
@@ -47,6 +47,12 @@ export interface EndpointModel {
   };
   system_shared_token: boolean;
   sso_allowed: boolean;
+  // Expiry (epoch seconds) of this user's stored token; only present when the
+  // user has connected the endpoint. 0/absent means no expiry is known.
+  token_expiry?: number;
+  // True when jetstream holds a refresh token for this endpoint and can mint
+  // a fresh session on use — expiry of the access token is then harmless.
+  token_renewable?: boolean;
   // These are generated client side when we login
   connectionStatus?: endpointConnectionStatus;
   metricsAvailable: boolean;

--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -312,6 +312,8 @@ type EndpointDetail struct {
 	User              *ConnectedUser    `json:"user"`
 	Creator           *CreatorInfo      `json:"creator"`
 	Metadata          map[string]string `json:"metadata,omitempty"`
+	TokenExpiry       int64             `json:"token_expiry,omitempty"`
+	TokenRenewable    bool              `json:"token_renewable,omitempty"`
 	TokenMetadata     string            `json:"-"`
 	SystemSharedToken bool              `json:"system_shared_token"`
 }

--- a/src/jetstream/info.go
+++ b/src/jetstream/info.go
@@ -105,6 +105,10 @@ func (p *portalProxy) getInfo(c echo.Context) (*api.Info, error) {
 		cnsiUser, token, ok := p.GetCNSIUserAndToken(cnsi.GUID, userGUID)
 		if ok {
 			endpoint.User = cnsiUser
+			endpoint.TokenExpiry = token.TokenExpiry
+			// A refresh token means jetstream can mint a fresh session on use,
+			// so an expired access token does not make the endpoint dead.
+			endpoint.TokenRenewable = token.RefreshToken != ""
 			endpoint.TokenMetadata = token.Metadata
 			endpoint.SystemSharedToken = token.SystemShared
 		}


### PR DESCRIPTION
## What

Home previously double-filtered its cards to connected endpoints, so a starred endpoint that went down silently disappeared — absence read as "not favorited" rather than "down". Home can now answer both questions the issue names: "show me my connected endpoints" and "show me my starred endpoints, up or not".

## Changes

### Which-endpoints control
- New header segmented control: **Favorites | Connected | All** (replaces the "Show connected endpoints" checkbox row that lived inside the layout menu — a content filter fused into a presentation menu, with the active mode invisible until opened).
  - Favorites: every starred endpoint (directly, or via starred child entities), any connection state.
  - Connected: every connected endpoint, favorites first (previous behavior).
  - All: every registered endpoint, any state, favorites first.
- The persisted boolean preference migrates to the three-way mode; the deployment default (`homeViewShowFavoritesOnly`) keeps its meaning.

### Disconnected presentation
- A shown endpoint that is disconnected renders a Disconnected panel with a Connect button (the endpoints-page connect dialog) — its home card never loads, so no half-loaded or error card. Connecting while the card is on screen swaps the real card in.
- Token expiry presents as Disconnected **only when jetstream cannot mint a fresh session**: `/pp/v1/info` now exposes `token_expiry` and `token_renewable` (refresh token present) per connected endpoint. Refresh-capable endpoints (UAA/SSO) renew transparently on use, so their hourly access-token expiry stays harmless — the rule exists for korifi-style pasted tokens (#5489), which have no refresh and always end in expiry. (The issue text said expired → Disconnected flatly; that would have flapped every idle CF endpoint, hence the renewable gate.)

### Sorting
- Cards order by favorites group → endpoint type (`renderPriority`) → natural name (cf1 < cf2 < cf10; previously payload map order).
- A direction icon attached to the segmented control flips the name order, tooltip explains what is sorted; direction never reorders groups or types. Persisted per user with the other Home prefs.
- A divider separates the endpoint controls from the layout menu, which is back to column presets only.

### Card layouts
- Home cards gain a per-endpoint layout choice (`homeCard.linksBelow`): kubernetes renders its counts as a horizontal tile row with a Favorites/Shortcuts strip below; CF keeps the classic right-hand sidebar. Kube shortcuts moved to the definition level (like CF); the old in-card conditional shortcuts (Open Terminal / View Dashboard) needed async checks the sync definition hook can't express and remain reachable from the kubernetes pages.
- Shortcut links wrap inside their column instead of overflowing the card edge.
- Fixed a card double-render race (`ngAfterViewInit` + input rebind both creating the card while its lazy chunk import was in flight) — regression spec included.

## Testing

- 27 unit tests across home page, endpoint card, kube card, and dashboard prefs (mode filtering incl. ethereal favorite groups, expiry/renewable presentation, sort tiebreak + direction, pref migration, double-create race).
- Full gate (lint + unit + production build + backend tests) green locally.
- Live-verified against a dev stack with 4 CF + 5 kube endpoints: starred+disconnected card, korifi-shape expired token (refresh blanked in DB), renewable expiry staying connected, Connect dialog round-trip, mode switching, sort direction, card layouts at single/two/three-column widths.

Closes #5588