### PR TITLE
perf(cloudfoundry): skip dead per-space enrichment on prewarm drain

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/drain-pages.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/drain-pages.ts
@@ -41,7 +41,7 @@ function isTransientCfError(err: unknown): boolean {
       err.headers?.get(STRATOS_ERROR_REASON_HEADER) === 'unreachable');
 }
 
-export function drainCfPages<T>(http: HttpClient, urlBase: string): Observable<DrainedPages<T>> {
+export function drainCfPages<T>(http: HttpClient, urlBase: string, extraParams = ''): Observable<DrainedPages<T>> {
   const perPage = 500;
   type Paged<U> = { resources: U[]; totalResults?: number; pagination?: { totalResults?: number; totalPages?: number } };
   const totalResultsOf = <U>(r: Paged<U>): number => r.pagination?.totalResults ?? r.totalResults ?? r.resources.length;
@@ -49,7 +49,7 @@ export function drainCfPages<T>(http: HttpClient, urlBase: string): Observable<D
   // re-fetches only page 7. Non-transient errors rethrow immediately and
   // fail the drain as before.
   const fetchPage = (page: number) =>
-    http.get<Paged<T>>(`${urlBase}?per_page=${perPage}&page=${page}`).pipe(
+    http.get<Paged<T>>(`${urlBase}?per_page=${perPage}&page=${page}${extraParams ? '&' + extraParams : ''}`).pipe(
       retry({
         count: RETRY_DELAYS_MS.length,
         delay: (err, retryCount) => {

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.spec.ts
@@ -13,7 +13,7 @@ const APPS_URL = '/pp/v1/cf/apps/test-cnsi-guid?return=recent';
 const ROUTES_URL = '/pp/v1/cf/routes/test-cnsi-guid?return=counts';
 const ORGS_FULL_URL = '/pp/v1/cf/orgs/test-cnsi-guid?per_page=500&page=1';
 const APPS_FULL_URL = '/pp/v1/cf/apps/test-cnsi-guid?per_page=500&page=1';
-const SPACES_FULL_URL = '/pp/v1/cf/spaces/test-cnsi-guid?per_page=500&page=1';
+const SPACES_FULL_URL = '/pp/v1/cf/spaces/test-cnsi-guid?per_page=500&page=1&enrich=none';
 
 const SERVICE_INSTANCES_COUNTS_URL = '/pp/v1/cf/service_instances/test-cnsi-guid?return=counts';
 const SERVICE_OFFERINGS_COUNTS_URL = '/pp/v1/cf/service_offerings/test-cnsi-guid?return=counts';

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/endpoint-data.service.ts
@@ -370,7 +370,7 @@ export class EndpointDataService {
     }
     this.diagnostics?.emitCounter('cache-miss', { service: 'EndpointDataService', method: 'loadSpaces' });
     this._isLoadingSpaces.set(true);
-    this._inFlightLoadSpaces = drainCfPages<StSpace>(this.http, `/pp/v1/cf/spaces/${this.guid}`).pipe(
+    this._inFlightLoadSpaces = drainCfPages<StSpace>(this.http, `/pp/v1/cf/spaces/${this.guid}`, 'enrich=none').pipe(
       // Stamp on success only — see loadOrgs.
       tap(resp => {
         this._spaces.set(resp.resources);
@@ -548,7 +548,7 @@ export class EndpointDataService {
   refreshSpaces(): Observable<void> {
     this.diagnostics?.emitCounter('service-call-count', { service: 'EndpointDataService', method: 'refreshSpaces' });
     this._isLoadingSpaces.set(true);
-    return drainCfPages<StSpace>(this.http, `/pp/v1/cf/spaces/${this.guid}`).pipe(
+    return drainCfPages<StSpace>(this.http, `/pp/v1/cf/spaces/${this.guid}`, 'enrich=none').pipe(
       // Stamp on success only — see loadOrgs.
       tap(resp => {
         this._spaces.set(resp.resources);

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -814,9 +814,19 @@ func (c *CloudFoundrySpecification) getNativeSpaces(ctx echo.Context) (err error
 		return err
 	}
 
+	// ?enrich=none skips the per-space app/route count enrichment. The
+	// EndpointDataService prewarm drains the full space list purely as a
+	// guid→name catalog (routes/users/audit-events resolvers read only
+	// name+guid); the per-space counts it would compute here are never
+	// displayed off this list — the org→spaces tab sources counts from
+	// getNativeOrgSpaces instead. Skipping the enrichment turns each page
+	// from ~8 sequential filtered CAPI round-trips into one, which is the
+	// dominant cost on large foundations.
+	skipEnrich := ctx.QueryParam("enrich") == "none"
+
 	spaces := make([]StSpace, 0, len(raw.Resources))
-	if guidsFilter != "" {
-		// Name-resolution lookup path: skip enrichment.
+	if guidsFilter != "" || skipEnrich {
+		// Name-resolution / no-enrich path: skip enrichment.
 		for _, r := range raw.Resources {
 			spaces = append(spaces, toStSpace(r, cnsiGUID))
 		}

--- a/src/jetstream/plugins/cloudfoundry/native_handlers_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers_test.go
@@ -997,6 +997,76 @@ func TestGetNativeSpaces_OrganizationGuidsFilter(t *testing.T) {
 	assert.Equal(t, "sp-b", resp.Resources[1].GUID)
 }
 
+// TestGetNativeSpaces_EnrichNoneSkipsCounts verifies that ?enrich=none
+// skips the per-space app/route count enrichment even with no guids
+// filter present — the prewarm-drain fast path. The full space list must
+// still be returned (the drain uses it as a guid→name catalog); only the
+// dead per-space count round-trips are elided.
+func TestGetNativeSpaces_EnrichNoneSkipsCounts(t *testing.T) {
+	var sawApps, sawRoutes bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case "/v3/spaces":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 2, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					{
+						"guid": "sp-a", "name": "alpha",
+						"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z",
+						"relationships": map[string]interface{}{
+							"organization": map[string]interface{}{"data": map[string]interface{}{"guid": "org-1"}},
+						},
+					},
+					{
+						"guid": "sp-b", "name": "beta",
+						"created_at": "2024-01-03T00:00:00Z", "updated_at": "2024-01-04T00:00:00Z",
+						"relationships": map[string]interface{}{
+							"organization": map[string]interface{}{"data": map[string]interface{}{"guid": "org-2"}},
+						},
+					},
+				},
+			})
+		case "/v3/apps":
+			sawApps = true
+			_, _ = w.Write([]byte(`{"pagination":{"total_results":0,"total_pages":0,"next":null},"resources":[]}`))
+		case "/v3/routes":
+			sawRoutes = true
+			_, _ = w.Write([]byte(`{"pagination":{"total_results":0,"total_pages":0,"next":null},"resources":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(srv.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/spaces/cnsi-1?enrich=none&per_page=500&page=1", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("cnsi-1")
+
+	require.NoError(t, plugin.getNativeSpaces(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, sawApps, "enrich=none must skip app-count enrichment")
+	assert.False(t, sawRoutes, "enrich=none must skip route-count enrichment")
+
+	var resp StratosPagedResponse[StSpace]
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Len(t, resp.Resources, 2, "full space list must still be returned")
+	assert.Equal(t, "sp-a", resp.Resources[0].GUID)
+	assert.Equal(t, "sp-b", resp.Resources[1].GUID)
+}
+
 // TestGetNativeApps_GuidsFilter verifies the apps handler forwards
 // ?guids=g1,g2 verbatim as the V3 filter — the transport piece of the
 // slice-3 Routes-tab Apps-Attached column resolver. Skipping per-app


### PR DESCRIPTION
## Problem

`EndpointDataService` prewarms a hot cache by draining the whole space list (`loadSpaces` / `refreshSpaces` → `drainCfPages('/pp/v1/cf/spaces/{cnsi}')`). That hits `getNativeSpaces`, whose default path enriches every returned space with app and route counts via `fetchAppCountsForSpaces` / `fetchRouteCountsForSpaces` — chunked, **sequential** filtered CAPI round-trips, ~8 per page.

Nothing displays those per-space counts off the all-spaces list. Every consumer of `EndpointDataService.spaces()` (routes / users / audit-events / space-roles resolvers, add-edit-space) reads only `name` + `guid`. The counts shown on the org→spaces tab come from a different handler, `getNativeOrgSpaces`, which is untouched here. So the prewarm enrichment is computed and discarded.

On a large foundation the enrichment dominates the drain cost and, fanned out across the prewarm's pages, saturates the jetstream→CF proxy path.

## Fix

- **Backend:** `getNativeSpaces` honors `?enrich=none`, routing through the existing skip branch so no count fetches are issued. Default requests and `getNativeOrgSpaces` are unchanged.
- **Frontend:** `drainCfPages` gains an `extraParams` argument; the two prewarm drains pass `enrich=none`. Only the speculative space prewarm is affected — orgs/apps drains are untouched.

## Measurement

Foundation with 2511 spaces but only 54 apps / 54 routes (so the counts are cheap for CF to compute — the cost is the serial round-trips, not CF):

| Request | Time | Result |
|---|---|---|
| default (with enrich) | 5.3–5.8s | 500 spaces |
| `?enrich=none` | 1.75–1.85s | 500 spaces (identical guid/name/org data) |

Raw `cf curl /v3/spaces?per_page=500` is ~1.5s, so `enrich=none` is at the CF floor.

## Tests

Adds `TestGetNativeSpaces_EnrichNoneSkipsCounts` — asserts `enrich=none` skips app/route enrichment with no guids filter present while still returning the full space list. Full `plugins/cloudfoundry` package passes.