### PR TITLE
fix(e2e): modernize Playwright selectors for the Tailwind frontend

### DIFF
--- a/e2e/components/breadcrumbs.component.ts
+++ b/e2e/components/breadcrumbs.component.ts
@@ -8,11 +8,17 @@ export class BreadcrumbsComponent {
   private breadcrumbs: Locator;
 
   constructor(private page: Page) {
-    this.breadcrumbs = page.locator('app-breadcrumbs, .breadcrumbs');
+    // Breadcrumbs render in the top toolbar (.page-header-breadcrumbs) and/or
+    // the sub-nav bar; app-breadcrumbs still exists for standalone uses
+    this.breadcrumbs = page.locator(
+      'app-breadcrumbs, .breadcrumbs, .page-header-breadcrumbs, .page-header-sub-nav-breadcrumbs'
+    );
   }
 
   getBreadcrumbs(): Locator {
-    return this.breadcrumbs.locator('a, .breadcrumb-item');
+    return this.breadcrumbs.locator(
+      'a, .breadcrumb-item, .page-header-breadcrumb, .page-header-sub-nav-breadcrumb'
+    );
   }
 
   async getBreadcrumbCount(): Promise<number> {

--- a/e2e/components/confirm-dialog.ts
+++ b/e2e/components/confirm-dialog.ts
@@ -19,7 +19,7 @@ export class ConfirmDialogComponent {
   private dialog: Locator;
 
   constructor(private page: Page) {
-    this.dialog = page.locator('app-dialog-confirm, app-confirm-dialog, mat-dialog-container');
+    this.dialog = page.locator('app-dialog-confirm, app-dialog-confirm');
   }
 
   /**

--- a/e2e/components/index.ts
+++ b/e2e/components/index.ts
@@ -33,7 +33,7 @@ export { ChipComponent, ChipsComponent } from './chips.component';
 export { MenuComponent } from './menu.component';
 export { BreadcrumbsComponent } from './breadcrumbs.component';
 export { PageHeaderComponent, PageHeaderSubComponent } from './page-header.component';
-export { PageTabsComponent } from './page-tabs.component';
+export { PageTabsComponent, pageTab } from './page-tabs.component';
 
 // Feedback Components
 export { SnackBarComponent } from './snackbar.component';

--- a/e2e/components/page-header.component.ts
+++ b/e2e/components/page-header.component.ts
@@ -2,17 +2,20 @@ import { Page, Locator } from '@playwright/test';
 
 /**
  * Page Header Component
- * Top page header with title and actions
+ * Top page header with title and actions.
+ *
+ * The app-page-header element is a portal *source* (zero-height); its content
+ * renders inside app-show-page-header in the top toolbar.
  */
 export class PageHeaderComponent {
   private header: Locator;
 
   constructor(private page: Page) {
-    this.header = page.locator('app-page-header, .page-header');
+    this.header = page.locator('app-show-page-header');
   }
 
   getTitleText(): Locator {
-    return this.header.locator('.page-header__title, h1');
+    return this.header.locator('h1');
   }
 
   async getTitle(): Promise<string> {
@@ -20,7 +23,8 @@ export class PageHeaderComponent {
   }
 
   getActionsSection(): Locator {
-    return this.header.locator('.page-header__actions');
+    // Page-level actions portal into the sub-nav bar below the toolbar
+    return this.page.locator('.page-header-sub-nav');
   }
 
   getActionButton(text: string): Locator {
@@ -35,21 +39,21 @@ export class PageHeaderComponent {
 
 /**
  * Page Header Sub Component
- * Sub-header with additional actions
+ * Sub-nav bar with per-page action buttons (edit/delete/refresh/...).
+ * Buttons carry the material icon ligature as their text content.
  */
 export class PageHeaderSubComponent {
   private subHeader: Locator;
 
   constructor(private page: Page) {
-    this.subHeader = page.locator('app-page-header-sub, .page-header__sub');
+    this.subHeader = page.locator('.page-header-sub-nav');
   }
 
   async clickIconButton(iconText: string): Promise<void> {
-    const button = this.subHeader.locator('button mat-icon').filter({ hasText: iconText });
-    await button.click();
+    await this.getIconButton(iconText).click();
   }
 
   getIconButton(iconText: string): Locator {
-    return this.subHeader.locator('button mat-icon').filter({ hasText: iconText });
+    return this.subHeader.locator('button').filter({ hasText: iconText });
   }
 }

--- a/e2e/components/page-tabs.component.ts
+++ b/e2e/components/page-tabs.component.ts
@@ -1,18 +1,31 @@
 import { Page, Locator } from '@playwright/test';
 
 /**
+ * Locate a page tab link by its exact label.
+ *
+ * Tabs render as side-nav links (app-page-side-nav) whose text includes the
+ * icon ligature (e.g. "service Services"), so match the label <span> exactly —
+ * substring matching would collide ("Services" vs "User Services").
+ */
+export function pageTab(page: Page, label: string): Locator {
+  return page
+    .locator('app-page-side-nav a.page-side-nav__item')
+    .filter({ has: page.locator('span', { hasText: new RegExp(`^${label}$`) }) });
+}
+
+/**
  * Page Tabs Component
- * Material tab navigation
+ * Side-nav tab navigation (app-page-side-nav)
  */
 export class PageTabsComponent {
   private tabs: Locator;
 
   constructor(private page: Page) {
-    this.tabs = page.locator('app-page-tabs, mat-tab-group');
+    this.tabs = page.locator('app-page-side-nav');
   }
 
   getItem(label: string): Locator {
-    return this.tabs.locator('.mat-tab-label, .mat-mdc-tab').filter({ hasText: label });
+    return pageTab(this.page, label);
   }
 
   async clickItem(label: string): Promise<void> {
@@ -27,13 +40,13 @@ export class PageTabsComponent {
   }
 
   async getActiveTab(): Promise<string> {
-    const activeTab = this.tabs.locator('.mat-tab-label-active, .mat-mdc-tab[aria-selected="true"]');
-    return await activeTab.textContent() || '';
+    // Direct child span holds the label; the icon lives in app-custom-icon
+    const activeLabel = this.tabs.locator('.page-side-nav__item--active > span');
+    return (await activeLabel.textContent())?.trim() || '';
   }
 
   async isTabActive(label: string): Promise<boolean> {
-    const tab = this.getItem(label);
-    const ariaSelected = await tab.getAttribute('aria-selected');
-    return ariaSelected === 'true';
+    const cls = await this.getItem(label).getAttribute('class');
+    return (cls || '').includes('page-side-nav__item--active');
   }
 }

--- a/e2e/fixtures/test-base.ts
+++ b/e2e/fixtures/test-base.ts
@@ -316,7 +316,9 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
     await use(cfApi);
 
-    await cfApi.cleanupTestResources();
+    // Do NOT label-sweep here (cleanupTestResources): it deletes ALL
+    // stratos-e2e-test apps on the CF, including a parallel worker's app
+    // that is mid-test. Fixtures delete their own resources by guid.
     await request.dispose();
   },
 

--- a/e2e/helpers/cf-api.helper.ts
+++ b/e2e/helpers/cf-api.helper.ts
@@ -532,13 +532,20 @@ export class CFApiHelper {
   async mapRoute(appGuid: string, routeGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
 
-    await this.ppost(`${this.cfApiBase}/routes/${routeGuid}/destinations`, {
+    const body = {
       destinations: [{
         app: {
           guid: appGuid
         }
       }]
-    });
+    };
+    try {
+      await this.ppost(`${this.cfApiBase}/routes/${routeGuid}/destinations`, body);
+    } catch (e) {
+      // CC intermittently 500s on destination writes under load — one retry
+      await new Promise(resolve => setTimeout(resolve, 3000));
+      await this.ppost(`${this.cfApiBase}/routes/${routeGuid}/destinations`, body);
+    }
   }
 
   /**
@@ -547,7 +554,12 @@ export class CFApiHelper {
   async unmapRoute(routeGuid: string, appGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
 
-    await this.pdelete(`${this.cfApiBase}/routes/${routeGuid}/destinations/${appGuid}`);
+    // The destination guid is not the app guid — look up the destination
+    // that points at this app.
+    const res = await this.pget(`${this.cfApiBase}/routes/${routeGuid}/destinations`);
+    const dest = (res.destinations || []).find((d: any) => d.app?.guid === appGuid);
+    if (!dest) return; // already unmapped
+    await this.pdelete(`${this.cfApiBase}/routes/${routeGuid}/destinations/${dest.guid}`);
   }
 
   /**

--- a/e2e/helpers/cf-api.helper.ts
+++ b/e2e/helpers/cf-api.helper.ts
@@ -189,8 +189,29 @@ export class CFApiHelper {
       throw new Error(`CF endpoint not found: ${this.cfGuid}`);
     }
 
-    // CF API is proxied through Stratos
-    this.cfApiBase = `/pp/v1/proxy/v3/cf/${this.cfGuid}`;
+    // CF API is proxied through Stratos. The /pp/v1/proxy/ route prefix is
+    // stripped by makeRequestURI, so /pp/v1/proxy/v3/apps forwards to CF as
+    // /v3/apps. Passthrough requests must carry x-cap-cnsi-list (which CNSI to
+    // proxy to) and x-cap-passthrough=true (return the raw CF response).
+    this.cfApiBase = `/pp/v1/proxy/v3`;
+  }
+
+  /** Headers every proxied CF API call must carry (see passthrough.go). */
+  private get proxyHeaders(): Record<string, string> {
+    return { 'x-cap-cnsi-list': this.cfGuid, 'x-cap-passthrough': 'true' };
+  }
+
+  private pget(url: string): Promise<any> {
+    return this.request.get(url, this.proxyHeaders);
+  }
+  private ppost(url: string, body?: any): Promise<any> {
+    return this.request.post(url, body, this.proxyHeaders);
+  }
+  private ppatch(url: string, body?: any): Promise<any> {
+    return this.request.patch(url, body, this.proxyHeaders);
+  }
+  private pdelete(url: string): Promise<any> {
+    return this.request.delete(url, this.proxyHeaders);
   }
 
   // ============================================================================
@@ -226,7 +247,7 @@ export class CFApiHelper {
       }
     };
 
-    const app = await this.request.post(`${this.cfApiBase}/apps`, appData);
+    const app = await this.ppost(`${this.cfApiBase}/apps`, appData);
 
     // Set environment variables if provided
     if (params.environmentVariables) {
@@ -250,7 +271,7 @@ export class CFApiHelper {
    */
   async getApp(appGuid: string): Promise<CFApp> {
     if (!this.cfApiBase) await this.init();
-    return await this.request.get(`${this.cfApiBase}/apps/${appGuid}`);
+    return await this.pget(`${this.cfApiBase}/apps/${appGuid}`);
   }
 
   /**
@@ -258,7 +279,7 @@ export class CFApiHelper {
    */
   async updateApp(appGuid: string, updates: Partial<CFApp>): Promise<CFApp> {
     if (!this.cfApiBase) await this.init();
-    return await this.request.post(`${this.cfApiBase}/apps/${appGuid}`, updates);
+    return await this.ppost(`${this.cfApiBase}/apps/${appGuid}`, updates);
   }
 
   /**
@@ -266,7 +287,7 @@ export class CFApiHelper {
    */
   async deleteApp(appGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.delete(`${this.cfApiBase}/apps/${appGuid}`);
+    await this.pdelete(`${this.cfApiBase}/apps/${appGuid}`);
   }
 
   /**
@@ -274,7 +295,7 @@ export class CFApiHelper {
    */
   async startApp(appGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.post(`${this.cfApiBase}/apps/${appGuid}/actions/start`, {});
+    await this.ppost(`${this.cfApiBase}/apps/${appGuid}/actions/start`, {});
   }
 
   /**
@@ -282,7 +303,7 @@ export class CFApiHelper {
    */
   async stopApp(appGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.post(`${this.cfApiBase}/apps/${appGuid}/actions/stop`, {});
+    await this.ppost(`${this.cfApiBase}/apps/${appGuid}/actions/stop`, {});
   }
 
   /**
@@ -290,7 +311,7 @@ export class CFApiHelper {
    */
   async restartApp(appGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.post(`${this.cfApiBase}/apps/${appGuid}/actions/restart`, {});
+    await this.ppost(`${this.cfApiBase}/apps/${appGuid}/actions/restart`, {});
   }
 
   /**
@@ -308,7 +329,7 @@ export class CFApiHelper {
     if (scale.memory !== undefined) scaleData.memory_in_mb = scale.memory;
     if (scale.disk !== undefined) scaleData.disk_in_mb = scale.disk;
 
-    await this.request.post(`${this.cfApiBase}/apps/${appGuid}/processes/web/actions/scale`, scaleData);
+    await this.ppost(`${this.cfApiBase}/apps/${appGuid}/processes/web/actions/scale`, scaleData);
   }
 
   /**
@@ -316,7 +337,7 @@ export class CFApiHelper {
    */
   async updateAppEnvironment(appGuid: string, vars: Record<string, string>): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.post(`${this.cfApiBase}/apps/${appGuid}/environment_variables`, {
+    await this.ppost(`${this.cfApiBase}/apps/${appGuid}/environment_variables`, {
       var: vars
     });
   }
@@ -361,7 +382,7 @@ export class CFApiHelper {
       }
     };
 
-    return await this.request.post(`${this.cfApiBase}/organizations`, orgData);
+    return await this.ppost(`${this.cfApiBase}/organizations`, orgData);
   }
 
   /**
@@ -369,7 +390,7 @@ export class CFApiHelper {
    */
   async getOrg(orgGuid: string): Promise<CFOrganization> {
     if (!this.cfApiBase) await this.init();
-    return await this.request.get(`${this.cfApiBase}/organizations/${orgGuid}`);
+    return await this.pget(`${this.cfApiBase}/organizations/${orgGuid}`);
   }
 
   /**
@@ -377,7 +398,7 @@ export class CFApiHelper {
    */
   async deleteOrg(orgGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.delete(`${this.cfApiBase}/organizations/${orgGuid}`);
+    await this.pdelete(`${this.cfApiBase}/organizations/${orgGuid}`);
   }
 
   /**
@@ -386,7 +407,7 @@ export class CFApiHelper {
   async findOrgByName(name: string): Promise<CFOrganization | null> {
     if (!this.cfApiBase) await this.init();
 
-    const orgs = await this.request.get(`${this.cfApiBase}/organizations?names=${encodeURIComponent(name)}`);
+    const orgs = await this.pget(`${this.cfApiBase}/organizations?names=${encodeURIComponent(name)}`);
 
     return orgs.resources && orgs.resources.length > 0 ? orgs.resources[0] : null;
   }
@@ -417,7 +438,7 @@ export class CFApiHelper {
       }
     };
 
-    return await this.request.post(`${this.cfApiBase}/spaces`, spaceData);
+    return await this.ppost(`${this.cfApiBase}/spaces`, spaceData);
   }
 
   /**
@@ -425,7 +446,7 @@ export class CFApiHelper {
    */
   async getSpace(spaceGuid: string): Promise<CFSpace> {
     if (!this.cfApiBase) await this.init();
-    return await this.request.get(`${this.cfApiBase}/spaces/${spaceGuid}`);
+    return await this.pget(`${this.cfApiBase}/spaces/${spaceGuid}`);
   }
 
   /**
@@ -433,7 +454,7 @@ export class CFApiHelper {
    */
   async deleteSpace(spaceGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.delete(`${this.cfApiBase}/spaces/${spaceGuid}`);
+    await this.pdelete(`${this.cfApiBase}/spaces/${spaceGuid}`);
   }
 
   /**
@@ -442,7 +463,7 @@ export class CFApiHelper {
   async findSpaceByName(orgGuid: string, name: string): Promise<CFSpace | null> {
     if (!this.cfApiBase) await this.init();
 
-    const spaces = await this.request.get(
+    const spaces = await this.pget(
       `${this.cfApiBase}/spaces?organization_guids=${orgGuid}&names=${encodeURIComponent(name)}`
     );
 
@@ -459,11 +480,17 @@ export class CFApiHelper {
   async getDomains(spaceGuid?: string): Promise<CFDomain[]> {
     if (!this.cfApiBase) await this.init();
 
-    const url = spaceGuid
-      ? `${this.cfApiBase}/domains?space_guids=${spaceGuid}`
-      : `${this.cfApiBase}/domains`;
+    // CF v3 has no `space_guids` filter on /v3/domains (rejected 400). Domains
+    // usable within a space are the space's org's domains (shared + private),
+    // exposed as /v3/organizations/:org/domains. Resolve the space's org first.
+    let url = `${this.cfApiBase}/domains`;
+    if (spaceGuid) {
+      const space = await this.getSpace(spaceGuid);
+      const orgGuid = space.relationships.organization.data.guid;
+      url = `${this.cfApiBase}/organizations/${orgGuid}/domains`;
+    }
 
-    const response = await this.request.get(url);
+    const response = await this.pget(url);
     return response.resources || [];
   }
 
@@ -496,7 +523,7 @@ export class CFApiHelper {
     if (params.host) routeData.host = params.host;
     if (params.path) routeData.path = params.path;
 
-    return await this.request.post(`${this.cfApiBase}/routes`, routeData);
+    return await this.ppost(`${this.cfApiBase}/routes`, routeData);
   }
 
   /**
@@ -505,7 +532,7 @@ export class CFApiHelper {
   async mapRoute(appGuid: string, routeGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
 
-    await this.request.post(`${this.cfApiBase}/routes/${routeGuid}/destinations`, {
+    await this.ppost(`${this.cfApiBase}/routes/${routeGuid}/destinations`, {
       destinations: [{
         app: {
           guid: appGuid
@@ -520,7 +547,7 @@ export class CFApiHelper {
   async unmapRoute(routeGuid: string, appGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
 
-    await this.request.delete(`${this.cfApiBase}/routes/${routeGuid}/destinations/${appGuid}`);
+    await this.pdelete(`${this.cfApiBase}/routes/${routeGuid}/destinations/${appGuid}`);
   }
 
   /**
@@ -528,7 +555,7 @@ export class CFApiHelper {
    */
   async deleteRoute(routeGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.delete(`${this.cfApiBase}/routes/${routeGuid}`);
+    await this.pdelete(`${this.cfApiBase}/routes/${routeGuid}`);
   }
 
   // ============================================================================
@@ -541,7 +568,7 @@ export class CFApiHelper {
   async getServiceInstances(spaceGuid: string): Promise<CFServiceInstance[]> {
     if (!this.cfApiBase) await this.init();
 
-    const response = await this.request.get(
+    const response = await this.pget(
       `${this.cfApiBase}/service_instances?space_guids=${spaceGuid}`
     );
 
@@ -554,7 +581,7 @@ export class CFApiHelper {
   async bindService(appGuid: string, serviceInstanceGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
 
-    await this.request.post(`${this.cfApiBase}/service_credential_bindings`, {
+    await this.ppost(`${this.cfApiBase}/service_credential_bindings`, {
       type: 'app',
       relationships: {
         service_instance: {
@@ -576,7 +603,7 @@ export class CFApiHelper {
    */
   async unbindService(bindingGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.delete(`${this.cfApiBase}/service_credential_bindings/${bindingGuid}`);
+    await this.pdelete(`${this.cfApiBase}/service_credential_bindings/${bindingGuid}`);
   }
 
   // ============================================================================
@@ -618,7 +645,7 @@ export class CFApiHelper {
       quotaData.routes.total_reserved_ports = params.totalReservedRoutePorts;
     }
 
-    return await this.request.post(`${this.cfApiBase}/organization_quotas`, quotaData);
+    return await this.ppost(`${this.cfApiBase}/organization_quotas`, quotaData);
   }
 
   /**
@@ -626,7 +653,7 @@ export class CFApiHelper {
    */
   async getQuota(quotaGuid: string): Promise<CFQuota> {
     if (!this.cfApiBase) await this.init();
-    return await this.request.get(`${this.cfApiBase}/organization_quotas/${quotaGuid}`);
+    return await this.pget(`${this.cfApiBase}/organization_quotas/${quotaGuid}`);
   }
 
   /**
@@ -634,7 +661,7 @@ export class CFApiHelper {
    */
   async getQuotas(): Promise<CFQuota[]> {
     if (!this.cfApiBase) await this.init();
-    const response = await this.request.get(`${this.cfApiBase}/organization_quotas`);
+    const response = await this.pget(`${this.cfApiBase}/organization_quotas`);
     return response.resources || [];
   }
 
@@ -643,7 +670,7 @@ export class CFApiHelper {
    */
   async findQuotaByName(name: string): Promise<CFQuota | null> {
     if (!this.cfApiBase) await this.init();
-    const response = await this.request.get(`${this.cfApiBase}/organization_quotas?names=${name}`);
+    const response = await this.pget(`${this.cfApiBase}/organization_quotas?names=${name}`);
     return response.resources?.[0] || null;
   }
 
@@ -675,7 +702,7 @@ export class CFApiHelper {
       if (params.totalReservedRoutePorts !== undefined) quotaData.routes.total_reserved_ports = params.totalReservedRoutePorts;
     }
 
-    return await this.request.patch(`${this.cfApiBase}/organization_quotas/${quotaGuid}`, quotaData);
+    return await this.ppatch(`${this.cfApiBase}/organization_quotas/${quotaGuid}`, quotaData);
   }
 
   /**
@@ -683,7 +710,7 @@ export class CFApiHelper {
    */
   async deleteQuota(quotaGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.delete(`${this.cfApiBase}/organization_quotas/${quotaGuid}`);
+    await this.pdelete(`${this.cfApiBase}/organization_quotas/${quotaGuid}`);
   }
 
   // ============================================================================
@@ -732,7 +759,7 @@ export class CFApiHelper {
       quotaData.routes.total_reserved_ports = params.totalReservedRoutePorts;
     }
 
-    return await this.request.post(`${this.cfApiBase}/space_quotas`, quotaData);
+    return await this.ppost(`${this.cfApiBase}/space_quotas`, quotaData);
   }
 
   /**
@@ -740,7 +767,7 @@ export class CFApiHelper {
    */
   async getSpaceQuota(quotaGuid: string): Promise<CFSpaceQuota> {
     if (!this.cfApiBase) await this.init();
-    return await this.request.get(`${this.cfApiBase}/space_quotas/${quotaGuid}`);
+    return await this.pget(`${this.cfApiBase}/space_quotas/${quotaGuid}`);
   }
 
   /**
@@ -748,7 +775,7 @@ export class CFApiHelper {
    */
   async getSpaceQuotas(orgGuid: string): Promise<CFSpaceQuota[]> {
     if (!this.cfApiBase) await this.init();
-    const response = await this.request.get(`${this.cfApiBase}/space_quotas?organization_guids=${orgGuid}`);
+    const response = await this.pget(`${this.cfApiBase}/space_quotas?organization_guids=${orgGuid}`);
     return response.resources || [];
   }
 
@@ -757,7 +784,7 @@ export class CFApiHelper {
    */
   async findSpaceQuotaByName(orgGuid: string, name: string): Promise<CFSpaceQuota | null> {
     if (!this.cfApiBase) await this.init();
-    const response = await this.request.get(`${this.cfApiBase}/space_quotas?organization_guids=${orgGuid}&names=${name}`);
+    const response = await this.pget(`${this.cfApiBase}/space_quotas?organization_guids=${orgGuid}&names=${name}`);
     return response.resources?.[0] || null;
   }
 
@@ -789,7 +816,7 @@ export class CFApiHelper {
       if (params.totalReservedRoutePorts !== undefined) quotaData.routes.total_reserved_ports = params.totalReservedRoutePorts;
     }
 
-    return await this.request.patch(`${this.cfApiBase}/space_quotas/${quotaGuid}`, quotaData);
+    return await this.ppatch(`${this.cfApiBase}/space_quotas/${quotaGuid}`, quotaData);
   }
 
   /**
@@ -797,7 +824,7 @@ export class CFApiHelper {
    */
   async deleteSpaceQuota(quotaGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.delete(`${this.cfApiBase}/space_quotas/${quotaGuid}`);
+    await this.pdelete(`${this.cfApiBase}/space_quotas/${quotaGuid}`);
   }
 
   /**
@@ -805,7 +832,7 @@ export class CFApiHelper {
    */
   async applySpaceQuota(spaceGuid: string, quotaGuid: string): Promise<void> {
     if (!this.cfApiBase) await this.init();
-    await this.request.patch(`${this.cfApiBase}/spaces/${spaceGuid}/relationships/quota`, {
+    await this.ppatch(`${this.cfApiBase}/spaces/${spaceGuid}/relationships/quota`, {
       data: {
         guid: quotaGuid
       }
@@ -823,7 +850,7 @@ export class CFApiHelper {
     if (!this.cfApiBase) await this.init();
 
     // Delete apps with e2e label
-    const apps = await this.request.get(`${this.cfApiBase}/apps?label_selector=stratos-e2e-test`);
+    const apps = await this.pget(`${this.cfApiBase}/apps?label_selector=stratos-e2e-test`);
     if (apps.resources) {
       for (const app of apps.resources) {
         await this.deleteApp(app.guid).catch(() => {});
@@ -831,7 +858,7 @@ export class CFApiHelper {
     }
 
     // Delete routes with e2e label
-    const routes = await this.request.get(`${this.cfApiBase}/routes?label_selector=stratos-e2e-test`);
+    const routes = await this.pget(`${this.cfApiBase}/routes?label_selector=stratos-e2e-test`);
     if (routes.resources) {
       for (const route of routes.resources) {
         await this.deleteRoute(route.guid).catch(() => {});
@@ -839,7 +866,7 @@ export class CFApiHelper {
     }
 
     // Delete spaces with e2e label
-    const spaces = await this.request.get(`${this.cfApiBase}/spaces?label_selector=stratos-e2e-test`);
+    const spaces = await this.pget(`${this.cfApiBase}/spaces?label_selector=stratos-e2e-test`);
     if (spaces.resources) {
       for (const space of spaces.resources) {
         await this.deleteSpace(space.guid).catch(() => {});
@@ -847,7 +874,7 @@ export class CFApiHelper {
     }
 
     // Delete orgs with e2e label
-    const orgs = await this.request.get(`${this.cfApiBase}/organizations?label_selector=stratos-e2e-test`);
+    const orgs = await this.pget(`${this.cfApiBase}/organizations?label_selector=stratos-e2e-test`);
     if (orgs.resources) {
       for (const org of orgs.resources) {
         await this.deleteOrg(org.guid).catch(() => {});

--- a/e2e/helpers/request.helper.ts
+++ b/e2e/helpers/request.helper.ts
@@ -139,12 +139,12 @@ export class RequestHelper {
   /**
    * Send GET request
    */
-  async get(url: string): Promise<any> {
+  async get(url: string, extraHeaders?: Record<string, string>): Promise<any> {
     if (!this.context) {
       throw new Error('Request context not initialized. Call init() first.');
     }
 
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = { ...extraHeaders };
     if (this.xsrfToken) {
       headers['x-xsrf-token'] = this.xsrfToken;
     }
@@ -162,7 +162,7 @@ export class RequestHelper {
       return text ? JSON.parse(text) : null;
     }
 
-    throw new Error(`GET ${url} failed: ${response.status()} ${response.statusText()}`);
+    throw new Error(`GET ${url} failed: ${response.status()} ${response.statusText()} ${(await response.text().catch(() => '')).slice(0, 400)}`);
   }
 
   /**
@@ -201,19 +201,20 @@ export class RequestHelper {
       return text ? JSON.parse(text) : null;
     }
 
-    throw new Error(`POST ${url} failed: ${response.status()} ${response.statusText()}`);
+    throw new Error(`POST ${url} failed: ${response.status()} ${response.statusText()} ${(await response.text().catch(() => '')).slice(0, 400)}`);
   }
 
   /**
    * Send POST request with JSON body
    */
-  async post(url: string, body?: any): Promise<any> {
+  async post(url: string, body?: any, extraHeaders?: Record<string, string>): Promise<any> {
     if (!this.context) {
       throw new Error('Request context not initialized. Call init() first.');
     }
 
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...extraHeaders
     };
     if (this.xsrfToken) {
       headers['x-xsrf-token'] = this.xsrfToken;
@@ -235,19 +236,20 @@ export class RequestHelper {
       return text ? JSON.parse(text) : null;
     }
 
-    throw new Error(`POST ${url} failed: ${response.status()} ${response.statusText()}`);
+    throw new Error(`POST ${url} failed: ${response.status()} ${response.statusText()} ${(await response.text().catch(() => '')).slice(0, 400)}`);
   }
 
   /**
    * Send PATCH request with JSON body
    */
-  async patch(url: string, body?: any): Promise<any> {
+  async patch(url: string, body?: any, extraHeaders?: Record<string, string>): Promise<any> {
     if (!this.context) {
       throw new Error('Request context not initialized. Call init() first.');
     }
 
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...extraHeaders
     };
     if (this.xsrfToken) {
       headers['x-xsrf-token'] = this.xsrfToken;
@@ -269,18 +271,18 @@ export class RequestHelper {
       return text ? JSON.parse(text) : null;
     }
 
-    throw new Error(`PATCH ${url} failed: ${response.status()} ${response.statusText()}`);
+    throw new Error(`PATCH ${url} failed: ${response.status()} ${response.statusText()} ${(await response.text().catch(() => '')).slice(0, 400)}`);
   }
 
   /**
    * Send DELETE request
    */
-  async delete(url: string): Promise<any> {
+  async delete(url: string, extraHeaders?: Record<string, string>): Promise<any> {
     if (!this.context) {
       throw new Error('Request context not initialized. Call init() first.');
     }
 
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = { ...extraHeaders };
     if (this.xsrfToken) {
       headers['x-xsrf-token'] = this.xsrfToken;
     }
@@ -298,7 +300,7 @@ export class RequestHelper {
       return text ? JSON.parse(text) : null;
     }
 
-    throw new Error(`DELETE ${url} failed: ${response.status()} ${response.statusText()}`);
+    throw new Error(`DELETE ${url} failed: ${response.status()} ${response.statusText()} ${(await response.text().catch(() => '')).slice(0, 400)}`);
   }
 
   /**

--- a/e2e/helpers/request.helper.ts
+++ b/e2e/helpers/request.helper.ts
@@ -34,6 +34,7 @@ export class RequestHelper {
     this.context = await playwrightRequest.newContext({
       baseURL: this.baseURL,
       ignoreHTTPSErrors: true,
+      timeout: 30000, // CF writes (app create) regularly exceed the 10s actionTimeout under load
       extraHTTPHeaders: {
         'Content-Type': 'application/json',
         'Accept': 'application/json'
@@ -58,6 +59,7 @@ export class RequestHelper {
     this.context = await playwrightRequest.newContext({
       baseURL: this.baseURL,
       ignoreHTTPSErrors: true,
+      timeout: 30000, // CF writes (app create) regularly exceed the 10s actionTimeout under load
       extraHTTPHeaders: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
@@ -120,6 +122,7 @@ export class RequestHelper {
       this.context = await playwrightRequest.newContext({
         baseURL: this.baseURL,
         ignoreHTTPSErrors: true,
+        timeout: 30000, // CF writes (app create) regularly exceed the 10s actionTimeout under load
         extraHTTPHeaders: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',

--- a/e2e/pages/api-keys/api-key-add-dialog.page.ts
+++ b/e2e/pages/api-keys/api-key-add-dialog.page.ts
@@ -12,7 +12,7 @@ export class ApiKeyAddDialogPage {
   private readonly dialog: Locator;
 
   constructor(private page: Page) {
-    this.dialog = page.locator('app-add-api-key-dialog, mat-dialog-container').first();
+    this.dialog = page.locator('app-add-api-key-dialog, [role="dialog"]').first();
     this.form = new FormComponent(page, this.dialog.locator('.key-dialog, form').first());
     this.buttons = new MenuComponent(page, this.dialog.locator('.key-dialog__actions, mat-dialog-actions, .dialog-actions').first());
   }

--- a/e2e/pages/application/application.page.ts
+++ b/e2e/pages/application/application.page.ts
@@ -1,6 +1,7 @@
 import { Page, Locator } from '@playwright/test';
 import { BasePage } from '../base.page';
 import { BreadcrumbsComponent } from '../../components/breadcrumbs.component';
+import { pageTab } from '../../components/page-tabs.component';
 
 /**
  * Application Base Page Object
@@ -23,10 +24,12 @@ export class ApplicationBasePage extends BasePage {
   ) {
     super(page);
 
-    this.tabs = page.locator('app-page-tabs, mat-tab-group');
-    this.pageHeader = page.locator('app-page-header');
-    this.subHeader = page.locator('app-page-sub-header');
-    this.deleteButton = this.subHeader.locator('button[aria-label="delete"]');
+    // app-page-header/app-page-tabs are portal sources (zero-height) in the
+    // modernized frontend — target the rendered locations instead.
+    this.tabs = page.locator('app-page-side-nav');
+    this.pageHeader = page.locator('app-show-page-header');
+    this.subHeader = page.locator('.page-header-sub-nav');
+    this.deleteButton = this.subHeader.locator('button').filter({ hasText: 'delete' });
     this.breadcrumbs = new BreadcrumbsComponent(page);
   }
 
@@ -34,7 +37,13 @@ export class ApplicationBasePage extends BasePage {
    * Wait for page to be fully loaded
    */
   async waitForPage(): Promise<void> {
-    await this.pageHeader.waitFor({ state: 'visible', timeout: 10000 });
+    // The tab side-nav only renders on tabbed detail pages. Don't anchor on
+    // app-application-action-bar — its buttons portal to the sub-nav bar, so
+    // the host element is hidden for stopped apps.
+    await this.tabs.waitFor({ state: 'visible', timeout: 10000 });
+    // The "Retrieving..." overlay intercepts clicks while the app entity
+    // loads; the side-nav is visible beneath it, so wait it out explicitly.
+    await this.page.locator('.loading-page__overlay').waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {});
     await this.page.waitForTimeout(500); // Allow time for initial render
   }
 
@@ -137,15 +146,18 @@ export class ApplicationBasePage extends BasePage {
    * Wait for Autoscaler tab to appear
    */
   async waitForAutoscalerTab(): Promise<void> {
-    await this.tabs.locator('button, a').filter({ hasText: 'Autoscale' }).waitFor({ timeout: 15000 });
+    await pageTab(this.page, 'Autoscale').waitFor({ timeout: 15000 });
   }
 
   /**
    * Navigate to a specific tab
    */
   private async goToTab(label: string, urlSuffix: string): Promise<void> {
-    const tabButton = this.tabs.locator('button, a').filter({ hasText: label });
-    await tabButton.click();
+    const tabButton = pageTab(this.page, label);
+    // The "Retrieving..." overlay intercepts clicks while entities load and
+    // can reappear at any moment — let the click's actionability retry
+    // outlast it rather than racing a pre-wait.
+    await tabButton.click({ timeout: 60000 });
 
     const expectedUrl = `/applications/${this.cfGuid}/${this.appGuid}/${urlSuffix}`;
     await this.page.waitForURL(new RegExp(expectedUrl.replace(/\//g, '\\/')));
@@ -155,7 +167,7 @@ export class ApplicationBasePage extends BasePage {
    * Get application name from header
    */
   async getAppName(): Promise<string> {
-    const titleElement = this.pageHeader.locator('h1, .page-header__title');
+    const titleElement = this.pageHeader.locator('h1');
     return await titleElement.textContent() || '';
   }
 

--- a/e2e/pages/application/route-create-dialog.page.ts
+++ b/e2e/pages/application/route-create-dialog.page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from '../base.page';
 
 /**
@@ -19,11 +19,12 @@ export class RouteCreateDialogPage extends BasePage {
   constructor(page: Page) {
     super(page);
 
-    this.dialog = page.locator('mat-dialog-container, app-add-route-dialog, app-create-route-dialog').first();
-    this.domainSelect = this.dialog.locator('mat-select[placeholder*="domain"], select[name="domain"]').first();
-    this.hostInput = this.dialog.locator('input[name="host"], input[placeholder*="host"]').first();
-    this.pathInput = this.dialog.locator('input[name="path"], input[placeholder*="path"]').first();
-    this.tcpPortInput = this.dialog.locator('input[name="port"], input[type="number"]').first();
+    // "Create Route" is a routed stepper page (/add-route), not an overlay dialog
+    this.dialog = page.locator('app-add-route-stepper').first();
+    this.domainSelect = this.dialog.locator('.select-trigger').first();
+    this.hostInput = this.dialog.locator('input[formcontrolname="host"]').first();
+    this.pathInput = this.dialog.locator('input[formcontrolname="path"]').first();
+    this.tcpPortInput = this.dialog.locator('input[formcontrolname="port"], input[type="number"]').first();
     this.createButton = this.dialog.locator('button').filter({ hasText: /create|add|map/i });
     this.cancelButton = this.dialog.locator('button').filter({ hasText: /cancel|close/i });
     this.mapExistingButton = this.dialog.locator('button').filter({ hasText: /map.*existing|existing.*route/i });
@@ -47,11 +48,15 @@ export class RouteCreateDialogPage extends BasePage {
    * Select domain from dropdown
    */
   async selectDomain(domainName: string): Promise<void> {
-    await this.domainSelect.click();
-    await this.page.waitForTimeout(500);
-
-    const option = this.page.locator('mat-option, option').filter({ hasText: domainName });
-    await option.click();
+    // Custom dropdown renders options in a .select-options overlay. Domains
+    // load async — the overlay can open empty, so retry until the option
+    // renders (each click toggles the overlay; toPass absorbs that).
+    const option = this.page.locator('.custom-option-content').filter({ hasText: domainName }).first();
+    await expect(async () => {
+      await this.domainSelect.click();
+      await option.waitFor({ state: 'visible', timeout: 3000 });
+      await option.click({ timeout: 2000 });
+    }).toPass({ timeout: 30000 });
   }
 
   /**

--- a/e2e/pages/application/route-map-dialog.page.ts
+++ b/e2e/pages/application/route-map-dialog.page.ts
@@ -17,11 +17,13 @@ export class RouteMapDialogPage extends BasePage {
   constructor(page: Page) {
     super(page);
 
-    this.dialog = page.locator('mat-dialog-container, app-map-route-dialog').first();
-    this.routeList = this.dialog.locator('app-list, mat-list, mat-table');
-    this.domainFilter = this.dialog.locator('mat-select[placeholder*="domain"], select[name="domain"]').first();
-    this.searchInput = this.dialog.locator('input[type="text"], input[placeholder*="search"]').first();
-    this.mapButton = this.dialog.locator('button').filter({ hasText: /map|add/i });
+    // Mapping an existing route is the "attach an existing route" section of
+    // the Add Route page — there is no separate dialog in the modern UI.
+    this.dialog = page.locator('app-add-route-stepper').first();
+    this.routeList = this.dialog.locator('[data-test="available-routes"] app-signal-list');
+    this.domainFilter = this.dialog.locator('select[name="domain"]').first(); // gone in modern UI; guarded no-op
+    this.searchInput = this.dialog.locator('[data-test="available-routes"] input[placeholder*="Filter"]').first();
+    this.mapButton = this.dialog.locator('button').filter({ hasText: /create|map|attach/i });
     this.cancelButton = this.dialog.locator('button').filter({ hasText: /cancel|close/i });
   }
 
@@ -76,8 +78,11 @@ export class RouteMapDialogPage extends BasePage {
    * Select a route from the list
    */
   async selectRoute(routeUrl: string): Promise<void> {
-    const routeItem = this.routeList.locator('mat-list-item, mat-row, tr').filter({ hasText: routeUrl });
-    await routeItem.click();
+    // Narrow the list first — the route may be beyond the first page
+    await this.searchInput.fill(routeUrl).catch(() => {});
+    const routeItem = this.routeList.locator('tbody tr').filter({ hasText: routeUrl });
+    // Rows carry a selection radio in the first cell
+    await routeItem.locator('input[type="radio"]').first().click({ timeout: 30000 });
   }
 
   /**

--- a/e2e/pages/application/tabs/routes.page.ts
+++ b/e2e/pages/application/tabs/routes.page.ts
@@ -17,7 +17,7 @@ export class ApplicationPageRoutesTab extends ApplicationBasePage {
 
     this.listComponent = page.locator('app-list');
     this.addRouteButton = page.locator('button').filter({ hasText: /add.*route|create.*route/i });
-    this.mapRouteButton = page.locator('button').filter({ hasText: /map.*route/i });
+    this.mapRouteButton = page.locator('button').filter({ hasText: /add.*route/i }); // mapping now lives on the Add Route page
   }
 
   /**
@@ -138,14 +138,14 @@ export class ApplicationPageRoutesTab extends ApplicationBasePage {
    * Click add route button
    */
   async clickAddRoute(): Promise<void> {
-    await this.addRouteButton.first().click();
+    await this.addRouteButton.first().click({ timeout: 60000 }); // outlast the loading overlay (CF-latency bound)
   }
 
   /**
    * Click map route button
    */
   async clickMapRoute(): Promise<void> {
-    await this.mapRouteButton.first().click();
+    await this.mapRouteButton.first().click({ timeout: 60000 }); // outlast the loading overlay (CF-latency bound)
   }
 
   /**

--- a/e2e/pages/application/tabs/variables.page.ts
+++ b/e2e/pages/application/tabs/variables.page.ts
@@ -85,7 +85,7 @@ export class ApplicationPageVariablesTab extends ApplicationBasePage {
     await deleteOption.click();
 
     // Wait for confirmation dialog
-    const confirmDialog = this.page.locator('app-confirm-dialog, mat-dialog-container');
+    const confirmDialog = this.page.locator('app-dialog-confirm');
     await confirmDialog.waitFor({ state: 'visible' });
 
     // Verify message

--- a/e2e/pages/cloud-foundry/cf-level/cf-top-level.page.ts
+++ b/e2e/pages/cloud-foundry/cf-level/cf-top-level.page.ts
@@ -1,5 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { BasePage } from '../../base.page';
+import { pageTab } from '../../../components/page-tabs.component';
 
 /**
  * Cloud Foundry Top Level Page
@@ -12,8 +13,8 @@ export class CfTopLevelPage extends BasePage {
   constructor(page: Page, navLink: string = '/cloud-foundry') {
     super(page);
     this.navLink = navLink;
-    // CF page uses sidebar navigation (mat-nav-list), not tab-group
-    this.tabs = page.locator('mat-nav-list, app-page-tabs, mat-tab-group');
+    // CF page tabs render as side-nav links
+    this.tabs = page.locator('app-page-side-nav');
   }
 
   static forEndpoint(page: Page, guid: string): CfTopLevelPage {
@@ -95,8 +96,7 @@ export class CfTopLevelPage extends BasePage {
   }
 
   private async goToTab(label: string, urlSuffix: string): Promise<void> {
-    // Navigation uses sidebar links (a elements in mat-nav-list)
-    const navLink = this.page.locator('a, button').filter({ hasText: new RegExp(`^\\s*${label}\\s*$`) }).first();
+    const navLink = pageTab(this.page, label);
     await navLink.waitFor({ state: 'visible', timeout: 10000 });
     await navLink.click();
     await this.page.waitForURL(new RegExp(`${this.navLink}.*/${urlSuffix}`), { timeout: 10000 });
@@ -143,7 +143,7 @@ export class CfTopLevelPage extends BasePage {
     await deleteOption.click();
 
     // Confirm dialog
-    const confirmDialog = this.page.locator('app-confirm-dialog, mat-dialog-container');
+    const confirmDialog = this.page.locator('app-dialog-confirm');
     await confirmDialog.waitFor({ state: 'visible' });
 
     const confirmButton = confirmDialog.locator('button').filter({ hasText: /confirm|delete/i });
@@ -196,7 +196,7 @@ export class CfTopLevelPage extends BasePage {
     await deleteOption.click();
 
     // Confirm dialog
-    const confirmDialog = this.page.locator('app-confirm-dialog, mat-dialog-container');
+    const confirmDialog = this.page.locator('app-dialog-confirm');
     await confirmDialog.waitFor({ state: 'visible' });
 
     const confirmButton = confirmDialog.locator('button').filter({ hasText: /confirm|delete/i });

--- a/e2e/pages/cloud-foundry/org-level/cf-org-level.page.ts
+++ b/e2e/pages/cloud-foundry/org-level/cf-org-level.page.ts
@@ -1,5 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { BasePage } from '../../base.page';
+import { pageTab } from '../../../components/page-tabs.component';
 
 /**
  * Cloud Foundry Organization Level Page
@@ -12,7 +13,7 @@ export class CfOrgLevelPage extends BasePage {
   constructor(page: Page, navLink?: string) {
     super(page);
     this.navLink = navLink || '';
-    this.tabs = page.locator('app-page-tabs, mat-tab-group');
+    this.tabs = page.locator('app-page-side-nav');
   }
 
   static forEndpoint(page: Page, guid: string, orgGuid: string): CfOrgLevelPage {
@@ -50,6 +51,14 @@ export class CfOrgLevelPage extends BasePage {
   }
 
   /**
+   * Wait for page to be loaded
+   */
+  async waitForPage(): Promise<void> {
+    await this.page.waitForURL(new RegExp(this.navLink), { timeout: 10000 });
+    await this.tabs.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /**
    * Tab navigation
    */
   async goToSummaryTab(): Promise<void> {
@@ -69,7 +78,7 @@ export class CfOrgLevelPage extends BasePage {
   }
 
   private async goToTab(label: string, urlSuffix: string): Promise<void> {
-    const tabButton = this.tabs.locator(`button, a`).filter({ hasText: label });
+    const tabButton = pageTab(this.page, label);
     await tabButton.waitFor({ state: 'visible', timeout: 10000 });
     await tabButton.click();
     await this.page.waitForURL(new RegExp(`${this.navLink}.*/${urlSuffix}`), { timeout: 10000 });
@@ -101,7 +110,7 @@ export class CfOrgLevelPage extends BasePage {
     await deleteOption.click();
 
     // Confirm dialog
-    const confirmDialog = this.page.locator('app-confirm-dialog, mat-dialog-container');
+    const confirmDialog = this.page.locator('app-dialog-confirm');
     await confirmDialog.waitFor({ state: 'visible' });
 
     const confirmButton = confirmDialog.locator('button').filter({ hasText: /confirm|delete/i });
@@ -154,7 +163,7 @@ export class CfOrgLevelPage extends BasePage {
     await deleteOption.click();
 
     // Confirm dialog
-    const confirmDialog = this.page.locator('app-confirm-dialog, mat-dialog-container');
+    const confirmDialog = this.page.locator('app-dialog-confirm');
     await confirmDialog.waitFor({ state: 'visible' });
 
     const confirmButton = confirmDialog.locator('button').filter({ hasText: /confirm|delete/i });

--- a/e2e/pages/cloud-foundry/space-level/cf-space-level.page.ts
+++ b/e2e/pages/cloud-foundry/space-level/cf-space-level.page.ts
@@ -1,5 +1,6 @@
 import { Page, Locator } from '@playwright/test';
 import { BasePage } from '../../base.page';
+import { pageTab } from '../../../components/page-tabs.component';
 
 /**
  * Cloud Foundry Space Level Page
@@ -12,7 +13,7 @@ export class CfSpaceLevelPage extends BasePage {
   constructor(page: Page, navLink: string) {
     super(page);
     this.navLink = navLink;
-    this.tabs = page.locator('app-page-tabs, mat-tab-group');
+    this.tabs = page.locator('app-page-side-nav');
   }
 
   static forEndpoint(page: Page, guid: string, orgGuid: string, spaceGuid: string): CfSpaceLevelPage {
@@ -55,6 +56,14 @@ export class CfSpaceLevelPage extends BasePage {
   }
 
   /**
+   * Wait for page to be loaded
+   */
+  async waitForPage(): Promise<void> {
+    await this.page.waitForURL(new RegExp(this.navLink), { timeout: 10000 });
+    await this.tabs.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /**
    * Tab navigation
    */
   async goToSummaryTab(): Promise<void> {
@@ -82,7 +91,7 @@ export class CfSpaceLevelPage extends BasePage {
   }
 
   private async goToTab(label: string, urlSuffix: string): Promise<void> {
-    const tabButton = this.tabs.locator(`button, a`).filter({ hasText: label });
+    const tabButton = pageTab(this.page, label);
     await tabButton.waitFor({ state: 'visible', timeout: 10000 });
     await tabButton.click();
     await this.page.waitForURL(new RegExp(`${this.navLink}.*/${urlSuffix}`), { timeout: 10000 });
@@ -92,12 +101,12 @@ export class CfSpaceLevelPage extends BasePage {
    * Delete space
    */
   async deleteSpace(spaceName: string): Promise<void> {
-    const subHeader = this.page.locator('app-page-header-sub, .page-header__sub');
-    const deleteButton = subHeader.locator('button[aria-label="delete"], button').filter({ hasText: /delete/i });
+    const subHeader = this.page.locator('.page-header-sub-nav');
+    const deleteButton = subHeader.locator('button').filter({ hasText: /delete/i });
     await deleteButton.click();
 
     // Confirm dialog
-    const confirmDialog = this.page.locator('app-confirm-dialog, mat-dialog-container');
+    const confirmDialog = this.page.locator('app-dialog-confirm');
     await confirmDialog.waitFor({ state: 'visible' });
 
     const confirmButton = confirmDialog.locator('button').filter({ hasText: /confirm|delete/i });

--- a/e2e/pages/endpoints/endpoints.page.ts
+++ b/e2e/pages/endpoints/endpoints.page.ts
@@ -39,7 +39,7 @@ export class EndpointsPage extends BasePage {
   constructor(page: Page) {
     super(page);
 
-    this.addButton = page.locator('app-page-header button[aria-label="add"]');
+    this.addButton = page.locator('button').filter({ hasText: 'Register Endpoint' });
     this.welcomeMessage = page.locator('.app-no-content-container');
     this.welcomeFirstLine = this.welcomeMessage.locator('.first-line');
     this.welcomeSecondLine = this.welcomeMessage.locator('.second-line');
@@ -52,7 +52,8 @@ export class EndpointsPage extends BasePage {
     this.cards = this;
     this.header = {
       hasIconButton: async (icon: string) => {
-        const btn = page.locator(`app-page-header button[aria-label="${icon}"], app-page-header button mat-icon`).filter({ hasText: icon });
+        // Header buttons carry the material icon ligature as text
+        const btn = page.locator('app-show-page-header button').filter({ hasText: icon });
         return await btn.isVisible().catch(() => false);
       }
     };

--- a/e2e/pages/endpoints/register-dialog.page.ts
+++ b/e2e/pages/endpoints/register-dialog.page.ts
@@ -22,7 +22,7 @@ export class RegisterStepperPage extends BasePage {
 
     this.stepper = page.locator('app-steppers, mat-horizontal-stepper');
     this.form = page.locator('form');
-    this.pageHeader = page.locator('app-page-header');
+    this.pageHeader = page.locator('app-show-page-header');
     this.nameField = page.locator('input[name="name"], input[formcontrolname="name"]').first();
     this.addressField = page.locator('input[name="url"], input[formcontrolname="url"]').first();
     this.nextButton = page.locator('button').filter({ hasText: /next/i });
@@ -49,7 +49,7 @@ export class RegisterStepperPage extends BasePage {
    * Get page title text
    */
   async getTitleText(): Promise<string> {
-    const titleElement = this.pageHeader.locator('h1, .page-header__title');
+    const titleElement = this.pageHeader.locator('h1');
     return await titleElement.textContent() || '';
   }
 

--- a/e2e/tests/application/application-autoscaler.spec.ts
+++ b/e2e/tests/application/application-autoscaler.spec.ts
@@ -34,7 +34,7 @@ test.describe('Application Autoscaler', () => {
       await appPage.navigateTo();
       await page.waitForLoadState('networkidle');
 
-      const summaryPage = page.locator('app-application-page');
+      const summaryPage = page.locator('app-page-side-nav');
       await expect(summaryPage).toBeVisible();
     });
 
@@ -49,7 +49,7 @@ test.describe('Application Autoscaler', () => {
       // Check if autoscaler tab/feature is available
       // Note: This test documents the autoscaler integration point
       // Actual autoscaler tab presence depends on extension being enabled
-      const appPageElement = page.locator('app-application-page');
+      const appPageElement = page.locator('app-page-side-nav');
       await expect(appPageElement).toBeVisible();
 
       // The autoscaler tab would appear here if extension is enabled
@@ -67,7 +67,7 @@ test.describe('Application Autoscaler', () => {
       await page.waitForLoadState('networkidle');
 
       // Check if autoscaler tab is present
-      const autoscalerTab = page.locator('app-page-tabs, mat-tab-group').locator('button, a').filter({ hasText: /autoscale/i });
+      const autoscalerTab = page.locator('app-page-side-nav .page-side-nav__item').filter({ hasText: /autoscale/i });
       const tabVisible = await autoscalerTab.isVisible().catch(() => false);
 
       if (!tabVisible) {
@@ -87,7 +87,7 @@ test.describe('Application Autoscaler', () => {
       await page.waitForLoadState('networkidle');
 
       // Check if autoscaler tab exists
-      const autoscalerTab = page.locator('app-page-tabs, mat-tab-group').locator('button, a').filter({ hasText: /autoscale/i });
+      const autoscalerTab = page.locator('app-page-side-nav .page-side-nav__item').filter({ hasText: /autoscale/i });
       const tabVisible = await autoscalerTab.isVisible().catch(() => false);
 
       if (!tabVisible) {
@@ -114,7 +114,7 @@ test.describe('Application Autoscaler', () => {
       await page.waitForLoadState('networkidle');
 
       // Check for autoscaler tab
-      const autoscalerTab = page.locator('app-page-tabs, mat-tab-group').locator('button, a').filter({ hasText: /autoscale/i });
+      const autoscalerTab = page.locator('app-page-side-nav .page-side-nav__item').filter({ hasText: /autoscale/i });
       const tabVisible = await autoscalerTab.isVisible().catch(() => false);
 
       if (!tabVisible) {
@@ -164,7 +164,7 @@ test.describe('Application Autoscaler', () => {
         await createButton.click();
 
         // Verify policy creation dialog/form opened
-        const policyDialog = page.locator('app-dialog, mat-dialog-container, app-autoscaler-policy-form');
+        const policyDialog = page.locator('app-dialog, [role="dialog"], app-autoscaler-policy-form');
         await expect(policyDialog.first()).toBeVisible({ timeout: 10000 });
       }
     });
@@ -398,7 +398,7 @@ test.describe('Application Autoscaler', () => {
         await editButton.click();
 
         // Verify policy edit dialog/form opened
-        const policyDialog = page.locator('app-dialog, mat-dialog-container, app-autoscaler-policy-form');
+        const policyDialog = page.locator('app-dialog, [role="dialog"], app-autoscaler-policy-form');
         await expect(policyDialog.first()).toBeVisible({ timeout: 10000 });
 
         // Verify fields are populated with existing values
@@ -539,7 +539,7 @@ test.describe('Application Autoscaler', () => {
         await deleteButton.click();
 
         // Verify confirmation dialog appears
-        const confirmDialog = page.locator('app-dialog-confirm, app-confirm-dialog, mat-dialog-container');
+        const confirmDialog = page.locator('app-dialog-confirm, app-dialog-confirm');
         await expect(confirmDialog.first()).toBeVisible({ timeout: 10000 });
       }
     });
@@ -563,7 +563,7 @@ test.describe('Application Autoscaler', () => {
         await deleteButton.click();
 
         // Confirm deletion
-        const confirmButton = page.locator('mat-dialog-container button, app-confirm-dialog button').filter({ hasText: /delete|confirm/i });
+        const confirmButton = page.locator('app-dialog-confirm button').filter({ hasText: /delete|confirm/i });
         if (await confirmButton.isVisible().catch(() => false)) {
           await confirmButton.first().click();
 

--- a/e2e/tests/application/application-delete.spec.ts
+++ b/e2e/tests/application/application-delete.spec.ts
@@ -148,7 +148,7 @@ test.describe('Application Delete', () => {
       await page.waitForURL(new RegExp(`/applications/${testApp.cfGuid}/${testApp.app.guid}/(summary|$)`), { timeout: 10000 });
 
       // Verify we're on the app summary page
-      const appPage = page.locator('app-application-page, app-page-header');
+      const appPage = page.locator('app-page-side-nav');
       await expect(appPage).toBeVisible();
     });
 
@@ -167,7 +167,7 @@ test.describe('Application Delete', () => {
       await page.waitForURL(new RegExp(`/applications/${testApp.cfGuid}/[^/]*$`), { timeout: 30000 });
 
       // Verify we're on the applications page
-      const appsPage = page.locator('app-applications-list, app-page-header');
+      const appsPage = page.locator('app-application-wall');
       await expect(appsPage.first()).toBeVisible({ timeout: 15000 });
 
       // Verify app is actually deleted

--- a/e2e/tests/application/application-routes.spec.ts
+++ b/e2e/tests/application/application-routes.spec.ts
@@ -30,7 +30,7 @@ test.describe('Application Routes', () => {
       await appSummary.goToRoutesTab();
 
       // Verify routes tab is active
-      const routesTab = page.locator('.mat-tab-label, mat-tab-header').filter({ hasText: /routes/i });
+      const routesTab = page.locator('.page-side-nav__item--active').filter({ hasText: /routes/i });
       await expect(routesTab).toBeVisible();
     });
 
@@ -50,8 +50,8 @@ test.describe('Application Routes', () => {
       await page.waitForTimeout(1000);
 
       // Verify route is displayed
-      const routesList = page.locator('.routes-list, app-app-routes, mat-table').first();
-      await expect(routesList).toBeVisible();
+      const routesList = page.locator('app-routes-tab table').first();
+      await expect(routesList).toBeVisible({ timeout: 30000 });
     });
 
     test('should show route details (domain, host, path)', async ({ withTestApp }) => {
@@ -252,7 +252,7 @@ test.describe('Application Routes', () => {
       await dialog.enterHost(testHost);
 
       // Verify host was entered
-      const hostInput = page.locator('input[name="host"], input[placeholder*="host"]').first();
+      const hostInput = page.locator('input[formcontrolname="host"]').first();
       const hostValue = await hostInput.inputValue();
       expect(hostValue).toBe(testHost);
 
@@ -372,8 +372,8 @@ test.describe('Application Routes', () => {
       // Create the route
       await dialog.clickCreate();
 
-      // Wait for dialog to close
-      await page.waitForTimeout(2000);
+      // Wait for the stepper page to close (create + map + nav can be slow)
+      await page.locator('app-add-route-stepper').waitFor({ state: 'hidden', timeout: 30000 });
 
       // Verify dialog closed
       const isVisible = await dialog.isVisible();
@@ -408,12 +408,15 @@ test.describe('Application Routes', () => {
       await page.waitForTimeout(500);
       await dialog.clickCreate();
 
-      // Wait for route to be created and list to refresh
-      await page.waitForTimeout(3000);
+      // Wait for the stepper page to close (create + map + nav can be slow)
+      await page.locator('app-add-route-stepper').waitFor({ state: 'hidden', timeout: 60000 }).catch(() => {});
 
-      // Verify route appears in list
+      // Verify route appears in list; nudge a refresh if the list came back cached
       const routeRow = page.locator('mat-row, tr').filter({ hasText: testHost });
-      await expect(routeRow).toBeVisible({ timeout: 10000 });
+      if (!(await routeRow.isVisible().catch(() => false))) {
+        await page.locator('app-routes-tab button').filter({ hasText: 'refresh' }).first().click().catch(() => {});
+      }
+      await expect(routeRow).toBeVisible({ timeout: 30000 });
     });
   });
 
@@ -546,7 +549,7 @@ test.describe('Application Routes', () => {
         await dialog.clickMap();
 
         // Wait for mapping to complete
-        await page.waitForTimeout(2000);
+        await page.locator('app-add-route-stepper').waitFor({ state: 'hidden', timeout: 60000 }).catch(() => {});
 
         // Dialog should close
         const isVisible = await dialog.isVisible();
@@ -593,7 +596,8 @@ test.describe('Application Routes', () => {
       const isMapEnabled = await dialog.isMapEnabled();
       if (isMapEnabled) {
         await dialog.clickMap();
-        await page.waitForTimeout(3000);
+        // Mapping navigates back to the routes tab when it completes
+        await page.locator('app-add-route-stepper').waitFor({ state: 'hidden', timeout: 60000 }).catch(() => {});
       } else {
         await dialog.clickCancel();
       }
@@ -628,6 +632,8 @@ test.describe('Application Routes', () => {
       await expect(routeRow).toBeVisible({ timeout: 10000 });
 
       // Find and click unmap button
+      // Row actions live behind the more_vert menu
+      await routeRow.locator('button[aria-label="Row actions"]').click({ timeout: 60000 }); // outlast the loading overlay (CF-latency bound)
       const unmapButton = routeRow.locator('button, mat-icon').filter({ hasText: /unmap|remove|delete/i }).first();
       await expect(unmapButton).toBeVisible();
       await unmapButton.click();
@@ -655,11 +661,13 @@ test.describe('Application Routes', () => {
       await expect(routeRow).toBeVisible({ timeout: 10000 });
 
       // Click unmap button
+      // Row actions live behind the more_vert menu
+      await routeRow.locator('button[aria-label="Row actions"]').click({ timeout: 60000 }); // outlast the loading overlay (CF-latency bound)
       const unmapButton = routeRow.locator('button, mat-icon').filter({ hasText: /unmap|remove|delete/i }).first();
       await unmapButton.click();
 
       // Look for confirmation dialog
-      const confirmDialog = page.locator('mat-dialog-container, .confirm-dialog, [role="dialog"]').first();
+      const confirmDialog = page.locator('[role="dialog"], .confirm-dialog').first();
 
       // Either we see a confirmation dialog or the action completes directly
       const dialogVisible = await confirmDialog.isVisible().catch(() => false);
@@ -698,7 +706,10 @@ test.describe('Application Routes', () => {
 
       // For single-app routes, the unmap operation should be available
       // Shared routes (multiple apps) would show different behavior
+      // Row actions live behind the more_vert menu
+      await routeRow.locator('button[aria-label="Row actions"]').click({ timeout: 60000 }); // outlast the loading overlay (CF-latency bound)
       const unmapButton = routeRow.locator('button, mat-icon').filter({ hasText: /unmap|remove/i }).first();
+      await unmapButton.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {}); // menu renders async
       const buttonExists = await unmapButton.count() > 0;
       expect(buttonExists).toBeTruthy();
     });
@@ -722,6 +733,8 @@ test.describe('Application Routes', () => {
       await expect(routeRow).toBeVisible({ timeout: 10000 });
 
       // Click unmap/delete button
+      // Row actions live behind the more_vert menu
+      await routeRow.locator('button[aria-label="Row actions"]').click({ timeout: 60000 }); // outlast the loading overlay (CF-latency bound)
       const actionButton = routeRow.locator('button, mat-icon').filter({ hasText: /unmap|remove|delete/i }).first();
       await actionButton.click();
 
@@ -729,7 +742,7 @@ test.describe('Application Routes', () => {
       await page.waitForTimeout(1000);
 
       // Look for dialog with delete option
-      const dialog = page.locator('mat-dialog-container, [role="dialog"]').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogVisible = await dialog.isVisible().catch(() => false);
 
       if (dialogVisible) {
@@ -860,7 +873,7 @@ test.describe('Application Routes', () => {
 
       // For TCP routes, port can be auto-assigned
       // Either port input should be optional or show auto-assign option
-      const portInput = page.locator('input[name="port"], input[type="number"]').first();
+      const portInput = page.locator('input[formcontrolname="port"], input[type="number"]').first();
       const portInputExists = await portInput.isVisible().catch(() => false);
 
       // TCP port input should exist for TCP domains
@@ -899,7 +912,7 @@ test.describe('Application Routes', () => {
       await page.waitForTimeout(1500);
 
       // If TCP routes exist, they should display with port numbers
-      const routesList = page.locator('app-list, mat-table').first();
+      const routesList = page.locator('app-signal-list, table').first();
       await expect(routesList).toBeVisible();
 
       // TCP routes typically show as "domain:port" format
@@ -944,7 +957,7 @@ test.describe('Application Routes', () => {
       await page.waitForTimeout(500);
 
       // Try to enter port that might be out of range
-      const portInput = page.locator('input[name="port"], input[type="number"]').first();
+      const portInput = page.locator('input[formcontrolname="port"], input[type="number"]').first();
       const portInputExists = await portInput.isVisible().catch(() => false);
 
       if (portInputExists) {
@@ -1071,7 +1084,7 @@ test.describe('Application Routes', () => {
         }
 
         // Clear input for next test
-        const hostInput = page.locator('input[name="host"], input[placeholder*="host"]').first();
+        const hostInput = page.locator('input[formcontrolname="host"]').first();
         await hostInput.clear();
       }
 
@@ -1101,15 +1114,13 @@ test.describe('Application Routes', () => {
 
       // Verify at least one domain is available in the dropdown
       // If no domains were available, the dialog wouldn't function properly
-      const domainSelect = page.locator('mat-select[placeholder*="domain"], select[name="domain"]').first();
+      const domainSelect = page.locator('.select-trigger').first();
       await expect(domainSelect).toBeVisible();
 
-      // Domain list should be populated
+      // Domain list should be populated (domains load async — wait for the first option)
       await domainSelect.click();
-      await page.waitForTimeout(500);
-
-      // Options should be available
-      const domainOptions = page.locator('mat-option, option');
+      const domainOptions = page.locator('.custom-option-content, option');
+      await domainOptions.first().waitFor({ state: 'visible', timeout: 15000 }).catch(() => {});
       const optionCount = await domainOptions.count();
 
       // At least one domain should be available

--- a/e2e/tests/application/revisions-action-bar.spec.ts
+++ b/e2e/tests/application/revisions-action-bar.spec.ts
@@ -68,7 +68,7 @@ test.describe('Application Revisions Tab Action Bar', () => {
       await restartButton.click();
 
       // Verify confirmation dialog or prompt appears
-      const dialog = page.locator('mat-dialog-container, [role="dialog"]');
+      const dialog = page.locator('[role="dialog"]');
       await expect(dialog).toBeVisible({ timeout: 5000 });
 
       // Cancel out of the dialog (escape key or close button)
@@ -92,7 +92,7 @@ test.describe('Application Revisions Tab Action Bar', () => {
       await restageButton.click();
 
       // Verify confirmation dialog or prompt appears
-      const dialog = page.locator('mat-dialog-container, [role="dialog"]');
+      const dialog = page.locator('[role="dialog"]');
       await expect(dialog).toBeVisible({ timeout: 5000 });
 
       // Cancel out of the dialog (escape key or close button)

--- a/e2e/tests/application/revisions-rollback-happy.spec.ts
+++ b/e2e/tests/application/revisions-rollback-happy.spec.ts
@@ -74,7 +74,7 @@ test.describe('Application Revisions', () => {
       expect(rollbackClicked).toBeTruthy();
 
       // Wait for and verify rollback dialog
-      const dialog = page.locator('mat-dialog-container, [role="dialog"]').first();
+      const dialog = page.locator('[role="dialog"]').first();
       await expect(dialog).toBeVisible({ timeout: 5000 });
 
       // Assert dialog contains revision number

--- a/e2e/tests/cloud-foundry/cf-level/cf-invite-config.spec.ts
+++ b/e2e/tests/cloud-foundry/cf-level/cf-invite-config.spec.ts
@@ -54,7 +54,7 @@ test.describe('CF User Invite Configuration', () => {
       await configButton.click();
 
       // Verify configuration dialog opened
-      const dialog = page.locator('app-invite-configuration, mat-dialog-container');
+      const dialog = page.locator('app-invite-configuration, [role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -111,7 +111,7 @@ test.describe('CF User Invite Configuration', () => {
       await configButton.click();
 
       // Wait for dialog
-      const dialog = page.locator('mat-dialog-container').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/cloud-foundry/cf-level/cf-top-level.spec.ts
+++ b/e2e/tests/cloud-foundry/cf-level/cf-top-level.spec.ts
@@ -40,7 +40,7 @@ test.describe('CF Top Level', () => {
       await cfPage.waitForPage();
 
       // Check page header
-      const header = page.locator('app-page-header, h1, .page-header').first();
+      const header = page.locator('h1, .page-header').first();
       await expect(header).toBeVisible();
 
       const headerText = await header.textContent() || '';
@@ -138,7 +138,7 @@ test.describe('CF Top Level', () => {
       await cfPage.navigateTo();
       await cfPage.waitForPage();
 
-      const header = page.locator('app-page-header, h1, .page-header').first();
+      const header = page.locator('h1, .page-header').first();
       await expect(header).toBeVisible();
 
       const headerText = await header.textContent() || '';
@@ -200,7 +200,7 @@ test.describe('CF Top Level', () => {
       await addButton.click();
 
       // Verify stepper dialog opened
-      const stepper = page.locator('app-create-organization-stepper, app-stepper-dialog, mat-dialog-container');
+      const stepper = page.locator('app-create-organization-stepper, app-stepper-dialog, [role="dialog"]');
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (stepperExists) {
@@ -334,7 +334,7 @@ test.describe('CF Top Level', () => {
       await addButton.click();
 
       // Verify stepper dialog opened
-      const stepper = page.locator('app-create-quota-stepper, app-stepper-dialog, mat-dialog-container');
+      const stepper = page.locator('app-create-quota-stepper, app-stepper-dialog, [role="dialog"]');
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (stepperExists) {
@@ -537,7 +537,7 @@ test.describe('CF Top Level', () => {
       await inviteConfigButton.click();
 
       // Look for configuration form or dialog
-      const configForm = page.locator('form, mat-dialog-container, .invite-config');
+      const configForm = page.locator('form, [role="dialog"], .invite-config');
       const formExists = await configForm.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (formExists) {
@@ -579,7 +579,7 @@ test.describe('CF Top Level', () => {
       await inviteConfigButton.click();
 
       // Look for enable/disable toggle
-      const configDialog = page.locator('mat-dialog-container, form, .invite-config').first();
+      const configDialog = page.locator('[role="dialog"], form, .invite-config').first();
       const dialogExists = await configDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/cloud-foundry/cf-level/cf-users-list.spec.ts
+++ b/e2e/tests/cloud-foundry/cf-level/cf-users-list.spec.ts
@@ -153,7 +153,7 @@ test.describe('CF Users List', () => {
 
       // Check if we navigated to a user details page or if a dialog opened
       const urlChanged = page.url().includes('users/') && !page.url().endsWith('/users');
-      const dialog = page.locator('mat-dialog-container, app-user-details');
+      const dialog = page.locator('[role="dialog"], app-user-details');
       const dialogOpened = await dialog.isVisible({ timeout: 2000 }).catch(() => false);
 
       if (!urlChanged && !dialogOpened) {

--- a/e2e/tests/cloud-foundry/cf-level/cf-users-removal.spec.ts
+++ b/e2e/tests/cloud-foundry/cf-level/cf-users-removal.spec.ts
@@ -76,7 +76,7 @@ test.describe('CF Users Removal', () => {
         await removeOption.click();
 
         // Check if dialog has "remove from all spaces" option
-        const dialog = page.locator('mat-dialog-container');
+        const dialog = page.locator('[role="dialog"]');
         const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (dialogExists) {
@@ -150,7 +150,7 @@ test.describe('CF Users Removal', () => {
         await removeOption.click();
 
         // Check if dialog has "remove from all orgs" option
-        const dialog = page.locator('mat-dialog-container');
+        const dialog = page.locator('[role="dialog"]');
         const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (dialogExists) {
@@ -215,7 +215,7 @@ test.describe('CF Users Removal', () => {
       await removeOption.click();
 
       // Verify confirmation dialog appears
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       const dialogExists = await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -284,7 +284,7 @@ test.describe('CF Users Removal', () => {
       await removeOption.click();
 
       // Verify confirmation dialog appears
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       const dialogExists = await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/cloud-foundry/cf-level/manage-org.spec.ts
+++ b/e2e/tests/cloud-foundry/cf-level/manage-org.spec.ts
@@ -241,7 +241,7 @@ test.describe('Manage Organization', () => {
         await deleteButton.click();
 
         // Confirm deletion dialog
-        const confirmDialog = page.locator('mat-dialog-container, app-confirm-dialog');
+        const confirmDialog = page.locator('app-dialog-confirm');
         await confirmDialog.waitFor({ state: 'visible', timeout: 5000 });
 
         const confirmButton = confirmDialog.locator('button').filter({ hasText: /delete|confirm|yes/i });

--- a/e2e/tests/cloud-foundry/cf-level/manage-quota.spec.ts
+++ b/e2e/tests/cloud-foundry/cf-level/manage-quota.spec.ts
@@ -274,7 +274,7 @@ test.describe('Manage Quota', () => {
         await deleteButton.click();
 
         // Confirm deletion dialog
-        const confirmDialog = page.locator('mat-dialog-container, app-confirm-dialog');
+        const confirmDialog = page.locator('app-dialog-confirm');
         await confirmDialog.waitFor({ state: 'visible', timeout: 5000 });
 
         const confirmButton = confirmDialog.locator('button').filter({ hasText: /delete|confirm|yes/i });
@@ -352,7 +352,7 @@ test.describe('Manage Quota', () => {
 
           // Should show error or be disabled if quota is attached
           // This is UI-dependent behavior that we can verify exists
-          const confirmDialog = page.locator('mat-dialog-container, app-confirm-dialog');
+          const confirmDialog = page.locator('app-dialog-confirm');
           const dialogAppears = await confirmDialog.isVisible({ timeout: 2000 }).catch(() => false);
 
           if (dialogAppears) {

--- a/e2e/tests/cloud-foundry/manage-users-by-username-stepper.spec.ts
+++ b/e2e/tests/cloud-foundry/manage-users-by-username-stepper.spec.ts
@@ -42,7 +42,7 @@ test.describe('Manage Users By Username Stepper', () => {
       await manageButton.click();
 
       // Verify stepper/wizard dialog opened
-      const stepper = page.locator('app-manage-users-stepper, app-add-user-stepper, mat-dialog-container, app-stepper');
+      const stepper = page.locator('app-manage-users-stepper, app-add-user-stepper, [role="dialog"], app-stepper');
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!stepperExists) {
@@ -78,7 +78,7 @@ test.describe('Manage Users By Username Stepper', () => {
       await manageButton.click();
 
       // Wait for stepper
-      const stepper = page.locator('mat-dialog-container, app-stepper').first();
+      const stepper = page.locator('[role="dialog"], app-stepper').first();
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!stepperExists) {
@@ -131,7 +131,7 @@ test.describe('Manage Users By Username Stepper', () => {
       await manageButton.click();
 
       // Wait for stepper
-      const stepper = page.locator('mat-dialog-container, app-stepper').first();
+      const stepper = page.locator('[role="dialog"], app-stepper').first();
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!stepperExists) {
@@ -192,7 +192,7 @@ test.describe('Manage Users By Username Stepper', () => {
       await manageButton.click();
 
       // Wait for stepper
-      const stepper = page.locator('mat-dialog-container, app-stepper').first();
+      const stepper = page.locator('[role="dialog"], app-stepper').first();
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!stepperExists) {
@@ -252,7 +252,7 @@ test.describe('Manage Users By Username Stepper', () => {
       await manageButton.click();
 
       // Wait for stepper
-      const stepper = page.locator('mat-dialog-container, app-stepper').first();
+      const stepper = page.locator('[role="dialog"], app-stepper').first();
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!stepperExists) {

--- a/e2e/tests/cloud-foundry/manage-users-stepper.spec.ts
+++ b/e2e/tests/cloud-foundry/manage-users-stepper.spec.ts
@@ -42,7 +42,7 @@ test.describe('Manage Users Stepper', () => {
       await manageButton.click();
 
       // Verify wizard/stepper dialog opened
-      const wizard = page.locator('app-manage-users-stepper, app-user-management-wizard, mat-dialog-container, app-stepper');
+      const wizard = page.locator('app-manage-users-stepper, app-user-management-wizard, [role="dialog"], app-stepper');
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!wizardExists) {
@@ -78,7 +78,7 @@ test.describe('Manage Users Stepper', () => {
       await manageButton.click();
 
       // Wait for wizard
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!wizardExists) {
@@ -131,7 +131,7 @@ test.describe('Manage Users Stepper', () => {
       await manageButton.click();
 
       // Wait for wizard
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!wizardExists) {
@@ -191,7 +191,7 @@ test.describe('Manage Users Stepper', () => {
       await manageButton.click();
 
       // Wait for wizard
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!wizardExists) {
@@ -253,7 +253,7 @@ test.describe('Manage Users Stepper', () => {
       await manageButton.click();
 
       // Wait for wizard
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!wizardExists) {
@@ -307,7 +307,7 @@ test.describe('Manage Users Stepper', () => {
       await manageButton.click();
 
       // Wait for wizard
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!wizardExists) {

--- a/e2e/tests/cloud-foundry/org-level/cf-org-delete.spec.ts
+++ b/e2e/tests/cloud-foundry/org-level/cf-org-delete.spec.ts
@@ -53,7 +53,7 @@ test.describe('CF Org Delete', () => {
         await deleteButton.click();
 
         // Confirm deletion dialog
-        const confirmDialog = page.locator('mat-dialog-container, app-confirm-dialog');
+        const confirmDialog = page.locator('app-dialog-confirm');
         await confirmDialog.waitFor({ state: 'visible', timeout: 5000 });
 
         const confirmButton = confirmDialog.locator('button').filter({ hasText: /delete|confirm|yes/i });
@@ -100,7 +100,7 @@ test.describe('CF Org Delete', () => {
         await deleteButton.click();
 
         // Verify confirmation dialog appears
-        const confirmDialog = page.locator('mat-dialog-container, app-confirm-dialog');
+        const confirmDialog = page.locator('app-dialog-confirm');
         await confirmDialog.waitFor({ state: 'visible' });
 
         // Verify dialog has confirm/delete button
@@ -145,7 +145,7 @@ test.describe('CF Org Delete', () => {
         await deleteButton.click();
 
         // Confirm deletion
-        const confirmDialog = page.locator('mat-dialog-container, app-confirm-dialog');
+        const confirmDialog = page.locator('app-dialog-confirm');
         await confirmDialog.waitFor({ state: 'visible', timeout: 5000 });
 
         const confirmButton = confirmDialog.locator('button').filter({ hasText: /delete|confirm|yes/i });

--- a/e2e/tests/cloud-foundry/org-level/cf-org-level.spec.ts
+++ b/e2e/tests/cloud-foundry/org-level/cf-org-level.spec.ts
@@ -60,7 +60,7 @@ test.describe('CF Org Level', () => {
       await orgPage.waitForPage();
 
       // Check breadcrumbs
-      const breadcrumb = page.locator('app-page-header-events app-breadcrumbs, .breadcrumbs').first();
+      const breadcrumb = page.locator('.page-header-breadcrumb, .page-header-sub-nav-breadcrumb').first();
       await expect(breadcrumb).toBeVisible();
 
       // Breadcrumb should contain CF name
@@ -135,7 +135,7 @@ test.describe('CF Org Level', () => {
       await orgPage.navigateTo();
       await orgPage.waitForPage();
 
-      const breadcrumb = page.locator('app-page-header-events app-breadcrumbs, .breadcrumbs').first();
+      const breadcrumb = page.locator('.page-header-breadcrumb, .page-header-sub-nav-breadcrumb').first();
       await expect(breadcrumb).toBeVisible();
     });
 
@@ -185,7 +185,7 @@ test.describe('CF Org Level', () => {
       await addButton.click();
 
       // Verify stepper dialog opened
-      const stepper = page.locator('app-create-space-stepper, app-stepper-dialog, mat-dialog-container');
+      const stepper = page.locator('app-create-space-stepper, app-stepper-dialog, [role="dialog"]');
       const stepperExists = await stepper.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (stepperExists) {
@@ -260,7 +260,7 @@ test.describe('CF Org Level', () => {
       await manageButton.click();
 
       // Verify user management dialog opened
-      const dialog = page.locator('app-add-org-user, app-invite-users, mat-dialog-container');
+      const dialog = page.locator('app-add-org-user, app-invite-users, [role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (dialogExists) {

--- a/e2e/tests/cloud-foundry/org-level/org-invite-user.spec.ts
+++ b/e2e/tests/cloud-foundry/org-level/org-invite-user.spec.ts
@@ -46,7 +46,7 @@ test.describe('Org Invite User', () => {
       await inviteButton.click();
 
       // Verify invite dialog opened
-      const dialog = page.locator('app-invite-users, app-add-user, mat-dialog-container');
+      const dialog = page.locator('app-invite-users, app-add-user, [role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -84,7 +84,7 @@ test.describe('Org Invite User', () => {
       await inviteButton.click();
 
       // Wait for dialog
-      const dialog = page.locator('mat-dialog-container').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -139,7 +139,7 @@ test.describe('Org Invite User', () => {
       await inviteButton.click();
 
       // Wait for dialog
-      const dialog = page.locator('mat-dialog-container').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -200,7 +200,7 @@ test.describe('Org Invite User', () => {
       await inviteButton.click();
 
       // Wait for dialog
-      const dialog = page.locator('mat-dialog-container').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/cloud-foundry/org-level/org-users-list.spec.ts
+++ b/e2e/tests/cloud-foundry/org-level/org-users-list.spec.ts
@@ -145,7 +145,7 @@ test.describe('Org Users List', () => {
       await manageRolesOption.click();
 
       // Verify role management dialog/page opened
-      const roleDialog = page.locator('app-manage-user-roles, mat-dialog-container');
+      const roleDialog = page.locator('app-manage-user-roles, [role="dialog"]');
       const dialogExists = await roleDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (dialogExists) {

--- a/e2e/tests/cloud-foundry/org-level/org-users-removal.spec.ts
+++ b/e2e/tests/cloud-foundry/org-level/org-users-removal.spec.ts
@@ -128,7 +128,7 @@ test.describe('Org Users Removal', () => {
         await removeOption.click();
 
         // Look for "remove from all spaces" checkbox in confirmation dialog
-        const dialog = page.locator('mat-dialog-container');
+        const dialog = page.locator('[role="dialog"]');
         const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (dialogExists) {
@@ -195,7 +195,7 @@ test.describe('Org Users Removal', () => {
       await removeOption.click();
 
       // Verify confirmation dialog appears
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       const dialogExists = await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/cloud-foundry/space-level/cf-space-delete.spec.ts
+++ b/e2e/tests/cloud-foundry/space-level/cf-space-delete.spec.ts
@@ -105,7 +105,7 @@ test.describe('CF Space Delete', () => {
         await deleteOption.click();
 
         // Verify confirmation dialog appears
-        const confirmDialog = page.locator('app-confirm-dialog, mat-dialog-container');
+        const confirmDialog = page.locator('app-dialog-confirm');
         await confirmDialog.waitFor({ state: 'visible' });
 
         // Verify dialog has confirm/delete button
@@ -160,7 +160,7 @@ test.describe('CF Space Delete', () => {
           await deleteButton.click();
 
           // Confirm deletion
-          const confirmDialog = page.locator('mat-dialog-container, app-confirm-dialog');
+          const confirmDialog = page.locator('app-dialog-confirm');
           await confirmDialog.waitFor({ state: 'visible', timeout: 5000 });
 
           const confirmButton = confirmDialog.locator('button').filter({ hasText: /delete|confirm|yes/i });

--- a/e2e/tests/cloud-foundry/space-level/cf-space-level.spec.ts
+++ b/e2e/tests/cloud-foundry/space-level/cf-space-level.spec.ts
@@ -58,7 +58,7 @@ test.describe('CF Space Level', () => {
       await spacePage.waitForPage();
 
       // Check breadcrumbs
-      const breadcrumb = page.locator('app-page-header-events app-breadcrumbs, .breadcrumbs').first();
+      const breadcrumb = page.locator('.page-header-breadcrumb, .page-header-sub-nav-breadcrumb').first();
       await expect(breadcrumb).toBeVisible();
 
       // Breadcrumb should contain CF name and org name
@@ -156,7 +156,7 @@ test.describe('CF Space Level', () => {
       await spacePage.navigateTo();
       await spacePage.waitForPage();
 
-      const breadcrumb = page.locator('app-page-header-events app-breadcrumbs, .breadcrumbs').first();
+      const breadcrumb = page.locator('.page-header-breadcrumb, .page-header-sub-nav-breadcrumb').first();
       await expect(breadcrumb).toBeVisible();
     });
 
@@ -217,7 +217,7 @@ test.describe('CF Space Level', () => {
       await addButton.click();
 
       // Verify deployment wizard or stepper opened
-      const wizard = page.locator('app-deploy-application, app-stepper-dialog, mat-dialog-container');
+      const wizard = page.locator('app-deploy-application, app-stepper-dialog, [role="dialog"]');
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (wizardExists) {
@@ -255,7 +255,7 @@ test.describe('CF Space Level', () => {
       await addButton.click();
 
       // Verify service creation wizard or marketplace opened
-      const wizard = page.locator('app-create-service-instance, app-add-service-instance, mat-dialog-container, .marketplace');
+      const wizard = page.locator('app-create-service-instance, app-add-service-instance, [role="dialog"], .marketplace');
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (wizardExists) {
@@ -297,7 +297,7 @@ test.describe('CF Space Level', () => {
       await manageButton.click();
 
       // Verify user management dialog opened
-      const dialog = page.locator('app-add-space-user, app-manage-users, mat-dialog-container');
+      const dialog = page.locator('app-add-space-user, app-manage-users, [role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (dialogExists) {
@@ -335,7 +335,7 @@ test.describe('CF Space Level', () => {
       await addButton.click();
 
       // Verify route creation dialog opened
-      const dialog = page.locator('app-create-route, app-add-route, mat-dialog-container');
+      const dialog = page.locator('app-create-route, app-add-route, [role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (dialogExists) {

--- a/e2e/tests/cloud-foundry/space-level/space-invite-user.spec.ts
+++ b/e2e/tests/cloud-foundry/space-level/space-invite-user.spec.ts
@@ -48,7 +48,7 @@ test.describe('Space Invite User', () => {
       await inviteButton.click();
 
       // Verify invite dialog opened
-      const dialog = page.locator('app-invite-users, app-add-user, mat-dialog-container');
+      const dialog = page.locator('app-invite-users, app-add-user, [role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -87,7 +87,7 @@ test.describe('Space Invite User', () => {
       await inviteButton.click();
 
       // Wait for dialog
-      const dialog = page.locator('mat-dialog-container').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -143,7 +143,7 @@ test.describe('Space Invite User', () => {
       await inviteButton.click();
 
       // Wait for dialog
-      const dialog = page.locator('mat-dialog-container').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -205,7 +205,7 @@ test.describe('Space Invite User', () => {
       await inviteButton.click();
 
       // Wait for dialog
-      const dialog = page.locator('mat-dialog-container').first();
+      const dialog = page.locator('[role="dialog"]').first();
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/cloud-foundry/space-level/space-routes.spec.ts
+++ b/e2e/tests/cloud-foundry/space-level/space-routes.spec.ts
@@ -64,7 +64,7 @@ test.describe('Space Routes', () => {
       await createButton.click();
 
       // Verify route creation dialog opened
-      const dialog = page.locator('app-create-route, app-add-route, mat-dialog-container');
+      const dialog = page.locator('app-create-route, app-add-route, [role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -129,7 +129,7 @@ test.describe('Space Routes', () => {
       await mapOption.click();
 
       // Verify map dialog opened
-      const dialog = page.locator('mat-dialog-container');
+      const dialog = page.locator('[role="dialog"]');
       const dialogExists = await dialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (dialogExists) {
@@ -242,7 +242,7 @@ test.describe('Space Routes', () => {
       await deleteOption.click();
 
       // Verify confirmation dialog
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       const dialogExists = await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/cloud-foundry/space-level/space-users-list.spec.ts
+++ b/e2e/tests/cloud-foundry/space-level/space-users-list.spec.ts
@@ -149,7 +149,7 @@ test.describe('Space Users List', () => {
       await manageRolesOption.click();
 
       // Verify role management dialog/page opened
-      const roleDialog = page.locator('app-manage-space-user-roles, mat-dialog-container');
+      const roleDialog = page.locator('app-manage-space-user-roles, [role="dialog"]');
       const dialogExists = await roleDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (dialogExists) {

--- a/e2e/tests/cloud-foundry/space-level/space-users-removal.spec.ts
+++ b/e2e/tests/cloud-foundry/space-level/space-users-removal.spec.ts
@@ -120,7 +120,7 @@ test.describe('Space Users Removal', () => {
       await removeOption.click();
 
       // Verify confirmation dialog appears
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       const dialogExists = await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {

--- a/e2e/tests/marketplace/create-service-instance.spec.ts
+++ b/e2e/tests/marketplace/create-service-instance.spec.ts
@@ -64,7 +64,7 @@ test.describe('Create Service Instance', () => {
       await serviceCards.click();
 
       // Verify creation wizard or service summary page opened
-      const wizardOrSummary = page.locator('app-create-service-instance, app-service-summary, mat-dialog-container');
+      const wizardOrSummary = page.locator('app-create-service-instance, app-service-summary, [role="dialog"]');
       const pageOpened = await wizardOrSummary.first().isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!pageOpened) {

--- a/e2e/tests/marketplace/create-service-instances-bind-app.spec.ts
+++ b/e2e/tests/marketplace/create-service-instances-bind-app.spec.ts
@@ -65,7 +65,7 @@ test.describe('Create Service Instance and Bind to App', () => {
 
       if (!hasBindButton) {
         // Try looking in page header or action buttons
-        const headerButton = page.locator('app-page-header button').filter({ hasText: /bind|service/i }).first();
+        const headerButton = page.locator('.page-header-sub-nav button').filter({ hasText: /bind|service/i }).first();
         const hasHeaderButton = await headerButton.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (!hasHeaderButton) {
@@ -81,7 +81,7 @@ test.describe('Create Service Instance and Bind to App', () => {
 
       // Verify bind wizard or dialog opened
       await page.waitForTimeout(500);
-      const bindDialog = page.locator('mat-dialog-container, app-stepper, .bind-service').first();
+      const bindDialog = page.locator('[role="dialog"], app-stepper, .bind-service').first();
       const dialogExists = await bindDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -164,7 +164,7 @@ test.describe('Create Service Instance and Bind to App', () => {
       await bindButton.click();
       await page.waitForTimeout(500);
 
-      const bindDialog = page.locator('mat-dialog-container, app-stepper').first();
+      const bindDialog = page.locator('[role="dialog"], app-stepper').first();
       if (!await bindDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Bind dialog not displayed');
       }
@@ -260,7 +260,7 @@ test.describe('Create Service Instance and Bind to App', () => {
 
       if (!hasEnvVars) {
         // Environment variables tab exists but may be empty
-        const pageHeader = page.locator('app-page-header, h1').first();
+        const pageHeader = page.locator('h1').first();
         const hasHeader = await pageHeader.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (!hasHeader) {
@@ -420,7 +420,7 @@ test.describe('Create Service Instance and Bind to App', () => {
       // Snackbar won't be visible until error occurs
 
       // Verify page has error handling structure
-      const pageStructure = page.locator('app-page-header, .marketplace').first();
+      const pageStructure = page.locator('.marketplace').first();
       await expect(pageStructure).toBeVisible();
 
       // Actual error testing requires triggering a binding failure
@@ -543,7 +543,7 @@ test.describe('Create Service Instance and Bind to App', () => {
       await page.waitForLoadState('networkidle');
 
       // Verify page loads (permission checking happens at CF API level)
-      const pageStructure = page.locator('app-page-header, app-list').first();
+      const pageStructure = page.locator('app-list').first();
       const hasPage = await pageStructure.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!hasPage) {
@@ -634,7 +634,7 @@ test.describe('Create Service Instance and Bind to App', () => {
 
       if (!hasEnvVars) {
         // Page may be empty if no env vars
-        const pageHeader = page.locator('app-page-header, h1').first();
+        const pageHeader = page.locator('h1').first();
         const hasHeader = await pageHeader.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (!hasHeader) {
@@ -692,7 +692,7 @@ test.describe('Create Service Instance and Bind to App', () => {
 
       if (!hasBindButton) {
         // Button may be in header
-        const headerButton = page.locator('app-page-header button').filter({ hasText: /bind|service/i }).first();
+        const headerButton = page.locator('.page-header-sub-nav button').filter({ hasText: /bind|service/i }).first();
         const hasHeaderButton = await headerButton.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (!hasHeaderButton) {
@@ -707,7 +707,7 @@ test.describe('Create Service Instance and Bind to App', () => {
         await bindButton.click();
         await page.waitForTimeout(500);
 
-        const bindDialog = page.locator('mat-dialog-container, app-stepper').first();
+        const bindDialog = page.locator('[role="dialog"], app-stepper').first();
         const dialogExists = await bindDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
         if (dialogExists) {

--- a/e2e/tests/marketplace/delete-service-instance.spec.ts
+++ b/e2e/tests/marketplace/delete-service-instance.spec.ts
@@ -131,7 +131,7 @@ test.describe('Delete Service Instance', () => {
       await deleteOption.click();
 
       // Verify confirmation dialog opened
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       const dialogExists = await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -183,7 +183,7 @@ test.describe('Delete Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       if (!await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Confirmation dialog not displayed');
       }
@@ -239,7 +239,7 @@ test.describe('Delete Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       if (!await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Confirmation dialog not displayed');
       }
@@ -293,7 +293,7 @@ test.describe('Delete Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       if (!await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Confirmation dialog not displayed');
       }
@@ -345,7 +345,7 @@ test.describe('Delete Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       if (!await confirmDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Confirmation dialog not displayed');
       }
@@ -474,7 +474,7 @@ test.describe('Delete Service Instance', () => {
       await deleteOption.click();
 
       // Verify warning about bound applications
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       await expect(confirmDialog).toBeVisible({ timeout: 5000 });
 
       // Look for warning or disabled delete button
@@ -525,7 +525,7 @@ test.describe('Delete Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       await expect(confirmDialog).toBeVisible({ timeout: 5000 });
 
       // Check for unbind instructions or link
@@ -676,7 +676,7 @@ test.describe('Delete Service Instance', () => {
       await servicesPage.waitForPage();
 
       // Verify error message display infrastructure
-      const errorDisplay = page.locator('app-snack-bar, .mat-snack-bar-container, mat-dialog-container');
+      const errorDisplay = page.locator('app-snack-bar, .mat-snack-bar-container, [role="dialog"]');
 
       // Error handling should be present
       expect(true).toBe(true);
@@ -706,7 +706,7 @@ test.describe('Delete Service Instance', () => {
 
       // Verify error message UI components exist
       const snackBar = page.locator('app-snack-bar, .mat-snack-bar-container');
-      const errorDialog = page.locator('mat-dialog-container').filter({ hasText: /error|failed/i });
+      const errorDialog = page.locator('[role="dialog"]').filter({ hasText: /error|failed/i });
 
       // UI should support detailed error display
       expect(true).toBe(true);

--- a/e2e/tests/marketplace/delete-ups-service-instance.spec.ts
+++ b/e2e/tests/marketplace/delete-ups-service-instance.spec.ts
@@ -67,7 +67,7 @@ test.describe('Delete User-Provided Service Instance', () => {
       await addButton.click();
 
       // Verify wizard/dialog opened
-      const wizard = page.locator('app-create-service, app-add-service, mat-dialog-container, app-stepper');
+      const wizard = page.locator('app-create-service, app-add-service, [role="dialog"], app-stepper');
       const wizardExists = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!wizardExists) {
@@ -109,7 +109,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await addButton.click();
 
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       if (!await wizard.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Create service wizard not displayed');
       }
@@ -162,7 +162,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await addButton.click();
 
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       if (!await wizard.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Create service wizard not displayed');
       }
@@ -198,7 +198,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await addButton.click();
 
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       if (!await wizard.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Create service wizard not displayed');
       }
@@ -234,7 +234,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await addButton.click();
 
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       if (!await wizard.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Create service wizard not displayed');
       }
@@ -270,7 +270,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await addButton.click();
 
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       if (!await wizard.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Create service wizard not displayed');
       }
@@ -306,7 +306,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await addButton.click();
 
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       if (!await wizard.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Create service wizard not displayed');
       }
@@ -349,7 +349,7 @@ test.describe('Delete User-Provided Service Instance', () => {
       await addButton.click();
 
       // Look for UPS option
-      const wizard = page.locator('mat-dialog-container, app-stepper').first();
+      const wizard = page.locator('[role="dialog"], app-stepper').first();
       const hasWizard = await wizard.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!hasWizard) {
@@ -453,7 +453,7 @@ test.describe('Delete User-Provided Service Instance', () => {
       await deleteOption.click();
 
       // Verify confirmation dialog
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       await expect(confirmDialog).toBeVisible({ timeout: 5000 });
 
       await page.keyboard.press('Escape');
@@ -499,7 +499,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       await expect(confirmDialog).toBeVisible({ timeout: 5000 });
 
       // Look for UPS details (name, type, etc.)
@@ -553,7 +553,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       await expect(confirmDialog).toBeVisible({ timeout: 5000 });
 
       // Look for bound applications list
@@ -606,7 +606,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await deleteOption.click();
 
-      const confirmDialog = page.locator('mat-dialog-container');
+      const confirmDialog = page.locator('[role="dialog"]');
       await expect(confirmDialog).toBeVisible({ timeout: 5000 });
 
       // Verify confirm button exists
@@ -1019,7 +1019,7 @@ test.describe('Delete User-Provided Service Instance', () => {
         await editOption.click();
 
         // Verify edit form/wizard appears
-        const editForm = page.locator('mat-dialog-container, app-stepper, form');
+        const editForm = page.locator('[role="dialog"], app-stepper, form');
         const hasForm = await editForm.first().isVisible({ timeout: 5000 }).catch(() => false);
 
         if (hasForm) {
@@ -1079,7 +1079,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await editOption.click();
 
-      const editForm = page.locator('mat-dialog-container, app-stepper, form');
+      const editForm = page.locator('[role="dialog"], app-stepper, form');
       if (!await editForm.first().isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit form not displayed');
       }
@@ -1135,7 +1135,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await editOption.click();
 
-      const editForm = page.locator('mat-dialog-container, app-stepper, form');
+      const editForm = page.locator('[role="dialog"], app-stepper, form');
       if (!await editForm.first().isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit form not displayed');
       }
@@ -1191,7 +1191,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await editOption.click();
 
-      const editForm = page.locator('mat-dialog-container, app-stepper, form');
+      const editForm = page.locator('[role="dialog"], app-stepper, form');
       if (!await editForm.first().isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit form not displayed');
       }
@@ -1247,7 +1247,7 @@ test.describe('Delete User-Provided Service Instance', () => {
 
       await editOption.click();
 
-      const editForm = page.locator('mat-dialog-container, app-stepper, form');
+      const editForm = page.locator('[role="dialog"], app-stepper, form');
       if (!await editForm.first().isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit form not displayed');
       }

--- a/e2e/tests/marketplace/edit-service-instance.spec.ts
+++ b/e2e/tests/marketplace/edit-service-instance.spec.ts
@@ -80,7 +80,7 @@ test.describe('Edit Service Instance', () => {
       await editOption.click();
 
       // Verify edit dialog opened
-      const editDialog = page.locator('app-edit-service-instance, mat-dialog-container, app-stepper');
+      const editDialog = page.locator('app-edit-service-instance, [role="dialog"], app-stepper');
       const dialogExists = await editDialog.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!dialogExists) {
@@ -131,7 +131,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container, app-stepper').first();
+      const editDialog = page.locator('[role="dialog"], app-stepper').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -193,7 +193,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container, app-stepper').first();
+      const editDialog = page.locator('[role="dialog"], app-stepper').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -247,7 +247,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container, app-stepper').first();
+      const editDialog = page.locator('[role="dialog"], app-stepper').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -300,7 +300,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container, app-stepper').first();
+      const editDialog = page.locator('[role="dialog"], app-stepper').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -403,7 +403,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -450,7 +450,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -502,7 +502,7 @@ test.describe('Edit Service Instance', () => {
       expect(url).toMatch(/[0-9a-f-]{36}/); // Contains GUID
 
       // Verify details page elements are present
-      const detailsContent = page.locator('.service-instance-summary, .service-details, app-page-header').first();
+      const detailsContent = page.locator('.service-instance-summary, .service-details, h1').first();
       const hasDetails = await detailsContent.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!hasDetails) {
@@ -713,7 +713,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container, app-stepper').first();
+      const editDialog = page.locator('[role="dialog"], app-stepper').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -779,7 +779,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -839,7 +839,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -923,7 +923,7 @@ test.describe('Edit Service Instance', () => {
 
       // Progress may not be visible until an actual operation is in progress
       // Just verify the page structure supports progress display
-      const pageStructure = page.locator('app-list, app-page-header').first();
+      const pageStructure = page.locator('app-list').first();
       await expect(pageStructure).toBeVisible();
     });
 
@@ -990,7 +990,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -1042,7 +1042,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -1100,7 +1100,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -1154,7 +1154,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }
@@ -1208,7 +1208,7 @@ test.describe('Edit Service Instance', () => {
 
       await editOption.click();
 
-      const editDialog = page.locator('mat-dialog-container').first();
+      const editDialog = page.locator('[role="dialog"]').first();
       if (!await editDialog.isVisible({ timeout: 5000 }).catch(() => false)) {
         test.skip('Edit dialog not displayed');
       }

--- a/e2e/tests/marketplace/marketplace-create-service-instances.spec.ts
+++ b/e2e/tests/marketplace/marketplace-create-service-instances.spec.ts
@@ -135,7 +135,7 @@ test.describe('Marketplace Create Service Instances', () => {
       await serviceCards.click();
 
       // Wait for navigation to service details/summary
-      const summaryOrDetails = page.locator('app-service-summary, app-service-details, mat-dialog-container').first();
+      const summaryOrDetails = page.locator('app-service-summary, app-service-details, [role="dialog"]').first();
       const detailsVisible = await summaryOrDetails.isVisible({ timeout: 5000 }).catch(() => false);
 
       if (!detailsVisible) {

--- a/e2e/tests/marketplace/ups-reads-stage9e-smoke.spec.ts
+++ b/e2e/tests/marketplace/ups-reads-stage9e-smoke.spec.ts
@@ -85,7 +85,7 @@ test.describe('Stage 9e — UPS reads smoke', () => {
     }
 
     await addButton.click();
-    const wizard = page.locator('mat-dialog-container, app-stepper').first();
+    const wizard = page.locator('[role="dialog"], app-stepper').first();
     await expect(wizard).toBeVisible({ timeout: 10000 });
 
     // The picker component is reachable via the UPS option — its sole


### PR DESCRIPTION
## What

The Playwright e2e suite was mass-failing: every application/CF test timed out at `waitForPage`. The page objects still targeted Material-era selectors that the Tailwind modernization removed or turned into zero-height CDK portal sources (`app-page-header`, `app-page-tabs`, `mat-tab-group`, `mat-dialog-container`, ...). The failures were load-independent — the app rendered fine; the tests were looking at elements that can never become visible.

## Changes

**Page objects & shared components** — re-point at the rendered DOM:
- header/title → `app-show-page-header` (portal target), tabs → `app-page-side-nav`
- shared `pageTab()` matcher that matches the tab label span exactly (link text includes the icon ligature, and substring matching collides on "Services" vs "User Services")
- page actions → `.page-header-sub-nav`, confirm dialog → `app-dialog-confirm`
- create-route and map-existing-route both live on the routed Add Route page now; the map flow drives the `data-test="available-routes"` list with filter-first radio selection
- add the `waitForPage()` the org/space specs already call

**Specs** — sweep the inline copies: `mat-dialog-container` → `[role="dialog"]` (~60 refs), dead component anchors → real ones, row actions opened via the `more_vert` menu, fixed sleeps replaced with waits on real state transitions, extended click timeouts where the "Retrieving…" loading overlay races actionability.

**Test infra** — three latent bugs found while verifying:
- the `cfApi` fixture teardown label-swept **all** `stratos-e2e-test` apps after every test, deleting parallel workers' apps mid-test (source of most "random" flakes at 2+ workers)
- `unmapRoute()` passed the app guid where CF v3 expects the destination guid — it always 422'd and was swallowed by `.catch()`
- API request contexts inherited the 10s `actionTimeout`; CF writes regularly exceed that under load → explicit 30s, plus one retry on CC's intermittent destination-write 500s

## Verification

`application-routes` @2 workers against a live dev stack (4 CF endpoints): **26 passed / 2 failed / 4 skipped**, up from **0 passing** before the series. The 2 remaining failures are a single map-existing-route flow (Create after radio selection), tracked as follow-up work along with running the CF org/space suites against these page objects.

## Notes for reviewers

- All changes are under `e2e/`; no product code touched.
- Selector choices were harvested from the live rendered DOM (the templates hide most of this behind portals), then verified by the runs above.
- Draft until the map-existing flow follow-up lands and the CF-level suites get a verification run.