### PR TITLE
Render bind-existing service instance options from v3 rows

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.html
@@ -61,9 +61,8 @@
       <app-form-field>
         <app-select class="form-control" required placeholder="Service Instance" formControlName="serviceInstance" [autoSelectSingleOption]="false">
           <app-option [value]="null">None</app-option>
-          @for (sI of bindableServiceInstances$ | async; track sI) {
-            <app-option [disabled]="!sI.metadata.guid"
-            [value]="sI.metadata.guid">{{ sI.entity.name }}</app-option>
+          @for (sI of bindableServiceInstances$ | async; track sI.guid) {
+            <app-option [value]="sI.guid">{{ sI.name }}</app-option>
           }
         </app-select>
       </app-form-field>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.spec.ts
@@ -8,10 +8,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
 import { generateCfBaseTestModulesNoShared } from '@test-framework/cf';
+import { StServiceInstance } from '../../../../services/endpoint-data/stratos-types';
 import { SchemaFormComponent } from '../../schema-form/schema-form.component';
 import { CreateServiceInstanceHelperServiceFactory } from '../create-service-instance-helper-service-factory.service';
 import { CsiGuidsService } from '../csi-guids.service';
-import { CsiModeService } from '../csi-mode.service';
+import { CreateServiceFormMode, CsiModeService } from '../csi-mode.service';
 import { CsiStateService } from '../csi-state.service';
 import { SpecifyDetailsStepComponent } from './specify-details-step.component';
 
@@ -106,6 +107,32 @@ describe('SpecifyDetailsStepComponent', () => {
     await fixture.whenStable();
 
     expect(component.schemaFormConfig()?.schema).toEqual(schema);
+  });
+
+  // Regression (GH#5600 follow-up): the bind-existing dropdown rendered no
+  // options because the template still read the legacy v2 APIResource shape
+  // (sI.metadata.guid / sI.entity.name) off the flat v3 StServiceInstance
+  // rows the signal-native helper emits.
+  it('renders bind-existing options from flat v3 service instances', async () => {
+    const instances = [
+      { guid: 'si-1', name: 'instance-one' },
+      { guid: 'si-2', name: 'instance-two' },
+    ] as StServiceInstance[];
+    component.serviceInstances$ = of(instances);
+    component.bindableServiceInstances$ = of(instances);
+    component.hasInstances$ = of(true);
+    component.formMode.set(CreateServiceFormMode.BindServiceInstance);
+    // setInput (not a plain field write) so the OnPush view is marked dirty,
+    // same as the parent-template binding in the real wizard.
+    fixture.componentRef.setInput('showModeSelection', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const texts = Array.from(
+      fixture.nativeElement.querySelectorAll('app-option') as NodeListOf<HTMLElement>,
+    ).map(o => o.textContent?.trim());
+    expect(texts).toContain('instance-one');
+    expect(texts).toContain('instance-two');
   });
 
   it('onEnter skips the details fetch when the plan already carries a schema', () => {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
@@ -34,13 +34,21 @@
         }
       </div>
     } @else {
-      <div class="border border-content-border rounded-md overflow-hidden">
+      <div class="flex justify-end mb-1">
+        <button type="button" class="btn btn-secondary btn-sm" (click)="toggleFormat()" [disabled]="!canFormat()">
+          {{ isMinified() ? 'Format' : 'Minify' }}
+        </button>
+      </div>
+      <div class="h-[200px] min-h-[200px] resize-y overflow-hidden border border-content-border rounded-md">
         <app-monaco-editor
           [model]="{ language: 'json', value: jsonText }"
           [options]="monacoOptions"
           (editorInit)="onMonacoInit($event)">
         </app-monaco-editor>
       </div>
+      @if (!parseValid()) {
+        <div class="mt-1 text-sm text-warning-shade-500">Not valid JSON. Please specify a valid JSON object.</div>
+      }
       @if (warnings().length) {
         <ul class="mt-2 text-sm text-warning list-disc pl-5">
           @for (w of warnings(); track w.path + w.message) { <li>{{ w.message }}</li> }
@@ -49,13 +57,21 @@
     }
   </div>
 } @else {
-  <div class="border border-content-border rounded-md overflow-hidden">
+  <div class="flex justify-end mb-1">
+    <button type="button" class="btn btn-secondary btn-sm" (click)="toggleFormat()" [disabled]="!canFormat()">
+      {{ isMinified() ? 'Format' : 'Minify' }}
+    </button>
+  </div>
+  <div class="h-[200px] min-h-[200px] resize-y overflow-hidden border border-content-border rounded-md">
     <app-monaco-editor
       [model]="{ language: 'json', value: jsonText }"
       [options]="monacoOptions"
       (editorInit)="onMonacoInit($event)">
     </app-monaco-editor>
   </div>
+  @if (!parseValid()) {
+    <div class="mt-1 text-sm text-warning-shade-500">Not valid JSON. Please specify a valid JSON object.</div>
+  }
   @if (warnings().length) {
     <ul class="mt-2 text-sm text-warning list-disc pl-5">
       @for (w of warnings(); track w.path + w.message) { <li>{{ w.message }}</li> }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
@@ -34,11 +34,13 @@
         }
       </div>
     } @else {
-      <app-monaco-editor
-        [model]="{ language: 'json', value: jsonText }"
-        [options]="{ automaticLayout: true, minimap: { enabled: false } }"
-        (editorInit)="onMonacoInit($event)">
-      </app-monaco-editor>
+      <div class="border border-content-border rounded-md overflow-hidden">
+        <app-monaco-editor
+          [model]="{ language: 'json', value: jsonText }"
+          [options]="monacoOptions"
+          (editorInit)="onMonacoInit($event)">
+        </app-monaco-editor>
+      </div>
       @if (warnings().length) {
         <ul class="mt-2 text-sm text-warning list-disc pl-5">
           @for (w of warnings(); track w.path + w.message) { <li>{{ w.message }}</li> }
@@ -47,11 +49,13 @@
     }
   </div>
 } @else {
-  <app-monaco-editor
-    [model]="{ language: 'json', value: jsonText }"
-    [options]="{ automaticLayout: true, minimap: { enabled: false } }"
-    (editorInit)="onMonacoInit($event)">
-  </app-monaco-editor>
+  <div class="border border-content-border rounded-md overflow-hidden">
+    <app-monaco-editor
+      [model]="{ language: 'json', value: jsonText }"
+      [options]="monacoOptions"
+      (editorInit)="onMonacoInit($event)">
+    </app-monaco-editor>
+  </div>
   @if (warnings().length) {
     <ul class="mt-2 text-sm text-warning list-disc pl-5">
       @for (w of warnings(); track w.path + w.message) { <li>{{ w.message }}</li> }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
@@ -39,7 +39,7 @@
           {{ isMinified() ? 'Format' : 'Minify' }}
         </button>
       </div>
-      <div class="h-[200px] min-h-[200px] resize-y overflow-hidden border border-content-border rounded-md">
+      <div class="h-[200px] min-h-[200px] min-w-[16rem] resize overflow-hidden border border-content-border rounded-md">
         <app-monaco-editor
           [model]="{ language: 'json', value: jsonText }"
           [options]="monacoOptions"
@@ -62,7 +62,7 @@
       {{ isMinified() ? 'Format' : 'Minify' }}
     </button>
   </div>
-  <div class="h-[200px] min-h-[200px] resize-y overflow-hidden border border-content-border rounded-md">
+  <div class="h-[200px] min-h-[200px] min-w-[16rem] resize overflow-hidden border border-content-border rounded-md">
     <app-monaco-editor
       [model]="{ language: 'json', value: jsonText }"
       [options]="monacoOptions"

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, DestroyRef, EventEmitter, Input, Ou
 import { FormsModule } from '@angular/forms';
 import {
   MonacoEditorComponent,
+  MonacoEditorOptions,
   TailwindSnackBarService,
   safeStringToObj,
 } from '@stratosui/core';
@@ -67,6 +68,20 @@ export class SchemaFormComponent {
   readonly parseValid = signal<boolean>(true);   // the ONLY submission gate
   readonly warnings = signal<SchemaWarning[]>([]);
   jsonText = '';
+
+  // Compact JSON editor: no minimap / overview ruler / line-highlight chrome —
+  // the params box holds a few lines of JSON, not a code file.
+  readonly monacoOptions: MonacoEditorOptions = {
+    automaticLayout: true,
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    wordWrap: 'on',
+    tabSize: 2,
+    overviewRulerLanes: 0,
+    hideCursorInOverviewRuler: true,
+    overviewRulerBorder: false,
+    renderLineHighlight: 'none',
+  };
 
   cleanSchema: object | null | undefined;
   formInitialData: object | null | undefined;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
@@ -1,5 +1,5 @@
 
-import { ChangeDetectionStrategy, Component, DestroyRef, EventEmitter, Input, Output, inject, signal, effect } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, EventEmitter, Input, Output, computed, inject, signal, effect } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
   MonacoEditorComponent,
@@ -96,6 +96,49 @@ export class SchemaFormComponent {
 
   private _destroyed = false;
   private _jsonEditor: any = null;
+  // Signal mirror of jsonText (a plain field) so the Format/Minify button
+  // state tracks edits reactively.
+  private _jsonTextSig = signal('');
+
+  /** Format/Minify only offered when the text parses — reformatting
+   *  non-JSON makes no sense. Empty text never parses, so the button is
+   *  disabled on an untouched editor. */
+  readonly canFormat = computed(() => {
+    try {
+      JSON.parse(this._jsonTextSig());
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  /** Whether the text is canonical-minified JSON — drives the
+   *  Format <-> Minify toggle's label and direction. */
+  readonly isMinified = computed(() => {
+    try {
+      const t = this._jsonTextSig();
+      return t === JSON.stringify(JSON.parse(t));
+    } catch {
+      return false;
+    }
+  });
+
+  /** Toggle the editor text between pretty-printed (2-space) and canonical
+   *  minified JSON. Pure editing aid — submission always sends the parsed
+   *  object, so this never changes what is sent. No-op on invalid JSON. */
+  toggleFormat(): void {
+    try {
+      const parsed = JSON.parse(this.jsonText);
+      const minified = JSON.stringify(parsed);
+      const next = this.jsonText === minified ? JSON.stringify(parsed, null, 2) : minified;
+      this.setJsonText(next);
+      if (this._jsonEditor && this._jsonEditor.getValue() !== next) {
+        this._jsonEditor.setValue(next);
+      }
+    } catch {
+      // Invalid JSON — the button is disabled, nothing to do.
+    }
+  }
 
   constructor() {
     effect(() => this.dataChange.emit(this.data()));
@@ -106,6 +149,7 @@ export class SchemaFormComponent {
   /** Called by the Monaco JSON view (and tests) when JSON text changes. */
   setJsonText(text: string) {
     this.jsonText = text;
+    this._jsonTextSig.set(text);
     const obj = safeStringToObj(text);          // null when unparseable
     const parsed = text.trim() === '' || obj !== null;
     this.parseValid.set(parsed);

--- a/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
+++ b/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectionStrategy, AfterViewInit,
   Component,
+  effect,
   ElementRef,
   EventEmitter,
   forwardRef,
+  inject,
   Input,
   OnDestroy,
   Output,
@@ -10,6 +12,7 @@ import { ChangeDetectionStrategy, AfterViewInit,
  } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
+import { StratosBrandingService } from '../../../../../theme/stratos-branding.service';
 import { loadMonacoEditor } from '../../../monaco-loader';
 
 declare const monaco: typeof import('monaco-editor');
@@ -54,7 +57,21 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
   @Input() model?: MonacoEditorModel;
   @Output() editorInit = new EventEmitter<any>();
 
+  private branding = inject(StratosBrandingService);
   private editor: any;
+
+  constructor() {
+    // Monaco's theme is process-global (monaco.editor.setTheme), so one
+    // editor following the app theme re-skins every editor on the page.
+    // Callers that pin options.theme opt out of the sync.
+    effect(() => {
+      const dark = this.branding.isDarkMode();
+      if (!this.editor || this.options.theme || typeof monaco === 'undefined') {
+        return;
+      }
+      monaco.editor.setTheme(dark ? 'vs-dark' : 'vs');
+    });
+  }
   private value = '';
   private onChange: (value: string) => void = () => {};
   private onTouched: () => void = () => {};
@@ -91,7 +108,7 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
     const editorOptions = {
       value: this.value,
       language: this.model?.language || 'plaintext',
-      theme: this.options.theme || 'vs',
+      theme: this.options.theme || (this.branding.isDarkMode() ? 'vs-dark' : 'vs'),
       automaticLayout: false,
       readOnly: this.disabled,
       ...this.options,


### PR DESCRIPTION
## What

Fixes the empty "Bind to an Existing Service Instance" dropdown in the add-service-instance wizard (follow-up defect on #5600, reported by @metskem after the stepper fix landed).

## Why

The data layer for this wizard was migrated to flat v3 rows (`StServiceInstance`: `guid`, `name`, ...), but the dropdown template still read the legacy v2 `APIResource` shape (`sI.metadata.guid` / `sI.entity.name`). Both fields are undefined on v3 rows, so every option failed to render and only the "None" entry showed. `strictTemplates` is disabled, so the compiler could not catch the stale template.

## How

- Read `guid`/`name` directly and track options by `guid`.
- Dropped the `[disabled]="!sI.metadata.guid"` guard: v3 rows always carry a guid.
- Added a render regression test that drives the bind-existing branch with flat v3 rows and asserts the option texts; it fails against the old template.

## Testing

- `make check gate` green (full lint + frontend + backend suites).
- New spec red on the old template, green on the fix.

Fixes #5600


## Also in this PR: Monaco editor chrome in the wizard params editors

The service-params / binding-params JSON editors rendered Monaco with no frame, a phantom overview-ruler mark, stray scrollbars, and an always-light theme — on a white page it read as a broken input.

- `schema-form`: both editor embeds get the bordered/rounded container the variable-edit dialog already uses; editor options consolidated into one field (no minimap, overview ruler, line highlight, or scroll-beyond-last-line in a small params box).
- `monaco-editor` (core): theme now defaults from the app's dark mode and re-syncs on toggle; explicit `options.theme` still wins. This also fixes the always-light Monaco in the variable-edit dialog.

Live-verified in both light and dark modes.

Follow-up commit brings the params editors up to the variable-edit dialog conventions: Format/Minify toggle, a visible "Not valid JSON" warning under the editor (the step already blocked on bad JSON, but silently), and a vertically resizable editor frame — the legacy textarea was browser-resizable and the Monaco swap had lost that.

