### PR TITLE
Enable strictTemplates across frontend packages

### DIFF
--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-credential/edit-autoscaler-credential.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-credential/edit-autoscaler-credential.component.html
@@ -1,5 +1,5 @@
 <app-page-header>
-  <h1>Manage AutoScaler Credentials: {{ (applicationService.application$ | async)?.app.entity.name }} </h1>
+  <h1>Manage AutoScaler Credentials: {{ (applicationService.application$ | async)?.app?.entity?.name }} </h1>
   <div class="page-header-right">
     <button routerLink="{{parentUrl}}" class="btn-icon">
       <span class="material-icons">clear</span>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-base-step.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-base-step.ts
@@ -3,13 +3,13 @@ import { ActivatedRoute } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { StepOnNextFunction } from '@stratosui/core';
-import { AppAutoscalerPolicy, AppAutoscalerPolicyLocal } from '../../store/app-autoscaler.types';
+import { AppAutoscalerPolicyLocal } from '../../store/app-autoscaler.types';
 import { EditAutoscalerPolicyService } from './edit-autoscaler-policy-service';
 
 @Directive()
 export abstract class EditAutoscalerPolicyDirective implements OnInit {
   public currentPolicy!: AppAutoscalerPolicyLocal;
-  public appAutoscalerPolicy$!: Observable<AppAutoscalerPolicy>;
+  public appAutoscalerPolicy$!: Observable<AppAutoscalerPolicyLocal>;
   protected isCreate = false;
 
   protected service = inject(EditAutoscalerPolicyService);

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step1/edit-autoscaler-policy-step1.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step1/edit-autoscaler-policy-step1.component.html
@@ -8,7 +8,7 @@
         <input id="instance_min_count" name="instance_min_count"
           formControlName="instance_min_count" type="number" required class="input"
           placeholder="Minimum Instance Count">
-        @if (editLimitForm.get('instance_min_count').hasError('alertInvalidPolicyMinimumRange')) {
+        @if (editLimitForm.get('instance_min_count')?.hasError('alertInvalidPolicyMinimumRange')) {
           <div
             class="text-danger text-sm mt-1">
             {{policyAlert.alertInvalidPolicyMinimumRange}}
@@ -20,7 +20,7 @@
         <input id="instance_max_count" name="instance_max_count"
           formControlName="instance_max_count" type="number" required class="input"
           placeholder="Maximum Instance Count">
-        @if (editLimitForm.get('instance_max_count').hasError('alertInvalidPolicyMaximumRange')) {
+        @if (editLimitForm.get('instance_max_count')?.hasError('alertInvalidPolicyMaximumRange')) {
           <div
             class="text-danger text-sm mt-1">
             {{policyAlert.alertInvalidPolicyMaximumRange}}

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.html
@@ -87,27 +87,27 @@
                       <span>seconds.</span>
                     </form>
                     <div class="space-y-1">
-                      @if (editTriggerForm.get('metric_type').hasError('required')) {
+                      @if (editTriggerForm.get('metric_type')?.hasError('required')) {
                         <div class="text-danger text-sm">
                           Metric type is required
                         </div>
                       }
-                      @if (editTriggerForm.get('metric_type').hasError('alertInvalidPolicyTriggerMetricName')) {
+                      @if (editTriggerForm.get('metric_type')?.hasError('alertInvalidPolicyTriggerMetricName')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyTriggerMetricName}}
                         </div>
                       }
-                      @if (editTriggerForm.get('threshold').hasError('required')) {
+                      @if (editTriggerForm.get('threshold')?.hasError('required')) {
                         <div class="text-danger text-sm">
                           Threshold is required
                         </div>
                       }
-                      @if (editTriggerForm.get('threshold').hasError('alertInvalidPolicyTriggerThreshold100')) {
+                      @if (editTriggerForm.get('threshold')?.hasError('alertInvalidPolicyTriggerThreshold100')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyTriggerThreshold100}}
                         </div>
                       }
-                      @if (editTriggerForm.get('threshold').hasError('alertInvalidPolicyTriggerThresholdRange')) {
+                      @if (editTriggerForm.get('threshold')?.hasError('alertInvalidPolicyTriggerThresholdRange')) {
                         <div class="text-danger text-sm">
                           @if (editScaleType==='upper') {
                             <span>
@@ -121,17 +121,17 @@
                           }
                         </div>
                       }
-                      @if (editTriggerForm.get('breach_duration_secs').hasError('min') || editTriggerForm.get('breach_duration_secs').hasError('max')) {
+                      @if (editTriggerForm.get('breach_duration_secs')?.hasError('min') || editTriggerForm.get('breach_duration_secs')?.hasError('max')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyTriggerBreachDurationRange}}
                         </div>
                       }
-                      @if (editTriggerForm.get('adjustment').hasError('required')) {
+                      @if (editTriggerForm.get('adjustment')?.hasError('required')) {
                         <div class="text-danger text-sm">
                           Adjustment is required
                         </div>
                       }
-                      @if (editTriggerForm.get('adjustment').hasError('alertInvalidPolicyTriggerStepRange')) {
+                      @if (editTriggerForm.get('adjustment')?.hasError('alertInvalidPolicyTriggerStepRange')) {
                         <div class="text-danger text-sm">
                           @if (editAdjustmentType==='value') {
                             <span>
@@ -145,7 +145,7 @@
                           }
                         </div>
                       }
-                      @if (editTriggerForm.get('cool_down_secs').hasError('min') || editTriggerForm.get('cool_down_secs').hasError('max')) {
+                      @if (editTriggerForm.get('cool_down_secs')?.hasError('min') || editTriggerForm.get('cool_down_secs')?.hasError('max')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyTriggerCooldownRange}}
                         </div>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step2/edit-autoscaler-policy-step2.component.ts
@@ -73,9 +73,9 @@ export class EditAutoscalerPolicyStep2Component extends EditAutoscalerPolicyDire
   readonly editIndex$ = new BehaviorSubject<number>(-1);
   get editIndex(): number { return this.editIndex$.value; }
   set editIndex(v: number) { this.editIndex$.next(v); }
-  private editMetricType = '';
-  private editScaleType = 'upper';
-  private editAdjustmentType = 'value';
+  protected editMetricType = '';
+  protected editScaleType = 'upper';
+  protected editAdjustmentType = 'value';
   private subs: Subscription[] = [];
 
   constructor() {

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.html
@@ -136,52 +136,52 @@
                       </div>
                     </form>
                     <div class="space-y-1">
-                      @if (editRecurringScheduleForm.get('instance_min_count').hasError('alertInvalidPolicyMinimumRange')) {
+                      @if (editRecurringScheduleForm.get('instance_min_count')?.hasError('alertInvalidPolicyMinimumRange')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyMinimumRange}}
                         </div>
                       }
-                      @if (editRecurringScheduleForm.get('instance_max_count').hasError('alertInvalidPolicyMaximumRange')) {
+                      @if (editRecurringScheduleForm.get('instance_max_count')?.hasError('alertInvalidPolicyMaximumRange')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyMaximumRange}}
                         </div>
                       }
-                      @if (editRecurringScheduleForm.get('initial_min_instance_count').hasError('alertInvalidPolicyInitialMaximumRange')) {
+                      @if (editRecurringScheduleForm.get('initial_min_instance_count')?.hasError('alertInvalidPolicyInitialMaximumRange')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyInitialMaximumRange}}
                         </div>
                       }
-                      @if (editRecurringScheduleForm.get('start_date').hasError('alertInvalidPolicyScheduleDateBeforeNow') || editRecurringScheduleForm.get('end_date').hasError('alertInvalidPolicyScheduleDateBeforeNow')) {
+                      @if (editRecurringScheduleForm.get('start_date')?.hasError('alertInvalidPolicyScheduleDateBeforeNow') || editRecurringScheduleForm.get('end_date')?.hasError('alertInvalidPolicyScheduleDateBeforeNow')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleDateBeforeNow}}
                         </div>
                       }
-                      @if (editRecurringScheduleForm.get('start_date').hasError('alertInvalidPolicyScheduleEndDateBeforeStartDate')) {
+                      @if (editRecurringScheduleForm.get('start_date')?.hasError('alertInvalidPolicyScheduleEndDateBeforeStartDate')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleEndDateBeforeStartDate}}
                         </div>
                       }
-                      @if (editRecurringScheduleForm.get('start_time').hasError('alertInvalidPolicyScheduleEndTimeBeforeStartTime')) {
+                      @if (editRecurringScheduleForm.get('start_time')?.hasError('alertInvalidPolicyScheduleEndTimeBeforeStartTime')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleEndTimeBeforeStartTime}}
                         </div>
                       }
-                      @if (editRepeatType==='week' && editRecurringScheduleForm.get('days_of_week').hasError('required')) {
+                      @if (editRepeatType==='week' && editRecurringScheduleForm.get('days_of_week')?.hasError('required')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleRepeatOn}}
                         </div>
                       }
-                      @if (editRepeatType==='week' && editRecurringScheduleForm.get('days_of_week').hasError('alertInvalidPolicyScheduleRecurringConflict')) {
+                      @if (editRepeatType==='week' && editRecurringScheduleForm.get('days_of_week')?.hasError('alertInvalidPolicyScheduleRecurringConflict')) {
                         <div class="text-danger text-sm">
                           days_of_week {{policyAlert.alertInvalidPolicyScheduleRecurringConflict}}
                         </div>
                       }
-                      @if (editRepeatType==='month' && editRecurringScheduleForm.get('days_of_month').hasError('required')) {
+                      @if (editRepeatType==='month' && editRecurringScheduleForm.get('days_of_month')?.hasError('required')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleRepeatOn}}
                         </div>
                       }
-                      @if (editRepeatType==='month' && editRecurringScheduleForm.get('days_of_month').hasError('alertInvalidPolicyScheduleRecurringConflict')) {
+                      @if (editRepeatType==='month' && editRecurringScheduleForm.get('days_of_month')?.hasError('alertInvalidPolicyScheduleRecurringConflict')) {
                         <div class="text-danger text-sm">
                           days_of_month {{policyAlert.alertInvalidPolicyScheduleRecurringConflict}}
                         </div>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step3/edit-autoscaler-policy-step3.component.ts
@@ -70,8 +70,8 @@ export class EditAutoscalerPolicyStep3Component extends EditAutoscalerPolicyDire
   readonly editIndex$ = new BehaviorSubject<number>(-1);
   get editIndex(): number { return this.editIndex$.value; }
   set editIndex(v: number) { this.editIndex$.next(v); }
-  private editEffectiveType = 'always';
-  private editRepeatType = 'week';
+  protected editEffectiveType = 'always';
+  protected editRepeatType = 'week';
   private editMutualValidation = {
     limit: true,
     date: true,

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step4/edit-autoscaler-policy-step4.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy-step4/edit-autoscaler-policy-step4.component.html
@@ -65,37 +65,37 @@
                       </div>
                     </form>
                     <div class="space-y-1">
-                      @if (editSpecificDateForm.get('instance_min_count').hasError('alertInvalidPolicyMinimumRange')) {
+                      @if (editSpecificDateForm.get('instance_min_count')?.hasError('alertInvalidPolicyMinimumRange')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyMinimumRange}}
                         </div>
                       }
-                      @if (editSpecificDateForm.get('instance_max_count').hasError('alertInvalidPolicyMaximumRange')) {
+                      @if (editSpecificDateForm.get('instance_max_count')?.hasError('alertInvalidPolicyMaximumRange')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyMaximumRange}}
                         </div>
                       }
-                      @if (editSpecificDateForm.get('initial_min_instance_count').hasError('alertInvalidPolicyInitialMaximumRange')) {
+                      @if (editSpecificDateForm.get('initial_min_instance_count')?.hasError('alertInvalidPolicyInitialMaximumRange')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyInitialMaximumRange}}
                         </div>
                       }
-                      @if (editSpecificDateForm.get('start_date_time').hasError('alertInvalidPolicyScheduleStartDateTimeBeforeNow')) {
+                      @if (editSpecificDateForm.get('start_date_time')?.hasError('alertInvalidPolicyScheduleStartDateTimeBeforeNow')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleStartDateTimeBeforeNow}}
                         </div>
                       }
-                      @if (editSpecificDateForm.get('start_date_time').hasError('alertInvalidPolicyScheduleEndDateTimeBeforeStartDateTime')) {
+                      @if (editSpecificDateForm.get('start_date_time')?.hasError('alertInvalidPolicyScheduleEndDateTimeBeforeStartDateTime')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleEndDateTimeBeforeStartDateTime}}
                         </div>
                       }
-                      @if (editSpecificDateForm.get('start_date_time').hasError('alertInvalidPolicyScheduleSpecificConflict')) {
+                      @if (editSpecificDateForm.get('start_date_time')?.hasError('alertInvalidPolicyScheduleSpecificConflict')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleSpecificConflict}}
                         </div>
                       }
-                      @if (editSpecificDateForm.get('end_date_time').hasError('alertInvalidPolicyScheduleEndDateTimeBeforeNow')) {
+                      @if (editSpecificDateForm.get('end_date_time')?.hasError('alertInvalidPolicyScheduleEndDateTimeBeforeNow')) {
                         <div class="text-danger text-sm">
                           {{policyAlert.alertInvalidPolicyScheduleEndDateTimeBeforeNow}}
                         </div>

--- a/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/edit-autoscaler-policy/edit-autoscaler-policy.component.html
@@ -1,7 +1,7 @@
 <div class="h-full">
   <app-page-header>
     <h1>{{isCreate ? 'Create' : 'Edit' }} AutoScaler Policy:
-      {{ (applicationService.application$ | async)?.app.entity.name }} </h1>
+      {{ (applicationService.application$ | async)?.app?.entity?.name }} </h1>
     <div class="page-header-right">
       <button class="btn btn-icon" routerLink="{{parentUrl}}" aria-label="Close">
         <app-custom-icon>clear</app-custom-icon>

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.html
@@ -15,18 +15,17 @@
           <div class="flex justify-center">
             <canvas baseChart
               [type]="'doughnut'"
-              [data]="gaugeData"
-              [options]="gaugeOptions"
+              [data]="gaugeData()"
+              [options]="gaugeOptions()"
               width="200"
-              height="200"
-              (chartClick)="select($event)">
+              height="200">
             </canvas>
           </div>
           <div class="w-full">
             <app-autoscaler-combo-chart-component [scheme]="comboBarScheme" [colorSchemeLine]="lineChartScheme"
               [customColors]="metricData[0].entity.formated.colorTarget" [results]="metricData[0].entity.formated.target"
               [animations]="true" [lineChart]="metricData[0].entity.markline" [tooltipDisabled]="false"
-              [yLeftAxisScaleFactor]="yLeftAxisScale" [gradient]="false" [xAxis]="true" [yAxis]="true" [legend]="true"
+              [xAxis]="true" [yAxis]="true" [legend]="true"
               [legendData]="appAutoscalerAppMetricLegend.legendColor" [showGridLines]="true" [showXAxisLabel]="true"
               [showYAxisLabel]="true" [yAxisLabel]="metricData[0].entity.unit" [metricName]="metricType"
               [yScaleMax]="metricData[0].entity.chartMaxValue">

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/app-autoscaler-metric-chart-card.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, Signal, computed, effect, inject, signal } from '@angular/core';
+import { ChartConfiguration, TooltipItem } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 
 import { ApplicationService } from '../../../../../../cloud-foundry/src/features/applications/application.service';
@@ -14,6 +15,7 @@ import {
 import {
   AppAutoscalerMetricDataLocal,
   AppAutoscalerMetricDataPoint,
+  AppAutoscalerMetricLegend,
   AppScalingTrigger,
 } from '../../../../store/app-autoscaler.types';
 import { AppAutoscalerComboChartComponent } from './combo-chart/combo-chart.component';
@@ -73,7 +75,14 @@ export class AppAutoscalerMetricChartCardComponent extends CardCell<APIResource<
   private currentTrigger = signal<AppScalingTrigger | null>(null);
 
   public metricData!: Signal<APIResource<AppAutoscalerMetricDataLocal>[] | null>;
-  public appAutoscalerAppMetricLegend!: { legendValue: AppAutoscalerMetricDataPoint[], legendColor: unknown[] };
+  public appAutoscalerAppMetricLegend!: { legendValue: AppAutoscalerMetricDataPoint[], legendColor: AppAutoscalerMetricLegend[] };
+
+  // Doughnut gauge showing the latest metric reading against the chart
+  // maximum, coloured by trigger state — the same fields the legacy
+  // ngx-charts gauge bound (latest.target / latest.colorTarget /
+  // chartMaxValue / unit).
+  public gaugeData!: Signal<ChartConfiguration<'doughnut'>['data']>;
+  public gaugeOptions!: Signal<ChartConfiguration<'doughnut'>['options']>;
 
   constructor() {
     super();
@@ -102,6 +111,48 @@ export class AppAutoscalerMetricChartCardComponent extends CardCell<APIResource<
         entity: local,
         metadata: row.metadata,
       }];
+    });
+
+    this.gaugeData = computed(() => {
+      const entity = this.metricData()?.[0]?.entity;
+      if (!entity) {
+        return { labels: [], datasets: [] };
+      }
+      const value = Number(entity.latest.target[0]?.value ?? 0);
+      const color = String(entity.latest.colorTarget[0]?.value ?? 'rgba(0,0,0,0.2)');
+      return {
+        labels: [this.metricType, ''],
+        datasets: [{
+          data: [value, Math.max(entity.chartMaxValue - value, 0)],
+          backgroundColor: [color, 'rgba(0, 0, 0, 0.1)'],
+          borderWidth: 0,
+        }],
+      };
+    });
+
+    this.gaugeOptions = computed(() => {
+      const unit = this.metricData()?.[0]?.entity?.unit ?? '';
+      return {
+        // Fixed-size gauge (canvas width/height attributes), matching the
+        // legacy 200x200 gauge.
+        responsive: false,
+        // Legacy gauge geometry: a 240-degree arc starting at -120 degrees.
+        rotation: -120,
+        circumference: 240,
+        cutout: '70%',
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            // Only the value slice is meaningful; hide the filler slice.
+            filter: (item: TooltipItem<'doughnut'>) => item.dataIndex === 0,
+            callbacks: {
+              label: (item: TooltipItem<'doughnut'>) => unit ? `${item.parsed} ${unit}` : `${item.parsed}`,
+            },
+          },
+        },
+      };
     });
 
     // Whenever the row binding settles, fire the load() against the

--- a/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/combo-chart/combo-chart.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/shared/list-types/app-autoscaler-metric-chart/app-autoscaler-metric-chart-card/combo-chart/combo-chart.component.ts
@@ -1,6 +1,12 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, ViewEncapsulation, OnChanges, inject } from '@angular/core';
-import { ChartConfiguration, ChartEvent, ActiveElement } from 'chart.js';
+import { ChartConfiguration, ChartEvent } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
+
+import {
+  AppAutoscalerMetricDataLine,
+  AppAutoscalerMetricDataPoint,
+  AppAutoscalerMetricLegend,
+} from '../../../../../store/app-autoscaler.types';
 
 @Component({
   selector: 'app-autoscaler-combo-chart-component',
@@ -20,10 +26,30 @@ export class AppAutoscalerComboChartComponent implements OnChanges {
   @Input() width = 400;
   @Input() height = 300;
   @Input() legend = false;
+  @Input() xAxis = false;
+  @Input() yAxis = false;
+  @Input() showXAxisLabel = false;
+  @Input() showYAxisLabel = false;
+  @Input() showGridLines = true;
+  @Input() tooltipDisabled = false;
+  @Input() animations = true;
   @Input() xAxisLabel!: string;
   @Input() yAxisLabel!: string;
-  @Input() results: any[] = [];
-  @Input() lineChart: any[] = [];
+  // Name of the metric series; used as the bar dataset label (tooltips).
+  @Input() metricName!: string;
+  // Ensure the y axis extends at least this far, so trigger thresholds
+  // near the top of the range stay visible.
+  @Input() yScaleMax?: number;
+  // Flat time-bucket points — one bar per point.
+  @Input() results: AppAutoscalerMetricDataPoint[] = [];
+  // Trigger threshold mark-lines: one flat line series per scaling rule.
+  @Input() lineChart: AppAutoscalerMetricDataLine[] = [];
+  // Colour overrides matched by name: time-bucket names for the bars plus
+  // trigger names for the threshold lines (see buildMetricColorData).
+  @Input() customColors: AppAutoscalerMetricDataPoint[] = [];
+  // Informational legend entries (trigger threshold ranges) shown instead
+  // of the dataset labels, matching the legacy custom legend.
+  @Input() legendData: AppAutoscalerMetricLegend[] = [];
   @Input() colorSchemeLine: any;
   @Input() scheme: any;
 
@@ -33,44 +59,7 @@ export class AppAutoscalerComboChartComponent implements OnChanges {
   @Output() deactivate = new EventEmitter();
 
   public comboChartData: ChartConfiguration['data'] = { labels: [], datasets: [] };
-  public comboChartOptions: ChartConfiguration['options'] = {
-    responsive: true,
-    maintainAspectRatio: false,
-    interaction: {
-      intersect: false,
-    },
-    scales: {
-      x: {
-        display: true,
-        title: {
-          display: true,
-          text: ''
-        }
-      },
-      y: {
-        type: 'linear',
-        display: true,
-        position: 'left',
-        title: {
-          display: true,
-          text: ''
-        }
-      },
-      y1: {
-        type: 'linear',
-        display: true,
-        position: 'right',
-        grid: {
-          drawOnChartArea: false,
-        }
-      }
-    },
-    plugins: {
-      legend: {
-        display: true
-      }
-    }
-  };
+  public comboChartOptions: ChartConfiguration['options'] = this.buildOptions();
 
   ngOnChanges() {
     this.updateChartData();
@@ -78,71 +67,108 @@ export class AppAutoscalerComboChartComponent implements OnChanges {
   }
 
   private updateChartData() {
-    if (!this.results && !this.lineChart) {
-      this.comboChartData = { labels: [], datasets: [] };
-      return;
-    }
+    const results = this.results ?? [];
+    const lines = this.lineChart ?? [];
+    const colorByName = new Map<string, string>((this.customColors ?? []).map(item => [item.name, String(item.value)]));
 
-    // Get labels from the data
-    const labels = this.results && this.results.length > 0
-      ? this.results[0].series.map((item: any) => new Date(item.name).toLocaleDateString())
-      : [];
+    // Bars: one per pre-formatted time bucket, coloured by trigger state.
+    const barFallback: string = this.scheme?.domain?.[0] ?? '#01579b';
+    const datasets: ChartConfiguration['data']['datasets'] = [{
+      type: 'bar',
+      label: this.metricName,
+      data: results.map(point => Number(point.value)),
+      backgroundColor: results.map(point => colorByName.get(point.name) || barFallback),
+      yAxisID: 'y',
+    }];
 
-    const datasets: any[] = [];
-
-    // Add bar datasets
-    if (this.results) {
-      this.results.forEach((series: any, index: number) => {
-        datasets.push({
-          type: 'bar',
-          label: series.name,
-          data: series.series.map((item: any) => item.value),
-          backgroundColor: this.getColor(index, 'bar'),
-          yAxisID: 'y'
-        });
+    // Threshold mark-lines share the bars' unit and scale, so they render
+    // on the same axis; colours come from the trigger colour map.
+    const lineFallback: string[] = this.colorSchemeLine?.domain ?? ['#01579b'];
+    lines.forEach((series, index) => {
+      const color = colorByName.get(series.name) || lineFallback[index % lineFallback.length];
+      datasets.push({
+        type: 'line',
+        label: series.name,
+        data: series.series.map(point => Number(point.value)),
+        borderColor: color,
+        backgroundColor: color,
+        fill: false,
+        pointRadius: 0,
+        tension: 0,
+        yAxisID: 'y',
       });
-    }
+    });
 
-    // Add line datasets
-    if (this.lineChart) {
-      this.lineChart.forEach((series: any, index: number) => {
-        datasets.push({
-          type: 'line',
-          label: series.name,
-          data: series.series.map((item: any) => item.value),
-          borderColor: this.getColor(index, 'line'),
-          backgroundColor: this.getColor(index, 'line') + '20',
-          fill: false,
-          tension: 0.1,
-          yAxisID: 'y1'
-        });
-      });
-    }
-
-    this.comboChartData = { labels, datasets };
-
-    // Update axis labels
-    if (this.comboChartOptions?.scales?.x && 'title' in this.comboChartOptions.scales.x && this.comboChartOptions.scales.x.title) {
-      this.comboChartOptions.scales.x.title.text = this.xAxisLabel || '';
-    }
-    if (this.comboChartOptions?.scales?.y && 'title' in this.comboChartOptions.scales.y && this.comboChartOptions.scales.y.title) {
-      this.comboChartOptions.scales.y.title.text = this.yAxisLabel || '';
-    }
+    this.comboChartData = {
+      labels: results.map(point => point.name),
+      datasets,
+    };
+    this.comboChartOptions = this.buildOptions();
   }
 
-  private getColor(index: number, type: 'bar' | 'line'): string {
-    const barColors = ['#5AA454', '#A10A28', '#C7B42C', '#AAAAAA'];
-    const lineColors = ['#FF7F0E', '#2CA02C', '#D62728', '#9467BD'];
-
-    const colors = type === 'bar' ? barColors : lineColors;
-    return colors[index % colors.length];
+  private buildOptions(): ChartConfiguration['options'] {
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: this.animations ? undefined : false,
+      interaction: {
+        intersect: false,
+      },
+      scales: {
+        x: {
+          display: this.xAxis,
+          grid: {
+            display: false,
+          },
+          title: {
+            display: this.showXAxisLabel && !!this.xAxisLabel,
+            text: this.xAxisLabel ?? '',
+          },
+        },
+        y: {
+          type: 'linear',
+          display: this.yAxis,
+          position: 'left',
+          beginAtZero: true,
+          suggestedMax: this.yScaleMax,
+          grid: {
+            display: this.showGridLines,
+          },
+          title: {
+            display: this.showYAxisLabel && !!this.yAxisLabel,
+            text: this.yAxisLabel ?? '',
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          display: this.legend,
+          // The legend lists trigger threshold ranges (informational),
+          // not toggleable datasets — mirror the legacy custom legend.
+          ...(this.legendData?.length ? {
+            onClick: () => { /* informational entries — nothing to toggle */ },
+            labels: {
+              generateLabels: () => this.legendData.map(item => ({
+                text: item.name,
+                fillStyle: item.value,
+                strokeStyle: item.value,
+                lineWidth: 0,
+              })),
+            },
+          } : {}),
+        },
+        tooltip: {
+          enabled: !this.tooltipDisabled,
+        },
+      },
+    };
   }
 
-  onChartClick(event: ChartEvent, active: ActiveElement[]) {
+  onChartClick(event: ChartEvent | undefined, active: object[] | undefined) {
     this.select.emit({ event, active });
   }
 
-  onChartHover(event: ChartEvent, active: ActiveElement[]) {
+  onChartHover(event: ChartEvent, active: object[]) {
     this.activate.emit({ event, active });
   }
 }

--- a/src/frontend/packages/cf-autoscaler/tsconfig.lib.json
+++ b/src/frontend/packages/cf-autoscaler/tsconfig.lib.json
@@ -14,6 +14,6 @@
     "**/*.spec.ts"
   ],
   "angularCompilerOptions": {
-    "strictTemplates": false
+    "strictTemplates": true
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.html
@@ -66,9 +66,9 @@
             <ul class="list-disc list-inside m-0">
               @for (binding of selectedServiceBindings; track binding.guid) {
                 <li data-test="confirm-binding">
-                  {{ binding.serviceInstanceName }}
-                  @if (binding.serviceInstanceType) {
-                    <span class="text-content-muted"> ({{ binding.serviceInstanceType }})</span>
+                  {{ binding.serviceInstance.name }}
+                  @if (binding.serviceInstance.type) {
+                    <span class="text-content-muted"> ({{ binding.serviceInstance.type }})</span>
                   }
                 </li>
               }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -180,8 +180,8 @@
                       <div class="flex-1">
                         <app-metadata-item
                           class="mt-0"
-                          [iconFont]="deploySource.icon.fontName"
-                          [icon]="deploySource.icon.iconName"
+                          [iconFont]="deploySource.icon?.fontName"
+                          [icon]="deploySource.icon?.iconName ?? ''"
                           label="SCM"
                         >
                           {{ deploySource.label }}
@@ -278,7 +278,8 @@
                 {{ detail.process?.healthCheckType ?? "-" }}</app-metadata-item
               >
               <app-metadata-item icon="schedule" label="Health Check Timeout">
-                {{ $safeNavigationMigration(detail.process?.healthCheckTimeoutSeconds) | uptime }}</app-metadata-item
+                @let healthCheckTimeout = detail.process?.healthCheckTimeoutSeconds;
+                {{ healthCheckTimeout != null ? (healthCheckTimeout | uptime) : "-" }}</app-metadata-item
               >
               @if (detail.process?.healthCheckType === "http") {
                 <app-metadata-item icon="http" label="Health Check HTTP Endpoint">{{

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/view-buildpack/view-buildpack.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/view-buildpack/view-buildpack.component.ts
@@ -12,7 +12,7 @@ export class ViewBuildpackComponent implements OnInit, OnChanges {
 
   constructor() { }
 
-  @Input() buildPack!: string;
+  @Input() buildPack: string | undefined;
   isWebLink!: boolean;
 
   ngOnInit() { }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/gitscm-tab/gitscm-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/gitscm-tab/gitscm-tab.component.html
@@ -28,7 +28,7 @@
                       <div>
                         <app-metadata-item label="Commit">
                           <a href="{{ (commit$ | async)?.html_url }}" target="_blank">{{
-                            stratosProject.deploySource.commit | limitTo: 8
+                            (stratosProject.deploySource.commit ?? "") | limitTo: 8
                           }}</a>
                         </app-metadata-item>
                       </div>
@@ -110,7 +110,7 @@
                   <h3 class="text-lg font-semibold">Commit Details</h3>
                   <div>
                     <img
-                      src="{{ commitInfo.author.avatar_url }}"
+                      src="{{ commitInfo.author?.avatar_url }}"
                       alt="Commit author avatar"
                       class="h-12 w-12 rounded-full"
                     />
@@ -118,7 +118,7 @@
                 </div>
                 <div class="card-body">
                   <div>
-                    <app-metadata-item label="Message">{{ commitInfo.commit.message }}</app-metadata-item>
+                    <app-metadata-item label="Message">{{ commitInfo.commit?.message }}</app-metadata-item>
                     <app-metadata-item label="SHA">
                       <a href="{{ commitInfo.html_url }}" target="_blank">{{ commitInfo.sha | limitTo: 8 }}</a>
                     </app-metadata-item>
@@ -126,7 +126,7 @@
                       <app-github-commit-author [commit]="commitInfo" [showAvatar]="false"></app-github-commit-author>
                     </app-metadata-item>
                     <app-metadata-item label="Date:"
-                      >{{ commitInfo.commit.author.date | date: "medium" }}
+                      >{{ commitInfo.commit?.author?.date | date: "medium" }}
                     </app-metadata-item>
                   </div>
                 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step2/create-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step2/create-application-step2.component.ts
@@ -15,6 +15,7 @@ import { Observable, of as observableOf } from "rxjs";
 import { map } from "rxjs/operators";
 
 import {
+  AppErrorComponent,
   AppInputDirective,
   CustomFormFieldComponent,
   ErrorStateMatcher,
@@ -44,6 +45,7 @@ interface CreateApplicationForm {
   imports: [
     FormsModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     AppNameUniqueDirective,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application-step3/create-application-step3.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { from, Observable, of as observableOf, throwError } from 'rxjs';
 import { catchError, filter, map, mergeMap, switchMap } from 'rxjs/operators';
 
-import { AppInputDirective, CustomFormFieldComponent, CustomSelectComponent, CustomOptionComponent, ErrorStateMatcher, ShowOnDirtyErrorStateMatcher, StepOnNextFunction } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent, CustomSelectComponent, CustomOptionComponent, ErrorStateMatcher, ShowOnDirtyErrorStateMatcher, StepOnNextFunction } from '@stratosui/core';
 import { CnsiAppsSource } from '../../../../services/data-sources/cnsi-apps-source';
 import { CnsiRoutesSource } from '../../../../services/data-sources/cnsi-routes-source';
 import { EndpointDataRegistry } from '../../../../services/endpoint-data/endpoint-data.registry';
@@ -27,6 +27,7 @@ interface DomainHostForm {
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.html
@@ -3,7 +3,7 @@
 @if ((deployer.fileTransferStatus$.asObservable() | async); as fsStatus) {
   <div class="source-upload">
     <div class="source-upload__fileSize">{{ fsStatus.totalFiles }} files, {{ fsStatus.totalBytes | bytesToHumanSize }} data</div>
-    <app-upload-progress-indicator value="{{ 100 * fsStatus.filesSent / fsStatus.totalFiles }}"></app-upload-progress-indicator>
+    <app-upload-progress-indicator [value]="100 * fsStatus.filesSent / fsStatus.totalFiles"></app-upload-progress-indicator>
     @if (fsStatus.filesSent !== fsStatus.totalFiles) {
       <div class="source-upload__fileName">{{ fsStatus.fileName }}</div>
     }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs-scanner.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-fs/deploy-application-fs-scanner.ts
@@ -21,6 +21,7 @@ export interface FileScannerInfo {
   summaryItem: any;
   manifestFile: any;
   cfIgnoreFile: any;
+  rootFolderName?: string;
 }
 
 export class DeployApplicationFSScanner implements FileScannerInfo {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -128,10 +128,10 @@
                       <select id="repositoryBranch" class="input"
                         [disabled]="isRedeploy || !repository || !sourceSelectionForm.controls.projectName.valid"
                         [(ngModel)]="repositoryBranch" name="repositoryBranch"
-                        (change)="updateBranchName($event.target.value)" required>
-                        <option value="" disabled>Select a branch</option>
+                        (ngModelChange)="updateBranchName($event)" required>
+                        <option [ngValue]="undefined" disabled>Select a branch</option>
                         @for (branch of repositoryBranches$ | async; track branch) {
-                          <option [value]="branch">
+                          <option [ngValue]="branch">
                             {{ branch.name }}
                           </option>
                         }
@@ -141,21 +141,21 @@
                       <div
                         class="deploy-step2-form__project-info-group deploy-step2-form__commit">
                         <div>
-                          <img src="{{commitInfo.author.avatar_url}}" alt="">
+                          <img src="{{commitInfo.author?.avatar_url}}" alt="">
                         </div>
                         <div src="description">
                           <div>
                             <a href="{{commitInfo.html_url}}" target="_blank">{{commitInfo.sha | limitTo:8}}</a>
                           </div>
                           <div>
-                            {{commitInfo.commit.message}}
+                            {{commitInfo.commit?.message}}
                           </div>
                           <div class="author-info">
                             <div>
-                              {{commitInfo.commit.author.name}}
+                              {{commitInfo.commit?.author?.name}}
                             </div>
                             <div>
-                              {{commitInfo.commit.author.date | date: 'medium'}}
+                              {{commitInfo.commit?.author?.date | date: 'medium'}}
                             </div>
                           </div>
                         </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -48,6 +48,7 @@ import { ApplicationDeploySourceTypes, DEPLOY_TYPES_IDS } from '../deploy-applic
 import { GitSuggestedRepo } from './../../../../../../git/src/store/git.public-types';
 import { GithubProjectExistsDirective } from '../github-project-exists.directive';
 import { DeployApplicationFsComponent } from './deploy-application-fs/deploy-application-fs.component';
+import { FileScannerInfo } from './deploy-application-fs/deploy-application-fs-scanner';
 
 
 
@@ -104,8 +105,9 @@ export class DeployApplicationStep2Component
   canDeployType$!: Observable<boolean>;
   isLoading$!: Observable<boolean>;
 
-  // Local FS data when file or folder upload
-  // @Input('fsSourceData') fsSourceData;
+  // Local FS data when file or folder upload; bound via ngModel so the
+  // fsLocalSource control participates in form validation.
+  fsSourceData: FileScannerInfo | undefined;
 
   // ---- GIT ----------
   repositoryBranches$!: Observable<GitBranch[]>;

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.html
@@ -14,8 +14,8 @@
     <app-deploy-application-step2 [isRedeploy]="isRedeploy" #step2></app-deploy-application-step2>
   </app-step>
   <!-- Select the commit if source type is git -->
-  <app-step [hidden]="appGuid || (step2.sourceTypeGithub$ | async) === false" [title]="'Source Config'"
-    [skip]="skipConfig$ | async" [signalHandle]="step2_1Handle">
+  <app-step [hidden]="!!appGuid || (step2.sourceTypeGithub$ | async) === false" [title]="'Source Config'"
+    [skip]="(skipConfig$ | async) ?? false" [signalHandle]="step2_1Handle">
     <app-deploy-application-step2-1 #step2_1></app-deploy-application-step2-1>
   </app-step>
   <!-- Upload the source if source type is folder/archive  -->

--- a/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.html
@@ -1,5 +1,5 @@
 <app-page-header>
-  <h1>Edit Application: {{ (applicationService.application$ | async)?.app.entity.name }} </h1>
+  <h1>Edit Application: {{ (applicationService.application$ | async)?.app?.entity?.name }} </h1>
   <div class="page-header-right">
     <button class="btn btn-icon" routerLink="/applications/{{applicationService.cfGuid}}/{{applicationService.appGuid}}">
       <span class="material-icons">clear</span>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/edit-application/edit-application.component.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, inject, computed } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, Validators, FormBuilder, FormControl, FormGroup } from '@angular/forms';
-import { AppInputDirective, CustomFormFieldComponent } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent } from '@stratosui/core';
 import { Router, RouterModule } from '@angular/router';
 import { ErrorStateMatcher, ShowOnDirtyErrorStateMatcher } from '@stratosui/core';
 import { defer, firstValueFrom, from, Observable, of as observableOf, Subscription } from 'rxjs';
@@ -45,6 +45,7 @@ interface EditApplicationForm {
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomSlideToggleComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.html
@@ -7,7 +7,7 @@
       <h3>Select application source</h3>
       <p>To create an application you can either deploy from a specific source or create an application shell. An
         application shell is an empty application with no package associated with it.</p>
-      <app-tile-selector [options]="tileSelectorConfig$ | async" [dynamicSmallerTiles]="6"
+      <app-tile-selector [options]="(tileSelectorConfig$ | async) ?? []" [dynamicSmallerTiles]="6"
         (selection)="selectedTile = $event">
       </app-tile-selector>
     </div>

--- a/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/new-application-base-step/new-application-base-step.component.ts
@@ -60,20 +60,24 @@ export class NewApplicationBaseStepComponent {
   // selectionChange handler calling router.navigate.
   signalHandle: SignalStepHandle = { valid: signal(true).asReadonly() };
 
-  set selectedTile(tile: ITileConfig<IAppTileData>) {
-    if (tile && tile.data) {
+  // The selector's (selection) output is typed against the base ITileConfig
+  // (and emits null on deselect); the tiles are built in this component with
+  // IAppTileData, so the narrowing here is sound.
+  set selectedTile(tile: ITileConfig | null) {
+    const data = tile?.data as IAppTileData | undefined;
+    if (data) {
       const baseUrl = 'applications';
-      const type = tile.data.type;
+      const type = data.type;
       const query: { [key: string]: string } = {
         [BASE_REDIRECT_QUERY]: `${baseUrl}/new`
       };
-      if (tile.data.subType) {
-        query[AUTO_SELECT_DEPLOY_TYPE_URL_PARAM] = tile.data.subType;
+      if (data.subType) {
+        query[AUTO_SELECT_DEPLOY_TYPE_URL_PARAM] = data.subType;
         // endpointGuid is only present for deploy tiles auto-selected from a
         // specific CF; when absent the param is omitted (router drops undefined
         // params anyway, so this matches the prior behavior).
-        if (tile.data.endpointGuid) {
-          query[AUTO_SELECT_DEPLOY_TYPE_ENDPOINT_PARAM] = tile.data.endpointGuid;
+        if (data.endpointGuid) {
+          query[AUTO_SELECT_DEPLOY_TYPE_ENDPOINT_PARAM] = data.endpointGuid;
         }
       }
       const endpoint = this.activatedRoute.snapshot.params.endpointId;

--- a/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.html
@@ -3,7 +3,7 @@
     <div class="add-route__section-title">Create a new route</div>
     <form class="stepper-form w-1/2" [formGroup]="domainFormGroup">
       <app-form-field [fitContent]="true">
-        <app-select formControlName="domain" placeholder="Domain" required [appFocus]="domains()">
+        <app-select formControlName="domain" placeholder="Domain" [required]="true" [appFocus]="domains().length > 0">
           @for (domain of domains(); track domain.guid) {
             <app-option [value]="domain">{{domain.name}}</app-option>
           }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.ts
@@ -16,6 +16,7 @@ import { filter, startWith } from 'rxjs/operators';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 import {
+  AppErrorComponent,
   AppInputDirective,
   CustomFormFieldComponent,
   CustomSelectComponent,
@@ -93,6 +94,7 @@ const pathPattern = `^([\\w\\-\\/\\!\\#\\[\\]\\@\\&\\$\\'\\(\\)\\*\\+\\;\\=\\,]*
   imports: [
     FormsModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-organization/create-organization-step/create-organization-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-organization/create-organization-step/create-organization-step.component.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Observable, Subscription, firstValueFrom } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 
-import { AppInputDirective, CustomFormFieldComponent, CustomSelectComponent, CustomOptionComponent, FocusDirective, SignalStepHandle, TailwindSnackBarService } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent, CustomSelectComponent, CustomOptionComponent, FocusDirective, SignalStepHandle, TailwindSnackBarService } from '@stratosui/core';
 import { CnsiOrgsSource } from '../../../../services/data-sources/cnsi-orgs-source';
 import { EndpointDataRegistry } from '../../../../services/endpoint-data/endpoint-data.registry';
 import { QuotaDataService, SignalSource } from '../../../../services/endpoint-data/quota-data.service';
@@ -27,6 +27,7 @@ interface CreateOrganizationForm {
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-space/create-space-step/create-space-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-space/create-space-step/create-space-step.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { AppInputDirective, CustomFormFieldComponent } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent } from '@stratosui/core';
 import { Component, Injector, OnDestroy, OnInit, ChangeDetectionStrategy, effect, inject, runInInjectionContext, signal, Input } from '@angular/core';
 import { ReactiveFormsModule, Validators, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { CustomSelectComponent, CustomOptionComponent } from '../../../../../../core/src/shared/components/custom-select/custom-select.component';
@@ -32,6 +32,7 @@ interface CreateSpaceForm {
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry-tabs-base/cloud-foundry-tabs-base.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry-tabs-base/cloud-foundry-tabs-base.component.html
@@ -1,5 +1,5 @@
 <app-page-header class="flex-none" [tabs]="tabLinks" [tabsHeader]="tabsHeader" [favorite]="favorite$ | async">
-  <h1>{{ cfEndpointService.endpoint()?.entity.name }}</h1>
+  <h1>{{ cfEndpointService.endpoint()?.entity?.name }}</h1>
 </app-page-header>
 <app-loading-page class="flex flex-col flex-1 min-h-0 overflow-hidden" [isLoading]="isFetching$" [text]="'Retrieving Cloud Foundry details'">
   <router-outlet></router-outlet>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization-step/edit-organization-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization-step/edit-organization-step.component.ts
@@ -7,7 +7,7 @@ import { firstValueFrom, Observable, Subscription } from 'rxjs';
 import { filter, map, take, tap } from 'rxjs/operators';
 
 import { HttpClient } from '@angular/common/http';
-import { AppInputDirective, CustomFormFieldComponent, CustomOptionComponent, CustomSelectComponent, FocusDirective, SignalStepHandle, safeUnsubscribe } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent, CustomOptionComponent, CustomSelectComponent, FocusDirective, SignalStepHandle, safeUnsubscribe } from '@stratosui/core';
 import { CnsiOrgsSource } from '../../../../services/data-sources/cnsi-orgs-source';
 import { EndpointDataRegistry } from '../../../../services/endpoint-data/endpoint-data.registry';
 import { QuotaDataService, SignalSource } from '../../../../services/endpoint-data/quota-data.service';
@@ -42,6 +42,7 @@ interface EditOrganizationForm {
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space-step/edit-space-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space-step/edit-space-step.component.ts
@@ -8,6 +8,7 @@ import { firstValueFrom, from, Observable, of, Subscription, throwError } from '
 import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 import {
+  AppErrorComponent,
   AppInputDirective,
   CustomFormFieldComponent,
   CustomSelectComponent,
@@ -43,6 +44,7 @@ interface EditSpaceForm {
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomSelectComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition-form/quota-definition-form.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition-form/quota-definition-form.component.ts
@@ -3,6 +3,7 @@ import { AbstractControl, ReactiveFormsModule, ValidatorFn, Validators, FormCont
 import { Subscription } from 'rxjs';
 
 import {
+  AppErrorComponent,
   AppInputDirective,
   CustomCheckboxComponent,
   CustomFormFieldComponent,
@@ -29,6 +30,7 @@ export type QuotaFormValues = OrgQuotaFormValues;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomCheckboxComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.html
@@ -28,20 +28,20 @@
       <h2 class="m-0">{{ quotaDefinition.name }}</h2>
       <div class="flex my-2">
         <div class="mr-[10px] opacity-60">Non Basic Services Allowed:</div>
-        <app-boolean-indicator [isTrue]="quotaDefinition.paidServicesAllowed" type="yes-no" subtle="true">
+        <app-boolean-indicator [isTrue]="quotaDefinition.paidServicesAllowed" type="yes-no" [subtle]="true">
         </app-boolean-indicator>
       </div>
-      <app-tile-grid fit="true">
+      <app-tile-grid [fit]="true">
         <h3 class="my-[10px]">Quota Limits</h3>
         <h4 class="my-[10px] opacity-60">Memory</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="memory" label="Maximum Memory Usage" units="mb"
+            <app-card-number-metric [labelAtTop]="true" icon="memory" label="Maximum Memory Usage" units="mb"
               value="{{ quotaDefinition.totalMemoryInMB }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="memory" label="Maximum Application Instance Memory Usage"
+            <app-card-number-metric [labelAtTop]="true" icon="memory" label="Maximum Application Instance Memory Usage"
               units="mb" value="{{ quotaDefinition.totalInstanceMemoryInMB }}">
             </app-card-number-metric>
           </app-tile>
@@ -49,12 +49,12 @@
         <h4 class="my-[10px] opacity-60">Application</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="application_instance" iconFont="stratos-icons"  label="Maximum Application Instances"
+            <app-card-number-metric [labelAtTop]="true" icon="application_instance" iconFont="stratos-icons"  label="Maximum Application Instances"
               value="{{ quotaDefinition.totalInstances }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="apps" label="Maximum Application Tasks"
+            <app-card-number-metric [labelAtTop]="true" icon="apps" label="Maximum Application Tasks"
               value="{{ quotaDefinition.totalAppTasks }}">
             </app-card-number-metric>
           </app-tile>
@@ -62,12 +62,12 @@
         <h4 class="my-[10px] opacity-60">Service</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="service" iconFont="stratos-icons" label="Maximum Services"
+            <app-card-number-metric [labelAtTop]="true" icon="service" iconFont="stratos-icons" label="Maximum Services"
               value="{{ quotaDefinition.totalServiceInstances }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="service" iconFont="stratos-icons" label="Maximum Service Keys"
+            <app-card-number-metric [labelAtTop]="true" icon="service" iconFont="stratos-icons" label="Maximum Service Keys"
               value="{{ quotaDefinition.totalServiceKeys }}">
             </app-card-number-metric>
           </app-tile>
@@ -75,19 +75,19 @@
         <h4 class="my-[10px] opacity-60">Routes & Domains</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="route" iconFont="stratos-icons" label="Maximum Routes"
+            <app-card-number-metric [labelAtTop]="true" icon="route" iconFont="stratos-icons" label="Maximum Routes"
               value="{{ quotaDefinition.totalRoutes }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="route" iconFont="stratos-icons"
+            <app-card-number-metric [labelAtTop]="true" icon="route" iconFont="stratos-icons"
               label="Maximum Reserved Route Ports" value="{{ quotaDefinition.totalReservedPorts }}">
             </app-card-number-metric>
           </app-tile>
         </app-tile-group>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="domain" label="Maximum Private Domains"
+            <app-card-number-metric [labelAtTop]="true" icon="domain" label="Maximum Private Domains"
               value="{{ quotaDefinition.totalDomains }}">
             </app-card-number-metric>
           </app-tile>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition-form/space-quota-definition-form.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition-form/space-quota-definition-form.component.ts
@@ -3,7 +3,7 @@ import { AbstractControl, ReactiveFormsModule, ValidatorFn, Validators, FormCont
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 
-import { AppInputDirective, CustomFormFieldComponent, CustomCheckboxComponent, FocusDirective, UnlimitedInputComponent } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent, CustomCheckboxComponent, FocusDirective, UnlimitedInputComponent } from '@stratosui/core';
 import { QuotaDataService } from '../../../services/endpoint-data/quota-data.service';
 import { StSpaceQuota } from '../../../services/endpoint-data/stratos-types';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
@@ -23,6 +23,7 @@ export type { SpaceQuotaFormValues };
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomCheckboxComponent,
     CustomFormFieldComponent,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.html
@@ -28,20 +28,20 @@
       <h2 class="m-0">{{ quotaDefinition.name }}</h2>
       <div class="flex my-2">
         <div class="mr-[10px] opacity-60">Non Basic Services Allowed:</div>
-        <app-boolean-indicator [isTrue]="quotaDefinition.paidServicesAllowed" type="yes-no" subtle="true">
+        <app-boolean-indicator [isTrue]="quotaDefinition.paidServicesAllowed" type="yes-no" [subtle]="true">
         </app-boolean-indicator>
       </div>
-      <app-tile-grid fit="true">
+      <app-tile-grid [fit]="true">
         <h3 class="my-[10px]">Quota Limits</h3>
         <h4 class="my-[10px] opacity-60">Memory</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="memory" label="Maximum Memory Usage" units="mb"
+            <app-card-number-metric [labelAtTop]="true" icon="memory" label="Maximum Memory Usage" units="mb"
               value="{{ quotaDefinition.totalMemoryInMB }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="memory" label="Maximum Application Instance Memory Usage"
+            <app-card-number-metric [labelAtTop]="true" icon="memory" label="Maximum Application Instance Memory Usage"
               units="mb" value="{{ quotaDefinition.totalInstanceMemoryInMB }}">
             </app-card-number-metric>
           </app-tile>
@@ -49,12 +49,12 @@
         <h4 class="my-[10px] opacity-60">Application</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="application_instance" iconFont="stratos-icons" label="Maximum Application Instances"
+            <app-card-number-metric [labelAtTop]="true" icon="application_instance" iconFont="stratos-icons" label="Maximum Application Instances"
               value="{{ quotaDefinition.totalInstances }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="apps" label="Maximum Application Tasks"
+            <app-card-number-metric [labelAtTop]="true" icon="apps" label="Maximum Application Tasks"
               value="{{ quotaDefinition.totalAppTasks }}">
             </app-card-number-metric>
           </app-tile>
@@ -62,12 +62,12 @@
         <h4 class="my-[10px] opacity-60">Service</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="service" iconFont="stratos-icons" label="Maximum Services"
+            <app-card-number-metric [labelAtTop]="true" icon="service" iconFont="stratos-icons" label="Maximum Services"
               value="{{ quotaDefinition.totalServiceInstances }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="service" iconFont="stratos-icons" label="Maximum Service Keys"
+            <app-card-number-metric [labelAtTop]="true" icon="service" iconFont="stratos-icons" label="Maximum Service Keys"
               value="{{ quotaDefinition.totalServiceKeys }}">
             </app-card-number-metric>
           </app-tile>
@@ -75,12 +75,12 @@
         <h4 class="my-[10px] opacity-60">Routes</h4>
         <app-tile-group class="tile-group-2-cols">
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="route" iconFont="stratos-icons" label="Maximum Routes"
+            <app-card-number-metric [labelAtTop]="true" icon="route" iconFont="stratos-icons" label="Maximum Routes"
               value="{{ quotaDefinition.totalRoutes }}">
             </app-card-number-metric>
           </app-tile>
           <app-tile>
-            <app-card-number-metric labelAtTop="true" icon="route" iconFont="stratos-icons"
+            <app-card-number-metric [labelAtTop]="true" icon="route" iconFont="stratos-icons"
               label="Maximum Reserved Route Ports" value="{{ quotaDefinition.totalReservedPorts }}">
             </app-card-number-metric>
           </app-tile>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
@@ -17,13 +17,13 @@
   </button>
   <app-polling-indicator class="ml-auto"
     [manualPoll]="(cfSpaceService.loadingApps$ | async) === false"
-    [isPolling]="(cfSpaceService.loadingApps$ | async)"
+    [isPolling]="(cfSpaceService.loadingApps$ | async) ?? false"
     (poll)="cfSpaceService.fetchApps()">
   </app-polling-indicator>
 </app-page-sub-nav>
 
 <div>
-  <app-tile-grid fit="true">
+  <app-tile-grid [fit]="true">
     <app-tile-group class="tile-group-1-cols">
       <app-tile>
         <app-card-cf-space-details>
@@ -68,7 +68,7 @@
             value="{{ cfSpaceService.serviceInstancesCount() }}"
           limit="{{ (cfSpaceService.quotaDefinition$ | async)?.totalServiceInstances }}"></app-card-number-metric>
         </app-tile>
-        @if ((cfSpaceService.userProvidedServiceInstancesCount$ | async) > 0) {
+        @if (((cfSpaceService.userProvidedServiceInstancesCount$ | async) ?? 0) > 0) {
           <app-tile>
             <app-card-number-metric iconFont="stratos-icons" icon="service" label="User Service Instances"
             value="{{ (cfSpaceService.userProvidedServiceInstancesCount$ | async)}}"></app-card-number-metric>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.html
@@ -16,12 +16,12 @@
   </button>
   <app-polling-indicator class="ml-auto"
     [manualPoll]="(cfOrgService.loadingApps$ | async) === false"
-    [isPolling]="(cfOrgService.loadingApps$ | async)"
+    [isPolling]="(cfOrgService.loadingApps$ | async) ?? false"
     (poll)="cfOrgService.fetchApps()">
   </app-polling-indicator>
 </app-page-sub-nav>
 <div>
-  <app-tile-grid fit="true">
+  <app-tile-grid [fit]="true">
     <app-tile-group class="tile-group-1-cols">
       <app-tile>
         <app-card-cf-org-user-details>
@@ -69,7 +69,7 @@
             value="{{ cfOrgService.serviceInstancesCount() }}"
           limit="{{ (cfOrgService.quotaDefinition$ | async)?.totalServiceInstances }}"></app-card-number-metric>
         </app-tile>
-        @if ((cfOrgService.userProvidedServiceInstancesCount$ | async) > 0) {
+        @if (((cfOrgService.userProvidedServiceInstancesCount$ | async) ?? 0) > 0) {
           <app-tile>
             <app-card-number-metric iconFont="stratos-icons" icon="service_instance" label="User Service Instances"
             value="{{ (cfOrgService.userProvidedServiceInstancesCount$ | async) }}"></app-card-number-metric>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.html
@@ -4,13 +4,13 @@
   </button>
   <app-polling-indicator class="ml-auto"
     [manualPoll]="(cfEndpointService.appsLoading$ | async) === false"
-    [isPolling]="(cfEndpointService.appsLoading$ | async)"
+    [isPolling]="(cfEndpointService.appsLoading$ | async) ?? false"
     (poll)="cfEndpointService.fetchApps()">
   </app-polling-indicator>
 </app-page-sub-nav>
 
 <div class="flex h-full min-h-full w-full">
-  <app-tile-grid fit="true">
+  <app-tile-grid [fit]="true">
     <app-tile-group class="tile-group-1-cols">
       <app-tile>
         <app-card-cf-info></app-card-cf-info>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-confirm/table-cell-confirm-org-space/table-cell-confirm-org-space.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-confirm/table-cell-confirm-org-space/table-cell-confirm-org-space.component.ts
@@ -14,12 +14,13 @@ import { TableCellCustom } from '../../../../../../../../core/src/shared/compone
   ]
 })
 export class TableCellConfirmOrgSpaceComponent extends TableCellCustom<CfRoleChangeWithNames> {
-  chipsConfig!: AppChip<CfRoleChangeWithNames>[];
+  chipsConfig!: AppChip[];
   @Input()
   set row(row: CfRoleChangeWithNames) {
     super.row = row;
-    const chipConfig = new AppChip<CfRoleChangeWithNames>();
-    chipConfig.key = row;
+    // key is only used by app-chips as a track identity; the single chip's
+    // value is unique here, so the default (string) key type suffices.
+    const chipConfig = new AppChip();
     chipConfig.value = row.spaceGuid ? `Space: ${row.spaceName}` : `Org: ${row.orgName}`;
     this.chipsConfig = [chipConfig];
   }

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-modify/manage-users-modify.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-modify/manage-users-modify.component.html
@@ -8,7 +8,7 @@
   </div>
   <app-enumerate [collection]="usersNames$"></app-enumerate>
 </div>
-@if ((usersWithWarning$ | async).length) {
+@if ((usersWithWarning$ | async)?.length) {
   <div class="modify-users__users-warning"><i>* Not all roles are known for user.</i></div>
 }
 <app-role-assignment

--- a/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/card-cf-recent-apps.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/card-cf-recent-apps.component.html
@@ -4,7 +4,7 @@
       <app-card-header class="recent-apps-card__header">
         <app-card-title class="recent-apps-card__title">Recently updated applications</app-card-title>
         @if (canRefresh) {
-          <app-polling-indicator [manualPoll]="(loading$ | async) === false" [isPolling]="(loading$ | async)"
+          <app-polling-indicator [manualPoll]="(loading$ | async) === false" [isPolling]="(loading$ | async) ?? false"
           (poll)="refresh.emit()"></app-polling-indicator>
         }
       </app-card-header>

--- a/src/frontend/packages/cloud-foundry/src/features/home/cfhome-card/cfhome-card.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/home/cfhome-card/cfhome-card.component.html
@@ -1,4 +1,4 @@
-<app-tile-grid fit="true">
+<app-tile-grid [fit]="true">
   <app-tile-group class="cf-home-card__plain-tiles">
     <app-tile>
       <app-card-number-metric mode="plain" link="/cloud-foundry/{{guid}}/applications" icon="apps" label="Applications"
@@ -35,7 +35,7 @@
           @if (showDeployAppTiles) {
             <div>
               <div class="cf-home-card__no-apps-deploy">Get started by deploying an Application from ...</div>
-              <app-tile-selector [options]="tileSelectorConfig$ | async" [compactTiles]="true"
+              <app-tile-selector [options]="(tileSelectorConfig$ | async) ?? []" [compactTiles]="true"
               (selection)="selectedTile = $event"></app-tile-selector>
             </div>
           }

--- a/src/frontend/packages/cloud-foundry/src/features/home/cfhome-card/cfhome-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/home/cfhome-card/cfhome-card.component.ts
@@ -98,9 +98,12 @@ export class CFHomeCardComponent implements HomePageEndpointCard, OnDestroy {
     );
   }
 
-  set selectedTile(tile: ITileConfig<IAppTileData>) {
+  // The selector's (selection) output is typed against the base ITileConfig
+  // (and emits null on deselect); the tiles are built in this component with
+  // IAppTileData, so the narrowing here is sound.
+  set selectedTile(tile: ITileConfig | null) {
     if (tile && tile.data) {
-      const data = tile.data;
+      const data = tile.data as IAppTileData;
       const query: Record<string, string> = {
         [BASE_REDIRECT_QUERY]: `applications/new/${this.guid}`,
         [AUTO_SELECT_CF_URL_PARAM]: this.guid,

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-summary/service-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-summary/service-summary.component.html
@@ -3,7 +3,7 @@
 @let brokerAvailable = isBrokerAvailable();
 
 <div class="summary">
-  <app-tile-grid fit="true">
+  <app-tile-grid [fit]="true">
     @if (brokerAvailable) {
       <app-tile-group class="tile-group-2-cols">
         <app-tile>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.ts
@@ -50,13 +50,16 @@ export class AddServiceInstanceBaseStepComponent {
     )
   ];
 
-  private pSelectedTile: ITileConfig<ICreateServiceTilesData> | null = null;
+  private pSelectedTile: ITileConfig | null = null;
   public bindApp: boolean;
   get selectedTile() {
     return this.pSelectedTile;
   }
-  set selectedTile(tile: ITileConfig<ICreateServiceTilesData> | null) {
-    this.serviceType = tile?.data?.type;
+  // The tile-selector emits the base ITileConfig; our tiles carry
+  // ICreateServiceTilesData whose `type` is always a string.
+  set selectedTile(tile: ITileConfig | null) {
+    const type = tile?.data?.type;
+    this.serviceType = typeof type === 'string' ? type : undefined;
     this.pSelectedTile = tile;
     if (tile) {
       const baseUrl = this.createServiceTileUrl();

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.html
@@ -7,7 +7,7 @@
   </ng-template>
   <div class="h-full">
     <app-steppers [cancel]="modeService.cancelUrl"
-      [contextSummary]="contextSummaryParts().length > 0 ? contextSummaryTpl : null">
+      [contextSummary]="contextSummaryParts().length > 0 ? contextSummaryTpl : undefined">
       @if (serviceType === serviceTypes.SERVICE) {
         @if (modeService.viewDetail.showSelectCf && !isSpaceScoped()) {
           <app-step title="Cloud Foundry" [signalHandle]="selectCFHandle">
@@ -46,8 +46,8 @@
           </app-step>
         }
         <app-step title="Service Instance" [signalHandle]="supdHandle">
-          <app-specify-user-provided-details [appId]="appId" [showModeSelection]="!!appId" [cfGuid]="cfGuid$ | async"
-            [spaceGuid]="spaceGuid$ | async" [serviceInstanceId]="serviceInstanceId" #supd>
+          <app-specify-user-provided-details [appId]="appId" [showModeSelection]="!!appId" [cfGuid]="(cfGuid$ | async) ?? ''"
+            [spaceGuid]="(spaceGuid$ | async) ?? ''" [serviceInstanceId]="serviceInstanceId" #supd>
           </app-specify-user-provided-details>
         </app-step>
       }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.html
@@ -3,7 +3,7 @@
   <form class="stepper-form" [formGroup]="stepperForm">
     <app-form-field>
       <app-label>Service Plan</app-label>
-      <app-select class="form-control" formControlName="servicePlans" [appFocus]="servicePlans$ | async">
+      <app-select class="form-control" formControlName="servicePlans" [appFocus]="!!(servicePlans$ | async)">
         @for (servicePlan of servicePlans$ | async; track servicePlan.guid) {
           <app-option [value]="servicePlan.guid">{{ servicePlan.name }}</app-option>
         }
@@ -13,7 +13,7 @@
   @if (selectedPlan$ | async; as selPlan) {
     <app-card class="max-w-[450px]">
       @if (selectedPlanAccessibility()) {
-        <app-card-status [status]="selectedPlanAccessibility()"></app-card-status>
+        <app-card-status [status$]="selectedPlanAccessibility$"></app-card-status>
       }
       <app-metadata-item label="Name"> {{ getDisplayName(selPlan) }} </app-metadata-item>
       <app-metadata-item label="Description"> {{ selPlan.description }} </app-metadata-item>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/select-plan-step/select-plan-step.component.ts
@@ -26,6 +26,7 @@ import {
 import { ServiceCatalogDataService, SignalSource } from '../../../../../../cloud-foundry/src/services/endpoint-data/service-catalog-data.service';
 import { StServicePlan, StServicePlanVisibility } from '../../../../../../cloud-foundry/src/services/endpoint-data/stratos-types';
 import { safeUnsubscribe } from '../../../../../../core/src/core/utils.service';
+import { CardWrapperComponent } from '../../../../../../core/src/shared/components/cards/card/card.component';
 import { CardStatusComponent } from '../../../../../../core/src/shared/components/cards/card-status/card-status.component';
 import { FocusDirective } from '../../../../../../core/src/shared/components/focus.directive';
 import { MetadataItemComponent } from '../../../../../../core/src/shared/components/metadata-item/metadata-item.component';
@@ -62,6 +63,7 @@ interface SelectPlanForm {
     AsyncPipe,
     FocusDirective,
     MetadataItemComponent,
+    CardWrapperComponent,
     CardStatusComponent,
     ServicePlanPublicComponent,
     ServicePlanPriceComponent
@@ -85,6 +87,11 @@ export class SelectPlanStepComponent implements OnDestroy {
   selectedPlan$!: Observable<StServicePlan | undefined>;
   private selectedPlanAccessibilitySignal = signal<StratosStatus | null>(null);
   selectedPlanAccessibility = this.selectedPlanAccessibilitySignal.asReadonly();
+  // Observable bridge for <app-card-status [status$]> — skips the initial
+  // null so the status strip only paints once accessibility is resolved.
+  selectedPlanAccessibility$ = toObservable(this.selectedPlanAccessibility).pipe(
+    filter((status): status is StratosStatus => status !== null),
+  );
   cSIHelperService!: CreateServiceInstanceHelper;
   @ViewChild('noplans', { read: ViewContainerRef, static: true })
   noPlansDiv!: ViewContainerRef;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.html
@@ -59,7 +59,7 @@
     <form class="stepper-form"
       [formGroup]="selectExistingInstanceForm">
       <app-form-field>
-        <app-select class="form-control" required placeholder="Service Instance" formControlName="serviceInstance" [autoSelectSingleOption]="false">
+        <app-select class="form-control" [required]="true" placeholder="Service Instance" formControlName="serviceInstance" [autoSelectSingleOption]="false">
           <app-option [value]="null">None</app-option>
           @for (sI of bindableServiceInstances$ | async; track sI.guid) {
             <app-option [value]="sI.guid">{{ sI.name }}</app-option>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-details-step/specify-details-step.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AppInputDirective, CustomFormFieldComponent, MatLabelComponent } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent, MatLabelComponent } from '@stratosui/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { AfterContentInit, Component, Input, OnDestroy, effect, signal, ChangeDetectionStrategy, inject } from '@angular/core';
 import { AbstractControl, ValidationErrors, ValidatorFn, Validators, ReactiveFormsModule, FormsModule, FormControl, FormGroup } from '@angular/forms';
@@ -41,9 +41,8 @@ import { CreateServiceFormMode, CsiModeService } from '../csi-mode.service';
 import { CsiState, CsiStateService } from '../csi-state.service';
 
 // Local view of the schema-form config while it is being assembled: the
-// broker schema may not have arrived (or may not exist for the plan), so
-// `schema` is optional here even though SchemaFormConfig declares it
-// required. SchemaFormComponent.config tolerates an absent schema.
+// broker schema may not have arrived (or may not exist for the plan).
+// SchemaFormComponent.config tolerates an absent schema.
 type SchemaFormConfigState = Omit<SchemaFormConfig, 'schema'> & { schema?: object };
 
 @Component({
@@ -56,6 +55,7 @@ type SchemaFormConfigState = Omit<SchemaFormConfig, 'schema'> & { schema?: objec
     CommonModule,
     ReactiveFormsModule,
     FormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     MatLabelComponent,
@@ -497,7 +497,8 @@ export class SpecifyDetailsStepComponent implements OnDestroy, AfterContentInit 
     ).subscribe());
   }
 
-  addTagFromInput(event: KeyboardEvent): void {
+  // (keydown.*) template events are typed as plain Event by the compiler
+  addTagFromInput(event: Event): void {
     event.preventDefault();
     const input = event.target as HTMLInputElement;
     const value = input.value;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.html
@@ -115,7 +115,7 @@
     <app-form-field>
       <app-select
         class="form-control"
-        required
+        [required]="true"
         placeholder="User Provided Service Instance"
         formControlName="serviceInstances"
         [autoSelectSingleOption]="false"

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AppInputDirective, CustomFormFieldComponent, MatLabelComponent } from '@stratosui/core';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent, MatLabelComponent } from '@stratosui/core';
 import { HttpParams, HttpRequest } from '@angular/common/http';
 import { Component, Input, OnDestroy, signal, ChangeDetectionStrategy, inject } from '@angular/core';
 import { ReactiveFormsModule, FormsModule, Validators, FormControl, FormGroup } from '@angular/forms';
@@ -52,6 +52,7 @@ const { proxyAPIVersion } = environment;
     CommonModule,
     ReactiveFormsModule,
     FormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     MatLabelComponent,
@@ -396,7 +397,8 @@ export class SpecifyUserProvidedDetailsComponent implements OnDestroy {
   }
 
 
-  public addTagFromInput(event: KeyboardEvent): void {
+  // (keydown.*) template events are typed as plain Event by the compiler
+  public addTagFromInput(event: Event): void {
     event.preventDefault();
     const input = event.target as HTMLInputElement;
     const label = (input.value || '').trim();

--- a/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.html
@@ -55,8 +55,8 @@
       </div>
     }
     <a class="flex justify-center btn btn-info btn-icon"
-      [class.pointer-events-none]="(applicationService.applicationUrl$ | async) === null || (applicationService.application$ | async)?.app.entity.state !== 'STARTED'"
-      [class.opacity-50]="(applicationService.applicationUrl$ | async) === null || (applicationService.application$ | async)?.app.entity.state !== 'STARTED'"
+      [class.pointer-events-none]="(applicationService.applicationUrl$ | async) === null || (applicationService.application$ | async)?.app?.entity?.state !== 'STARTED'"
+      [class.opacity-50]="(applicationService.applicationUrl$ | async) === null || (applicationService.application$ | async)?.app?.entity?.state !== 'STARTED'"
       href="{{applicationService.applicationUrl$ | async}}" target="_blank" title="Visit">
       <span class="material-icons">launch</span>
     </a>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.html
@@ -25,7 +25,7 @@
 
         <div class="flex-1">
           <app-metadata-item class="mt-0" label="Org Status">
-            {{ $safeNavigationMigration(cfOrgService.orgDataService.org()?.status) | capitalizeFirst }}
+            {{ (cfOrgService.orgDataService.org()?.status ?? '') | capitalizeFirst }}
           </app-metadata-item>
           <app-metadata-item label="Created At">
             {{ $safeNavigationMigration(cfOrgService.orgDataService.org()?.createdAt) | date: "medium" }}

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.html
@@ -17,7 +17,7 @@
             } @else {
               None assigned
               @if (cfSpaceService.quotaDefinition$ | async; as quotaDefinition) {
-                <span> - <a [routerLink]="[]" (click)="goToOrgQuota($event)">view organization's quota</a> </span>
+                <span> - <a [routerLink]="[]" (click)="goToOrgQuota()">view organization's quota</a> </span>
               }
             }
           </app-metadata-item>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/cf-service-card.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/cf-service-card.component.html
@@ -1,7 +1,7 @@
 @if (!!offering) {
-  <app-meta-card [clickAction]="!disableCardClick ? goToServiceInstances:null"
+  <app-meta-card [clickAction]="!disableCardClick ? goToServiceInstances : undefined"
     >
-    <app-meta-card-title noMargin="true">
+    <app-meta-card-title [noMargin]="true">
       <div class="flex flex-row justify-between w-full">
         <app-multiline-title>{{ getDisplayName() }}</app-multiline-title>
         <app-service-icon [service]="offering"></app-service-icon>

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/cf-service-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/cf-service-card.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, booleanAttribute, inject } from '@angular/core';
 import { Router } from '@angular/router';
 
 import {
@@ -67,7 +67,8 @@ export class CfServiceCardComponent extends CardCell<StServiceOffering> {
     mode: TableCellServiceBrokerComponentMode.SCOPE
   };
 
-  @Input() disableCardClick = false;
+  // Attribute form (disableCardClick / disableCardClick="true") coerces to boolean
+  @Input({ transform: booleanAttribute }) disableCardClick = false;
 
   @Input()
   set row(row: StServiceOffering) {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/table-cell-service-tags/table-cell-service-tags.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/table-cell-service-tags/table-cell-service-tags.component.ts
@@ -4,10 +4,6 @@ import { of } from 'rxjs';
 import { AppChip, AppChipsComponent, TableCellCustom } from '@stratosui/core';
 import { StServiceOffering } from '../../../../../services/endpoint-data/stratos-types';
 
-export interface ServiceTag {
-  value: string;
-}
-
 @Component({
   selector: 'app-table-cell-service-tags',
   templateUrl: './table-cell-service-tags.component.html',
@@ -19,7 +15,8 @@ export interface ServiceTag {
 })
 export class TableCellServiceTagsComponent extends TableCellCustom<StServiceOffering> {
 
-  tags: AppChip<ServiceTag>[] = [];
+  // Plain string-keyed chips — the cell only sets `value`/`hideClearButton$`
+  tags: AppChip[] = [];
 
   @Input()
   set row(offering: StServiceOffering) {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.html
@@ -4,7 +4,7 @@
   <app-card-header class="recent-instances__header">
     <app-card-title>Recently updated service instances</app-card-title>
     @if (serviceInstances === null) {
-      <app-stateful-icon [state]="'busy'"></app-stateful-icon>
+      <app-stateful-icon [state]="stratosStatus.BUSY"></app-stateful-icon>
     }
   </app-card-header>
   @if (serviceInstances) {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.ts
@@ -21,6 +21,7 @@ import {
   CardWrapperComponent,
   StatefulIconComponent,
 } from '@stratosui/core';
+import { StratosStatus } from '@stratosui/store';
 import { EndpointDataRegistry } from '../../../../services/endpoint-data/endpoint-data.registry';
 import { EndpointDataService } from '../../../../services/endpoint-data/endpoint-data.service';
 import { StServiceInstance } from '../../../../services/endpoint-data/stratos-types';
@@ -59,6 +60,9 @@ const RECENT_ITEMS_COUNT = 10;
 export class ServiceRecentInstancesCardComponent implements OnInit, OnDestroy {
   private readonly registry = inject(EndpointDataRegistry);
   private readonly injector = inject(Injector);
+
+  // Exposed for the template's <app-stateful-icon [state]> binding
+  protected readonly stratosStatus = StratosStatus;
 
   private readonly _cfGuid = signal<string>('');
   private readonly _serviceGuid = signal<string>('');

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cf-org-space-links/cf-org-space-links.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cf-org-space-links/cf-org-space-links.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input , ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Params, RouterModule } from '@angular/router';
 
 import { CfOrgSpaceLabelService } from '../../services/cf-org-space-label.service';
 
@@ -17,5 +17,6 @@ import { CfOrgSpaceLabelService } from '../../services/cf-org-space-label.servic
 export class CfOrgSpaceLinksComponent {
 
   @Input() service!: CfOrgSpaceLabelService;
-  @Input() spaceBreadCrumbs!: string;
+  // Query params for the space link (e.g. { breadcrumbs: 'services-wall' })
+  @Input() spaceBreadCrumbs?: Params;
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cli-info/cli-info.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cli-info/cli-info.component.html
@@ -12,7 +12,7 @@
         <p>3. Login</p>
         <app-code-block>cf login</app-code-block>
         <p>Output</p>
-        <app-code-block codeBlockStyle="pre" hideCopy="true">
+        <app-code-block codeBlockStyle="pre" [hideCopy]="true">
           <pre>API endpoint: <b>{{context.apiEndpoint || '[Cloud Foundry API endpoint]'}}</b>
           Email> {{context.username || '[username]'}}
           Password> [password]

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.html
@@ -5,7 +5,7 @@
       <app-select id="cf" #cfSelect="ngModel" placeholder="Cloud Foundry" [autoSelectSingleOption]="false"
         [disabled]="cfOrgSpaceService.cf.loading() || isRedeploy || endpointScoped"
         [ngModel]="cfOrgSpaceService.cf.select()"
-        (selectionChange)="onCfChange($event.value)" required name="cf"
+        (selectionChange)="onCfChange($event.value)" [required]="true" name="cf"
         [appFocus]="!cfOrgSpaceService.cf.loading()">
         <app-option [value]="null">None</app-option>
         @for (cf of cfOrgSpaceService.cf.list(); track cf) {
@@ -21,7 +21,7 @@
       [disabled]="!cfOrgSpaceService.cf.select() || cfOrgSpaceService.org.loading() || isRedeploy"
       [loading]="cfOrgSpaceService.org.loading()"
       [ngModel]="cfOrgSpaceService.org.select()"
-      (selectionChange)="onOrgChange($event.value)" required name="org"
+      (selectionChange)="onOrgChange($event.value)" [required]="true" name="org"
       [appFocus]="isMarketplaceMode && !(!cfOrgSpaceService.cf.select() || cfOrgSpaceService.org.loading() || isRedeploy)">
       <app-option [value]="null">None</app-option>
       @for (org of cfOrgSpaceService.org.list(); track org) {
@@ -39,7 +39,7 @@
       [disabled]="!cfOrgSpaceService.org.select() || cfOrgSpaceService.space.loading() || isRedeploy"
       [loading]="cfOrgSpaceService.space.loading()"
       [ngModel]="cfOrgSpaceService.space.select()"
-      (selectionChange)="onSpaceChange($event.value)" required name="space">
+      (selectionChange)="onSpaceChange($event.value)" [required]="true" name="space">
       <app-option [value]="null">None</app-option>
       @for (space of spaces$ | async; track space) {
         <app-option [value]="space.guid" [label]="space.name">

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.html
@@ -25,7 +25,7 @@
     }
     @if (schemaView() === 'schemaForm') {
       <div class="schema-form__form">
-        <json-schema-form loadExternalAssets="false" [options]="{ addSubmit: false }" [schema]="cleanSchema" [framework]="'material-design'" [data]="formInitialData" [warnings]="warnings()" (changes)="onFormChange($event)" (renderError)="onRenderError($event)">
+        <json-schema-form loadExternalAssets="false" [options]="{ addSubmit: false }" [schema]="cleanSchema ?? {}" [framework]="'material-design'" [data]="formInitialData" [warnings]="warnings()" (changes)="onFormChange($event)" (renderError)="onRenderError($event)">
         </json-schema-form>
         @if (warnings().length) {
           <ul class="mt-2 text-sm text-warning list-disc pl-5">

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.ts
@@ -17,8 +17,9 @@ export interface SchemaFormValidationError {
 }
 
 export class SchemaFormConfig {
-  // strict: always supplied by callers building a config
-  schema!: object;
+  // Optional: the broker may not supply a schema for the plan — the form
+  // then falls back to the raw JSON editor (see the `config` setter).
+  schema?: object;
   initialData?: object;
 }
 
@@ -43,7 +44,7 @@ export class SchemaFormComponent {
   private schema: object | undefined;
 
   @Input()
-  set config(config: SchemaFormConfig) {
+  set config(config: SchemaFormConfig | undefined) {
     // Skip if no config... or schema is the same (avoids losing existing data in form)
     if (!config || (config.schema && config.schema === this.schema)) {
       return;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/select-service/select-service.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/select-service/select-service.component.html
@@ -9,6 +9,8 @@
         }
       </app-select>
     </app-form-field>
-    <app-cf-service-card disableCardClick="true" [row]="selectedService$ | async"></app-cf-service-card>
+    @if (selectedService$ | async; as selectedService) {
+      <app-cf-service-card disableCardClick="true" [row]="selectedService"></app-cf-service-card>
+    }
   </form>
 </div>

--- a/src/frontend/packages/cloud-foundry/src/shared/directives/app-name-unique.directive/app-name-unique.directive.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/directives/app-name-unique.directive/app-name-unique.directive.ts
@@ -5,6 +5,7 @@ import { Observable, of as observableOf, timer as observableTimer } from 'rxjs';
 import { catchError, filter, map, switchMap, take } from 'rxjs/operators';
 
 import { environment } from '@stratosui/core';
+import { StratosStatus } from '@stratosui/store';
 import { CreateAppStateService } from '../../data-services/create-app-state.service';
 
 const APP_UNIQUE_NAME_PROVIDER = {
@@ -19,18 +20,20 @@ export type UniqueValidatorRequestBuilder<T = any> = (name: string) => HttpReque
 export class AppNameUniqueChecking {
   busy!: boolean;
   taken: boolean | undefined;
-  status!: string;
+  // Consumed by <app-stateful-icon [state]> so it carries StratosStatus
+  // values (NONE renders nothing, OK renders the 'done' icon).
+  status: StratosStatus = StratosStatus.NONE;
 
   set(busy: boolean, taken?: boolean) {
     this.busy = busy;
     this.taken = taken;
 
     if (this.busy) {
-      this.status = 'busy';
+      this.status = StratosStatus.BUSY;
     } else if (this.taken === undefined) {
-      this.status = '';
+      this.status = StratosStatus.NONE;
     } else {
-      this.status = this.taken ? 'error' : 'done';
+      this.status = this.taken ? StratosStatus.ERROR : StratosStatus.OK;
     }
   }
 }

--- a/src/frontend/packages/cloud-foundry/tsconfig.lib.json
+++ b/src/frontend/packages/cloud-foundry/tsconfig.lib.json
@@ -10,6 +10,6 @@
     "**/*.spec.ts"
   ],
   "angularCompilerOptions": {
-    "strictTemplates": false
+    "strictTemplates": true
   }
 }

--- a/src/frontend/packages/core/src/core/byte-formatters.pipe.ts
+++ b/src/frontend/packages/core/src/core/byte-formatters.pipe.ts
@@ -5,13 +5,13 @@ import { Pipe, PipeTransform } from '@angular/core';
   standalone: true
 })
 export class BytesToHumanSize implements PipeTransform {
-  transform(value: string): string {
+  transform(value: string | number): string {
     // Handle null/undefined/empty string
     if (value == null || value === '') {
       return '';
     }
 
-    const bytes = parseInt(value, 10);
+    const bytes = parseInt(String(value), 10);
 
     // Type guard: ensure parsing succeeded
     if (isNaN(bytes)) {

--- a/src/frontend/packages/core/src/core/stateful-icon/stateful-icon.component.html
+++ b/src/frontend/packages/core/src/core/stateful-icon/stateful-icon.component.html
@@ -4,7 +4,7 @@
       <app-custom-icon [inline]="inline"
         [ngClass]="{'warning': stateKey === allStateKeys.WARNING, 'error': stateKey === allStateKeys.ERROR, 'ok': stateKey === allStateKeys.OK }"
         >
-      {{ selectedState.icon }}</app-custom-icon>
+      {{ selectedStateIcon }}</app-custom-icon>
     } @else {
       <app-spinner [diameter]="20"></app-spinner>
     }

--- a/src/frontend/packages/core/src/core/stateful-icon/stateful-icon.component.ts
+++ b/src/frontend/packages/core/src/core/stateful-icon/stateful-icon.component.ts
@@ -60,4 +60,9 @@ export class StatefulIconComponent {
     };
 
   public selectedState!: StatefulIconDefinition;
+
+  // Narrows the icon/template union for the template
+  get selectedStateIcon(): string {
+    return this.selectedState && 'icon' in this.selectedState ? this.selectedState.icon : '';
+  }
 }

--- a/src/frontend/packages/core/src/core/truncate.pipe.ts
+++ b/src/frontend/packages/core/src/core/truncate.pipe.ts
@@ -5,8 +5,8 @@ name: 'limitTo',
 standalone: true
 })
 export class TruncatePipe implements PipeTransform {
-  transform(value: string, args: string): string {
-    const limit = args ? parseInt(args, 10) : 10;
+  transform(value: string, args: string | number): string {
+    const limit = args ? parseInt(String(args), 10) : 10;
 
     return value.length > limit ? value.substring(0, limit) : value;
   }

--- a/src/frontend/packages/core/src/features/about/about-page/about-page.component.html
+++ b/src/frontend/packages/core/src/features/about/about-page/about-page.component.html
@@ -68,29 +68,29 @@
             <dl class="text-sm space-y-2">
               <div class="flex gap-2">
                 <dt class="text-content-muted w-20 shrink-0">Version</dt>
-                <dd class="text-content-text font-medium min-w-0 truncate" [title]="session.version.proxy_version">{{ session.version.proxy_version }}</dd>
+                <dd class="text-content-text font-medium min-w-0 truncate" [title]="session.version?.proxy_version">{{ session.version?.proxy_version }}</dd>
               </div>
               <div class="flex gap-2">
                 <dt class="text-content-muted w-20 shrink-0">Commit</dt>
-                <dd class="text-content-text font-mono min-w-0 truncate" [title]="session.version.git_commit">
-                  @if (backendCommitLink(session.version.git_commit)) {
-                    <a [href]="backendCommitLink(session.version.git_commit)" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">{{ session.version.git_commit }}</a>
+                <dd class="text-content-text font-mono min-w-0 truncate" [title]="session.version?.git_commit">
+                  @if (backendCommitLink(session.version?.git_commit)) {
+                    <a [href]="backendCommitLink(session.version?.git_commit)" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">{{ session.version?.git_commit }}</a>
                   } @else {
-                    {{ session.version.git_commit || '—' }}
+                    {{ session.version?.git_commit || '—' }}
                   }
                 </dd>
               </div>
               <div class="flex gap-2">
                 <dt class="text-content-muted w-20 shrink-0">Built</dt>
-                <dd class="text-content-text min-w-0 truncate" [title]="session.version.build_date">{{ session.version.build_date ? (session.version.build_date | date:"yyyy-MM-dd HH:mm 'UTC'":"UTC") : '—' }}</dd>
+                <dd class="text-content-text min-w-0 truncate" [title]="session.version?.build_date">{{ session.version?.build_date ? (session.version?.build_date | date:"yyyy-MM-dd HH:mm 'UTC'":"UTC") : '—' }}</dd>
               </div>
               <div class="flex gap-2">
                 <dt class="text-content-muted w-20 shrink-0">Branch</dt>
-                <dd class="text-content-text min-w-0 truncate" [title]="session.version.git_branch">
-                  @if (backendBranchLink(session.version.git_branch)) {
-                    <a [href]="backendBranchLink(session.version.git_branch)" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">{{ session.version.git_branch }}</a>
+                <dd class="text-content-text min-w-0 truncate" [title]="session.version?.git_branch">
+                  @if (backendBranchLink(session.version?.git_branch)) {
+                    <a [href]="backendBranchLink(session.version?.git_branch)" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">{{ session.version?.git_branch }}</a>
                   } @else {
-                    {{ session.version.git_branch || '—' }}
+                    {{ session.version?.git_branch || '—' }}
                   }
                 </dd>
               </div>
@@ -115,7 +115,7 @@
       <!-- Col 3: User / Login info — top aligned, centered -->
       <div class="p-6 flex flex-col items-center justify-start text-center gap-2 min-w-[120px]">
         <div class="text-xs font-semibold text-content-muted uppercase tracking-wider">Signed in as</div>
-        <div class="font-medium text-content-text text-base">{{ session.user.name }}</div>
+        <div class="font-medium text-content-text text-base">{{ session.user?.name }}</div>
         @if ((this.userIsAdmin$ | async)) {
           <span class="text-xs bg-warning-shade-100 text-warning-shade-700 dark:bg-warning-shade-900/30 dark:text-warning-shade-300 px-2 py-0.5 rounded-full">Admin</span>
         }

--- a/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-probes-page/diagnostic-probes-page.component.ts
@@ -48,7 +48,9 @@ export class DiagnosticProbesPageComponent {
     void this.endpoints.whenReady();
   }
 
-  stateFor(guid: string): ProbeState {
+  // guid is optional on EndpointModel; an endpoint without one has no probe state.
+  stateFor(guid: string | undefined): ProbeState {
+    if (!guid) { return { running: false }; }
     return this.states().get(guid) ?? { running: false };
   }
 
@@ -66,7 +68,8 @@ export class DiagnosticProbesPageComponent {
     return 'ok';
   }
 
-  async probe(guid: string): Promise<void> {
+  async probe(guid: string | undefined): Promise<void> {
+    if (!guid) { return; }
     this.patch(guid, { running: true, result: undefined, error: undefined });
     try {
       const result = await firstValueFrom(

--- a/src/frontend/packages/core/src/features/about/diagnostics-page/diagnostics-page.component.html
+++ b/src/frontend/packages/core/src/features/about/diagnostics-page/diagnostics-page.component.html
@@ -5,7 +5,7 @@
       <div class="flex flex-wrap gap-6 px-4 py-3 items-baseline">
         <span class="flex gap-2 items-baseline">
           <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">Version</span>
-          <span class="text-sm font-medium">{{ session.version.proxy_version }}</span>
+          <span class="text-sm font-medium">{{ session.version?.proxy_version }}</span>
         </span>
         <span class="flex gap-2 items-baseline">
           <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">Built</span>
@@ -109,7 +109,7 @@
             <div class="grid grid-cols-[1.5rem_auto_1fr] gap-x-2 items-center px-4 py-1 min-h-7">
               <app-custom-icon class="text-base text-content-muted">person</app-custom-icon>
               <span class="text-sm text-content-muted whitespace-nowrap">Name</span>
-              <span class="text-sm font-medium text-right">{{ session.user.name }}@if (isAdminUser) { <span class="text-content-muted">(admin)</span>}</span>
+              <span class="text-sm font-medium text-right">{{ session.user?.name }}@if (isAdminUser) { <span class="text-content-muted">(admin)</span>}</span>
             </div>
             @if (session.config.enableTechPreview) {
               <div class="grid grid-cols-[1.5rem_auto_1fr] gap-x-2 items-center px-4 py-1 min-h-7">
@@ -158,7 +158,7 @@
                 <tr class="hover:bg-content-secondary transition-colors">
                   <td class="px-3 py-1.5 whitespace-nowrap">{{ row.id }}</td>
                   <td class="px-3 py-1.5 whitespace-nowrap">{{ row.version_id }}</td>
-                  <td class="px-3 py-1.5 whitespace-nowrap"><app-boolean-indicator [isTrue]="row.is_applied" type="yes-no" subtle="true"></app-boolean-indicator></td>
+                  <td class="px-3 py-1.5 whitespace-nowrap"><app-boolean-indicator [isTrue]="row.is_applied" type="yes-no" [subtle]="true"></app-boolean-indicator></td>
                   <td class="px-3 py-1.5 whitespace-nowrap">{{ row.timestamp }}</td>
                 </tr>
               }

--- a/src/frontend/packages/core/src/features/about/diagnostics-page/diagnostics-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-page/diagnostics-page.component.ts
@@ -2,12 +2,13 @@ import { ChangeDetectionStrategy, Component, OnInit, VERSION, inject } from '@an
 import { CommonModule } from '@angular/common';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Meta } from '@angular/platform-browser';
-import { SessionData } from '@stratosui/store';
+import { Diagnostics, SessionData } from '@stratosui/store';
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
 import { AuthSignalService } from '../../../core/signals/auth-signal.service';
 import { BooleanIndicatorComponent } from '../../../shared/components/boolean-indicator/boolean-indicator.component';
+import { CardWrapperComponent } from '../../../shared/components/cards/card/card.component';
 import { CustomIconComponent } from '../../../shared/components/custom-material/custom-material.component';
 import { InfoCardComponent } from '../../../shared/components/info-card/info-card.component';
 import { BUILD_INFO } from '../../../environments/build-info';
@@ -19,6 +20,7 @@ import { BUILD_INFO } from '../../../environments/build-info';
   imports: [
     CommonModule,
     BooleanIndicatorComponent,
+    CardWrapperComponent,
     CustomIconComponent,
     InfoCardComponent
   ],
@@ -31,9 +33,8 @@ export class DiagnosticsPageComponent implements OnInit {
 
   // toObservable() requires an injection context — bridge the signal here
   // (field initializer runs in DI context) rather than in ngOnInit (which is not).
-  sessionData$: Observable<SessionData> = toObservable(this.auth.sessionData).pipe(
-    filter((sessionData): sessionData is SessionData => !!sessionData),
-    filter(sessionData => !!sessionData.diagnostics)
+  sessionData$: Observable<SessionData & { diagnostics: Diagnostics; }> = toObservable(this.auth.sessionData).pipe(
+    filter((sessionData): sessionData is SessionData & { diagnostics: Diagnostics; } => !!sessionData && !!sessionData.diagnostics)
   );
   versionNumber$!: Observable<string>;
   userIsAdmin$!: Observable<boolean>;

--- a/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.html
+++ b/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.html
@@ -18,7 +18,7 @@
     </app-form-field>
   </div>
 
-  <app-dialog-error [message]="hasErrored()" [show]="hasErrored() && !isBusy()">
+  <app-dialog-error [message]="hasErrored() ?? ''" [show]="!!hasErrored() && !isBusy()">
   </app-dialog-error>
   <div class="key-dialog__actions flex justify-end gap-2 mt-4">
     <button (click)="dialogRef.close()" class="btn btn-danger" type="button" [disabled]="isBusy()">Cancel</button>

--- a/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.ts
+++ b/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.ts
@@ -56,8 +56,10 @@ export class PageSideNavComponent implements OnInit {
     return this.pTabs;
   }
 
+  // Bound from async-piped streams that may emit null/undefined before the
+  // header resolves; interpolation renders those as an empty string.
   @Input()
-  public header!: string;
+  public header: string | null | undefined;
   public activeTab$!: Observable<string>;
   public breadcrumbs$!: Observable<IBreadcrumb[]>;
   public isMobile$: Observable<boolean>;

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-connection-cell/backup-connection-cell.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-connection-cell/backup-connection-cell.component.html
@@ -1,7 +1,7 @@
 @if (connectable) {
   <app-form-field>
-    <app-select [(value)]="service.state[row.guid][backupType.CONNECT]"
-      [disabled]="!service.state[row.guid][backupType.ENDPOINT]">
+    <app-select [(value)]="service.state[row.guid ?? ''][backupType.CONNECT]"
+      [disabled]="!service.state[row.guid ?? ''][backupType.ENDPOINT]">
       <app-option [value]="connectionTypes.NONE">None</app-option>
       <app-option [value]="connectionTypes.CURRENT" [disabled]="!!userConnectionWarning"
       [matTooltip]="userConnectionWarning">Current User</app-option>

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-restore-endpoints/backup-restore-endpoints.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-restore-endpoints/backup-restore-endpoints.component.ts
@@ -36,7 +36,8 @@ export class BackupRestoreEndpointsComponent {
   // to consumers that drive validity reactively.
   signalHandle: SignalStepHandle = { valid: signal(true).asReadonly() };
 
-  set selectedTile(tile: ITileConfig<IAppTileData>) {
+  // The tile selector emits the base ITileConfig shape (or null on deselect).
+  set selectedTile(tile: ITileConfig | null) {
     if (tile && tile.data) {
       const url = 'endpoints/backup-restore/' + tile.data.type;
       this.router.navigate(url.split('/'));

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.html
@@ -27,7 +27,7 @@
                     <p class="text-warning-shade-800 mb-3">
                       The database version of <app-product-name></app-product-name>
                       (<code class="bg-warning-shade-100 px-1 py-0.5 rounded text-xs">{{service.currentDbVersion$ | async}}</code>) and the backup
-                      (<code class="bg-warning-shade-100 px-1 py-0.5 rounded text-xs">{{file.content.dbVersion}}</code>) are different. Restoring this file may have adverse affects.
+                      (<code class="bg-warning-shade-100 px-1 py-0.5 rounded text-xs">{{file.content?.dbVersion}}</code>) are different. Restoring this file may have adverse affects.
                     </p>
                     <label class="flex items-center space-x-2 cursor-pointer" for="restore-ignore-db">
                       <input id="restore-ignore-db" type="checkbox" class="rounded border-content-border text-brand-600 focus:ring-brand-500" (change)="onIgnoreDbChange($event)">

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.ts
@@ -3,7 +3,6 @@ import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, Validators, FormControl, FormGroup } from '@angular/forms';
-import { MatCheckboxChange } from '../../../../shared/components/custom-checkbox/custom-checkbox.component';
 import { EndpointsDataService, httpErrorResponseToSafeString } from '@stratosui/store';
 import { Observable } from 'rxjs';
 import { take, defaultIfEmpty, map } from 'rxjs/operators';
@@ -87,8 +86,9 @@ export class RestoreEndpointsComponent {
     this.service.setFile(file);
   }
 
-  onIgnoreDbChange(event: MatCheckboxChange) {
-    this.service.setIgnoreDbVersion(event.checked);
+  // Native checkbox change event (the template uses a plain <input type="checkbox">).
+  onIgnoreDbChange(event: Event) {
+    this.service.setIgnoreDbVersion((event.target as HTMLInputElement).checked);
   }
 
   private runRestore(): Promise<void> {

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.html
@@ -18,7 +18,7 @@
   <app-connect-endpoint (valid)="valid = $event" (authType)="setHelpLink($event.help)" [connectService]="connectService" [formSubmit]="true">
   </app-connect-endpoint>
   <app-dialog-error message="{{connectService.connectingError$ | async}}"
-    [show]="(connectService.connectingError$ | async) && (connectService.isBusy$ | async) === false">
+    [show]="!!(connectService.connectingError$ | async) && (connectService.isBusy$ | async) === false">
   </app-dialog-error>
   <div class="dialog-actions connection-dialog__actions">
     <button (click)="dialogRef.close()" class="btn btn-warn">Cancel</button>

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
@@ -72,8 +72,9 @@ export class ConnectEndpointDialogComponent implements OnDestroy {
     this.hasConnected.unsubscribe();
   }
 
-  public setHelpLink(link: string) {
-    this._helpDocument.set(link);
+  // Auth types without a help document emit `help: undefined`.
+  public setHelpLink(link: string | undefined) {
+    this._helpDocument.set(link ?? null);
   }
 
   public connect() {

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.html
@@ -1,7 +1,7 @@
 <form class="flex flex-col gap-4" [formGroup]="endpointForm" (ngSubmit)="formSubmit && connectService.submit()">
   @if (authTypesForEndpoint.length > 1) {
     <app-form-field class="w-full">
-      <app-select (selectionChange)="authChanged($event)" id="authType" name="authType" formControlName="authType"
+      <app-select (selectionChange)="authChanged()" id="authType" name="authType" formControlName="authType"
         placeholder="Auth Type">
         @for (auth of authTypesForEndpoint; track auth) {
           <app-option [value]="auth.value">{{ auth.name }}</app-option>

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/base-endpoint-tile-manager.ts
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/base-endpoint-tile-manager.ts
@@ -15,6 +15,17 @@ export interface ICreateEndpointTilesData extends ITileData {
   type: string;
   parentType: string;
 }
+
+/**
+ * The tile selector's `(selection)` output is typed with the base ITileData
+ * shape (and emits null on deselect). Tiles built by BaseEndpointTileManager
+ * always carry the create-endpoint data, so narrow with a runtime check.
+ */
+export function isCreateEndpointTile(
+  tile: ITileConfig | null
+): tile is ITileConfig<ICreateEndpointTilesData> {
+  return !!tile && !!tile.data && typeof tile.data.type === 'string' && typeof tile.data.parentType === 'string';
+}
 type ExpandedEndpoint<T = number> = {
   current: number,
   limit: T;

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component.html
@@ -12,8 +12,8 @@
         the 'Connecting' process. To do this return to the Endpoints page.
       </p>
     -->
-      <app-tile-selector [options]="tileSelectorConfig$ | async" [dynamicSmallerTiles]="6"
-        (selection)="selectedTile = $event">
+      <app-tile-selector [options]="(tileSelectorConfig$ | async) ?? []" [dynamicSmallerTiles]="6"
+        (selection)="onTileSelected($event)">
       </app-tile-selector>
     </div>
   </app-step>

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component.ts
@@ -10,7 +10,7 @@ import {
 import { SessionSignalService } from '../../../../core/signals/session-signal.service';
 import { BASE_REDIRECT_QUERY } from '../../../../shared/components/stepper/stepper.types';
 import { ITileConfig } from '../../../../shared/components/tile/tile-selector.types';
-import { BaseEndpointTileManager, ICreateEndpointTilesData } from './base-endpoint-tile-manager';
+import { BaseEndpointTileManager, ICreateEndpointTilesData, isCreateEndpointTile } from './base-endpoint-tile-manager';
 import { PageHeaderComponent } from '../../../../shared/components/page-header/page-header.component';
 import { SteppersComponent } from '../../../../shared/components/stepper/steppers/steppers.component';
 import { StepComponent, SignalStepHandle } from '../../../../shared/components/stepper/step/step.component';
@@ -46,6 +46,14 @@ export class CreateEndpointBaseStepComponent extends BaseEndpointTileManager {
         `endpoints/new/${tile.data.parentType || tile.data.type}/${tile.data.parentType ? tile.data.type : ''}`.split('/'),
         { queryParams: { [BASE_REDIRECT_QUERY]: 'endpoints/new' } }
       );
+    }
+  }
+
+  // The tile selector emits the base ITileConfig shape (or null on deselect);
+  // narrow before handing off to the typed selectedTile setter.
+  onTileSelected(tile: ITileConfig | null) {
+    if (isCreateEndpointTile(tile)) {
+      this.selectedTile = tile;
     }
   }
 

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
@@ -14,9 +14,9 @@
           placeholder="Name"
           class="w-full placeholder:!text-transparent focus:outline-none"
           [appUnique]="
-            registerForm.value.createSystemEndpointField
+            (registerForm.value.createSystemEndpointField
               ? $safeNavigationMigration((customEndpoints | async)?.names)
-              : $safeNavigationMigration((existingPersonalEndpoints | async)?.names)
+              : $safeNavigationMigration((existingPersonalEndpoints | async)?.names)) ?? []
           "
         />
         @if (registerForm.controls.nameField.errors?.required) {

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-connect/create-endpoint-connect.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-connect/create-endpoint-connect.component.ts
@@ -38,7 +38,8 @@ export class CreateEndpointConnectComponent implements OnDestroy, IStepperStep {
 
 
   public validate!: Observable<boolean>;
-  public helpDocumentUrl!: string;
+  // Unset until an auth type with a help document is selected.
+  public helpDocumentUrl: string | undefined;
   public connectService!: ConnectEndpointService;
 
   // FWT-959 Part 2: signal-backed mirrors of `valid` and `doConnect` so
@@ -54,6 +55,9 @@ export class CreateEndpointConnectComponent implements OnDestroy, IStepperStep {
   set doConnect(v: boolean) { this.doConnectSignal.set(v); }
 
   showHelp() {
+    if (!this.helpDocumentUrl) {
+      return;
+    }
     this.sidePanelService.showModal(MarkdownPreviewComponent, { documentUrl: this.helpDocumentUrl });
   }
 

--- a/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.html
@@ -5,7 +5,7 @@
         <h1 class="edit-endpoint__section-title text-base font-medium mb-4" style="color: var(--content-text);">{{definition.label}} Information</h1>
         <app-form-field>
           <input class="w-full placeholder:!text-transparent focus:outline-none" appInput id="name" name="name" formControlName="name" required placeholder="Name"
-            [appUnique]="(existingEndpoinNames$ | async)">
+            [appUnique]="(existingEndpointNames$ | async) ?? []">
           @if (name.errors && name.errors.required) {
             <app-error>Name is required</app-error>
           }

--- a/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AppInputDirective, CustomFormFieldComponent } from '../../../../shared/components/custom-form-field/custom-form-field.component';
+import { AppErrorComponent, AppInputDirective, CustomFormFieldComponent } from '../../../../shared/components/custom-form-field/custom-form-field.component';
 import { CustomCheckboxComponent } from '../../../../shared/components/custom-checkbox/custom-checkbox.component';
 import { CustomIconComponent } from '../../../../shared/components/custom-material/custom-material.component';
 import {
@@ -48,6 +48,7 @@ interface EditEndpointForm {
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    AppErrorComponent,
     AppInputDirective,
     CustomFormFieldComponent,
     CustomCheckboxComponent,
@@ -177,9 +178,10 @@ export class EditEndpointStepComponent implements OnDestroy, IStepperStep {
     });
   }
 
-  get name() { return this.editEndpoint.get('name'); }
+  // Typed controls (get('name') would return AbstractControl | null).
+  get name() { return this.editEndpoint.controls.name; }
 
-  get clientID() { return this.editEndpoint.get('clientID'); }
+  get clientID() { return this.editEndpoint.controls.clientID; }
 
   updateControls() {
     if (!this.setClientInfo) {

--- a/src/frontend/packages/core/src/features/endpoints/endpoint-register-modal/endpoint-register-modal.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-register-modal/endpoint-register-modal.component.html
@@ -54,7 +54,7 @@
         @if (!selectedEndpointInfo) {
           <div>
             <app-tile-selector
-              [options]="tileSelectorConfig$ | async"
+              [options]="(tileSelectorConfig$ | async) ?? []"
               [dynamicSmallerTiles]="6"
               (selection)="onTileSelected($event)"
               class="endpoint-tile-selector">

--- a/src/frontend/packages/core/src/features/endpoints/endpoint-register-modal/endpoint-register-modal.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-register-modal/endpoint-register-modal.component.ts
@@ -10,7 +10,11 @@ import {
 
 import { SessionSignalService } from '../../../core/signals/session-signal.service';
 import { ITileConfig } from '../../../shared/components/tile/tile-selector.types';
-import { BaseEndpointTileManager, ICreateEndpointTilesData } from '../create-endpoint/create-endpoint-base-step/base-endpoint-tile-manager';
+import {
+  BaseEndpointTileManager,
+  ICreateEndpointTilesData,
+  isCreateEndpointTile,
+} from '../create-endpoint/create-endpoint-base-step/base-endpoint-tile-manager';
 import { TileSelectorComponent } from '../../../shared/components/tile-selector/tile-selector.component';
 
 @Component({
@@ -73,8 +77,10 @@ export class EndpointRegisterModalComponent extends BaseEndpointTileManager impl
     this.closeModal();
   }
 
-  onTileSelected(tile: ITileConfig<ICreateEndpointTilesData>) {
-    if (tile) {
+  // The tile selector emits the base ITileConfig shape (or null on deselect);
+  // narrow before storing/loading the typed create-endpoint tile.
+  onTileSelected(tile: ITileConfig | null) {
+    if (isCreateEndpointTile(tile)) {
       this.selectedEndpointInfo = tile;
       // Force the @if(selectedEndpointInfo) branch to render synchronously
       // so the #endpointFormContainer ViewChild is available — then load

--- a/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.html
+++ b/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.html
@@ -1,6 +1,6 @@
 @if (errorDetails$ | async; as errorDetails) {
   <app-page-header [hideEndpointErrors]="true">
-    <h1>{{ errorDetails.endpoint.name }} — Errors</h1>
+    <h1>{{ errorDetails.endpoint?.name }} — Errors</h1>
     <div class="page-header-right">
       <span>
         <button class="btn btn-icon" type="button" title="Close" [routerLink]="back$ | async" [queryParams]="backParams$ | async">
@@ -13,7 +13,7 @@
     @if (errorDetails.errors && errorDetails.errors.length) {
       <div class="flex items-center gap-2 mt-4 mb-2">
         <button class="btn btn-primary" type="button" aria-label="Dismiss errors"
-          (click)="dismissEndpointErrors(errorDetails.endpoint.guid)">
+          (click)="dismissEndpointErrors(errorDetails.endpoint?.guid)">
           Dismiss all
         </button>
         <a class="btn btn-icon" [href]="jsonDownloadHref$ | async"

--- a/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.ts
+++ b/src/frontend/packages/core/src/features/error-page/error-page/error-page.component.ts
@@ -50,7 +50,11 @@ export class ErrorPageComponent implements OnInit {
   public icon = StratosStatus.ERROR;
   public jsonDownloadHref$?: Observable<SafeUrl>;
 
-  public dismissEndpointErrors(endpointGuid: string) {
+  // The endpoint may not have resolved yet (guid optional on EndpointModel).
+  public dismissEndpointErrors(endpointGuid: string | undefined) {
+    if (!endpointGuid) {
+      return;
+    }
     this.errorEvents.clearEndpoint(endpointGuid);
   }
 

--- a/src/frontend/packages/core/src/features/event-page/events-page/events-page.component.ts
+++ b/src/frontend/packages/core/src/features/event-page/events-page/events-page.component.ts
@@ -8,6 +8,7 @@ import { Observable } from 'rxjs';
 import { take, distinctUntilChanged, map, share, switchMap, tap } from 'rxjs/operators';
 
 import { GlobalEventService, IGlobalEvent } from '../../../shared/global-events.service';
+import { CardWrapperComponent } from '../../../shared/components/cards/card/card.component';
 import { PageHeaderComponent } from '../../../shared/components/page-header/page-header.component';
 import { CustomIconComponent } from '../../../shared/components/custom-material/custom-material.component';
 
@@ -27,6 +28,7 @@ export enum EventFilterValues {
   imports: [
     CommonModule,
     RouterModule,
+    CardWrapperComponent,
     CustomIconComponent,
     CustomTooltipDirective,
     PageHeaderComponent

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.html
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.html
@@ -34,7 +34,9 @@
               }
             </div>
           }
-          <app-entity-favorite-star [confirmRemoval]="true" [favorite]="favorite"></app-entity-favorite-star>
+          @if (favorite; as fav) {
+            <app-entity-favorite-star [confirmRemoval]="true" [favorite]="fav"></app-entity-favorite-star>
+          }
         </div>
       </div>
     </div>

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
@@ -74,7 +74,8 @@ export class HomePageEndpointCardComponent implements OnInit, OnChanges, OnDestr
   // strict: assigned by the @Input set layout accessor; reads are guarded with if (this.rawLayout)
   private rawLayout!: HomePageCardLayout;
 
-  @Input() set layout(value: HomePageCardLayout) {
+  // Null until the parent's persisted layout hydrates; the guard below skips it.
+  @Input() set layout(value: HomePageCardLayout | null) {
     if (value) {
       this.rawLayout = value;
       this.computeEffectiveLayout();

--- a/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.html
+++ b/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async">{{ (metricsEndpoint$ | async)?.provider.name }}</app-page-header>
+<app-page-header [breadcrumbs]="breadcrumbs$ | async">{{ (metricsEndpoint$ | async)?.provider?.name }}</app-page-header>
 
 @if ((metricsEndpoint$ | async); as ep) {
   <div class="p-6">

--- a/src/frontend/packages/core/src/features/setup/local-account-wizard/local-account-wizard.component.html
+++ b/src/frontend/packages/core/src/features/setup/local-account-wizard/local-account-wizard.component.html
@@ -1,12 +1,12 @@
 <div class="setup flex flex-col h-full">
-  <app-page-header hideMenu="true" [showHistory]="false">
+  <app-page-header [hideMenu]="true" [showHistory]="false">
     <h1>{{title}} Setup with Local Admin Account</h1>
   </app-page-header>
   <app-show-page-header></app-show-page-header>
   <div class="p-6">
     <app-steppers class="flex flex-1 my-6" [cancel]="'/setup'">
       <app-step title="Local Account Information" [signalHandle]="signalHandle">
-        <app-loading-page [isLoading]="applyingSetup()" alert="Saving configuration"
+        <app-loading-page [isLoading]="applyingSetup$" alert="Saving configuration"
           text="Please wait - this will take a few moments">
           <div class="space-y-6">
             <div class="space-y-4">

--- a/src/frontend/packages/core/src/features/setup/local-account-wizard/local-account-wizard.component.ts
+++ b/src/frontend/packages/core/src/features/setup/local-account-wizard/local-account-wizard.component.ts
@@ -59,6 +59,8 @@ export class LocalAccountWizardComponent implements OnInit {
   passwordForm!: FormGroup;
   validateLocalAuthForm!: Observable<boolean>;
   applyingSetup = signal<boolean>(false);
+  // app-loading-page takes an Observable<boolean> — bridge the signal.
+  applyingSetup$ = toObservable(this.applyingSetup);
   signalHandle!: SignalStepHandle;
 
   showPassword: boolean[] = [];

--- a/src/frontend/packages/core/src/features/setup/setup-welcome/setup-welcome.component.html
+++ b/src/frontend/packages/core/src/features/setup/setup-welcome/setup-welcome.component.html
@@ -1,5 +1,5 @@
 <div class="page-container setup">
-  <app-page-header hideMenu="true" [showHistory]="false">
+  <app-page-header [hideMenu]="true" [showHistory]="false">
     <h1>{{title}} Setup</h1>
   </app-page-header>
   <app-show-page-header></app-show-page-header>

--- a/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.html
+++ b/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.html
@@ -1,5 +1,5 @@
 <div class="setup flex flex-col h-full">
-  <app-page-header hideMenu="true" [showHistory]="false">
+  <app-page-header [hideMenu]="true" [showHistory]="false">
     <h1>{{title}} Setup with Cloud Foundry UAA</h1>
   </app-page-header>
   <app-show-page-header></app-show-page-header>
@@ -87,7 +87,7 @@
     </div>
   </app-step>
   <app-step title="Admin Scope" [signalHandle]="uaaScopeStepHandle">
-    <app-loading-page [isLoading]="applyingSetup()" alert="Saving configuration"
+    <app-loading-page [isLoading]="applyingSetup$" alert="Saving configuration"
       text="Please wait - this will take a few moments">
       <div class="space-y-4">
         <p class="text-content-text">Please select the UAA scope to use to identify users as <app-product-name></app-product-name> Administrators:</p>

--- a/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.ts
+++ b/src/frontend/packages/core/src/features/setup/uaa-wizard/console-uaa-wizard.component.ts
@@ -62,7 +62,7 @@ export class ConsoleUaaWizardComponent implements OnInit, OnDestroy {
   private uaaSetup$ = toObservable(this.uaaSetupSignals.uaaSetup);
   private auth$ = toObservable(this.authSignals.auth);
 
-  private clientRedirectURI: string;
+  protected clientRedirectURI: string;
 
   constructor() {
     // Client Redirect URI for SSO
@@ -73,6 +73,8 @@ export class ConsoleUaaWizardComponent implements OnInit, OnDestroy {
   uaaScopes: string[] = [];
   selectedScope = '';
   applyingSetup = signal<boolean>(false);
+  // app-loading-page takes an Observable<boolean> — bridge the signal.
+  applyingSetup$ = toObservable(this.applyingSetup);
 
   // Tracks UAA form validity for the first step's signal handle. Updated
   // from the form's valueChanges subscription in ngOnInit so the step's

--- a/src/frontend/packages/core/src/features/user-profile/profile-info/profile-info.component.html
+++ b/src/frontend/packages/core/src/features/user-profile/profile-info/profile-info.component.html
@@ -17,7 +17,7 @@
   }
   @if (userProfile$ | async; as profile) {
     <app-user-profile-banner [user]="profile"
-      [allowGravatar]="allowGravatar$ | async">
+      [allowGravatar]="(allowGravatar$ | async) ?? false">
     </app-user-profile-banner>
   }
   @if (userProfile$ | async; as profile) {
@@ -73,7 +73,7 @@
               <h3 class="card-title">Groups</h3>
             </div>
             <div class="card-body">
-              <app-chips [chips]="profile.groups" [stacked]="false" lowerLimit="20" displayProperty="display"></app-chips>
+              <app-chips [chips]="profile.groups ?? []" [stacked]="false" [lowerLimit]="20" displayProperty="display"></app-chips>
             </div>
           </div>
         }

--- a/src/frontend/packages/core/src/public-api.ts
+++ b/src/frontend/packages/core/src/public-api.ts
@@ -127,7 +127,11 @@ export { TileComponent } from './shared/components/tile/tile/tile.component';
 export { LoadingPageComponent } from './shared/components/loading-page/loading-page.component';
 export { StatefulIconComponent } from './core/stateful-icon/stateful-icon.component';
 export { AppChipsComponent, AppChip, IAppChip } from './shared/components/chips/chips.component';
-export { BooleanIndicatorComponent } from './shared/components/boolean-indicator/boolean-indicator.component';
+export {
+  BooleanIndicatorComponent,
+  BooleanIndicatorType,
+  BooleanIndicatorTypeValue,
+} from './shared/components/boolean-indicator/boolean-indicator.component';
 export { CopyToClipboardComponent } from './shared/components/copy-to-clipboard/copy-to-clipboard.component';
 export { NoContentMessageComponent } from './shared/components/no-content-message/no-content-message.component';
 export { UploadProgressIndicatorComponent } from './shared/components/upload-progress-indicator/upload-progress-indicator.component';

--- a/src/frontend/packages/core/src/shared/components/app-action-monitor-icon/app-action-monitor-icon.component.html
+++ b/src/frontend/packages/core/src/shared/components/app-action-monitor-icon/app-action-monitor-icon.component.html
@@ -5,7 +5,7 @@
         <app-custom-icon class="monitor-icon__error">error</app-custom-icon>
       }
       @if (!state.error && state.busy) {
-        <app-progress-spinner diameter="20" mode="indeterminate"></app-progress-spinner>
+        <app-progress-spinner [diameter]="20" mode="indeterminate"></app-progress-spinner>
       }
       @if (!state.error && !state.busy && state.completed) {
         <app-custom-icon class="monitor-icon__done">done</app-custom-icon>

--- a/src/frontend/packages/core/src/shared/components/app-action-monitor-icon/app-action-monitor-icon.component.ts
+++ b/src/frontend/packages/core/src/shared/components/app-action-monitor-icon/app-action-monitor-icon.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit, Output, ChangeDetectionStrategy } from '@angu
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 import { CustomIconComponent } from '../../../shared/components/custom-material/custom-material.component';
+import { ProgressSpinnerComponent } from '../progress-spinner/progress-spinner.component';
 
 export interface IActionMonitorComponentState {
   busy: boolean;
@@ -17,7 +18,8 @@ export interface IActionMonitorComponentState {
   standalone: true,
   imports: [
     CommonModule,
-    CustomIconComponent
+    CustomIconComponent,
+    ProgressSpinnerComponent
   ]
 })
 export class AppActionMonitorIconComponent implements OnInit {

--- a/src/frontend/packages/core/src/shared/components/application-state/application-state-icon/application-state-icon.component.ts
+++ b/src/frontend/packages/core/src/shared/components/application-state/application-state-icon/application-state-icon.component.ts
@@ -17,6 +17,7 @@ import { ApplicationStateIconPipe } from './application-state-icon.pipe';
 })
 export class ApplicationStateIconComponent {
 
-  @Input() public status!: StratosStatus;
+  // Accepts null so callers can bind `status$ | async` directly
+  @Input() public status!: StratosStatus | null;
 
 }

--- a/src/frontend/packages/core/src/shared/components/application-state/application-state-icon/application-state-icon.pipe.ts
+++ b/src/frontend/packages/core/src/shared/components/application-state/application-state-icon/application-state-icon.pipe.ts
@@ -17,7 +17,7 @@ export class ApplicationStateIconPipe implements PipeTransform {
     }
   }
 
-  transform(value: string, args?: string): string {
+  transform(value: string | null, args?: string): string {
     if (!value) {
       return '';
     }

--- a/src/frontend/packages/core/src/shared/components/boolean-indicator/boolean-indicator.component.ts
+++ b/src/frontend/packages/core/src/shared/components/boolean-indicator/boolean-indicator.component.ts
@@ -8,9 +8,16 @@ export enum BooleanIndicatorType {
   yesNo = 'yes-no',
   trueFalse = 'true-false',
   healthyUnhealthy = 'healthy-unhealthy',
-  succeededFailed = 'success-failed',
-  progressProgress = 'progress-progress'
+  // Value must split into the 'Succeeded'/'Failed' icon-map keys
+  succeededFailed = 'succeeded-failed',
+  progressProgress = 'progress-progress',
+  addRemove = 'add-remove',
+  // Inverted severity: 'No' is the positive/expected state (e.g. node NotReady conditions)
+  noYes = 'no-yes'
 }
+
+// Accepts the enum or its string-literal form, so templates can write e.g. type="yes-no".
+export type BooleanIndicatorTypeValue = BooleanIndicatorType | `${BooleanIndicatorType}`;
 
 interface IBooleanConfig {
   isTrue?: boolean;
@@ -85,23 +92,25 @@ export class BooleanIndicatorComponent {
     Progress: 'cached'
   };
 
-  private pType!: BooleanIndicatorType;
+  private pType!: BooleanIndicatorTypeValue;
   @Input()
-  get type(): BooleanIndicatorType {
+  get type(): BooleanIndicatorTypeValue {
     return this.pType;
   }
-  set type(type: BooleanIndicatorType) {
+  set type(type: BooleanIndicatorTypeValue) {
     this.pType = type;
     this.updateBooleanOutput();
     this.cdr.markForCheck();
   }
 
-  private pIsTrue!: boolean;
+  // undefined/null render the 'Unknown' indicator (see updateBooleanOutput),
+  // so callers can bind not-yet-loaded data, including `| async` streams.
+  private pIsTrue?: boolean | null;
   @Input()
-  get isTrue(): boolean {
+  get isTrue(): boolean | null | undefined {
     return this.pIsTrue;
   }
-  set isTrue(isTrue: boolean) {
+  set isTrue(isTrue: boolean | null | undefined) {
     this.pIsTrue = isTrue;
     this.updateBooleanOutput();
     this.cdr.markForCheck();
@@ -110,7 +119,7 @@ export class BooleanIndicatorComponent {
   private updateBooleanOutput() {
     const isUnknown = typeof this.isTrue !== 'boolean';
     this.booleanOutput = this.getIconTextAndSeverity({
-      isTrue: this.isTrue,
+      isTrue: this.isTrue ?? undefined,
       isUnknown,
       inverse: this.inverse,
       subtle: this.subtle

--- a/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.ts
@@ -39,7 +39,7 @@ export class CardNumberMetricComponent implements OnInit, OnChanges {
   @Input() showUsage = false;
   @Input() textOnly = false;
   @Input() labelAtTop = false;
-  @Input() link?: () => void | string;
+  @Input() link?: string | (() => void | string);
   @Output() showAlerts = new EventEmitter<any>();
   @Input() mode!: string;
 

--- a/src/frontend/packages/core/src/shared/components/cards/card-status/card-status.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-status/card-status.component.ts
@@ -32,7 +32,7 @@ export function determineCardStatus(value: number, limit: number): StratosStatus
 export class CardStatusComponent {
   @Input() status$!: Observable<StratosStatus>;
 
-  private cardStatus = StratosStatus;
+  protected cardStatus = StratosStatus;
 
   constructor() { }
 }

--- a/src/frontend/packages/core/src/shared/components/chips/chips.component.html
+++ b/src/frontend/packages/core/src/shared/components/chips/chips.component.html
@@ -14,10 +14,10 @@
               class="app-chip__link hover:underline"
               [routerLink]="[chip.url.link]"
               [queryParams]="chip.url.params">
-              {{chip[displayProperty]}}
+              {{getDisplayValue(chip)}}
             </a>
           } @else {
-            <div class="flex-1 h-[18px] leading-[18px] break-all">{{chip[displayProperty]}}</div>
+            <div class="flex-1 h-[18px] leading-[18px] break-all">{{getDisplayValue(chip)}}</div>
           }
           @if (chip.clearAction && (chip.hideClearButton$ | async) === false) {
             @if (!chip.busy || (chip.busy | async) === false) {

--- a/src/frontend/packages/core/src/shared/components/chips/chips.component.ts
+++ b/src/frontend/packages/core/src/shared/components/chips/chips.component.ts
@@ -88,6 +88,13 @@ export class AppChipsComponent implements OnInit {
     this.cdr.markForCheck();
   }
 
+  // displayProperty allows callers to render arbitrary chip-shaped objects,
+  // so the lookup has to go through a dynamic string key
+  public getDisplayValue(chip: AppChip): string {
+    const value: unknown = Reflect.get(chip, this.displayProperty);
+    return value == null ? '' : String(value);
+  }
+
   public getChipClasses(color?: string): string {
     if (!color) {
       return 'bg-content-secondary border-content-border text-content-text';

--- a/src/frontend/packages/core/src/shared/components/code-block/code-block.component.html
+++ b/src/frontend/packages/core/src/shared/components/code-block/code-block.component.html
@@ -7,6 +7,7 @@
     <app-copy-to-clipboard
       class="absolute top-[10px] right-[20px]"
       [text]="text"
+      tooltip="Copy to clipboard"
       [compact]="true">
     </app-copy-to-clipboard>
   }

--- a/src/frontend/packages/core/src/shared/components/custom-button-toggle/custom-button-toggle.component.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-button-toggle/custom-button-toggle.component.ts
@@ -50,6 +50,15 @@ export class CustomButtonToggleGroupComponent implements ControlValueAccessor, A
   @Input() vertical = false;
   @Input() name!: string;
 
+  // Material API parity: mat-button-toggle-group supports a plain [value] input
+  @Input()
+  set value(value: any) {
+    this.writeValue(value);
+  }
+  get value(): any {
+    return this.multiple ? this.selectedValues : this.selectedValues[0];
+  }
+
   @Output() valueChange = new EventEmitter<any>();
   // eslint-disable-next-line @angular-eslint/no-output-native -- intentional Material API parity: drop-in for mat-button-toggle-group which emits (change)
   @Output() change = new EventEmitter<MatButtonToggleChange>();
@@ -68,6 +77,8 @@ export class CustomButtonToggleGroupComponent implements ControlValueAccessor, A
         this.selectToggle(selectedToggle);
       });
     });
+    // Reflect any value written before the toggles were available
+    this.updateToggles();
   }
 
   selectToggle(toggle: CustomButtonToggleComponent) {
@@ -100,6 +111,10 @@ export class CustomButtonToggleGroupComponent implements ControlValueAccessor, A
   }
 
   private updateToggles() {
+    if (!this.toggles) {
+      // writeValue can run before content children are resolved
+      return;
+    }
     this.toggles.forEach(toggle => {
       toggle.checked = this.selectedValues.includes(toggle.value);
     });

--- a/src/frontend/packages/core/src/shared/components/custom-material/custom-material.component.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-material/custom-material.component.ts
@@ -1,18 +1,20 @@
-import { ChangeDetectionStrategy, Component, Input, Output, EventEmitter, Directive  } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, Output, EventEmitter, Directive, booleanAttribute  } from '@angular/core';
 
 // Custom Icon Component
 @Component({
   selector: 'app-custom-icon',
-  template: `<i [class]="fontSet + ' custom-icon'" [class.inline]="inline" [attr.aria-label]="ariaLabel"><ng-content></ng-content></i>`,
+  template: `<i [class]="(fontSet || 'material-icons') + ' custom-icon'" [class.inline]="inline" [attr.aria-label]="ariaLabel"><ng-content></ng-content></i>`,
   styleUrls: ['./custom-material.component.scss'],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CustomIconComponent {
-  @Input() fontSet = 'material-icons';
+  // Undefined falls back to material-icons so callers can bind optional fonts
+  @Input() fontSet: string | undefined = 'material-icons';
   @Input() fontIcon = '';
   @Input() svgIcon = '';
-  @Input() inline = false;
+  // Attribute form (inline / inline="true") coerces like mat-icon did
+  @Input({ transform: booleanAttribute }) inline = false;
   @Input() ariaLabel = '';
 }
 

--- a/src/frontend/packages/core/src/shared/components/custom-select/custom-select.component.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-select/custom-select.component.ts
@@ -226,7 +226,7 @@ export class CustomSelectComponent implements ControlValueAccessor, AfterContent
    * Finds the clicked option by matching the DOM element to the
    * ContentChildren QueryList, bypassing subscription timing issues.
    */
-  onOptionsClick(event: MouseEvent) {
+  onOptionsClick(event: Event) {
     const clickTarget = event.target as HTMLElement;
     const target = clickTarget.closest('.custom-option-content');
     if (!target) return;

--- a/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
+++ b/src/frontend/packages/core/src/shared/components/custom-tooltip/custom-tooltip.directive.ts
@@ -1,8 +1,10 @@
-import { Directive, Input, ElementRef, Renderer2, OnDestroy, HostListener, SecurityContext, inject } from '@angular/core';
+import { Directive, Input, ElementRef, Renderer2, OnDestroy, HostListener, SecurityContext, inject, numberAttribute } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 @Directive({
   selector: '[matTooltip]',
+  // Material parity: templates use #ref="matTooltip"
+  exportAs: 'matTooltip',
   standalone: true
 })
 export class CustomTooltipDirective implements OnDestroy {
@@ -14,8 +16,9 @@ export class CustomTooltipDirective implements OnDestroy {
   @Input('matTooltipPosition') position: 'above' | 'below' | 'left' | 'right' = 'above';
   // eslint-disable-next-line @angular-eslint/no-input-rename -- intentional: drop-in replacement for Angular Material's matTooltip; the matTooltipClass alias IS the public API
   @Input('matTooltipClass') tooltipClass: string = '';
-  @Input('matTooltipShowDelay') showDelay: number = 250;
-  @Input('matTooltipHideDelay') hideDelay: number = 100;
+  // Coerce attribute-form values (matTooltipShowDelay="1000") like Material did
+  @Input({ alias: 'matTooltipShowDelay', transform: numberAttribute }) showDelay: number = 250;
+  @Input({ alias: 'matTooltipHideDelay', transform: numberAttribute }) hideDelay: number = 100;
   @Input('matTooltipDisabled') disabled: boolean = false;
 
   private tooltipElement: HTMLElement | null = null;

--- a/src/frontend/packages/core/src/shared/components/date-time/date-time.component.ts
+++ b/src/frontend/packages/core/src/shared/components/date-time/date-time.component.ts
@@ -20,29 +20,30 @@ export class DateTimeComponent implements OnDestroy {
   public time = new FormControl<string | null>(null);
   private sub!: Subscription;
   private changeSub!: Subscription;
-  private dateTimeValue!: Date;
+  // Null until a date is chosen (or when the bound value is cleared)
+  private dateTimeValue: Date | null = null;
 
   private dateObservable: Observable<string>;
   private timeObservable: Observable<string>;
 
   @Output()
-  public dateTimeChange = new EventEmitter<Date>();
+  public dateTimeChange = new EventEmitter<Date | null | undefined>();
 
   @Input()
-  get dateTime() {
+  get dateTime(): Date | null {
     return this.dateTimeValue;
   }
 
-  set dateTime(dateTime: Date) {
+  set dateTime(dateTime: Date | null | undefined) {
     const empty = !dateTime && this.dateTimeValue !== dateTime;
     const validDate = dateTime && isValid(dateTime) && (!this.dateTimeValue || !isEqual(dateTime, this.dateTimeValue));
     if (empty || validDate) {
-      this.dateTimeValue = dateTime;
+      this.dateTimeValue = dateTime ?? null;
       this.dateTimeChange.emit(this.dateTimeValue);
     }
   }
 
-  private isDifferentDate(oldDate: Date, newDate: Date) {
+  private isDifferentDate(oldDate: Date | null, newDate: Date) {
     return !oldDate || !newDate || !isValid(newDate) || !isEqual(oldDate, newDate);
   }
 

--- a/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.ts
+++ b/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.ts
@@ -25,6 +25,9 @@ export class DialogConfirmComponent {
 
   public textToMatch!: string;
 
+  // Bound via ngModel to the type-to-confirm input
+  public matchValue?: string;
+
   constructor() {
     const data = this.data;
 

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
@@ -4,13 +4,15 @@ import { entityCatalog, EndpointModel } from '@stratosui/store';
 
 import { TableCellCustom } from '../../signal-list/cell-base';
 import { CustomIconComponent } from '../../../../shared/components/custom-material/custom-material.component';
+import { AppSpinnerComponent } from '../../progress-spinner/app-spinner.component';
 
 @Component({
   selector: 'app-table-cell-endpoint-status',
   templateUrl: './table-cell-endpoint-status.component.html',
   standalone: true,
   imports: [
-    CustomIconComponent
+    CustomIconComponent,
+    AppSpinnerComponent
 ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/frontend/packages/core/src/shared/components/meta-card/meta-card-base/meta-card.component.ts
+++ b/src/frontend/packages/core/src/shared/components/meta-card/meta-card-base/meta-card.component.ts
@@ -53,10 +53,10 @@ export class MetaCardComponent {
   title!: MetaCardTitleComponent;
 
   @Input()
-  status$!: Observable<StratosStatus>;
+  status$?: Observable<StratosStatus>;
 
   @Input()
-  favorite?: UserFavorite<IFavoriteMetadata>;
+  favorite?: UserFavorite<IFavoriteMetadata> | null;
 
   // Vestigial no-op input. The legacy ngrx favorite-star fallback (entity
   // monitor -> UserFavoriteManager.getFavorite) was removed with the rest of
@@ -88,7 +88,7 @@ export class MetaCardComponent {
   clickAction?: () => void;
 
   @Input()
-  set actionMenu(actionMenu: MenuItem[]) {
+  set actionMenu(actionMenu: MenuItem[] | null) {
     if (actionMenu) {
       this.pActionMenu = actionMenu.map(menuItem => {
         if (!menuItem.can) {

--- a/src/frontend/packages/core/src/shared/components/metrics-chart/metrics-chart.component.html
+++ b/src/frontend/packages/core/src/shared/components/metrics-chart/metrics-chart.component.html
@@ -19,7 +19,7 @@
           <div class="metrics-chart">
             @if (results.length) {
               <div class="metrics-chart">
-                @switch (chartConfig.chartType) {
+                @switch (chartConfig?.chartType) {
                   @case (chartTypes.LINE) {
                     <canvas baseChart
                       [data]="chartJsData"
@@ -28,7 +28,7 @@
                     </canvas>
                   }
                   @default {
-                    <span> {{ chartConfig.chartType }} chart type not found </span>
+                    <span> {{ chartConfig?.chartType }} chart type not found </span>
                   }
                 }
               </div>
@@ -36,7 +36,7 @@
               <div class="no-content">No results found
                 @if (!title) {
                   <div class="no-content__name">
-                    {{ chartConfig.yAxisLabel }}
+                    {{ chartConfig?.yAxisLabel }}
                   </div>
                 }
               </div>

--- a/src/frontend/packages/core/src/shared/components/metrics-chart/metrics-chart.component.ts
+++ b/src/frontend/packages/core/src/shared/components/metrics-chart/metrics-chart.component.ts
@@ -14,6 +14,8 @@ import {
 import { BaseChartDirective } from 'ng2-charts';
 
 import { CardWrapperComponent } from '../cards/card/card.component';
+import { AppProgressBarComponent } from '../progress-bar/app-progress-bar.component';
+import { AppSpinnerComponent } from '../progress-spinner/app-spinner.component';
 import { MetricsRangeSelectorComponent } from '../metrics-range-selector/metrics-range-selector.component';
 import { MetricsChartTypes, MetricsLineChartConfig, YAxisTickFormattingFunc } from './metrics-chart.types';
 import { MetricsChartManager } from './metrics.component.manager';
@@ -38,7 +40,9 @@ export interface MetricsConfig<T = any> {
   imports: [
     CommonModule,
     BaseChartDirective,
-    CardWrapperComponent
+    CardWrapperComponent,
+    AppProgressBarComponent,
+    AppSpinnerComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/frontend/packages/core/src/shared/components/metrics-parent-range-selector/metrics-parent-range-selector.component.html
+++ b/src/frontend/packages/core/src/shared/components/metrics-parent-range-selector/metrics-parent-range-selector.component.html
@@ -35,7 +35,7 @@
         class="metrics-range-parent-selector__date-range">
         <app-start-end-date (isValid)="rangeSelectorManager.dateValid = $event" [(start)]="rangeSelectorManager.start" [(end)]="rangeSelectorManager.end"></app-start-end-date>
         <div class="metrics-range-parent-selector__date-range-buttons">
-          <button class="btn btn-primary metrics-range-parent-selector__date-set" type="button" (click)="rangeSelectorManager.commit()"
+          <button class="btn btn-primary metrics-range-parent-selector__date-set" type="button" (click)="rangeSelectorManager.commit?.()"
           [disabled]="!rangeSelectorManager.dateValid || !rangeSelectorManager.commit">Set</button>
         </div>
       </div>

--- a/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.ts
+++ b/src/frontend/packages/core/src/shared/components/metrics-range-selector/metrics-range-selector.component.ts
@@ -86,7 +86,7 @@ export class MetricsRangeSelectorComponent implements OnDestroy {
   }
 
   @Input()
-  public validate?: (start: Date, end: Date) => string;
+  public validate?: (start: Date | undefined, end: Date | undefined) => string;
 
   set showOverlay(show: boolean) {
     this.showOverlayValue = show;

--- a/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.ts
+++ b/src/frontend/packages/core/src/shared/components/no-content-message/no-content-message.component.ts
@@ -25,7 +25,7 @@ export class NoContentMessageComponent implements AfterViewInit {
   @Input() icon?: string;
   @Input() iconFont?: string;
   @Input() firstLine?: string;
-  @Input() secondLine?: NoContentMessageLine;
+  @Input() secondLine?: NoContentMessageLine | null;
   @Input() otherLines?: NoContentMessageLine[];
   @Input() toolbarLink?: {
     text: string;

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.html
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.html
@@ -123,7 +123,7 @@
                     class="absolute right-0 top-full mt-2 bg-content-bg rounded-lg shadow-lg border border-content-border z-50">
                     <div class="page-header-history p-4 w-80">
                       <h3 class="page-header-history-title text-lg font-semibold text-content-text mb-4">Recent Activity</h3>
-                      <app-recent-entities mode="menu" class="page-header-history-list" history="true">
+                      <app-recent-entities mode="menu" class="page-header-history-list" [history]="true">
                       </app-recent-entities>
                     </div>
                   </div>
@@ -132,7 +132,7 @@
             }
 
             <!-- Notifications button -->
-            @if ((events$ | async).length > 0) {
+            @if (((events$ | async) || []).length > 0) {
               <button
                 routerLink="/events"
                 matTooltip="Notifications"

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.ts
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.ts
@@ -20,6 +20,7 @@ import { combineLatest, firstValueFrom, Observable, shareReplay } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { TailwindSnackBarService } from '../../services/tailwind-snackbar.service';
 
+import { StratosActionType } from '../../../core/extension/extension-service';
 import { CurrentUserPermissionsService } from '../../../core/permissions/current-user-permissions.service';
 import { StratosCurrentUserPermissions } from '../../../core/permissions/stratos-user-permissions.checker';
 import { UserProfileService } from '../../../core/user-profile.service';
@@ -146,7 +147,7 @@ export class PageHeaderComponent implements OnDestroy, AfterViewInit {
   public unreadEventCount$: Observable<number>;
   public eventPriorityStatus$: Observable<StratosStatus | undefined>;
 
-  @Input() set favorite(favorite: UserFavorite<IFavoriteMetadata>) {
+  @Input() set favorite(favorite: UserFavorite<IFavoriteMetadata> | null) {
     if (favorite && (!this.pFavorite || (favorite.guid !== this.pFavorite.guid))) {
       if (favorite.canFavorite()) {
         this.pFavorite = favorite;
@@ -179,10 +180,10 @@ export class PageHeaderComponent implements OnDestroy, AfterViewInit {
   public refreshToken$!: Observable<string>;
   public tokenExpiry$!: Observable<Date | null>;
 
-  public actionsKey: string | null;
+  public actionsKey: StratosActionType | null;
 
   @Input()
-  set breadcrumbs(breadcrumbs: IHeaderBreadcrumb[]) {
+  set breadcrumbs(breadcrumbs: IHeaderBreadcrumb[] | null) {
     this.latestBreadcrumbs = breadcrumbs;
     this.breadcrumbDefinitions = this.getBreadcrumb(breadcrumbs);
     this.cdr.markForCheck();
@@ -191,7 +192,7 @@ export class PageHeaderComponent implements OnDestroy, AfterViewInit {
   // Used when non-admin logs in with no-endpoints -> only show logout in the menu
   @Input() logoutOnly?: boolean;
 
-  private getBreadcrumb(breadcrumbs: IHeaderBreadcrumb[]) {
+  private getBreadcrumb(breadcrumbs: IHeaderBreadcrumb[] | null) {
     if (!breadcrumbs || !breadcrumbs.length) {
       return [];
     }

--- a/src/frontend/packages/core/src/shared/components/profile-settings/profile-settings.component.html
+++ b/src/frontend/packages/core/src/shared/components/profile-settings/profile-settings.component.html
@@ -1,7 +1,7 @@
 <div class="user-profile__options">
   @if (canEdit$ | async) {
     <div class="user-profile__option">
-      @if (show[types.GRAVATAR] && gravatarEnabled$ | async; as enableGravatar) {
+      @if (show[types.GRAVATAR] && (gravatarEnabled$ | async); as enableGravatar) {
         <div class="user-profile__option-inner">
           <app-slide-toggle [checked]="enableGravatar === 'true'" (change)="updateGravatarEnabled(enableGravatar)">
             <div class="user-profile__option-header">Use Gravatar for user icon</div>
@@ -13,7 +13,7 @@
     </div>
   }
 
-  @if (show[types.SESSION_TIMEOUT] && timeoutSession$ | async; as timeoutSession) {
+  @if (show[types.SESSION_TIMEOUT] && (timeoutSession$ | async); as timeoutSession) {
     <div class="user-profile__option"
       [ngClass]="{'user-profile__option-warning': timeoutSession === 'false'}">
       <div class="user-profile__option-inner">
@@ -35,7 +35,7 @@
     </div>
   }
 
-  @if (show[types.POLLING] && pollingEnabled$ | async; as pollingEnabled) {
+  @if (show[types.POLLING] && (pollingEnabled$ | async); as pollingEnabled) {
     <div class="user-profile__option"
       [ngClass]="{'user-profile__option-warning': pollingEnabled === 'false'}">
       <div class="user-profile__option-inner">
@@ -73,7 +73,7 @@
     </div>
   }
 
-  @if (show[types.STORAGE] && localStorageSize$ | async; as localStorageSize) {
+  @if (show[types.STORAGE] && (localStorageSize$ | async); as localStorageSize) {
     <div class="user-profile__section user-profile__local-storage"
       >
       <app-card-title class="user-profile__section">Reset Preferences</app-card-title>

--- a/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.ts
+++ b/src/frontend/packages/core/src/shared/components/recent-entities/recent-entities.component.ts
@@ -15,6 +15,7 @@ import { map } from 'rxjs/operators';
 
 import { EndpointsSignalService } from '../../../core/signals/endpoints-signal.service';
 import { FreshEntityNameService } from '../../../core/signals/fresh-entity-name.service';
+import { CardWrapperComponent } from '../cards/card/card.component';
 import { NoContentMessageComponent } from '../no-content-message/no-content-message.component';
 
 class RenderableRecent {
@@ -57,6 +58,7 @@ class RenderableRecent {
     CommonModule,
     RouterModule,
     CustomIconComponent,
+    CardWrapperComponent,
     NoContentMessageComponent
   ]
 })

--- a/src/frontend/packages/core/src/shared/components/ring-chart/ring-chart.component.html
+++ b/src/frontend/packages/core/src/shared/components/ring-chart/ring-chart.component.html
@@ -20,8 +20,8 @@
           (keydown.enter)="onClick(item)"
           (keydown.space)="onClick(item); $event.preventDefault()">
           <div class="legend-color" [style.background-color]="getItemColor(i)"></div>
-          <span class="legend-label">{{ nameFormatting ? nameFormatting(item.name) : item.name }}</span>
-          <span class="legend-value">{{ valueFormatting ? valueFormatting(item.value) : item.value }}</span>
+          <span class="legend-label">{{ nameFormatting(item.name) }}</span>
+          <span class="legend-value">{{ valueFormatting(item.value) }}</span>
         </div>
       }
     </div>

--- a/src/frontend/packages/core/src/shared/components/routing-indicator/routing-indicator.component.ts
+++ b/src/frontend/packages/core/src/shared/components/routing-indicator/routing-indicator.component.ts
@@ -4,13 +4,16 @@ import { NavigationCancel, NavigationEnd, NavigationStart, Router } from '@angul
 import { interval, Observable, of as observableOf } from 'rxjs';
 import { filter, map, startWith, switchMap, delay, tap } from 'rxjs/operators';
 
+import { AppProgressBarComponent } from '../progress-bar/app-progress-bar.component';
+
 @Component({
   selector: 'app-routing-indicator',
   templateUrl: './routing-indicator.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
-    CommonModule
+    CommonModule,
+    AppProgressBarComponent
   ]
 })
 export class RoutingIndicatorComponent {

--- a/src/frontend/packages/core/src/shared/components/sidepanel-preview/sidepanel-preview.component.ts
+++ b/src/frontend/packages/core/src/shared/components/sidepanel-preview/sidepanel-preview.component.ts
@@ -22,11 +22,12 @@ import { CustomIconComponent } from '../../../shared/components/custom-material/
 export class SidepanelPreviewComponent {
   public sidePanelService = inject(SidePanelService);
 
+  // Null while the caller is still deriving the title (e.g. markdown preview)
   @Input()
-  title!: string;
+  title!: string | null;
 
   @Input()
-  favorite!: UserFavorite<IFavoriteMetadata>;
+  favorite?: UserFavorite<IFavoriteMetadata>;
 
   @Input() header?: Portal<any>;
 }

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -561,10 +561,11 @@
                 @if (col.kind === 'favorite' || col.kind === 'actions') {
                   <!-- Suppressed: rendered in the leading controls cell -->
                 } @else {
+                <!-- favorite/actions kinds are excluded by the branch above -->
                 <td class="px-3 py-2 align-top text-sm text-content-text"
-                    [class.truncate]="col.kind !== 'actions' && col.kind !== 'favorite' && col.kind !== 'radio' && col.kind !== 'checkbox' && col.kind !== 'gauge' && col.kind !== 'template'"
-                    [class.overflow-visible]="col.kind === 'actions' || col.kind === 'favorite' || col.kind === 'radio' || col.kind === 'checkbox' || col.kind === 'gauge' || col.kind === 'template'"
-                    [attr.title]="col.kind === 'actions' || col.kind === 'favorite' || col.kind === 'radio' || col.kind === 'checkbox' || col.kind === 'gauge' || col.kind === 'template' ? null : col.render(row)">
+                    [class.truncate]="col.kind !== 'radio' && col.kind !== 'checkbox' && col.kind !== 'gauge' && col.kind !== 'template'"
+                    [class.overflow-visible]="col.kind === 'radio' || col.kind === 'checkbox' || col.kind === 'gauge' || col.kind === 'template'"
+                    [attr.title]="col.kind === 'radio' || col.kind === 'checkbox' || col.kind === 'gauge' || col.kind === 'template' ? null : col.render(row)">
                   @if (col.externalLink && col.externalLink(row); as href) {
                     <a [href]="href" target="_blank" rel="noopener" (click)="$event.stopPropagation()" class="text-accent hover:underline inline-flex items-center gap-1">
                       <span class="material-icons text-base leading-none">launch</span>{{ col.render(row) }}
@@ -607,49 +608,6 @@
                           class="text-xs text-content-muted hover:text-accent hover:underline cursor-pointer self-start mt-0.5">
                           …show fewer
                         </button>
-                      }
-                    </div>
-                  } @else if (col.kind === 'favorite' && col.favorite) {
-                    <button
-                      data-test="favorite-star"
-                      type="button"
-                      (click)="onToggleFavorite(col, row, $event)"
-                      [title]="isFavorite(col, row) ? 'Remove from favorites' : 'Add to favorites'"
-                      class="inline-flex items-center justify-center p-0.5 text-content-muted hover:text-accent">
-                      <span class="material-icons text-xl leading-none" [class.text-accent]="isFavorite(col, row)">
-                        {{ isFavorite(col, row) ? 'star' : 'star_border' }}
-                      </span>
-                    </button>
-                  } @else if (col.kind === 'actions' && col.actions) {
-                    <div class="relative inline-block">
-                      <button
-                        data-test="row-actions"
-                        type="button"
-                        (click)="toggleRowActions(row, $event)"
-                        title="Actions"
-                        class="inline-flex items-center justify-center p-0.5 text-content-muted hover:text-accent">
-                        <span class="material-icons text-xl leading-none">more_vert</span>
-                      </button>
-                      @if (openActionsRowKey() === config.getRowKey(row)) {
-                        <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -- not interactive; (click) is only a stopPropagation guard so a click inside the menu doesn't bubble to the outside-click closer. Actions are real focusable <button>s below. -->
-                        <div
-                          data-test="row-actions-menu"
-                          (click)="$event.stopPropagation()"
-                          class="absolute right-0 top-full mt-1 z-20 min-w-[12rem] bg-content-bg border border-content-border rounded shadow-lg py-2">
-                          @for (act of col.actions(row); track act.label) {
-                            <button
-                              type="button"
-                              [disabled]="act.disabled"
-                              (click)="invokeAction(act, row, $event)"
-                              class="w-full text-left px-3 py-1.5 text-sm hover:bg-content-secondary disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"
-                              [class.text-danger]="act.danger">
-                              @if (act.icon) {
-                                <span class="material-icons text-base leading-none">{{ act.icon }}</span>
-                              }
-                              <span>{{ act.label }}</span>
-                            </button>
-                          }
-                        </div>
                       }
                     </div>
                   } @else if (col.kind === 'radio' && col.radio) {

--- a/src/frontend/packages/core/src/shared/components/ssh-viewer/ssh-viewer.component.ts
+++ b/src/frontend/packages/core/src/shared/components/ssh-viewer/ssh-viewer.component.ts
@@ -5,6 +5,7 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 
 import { EventWatcherService } from '../../../core/event-watcher/event-watcher.service';
+import { AppProgressBarComponent } from '../progress-bar/app-progress-bar.component';
 
 // Import Xterm and Xterm Fit Addon
 @Component({
@@ -14,7 +15,8 @@ import { EventWatcherService } from '../../../core/event-watcher/event-watcher.s
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
-    CommonModule
+    CommonModule,
+    AppProgressBarComponent
   ]
 })
 export class SshViewerComponent implements OnInit, OnDestroy {

--- a/src/frontend/packages/core/src/shared/components/start-end-date/start-end-date.component.ts
+++ b/src/frontend/packages/core/src/shared/components/start-end-date/start-end-date.component.ts
@@ -23,8 +23,9 @@ export class StartEndDateComponent {
     this.isValid.emit(this.validValue);
   }
 
+  // Accepts null/undefined so callers can bind not-yet-chosen range values
   @Input()
-  set start(start: Date) {
+  set start(start: Date | null | undefined) {
     this.valid = true;
     if (start && isValid(start)) {
       const clone = new Date(start);
@@ -37,12 +38,12 @@ export class StartEndDateComponent {
     }
   }
 
-  get start() {
+  get start(): Date | undefined {
     return this.startValue;
   }
 
   @Input()
-  set end(end: Date) {
+  set end(end: Date | null | undefined) {
     this.valid = true;
     if (end && isValid(end)) {
       const clone = new Date(end);
@@ -55,7 +56,7 @@ export class StartEndDateComponent {
     }
   }
 
-  get end() {
+  get end(): Date | undefined {
     return this.endValue;
   }
   @Output()
@@ -69,37 +70,42 @@ export class StartEndDateComponent {
   public validValue = true;
   public validMessage: string | null = null;
 
-  private startValue!: Date;
-  private endValue!: Date;
+  // Undefined until a valid date is set — validators see undefined for a missing date
+  private startValue?: Date;
+  private endValue?: Date;
 
-  private lastValidStartValue!: Date;
-  private lastValidEndValue!: Date;
+  private lastValidStartValue?: Date;
+  private lastValidEndValue?: Date;
 
   private emitChanges() {
-    if (this.isDifferentDate(this.lastValidStartValue, this.startValue)) {
+    if (this.startValue && this.isDifferentDate(this.lastValidStartValue, this.startValue)) {
       this.lastValidStartValue = this.startValue;
       this.startChange.emit(this.startValue);
     }
-    if (this.isDifferentDate(this.lastValidEndValue, this.endValue)) {
+    if (this.endValue && this.isDifferentDate(this.lastValidEndValue, this.endValue)) {
       this.lastValidEndValue = this.endValue;
       this.endChange.emit(this.endValue);
     }
   }
 
+  // Undefined (caller bound nothing) falls back to the default range check.
+  // Validators receive whichever date is missing as null/undefined, so a custom
+  // validator can also check a lone date.
   @Input()
-  public validate: (start: Date, end: Date) => string | null = (start: Date, end: Date): string | null => {
-    if (!end || !start) {
-      return null;
+  public validate: ((start: Date | undefined, end: Date | undefined) => string | null) | undefined =
+    (start: Date | undefined, end: Date | undefined): string | null => {
+      if (!end || !start) {
+        return null;
+      }
+      return isBefore(end, start) ? 'Start date must be before end date.' : null;
     }
-    return isBefore(end, start) ? 'Start date must be before end date.' : null;
-  }
 
-  private pValidate(start: Date, end: Date): boolean {
-    this.validMessage = this.validate(start, end);
+  private pValidate(start: Date | undefined, end: Date | undefined): boolean {
+    this.validMessage = this.validate ? this.validate(start, end) : null;
     return !this.validMessage;
   }
 
-  private isDifferentDate(oldDate: Date, newDate: Date) {
+  private isDifferentDate(oldDate: Date | undefined, newDate: Date | undefined) {
     return !oldDate || !newDate || !isEqual(oldDate, newDate);
   }
 }

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.html
@@ -111,7 +111,7 @@
                     'btn-primary': !steps[currentIndex()].destructiveStep
                   }"
                 type="submit"
-                (click)="goNext(currentIndex())"
+                (click)="goNext()"
                 [disabled]="steps[currentIndex()].busy || steps[currentIndex()].blocked || !canGoNext(currentIndex())">
                 <!-- Loading spinner -->
                 @if (showNextButtonProgress) {

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -416,7 +416,7 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
     return true;
   }
 
-  getIconLigature(_step: StepComponent, _index: number): string {
+  getIconLigature(): string {
     return 'done';
   }
 

--- a/src/frontend/packages/core/src/shared/components/tile-selector-tile/tile-selector-tile.component.html
+++ b/src/frontend/packages/core/src/shared/components/tile-selector-tile/tile-selector-tile.component.html
@@ -6,11 +6,11 @@
       (keydown.enter)="onClick(tile)"
       (keydown.space)="onClick(tile); $event.preventDefault()">
       <div class="tile-selector__header">
-        @if (tile.graphic.matIcon) {
+        @if (iconGraphic; as graphic) {
           <app-custom-icon class="tile-selector__icon"
-          [fontSet]="tile.graphic.matIconFont"> {{ tile.graphic.matIcon }}</app-custom-icon>
-        } @else {
-          <img src="{{tile.graphic.location}}" [style.transform]="tile.graphic.transform" alt="" />
+          [fontSet]="graphic.matIconFont"> {{ graphic.matIcon }}</app-custom-icon>
+        } @else if (imageGraphic; as graphic) {
+          <img src="{{graphic.location}}" [style.transform]="graphic.transform" alt="" />
         }
       </div>
       <div class="tile-selector__content">

--- a/src/frontend/packages/core/src/shared/components/tile-selector-tile/tile-selector-tile.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/tile-selector-tile/tile-selector-tile.component.spec.ts
@@ -3,12 +3,11 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 
 import { TileSelectorTileComponent } from './tile-selector-tile.component';
-import { ITileImgConfig } from '../tile/tile-selector.types';
 import { MDAppModule } from '../../../core/md.module';
 
 describe('TileSelectorTileComponent', () => {
-  let component: TileSelectorTileComponent<ITileImgConfig>;
-  let fixture: ComponentFixture<TileSelectorTileComponent<ITileImgConfig>>;
+  let component: TileSelectorTileComponent;
+  let fixture: ComponentFixture<TileSelectorTileComponent>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/src/frontend/packages/core/src/shared/components/tile-selector-tile/tile-selector-tile.component.ts
+++ b/src/frontend/packages/core/src/shared/components/tile-selector-tile/tile-selector-tile.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output  } from '@angular/core';
 
-import { ITileConfig, ITileData, ITileGraphic } from '../tile/tile-selector.types';
+import { ITileConfig, ITileIconConfig, ITileImgConfig } from '../tile/tile-selector.types';
 import { CustomIconComponent } from '../custom-material/custom-material.component';
 
 @Component({
@@ -15,9 +15,9 @@ import { CustomIconComponent } from '../custom-material/custom-material.componen
   styleUrls: ['./tile-selector-tile.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TileSelectorTileComponent<Y = ITileGraphic> {
+export class TileSelectorTileComponent {
 
-  @Input() tile!: ITileConfig<ITileData, Y>;
+  @Input() tile!: ITileConfig;
 
   @Input() active!: boolean;
 
@@ -29,6 +29,17 @@ export class TileSelectorTileComponent<Y = ITileGraphic> {
 
   public onClick(tile: ITileConfig) {
     this.tileSelect.emit(tile);
+  }
+
+  // Narrow the icon/image graphic union for the template
+  get iconGraphic(): ITileIconConfig | null {
+    const graphic = this.tile ? this.tile.graphic : null;
+    return graphic && 'matIcon' in graphic && graphic.matIcon ? graphic : null;
+  }
+
+  get imageGraphic(): ITileImgConfig | null {
+    const graphic = this.tile ? this.tile.graphic : null;
+    return graphic && 'location' in graphic ? graphic : null;
   }
 
 }

--- a/src/frontend/packages/core/tsconfig.app.json
+++ b/src/frontend/packages/core/tsconfig.app.json
@@ -16,6 +16,6 @@
     "src/**/*.d.ts"
   ],
   "angularCompilerOptions": {
-    "strictTemplates": false
+    "strictTemplates": true
   }
 }

--- a/src/frontend/packages/extension/tsconfig.lib.json
+++ b/src/frontend/packages/extension/tsconfig.lib.json
@@ -8,6 +8,6 @@
     "**/*.spec.ts"
   ],
   "angularCompilerOptions": {
-    "strictTemplates": false
+    "strictTemplates": true
   }
 }

--- a/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.html
+++ b/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.html
@@ -58,8 +58,8 @@
                   class="input"
                   [appUnique]="
                     registerForm.value.createSystemEndpointField
-                      ? $safeNavigationMigration((customEndpoints | async)?.names)
-                      : $safeNavigationMigration((existingPersonalEndpoints | async)?.names)
+                      ? ($safeNavigationMigration((customEndpoints | async)?.names) ?? [])
+                      : ($safeNavigationMigration((existingPersonalEndpoints | async)?.names) ?? [])
                   "
                 />
                 @if (registerForm.controls.nameField.errors?.required) {
@@ -81,8 +81,8 @@
                   class="input"
                   [appUnique]="
                     registerForm.value.createSystemEndpointField
-                      ? $safeNavigationMigration((customEndpoints | async)?.urls)
-                      : $safeNavigationMigration((existingPersonalEndpoints | async)?.urls)
+                      ? ($safeNavigationMigration((customEndpoints | async)?.urls) ?? [])
+                      : ($safeNavigationMigration((existingPersonalEndpoints | async)?.urls) ?? [])
                   "
                 />
                 @if (registerForm.controls.urlField.errors?.required) {
@@ -99,7 +99,7 @@
               </div>
               <div class="space-y-3">
                 @if (userEndpointsAndIsAdmin | async) {
-                  <label class="checkbox-label" for="git-create-system-endpoint" [class.hidden]="fixedUrl">
+                  <label class="checkbox-label" for="git-create-system-endpoint">
                     <input
                       id="git-create-system-endpoint"
                       type="checkbox"
@@ -111,7 +111,7 @@
                     <span class="checkbox-text">Create a system endpoint (visible to all users)</span>
                   </label>
                 }
-                <label class="checkbox-label" for="git-skip-ssl" [class.hidden]="fixedUrl">
+                <label class="checkbox-label" for="git-skip-ssl">
                   <input
                     id="git-skip-ssl"
                     type="checkbox"

--- a/src/frontend/packages/git/src/shared/components/github-commit-author/github-commit-author.component.html
+++ b/src/frontend/packages/git/src/shared/components/github-commit-author/github-commit-author.component.html
@@ -2,13 +2,13 @@
   <div class="flex items-center space-x-2">
     @if (commit.author.html_url) {
       <a href="{{commit.author.html_url}}" target="_blank"
-      class="text-brand-600 hover:text-brand-800 font-medium">{{commit.commit.author.name}}</a>
+      class="text-brand-600 hover:text-brand-800 font-medium">{{commit.commit?.author?.name}}</a>
     }
     @if (!commit.author.html_url) {
-      <span class="text-content-text font-medium">{{commit.commit.author.name}}</span>
+      <span class="text-content-text font-medium">{{commit.commit?.author?.name}}</span>
     }
     @if (showAvatar && commit.author.avatar_url) {
-      <img src="{{commit.author.avatar_url}}" alt="Avatar for {{commit.commit.author.name}}"
+      <img src="{{commit.author.avatar_url}}" alt="Avatar for {{commit.commit?.author?.name}}"
         class="w-6 h-6 rounded-full shrink-0">
     }
   </div>

--- a/src/frontend/packages/git/src/store/git.public-types.ts
+++ b/src/frontend/packages/git/src/store/git.public-types.ts
@@ -29,6 +29,9 @@ export interface GitUser {
   html_url: string;
   id: number;
   login: string;
+  // GitLab repo owners are mapped with a display name instead of a login
+  // (see GitLabSCM.convertProject), so consumers can fall back to it.
+  name?: string;
 }
 
 export interface GitBranch extends GitEntity {

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-usage/chart-details-usage.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-usage/chart-details-usage.component.ts
@@ -2,7 +2,7 @@ import { AsyncPipe } from '@angular/common';
 import { Component, Input, ViewEncapsulation, inject, ChangeDetectionStrategy } from '@angular/core';
 import { CustomTooltipDirective } from '@stratosui/core';
 import { TailwindSnackBarService } from '@stratosui/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 
 import { EndpointsService } from '../../../../../../core/src/core/endpoints.service';
 import { Chart } from '../../shared/models/chart';
@@ -14,7 +14,7 @@ import { getMonocularEndpoint } from '../../stratos-monocular.helper';
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [AsyncPipe, CustomTooltipDirective]
+  imports: [AsyncPipe, CustomTooltipDirective, RouterLink]
 })
 export class ChartDetailsUsageComponent {
   @Input() chart!: Chart;

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-versions/chart-details-versions.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-versions/chart-details-versions.component.ts
@@ -4,7 +4,8 @@ import {
   inject,
   ChangeDetectionStrategy,
 } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { DatePipe, SlicePipe } from "@angular/common";
+import { ActivatedRoute, RouterLink } from "@angular/router";
 
 import { ChartAttributes } from "../../shared/models/chart";
 import { ChartVersion } from "../../shared/models/chart-version";
@@ -15,6 +16,7 @@ import { ChartsService } from "../../shared/services/charts.service";
   templateUrl: "./chart-details-versions.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
+  imports: [DatePipe, RouterLink, SlicePipe],
 })
 export class ChartDetailsVersionsComponent {
   @Input() versions!: ChartVersion[];

--- a/src/frontend/packages/kubernetes/src/helm/monocular/loader/loader.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/loader/loader.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import { AppSpinnerComponent } from '@stratosui/core';
 
 
 @Component({
@@ -6,7 +7,7 @@ import { ChangeDetectionStrategy, Component, Input} from '@angular/core';
   selector: 'app-loader',
   templateUrl: './loader.component.html',
   standalone: true,
-  imports: []
+  imports: [AppSpinnerComponent]
 })
 export class LoaderComponent {
   // Show the loader or the content

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-viewer.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/analysis-report-viewer.component.ts
@@ -27,7 +27,7 @@ export class AnalysisReportViewerComponent implements OnDestroy {
   private id!: string;
 
   @Input()
-  set report(report: AnalysisReport) {
+  set report(report: AnalysisReport | null) {
     if (report === null || report.id === this.id) {
       return;
     }

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/kube-score-report-viewer/kube-score-report-viewer.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/kube-score-report-viewer/kube-score-report-viewer.component.html
@@ -23,9 +23,9 @@
               }
             }
           </div>
-          <div>{{ check.Check.Name }}</div>
+          <div>{{ check.Check?.Name }}</div>
         </div>
-        @for (comment of check.Comments; track comment) {
+        @for (comment of check.Comments ?? []; track comment) {
           <div class="list-item list-square ml-[58px]">
             <div>{{ comment.Summary }}</div>
           </div>

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/kube-score-report-viewer/kube-score-report-viewer.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/kube-score-report-viewer/kube-score-report-viewer.component.ts
@@ -3,6 +3,13 @@ import { ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 import { AnalysisReport } from '../../store/kube.types';
 import { IReportViewer } from '../analysis-report-viewer.component';
 
+interface KubeScoreCheck {
+  Grade?: number;
+  Skipped?: boolean;
+  Check?: { Name?: string };
+  Comments?: Array<{ Summary?: string }>;
+}
+
 @Component({
 changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-kube-score-report-viewer',
@@ -22,7 +29,7 @@ export class KubeScoreReportViewerComponent implements OnInit, IReportViewer {
   */
 
   report!: AnalysisReport;
-  processed: Array<{ _checks: unknown[]; _name: string }> = [];
+  processed: Array<{ _checks: KubeScoreCheck[]; _name: string }> = [];
 
   constructor() { }
 
@@ -30,7 +37,7 @@ export class KubeScoreReportViewerComponent implements OnInit, IReportViewer {
     this.processed = [];
     // Turn the report into an array
     if (this.report?.report) {
-      const reportData = this.report.report as Record<string, { Checks?: Array<{ Grade?: number; Skipped?: boolean }> }>;
+      const reportData = this.report.report as Record<string, { Checks?: KubeScoreCheck[] }>;
       Object.keys(reportData).forEach(key => {
         const filtered = this.filter(reportData[key]);
         if (filtered.length > 0) {
@@ -44,8 +51,8 @@ export class KubeScoreReportViewerComponent implements OnInit, IReportViewer {
     }
   }
 
-  public filter(report: { Checks?: Array<{ Grade?: number; Skipped?: boolean }> }): Array<{ Grade?: number; Skipped?: boolean }> {
-    const filtered: Array<{ Grade?: number; Skipped?: boolean }> = [];
+  public filter(report: { Checks?: KubeScoreCheck[] }): KubeScoreCheck[] {
+    const filtered: KubeScoreCheck[] = [];
     if (report.Checks) {
       report.Checks.forEach(r => {
         if (r.Grade !== 10 && !r.Skipped) {

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/popeye-report-viewer/popeye-report-viewer.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/popeye-report-viewer/popeye-report-viewer.component.ts
@@ -4,6 +4,32 @@ import { ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 import { AnalysisReport } from '../../store/kube.types';
 import { IReportViewer } from '../analysis-report-viewer.component';
 
+interface PopeyeIssue {
+  level?: number;
+  message?: string;
+}
+
+interface PopeyeIssueGroup {
+  name: string;
+  issues: PopeyeIssue[];
+}
+
+interface PopeyeSanitizer {
+  sanitizer: string;
+  tally: { ok: number; info: number; warning: number; error: number; score: number };
+  issues?: Record<string, PopeyeIssue[]>;
+  hide: boolean;
+  groups: PopeyeIssueGroup[];
+}
+
+interface PopeyeReport {
+  popeye: {
+    score: number;
+    grade: string;
+    sanitizers: PopeyeSanitizer[];
+  };
+}
+
 @Component({
 changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-popeye-report-viewer',
@@ -14,13 +40,13 @@ changeDetection: ChangeDetectionStrategy.OnPush,
 export class PopeyeReportViewerComponent implements OnInit, IReportViewer {
 
   report!: AnalysisReport;
-  processed: unknown;
+  processed: PopeyeReport | undefined;
 
   ngOnInit() {
     this.processed = this.apply(this.report);
   }
 
-  private apply(response: AnalysisReport): unknown {
+  private apply(response: AnalysisReport): PopeyeReport | undefined {
     const reportData = response.report as { popeye?: { sanitizers?: unknown[] } } | undefined;
     if (reportData?.popeye?.sanitizers) {
       // In order to supplement the sanitizers with extra properties need to create new obj (see spread below and `reduce`)

--- a/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/resource-alert-preview/resource-alert-preview.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/analysis-report-viewer/resource-alert-preview/resource-alert-preview.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component} from '@angular/core';
 
 import { PreviewableComponent } from '../../../../../core/src/shared/previewable-component';
 import { SidepanelPreviewComponent } from '../../../../../core/src/shared/components/sidepanel-preview/sidepanel-preview.component';
+import { ResourceAlertViewComponent } from './resource-alert-view/resource-alert-view.component';
 
 @Component({
 changeDetection: ChangeDetectionStrategy.OnPush,
@@ -9,7 +10,8 @@ changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './resource-alert-preview.component.html',
   standalone: true,
   imports: [
-    SidepanelPreviewComponent
+    SidepanelPreviewComponent,
+    ResourceAlertViewComponent
   ]
 })
 export class ResourceAlertPreviewComponent implements PreviewableComponent {

--- a/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.html
@@ -1,4 +1,4 @@
-<app-tile-grid fit="true">
+<app-tile-grid [fit]="true">
   <app-tile-group class="tile-group-3-cols tile-group-compact">
     <app-tile>
       <app-card-number-metric mode="plain" link="/kubernetes/{{endpoint.guid}}/nodes" icon="apps" label="Nodes"

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-table-cert/kube-config-table-cert.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-config-registration/kube-config-selection/kube-config-table-cert/kube-config-table-cert.component.html
@@ -1,7 +1,7 @@
-@if ((initialValue$ | async) === null) {
-  <app-progress-spinner diameter="20" mode="indeterminate">
-  </app-progress-spinner>
-} @else {
-  <app-checkbox [checked]="(initialValue$ | async).checked" (change)="valueChanged($event.checked)" color="primary">
+@if (initialValue$ | async; as initialValue) {
+  <app-checkbox [checked]="initialValue.checked" (change)="valueChanged($event.checked)" color="primary">
   </app-checkbox>
+} @else {
+  <app-progress-spinner [diameter]="20" mode="indeterminate">
+  </app-progress-spinner>
 }

--- a/src/frontend/packages/kubernetes/src/kubernetes/kube-terminal/kube-console.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kube-terminal/kube-console.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async">
+<app-page-header [breadcrumbs]="(breadcrumbs$ | async) ?? []">
   <h1>Kubernetes Terminal</h1>
   <div class="page-header-right">
     <span>

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubedash-configuration/kubedash-configuration.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubedash-configuration/kubedash-configuration.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async">
+<app-page-header [breadcrumbs]="(breadcrumbs$ | async) ?? []">
   <h1>Dashboard Configuration</h1>
 </app-page-header>
 
@@ -22,7 +22,7 @@
         @if (status.service && status.serviceAccount) {
           <div class="flex my-5 [&>div]:flex-1">
             <div class="flex">
-              <app-boolean-indicator [showText]="false" [isTrue]="true" type="yes-no"></app-boolean-indicator>
+              <app-boolean-indicator [showText]="false" [isTrue]="true" [type]="booleanIndicatorType.yesNo"></app-boolean-indicator>
               <div>Kubernetes Dashboard is installed and a Service Account exists - you can access the dashboard using the
               'View Dashboard' button on the Summary view for this cluster.</div>
             </div>
@@ -35,12 +35,12 @@
           </div>
         }
         <app-card class="mb-5">
-          <app-card-progress-overlay [busy]="dashboardUIBusy()" [label]="dashboardUIMsg"></app-card-progress-overlay>
+          <app-card-progress-overlay [busy]="dashboardUIBusy$" [label]="dashboardUIMsg"></app-card-progress-overlay>
           <div class="card-header">
             <div class="card-title">Kubernetes Dashboard Installation</div>
             <div class="absolute right-5 top-5">
               @if (status.service) {
-                <app-boolean-indicator [showText]="false" [isTrue]="true" type="yes-no">
+                <app-boolean-indicator [showText]="false" [isTrue]="true" [type]="booleanIndicatorType.yesNo">
                 </app-boolean-indicator>
               }
               @if (!status.service) {
@@ -86,12 +86,12 @@
           }
         </app-card>
         <app-card class="mb-5">
-          <app-card-progress-overlay [busy]="serviceAccountBusy()" [label]="serviceAccountMsg"></app-card-progress-overlay>
+          <app-card-progress-overlay [busy]="serviceAccountBusy$" [label]="serviceAccountMsg"></app-card-progress-overlay>
           <div class="card-header">
             <div class="card-title">Service Account</div>
             <div class="absolute right-5 top-5">
               @if (status.serviceAccount) {
-                <app-boolean-indicator [showText]="false" [isTrue]="true" type="yes-no">
+                <app-boolean-indicator [showText]="false" [isTrue]="true" [type]="booleanIndicatorType.yesNo">
                 </app-boolean-indicator>
               }
               @if (!status.serviceAccount) {

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubedash-configuration/kubedash-configuration.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubedash-configuration/kubedash-configuration.component.ts
@@ -1,11 +1,13 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, signal, computed, inject, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BooleanIndicatorComponent, MetadataItemComponent, CardProgressOverlayComponent } from '@stratosui/core';
+import { BooleanIndicatorComponent, CardWrapperComponent, MetadataItemComponent, CardProgressOverlayComponent } from '@stratosui/core';
 
+import { BooleanIndicatorType } from '../../../../../core/src/shared/components/boolean-indicator/boolean-indicator.component';
 import { ConfirmationDialogConfig } from '../../../../../core/src/shared/components/confirmation-dialog.config';
 import { ConfirmationDialogService } from '../../../../../core/src/shared/components/confirmation-dialog.service';
 import { IHeaderBreadcrumb } from '../../../../../core/src/shared/components/page-header/page-header.types';
@@ -47,6 +49,7 @@ type MessageUpdater = (msg: string) => void;
     CommonModule,
     RouterModule,
     BooleanIndicatorComponent,
+    CardWrapperComponent,
     MetadataItemComponent,
     CardProgressOverlayComponent,
     PageHeaderModule,
@@ -98,6 +101,8 @@ export class KubedashConfigurationComponent implements OnDestroy {
 
   public breadcrumbs$: Observable<IHeaderBreadcrumb[]>;
 
+  public booleanIndicatorType = BooleanIndicatorType;
+
   // Signal-native dashboard status — fetched directly from the kubedash
   // status endpoint, no ngrx dispatch. Wave-3 deletes the ngrx kubeEntityCatalog
   // dashboard slice; the consumer (this component) is the only reader, so it
@@ -115,9 +120,12 @@ export class KubedashConfigurationComponent implements OnDestroy {
 
   // Signals for busy state tracking
   public serviceAccountBusy = signal<boolean>(false);
+  // Observable view — app-card-progress-overlay's `busy` input is an Observable<boolean>
+  public serviceAccountBusy$ = toObservable(this.serviceAccountBusy);
   public serviceAccountMsg = '';
 
   public dashboardUIBusy = signal<boolean>(false);
+  public dashboardUIBusy$ = toObservable(this.dashboardUIBusy);
   public dashboardUIMsg = '';
 
   // Are we busy with an operation - disable buttons if we are

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubernetes-dashboard.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubernetes-dashboard.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async">
+<app-page-header [breadcrumbs]="(breadcrumbs$ | async) ?? []">
   <h1>Dashboard</h1>
   <div class="page-header-right" [ngClass]="{'hidden': (isLoading$ | async) }">
     <span>

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubernetes-dashboard.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-dashboard/kubernetes-dashboard.component.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../core/src/shared/components/endpoints-missing/endpoints-missing.component';
 import { IHeaderBreadcrumb } from '../../../../core/src/shared/components/page-header/page-header.types';
 import { PageHeaderModule } from '../../../../core/src/shared/components/page-header/page-header.module';
-import { LoadingPageComponent } from '@stratosui/core';
+import { LoadingPageComponent, NoContentMessageComponent } from '@stratosui/core';
 import { BaseKubeGuid } from '../kubernetes-page.types';
 import { KubernetesEndpointService } from '../services/kubernetes-endpoint.service';
 import { KubernetesService } from '../services/kubernetes.service';
@@ -25,7 +25,8 @@ import { KubernetesService } from '../services/kubernetes.service';
     CommonModule,
     RouterModule,
     PageHeaderModule,
-    LoadingPageComponent
+    LoadingPageComponent,
+    NoContentMessageComponent
   ],
   providers: [
     {
@@ -176,7 +177,7 @@ export class KubernetesDashboardTabComponent implements OnInit {
   }
 
   // toggle visibility of the kube dashboard header bar
-  toggle(val: boolean) {
+  toggle(val?: boolean) {
     if (val !== undefined) {
       this.expanded = val;
     } else {

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-namespace/kubernetes-namespace-analysis-report/kubernetes-namespace-analysis-report.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-namespace/kubernetes-namespace-analysis-report/kubernetes-namespace-analysis-report.component.ts
@@ -38,7 +38,7 @@ export class KubernetesNamespaceAnalysisReportComponent {
 
   public report$ = new Subject<AnalysisReport | null>();
 
-  path: string | undefined;
+  path: string;
 
   currentReport: string | null = null;
 

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node-metrics/kubernetes-node-metric-stats-card/kubernetes-node-metric-stats-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node-metrics/kubernetes-node-metric-stats-card/kubernetes-node-metric-stats-card.component.html
@@ -5,8 +5,8 @@
   @if (metric==='container_memory_usage_bytes') {
     <div class="card-content p-4">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <app-kubernetes-node-simple-metric key="Mean" value="{{ (mean$ | async) | bytesToHumanSize }}" [unit]=""></app-kubernetes-node-simple-metric>
-        <app-kubernetes-node-simple-metric key="Maximum" value="{{ (max$ | async ) | bytesToHumanSize }}" [unit]=""></app-kubernetes-node-simple-metric>
+        <app-kubernetes-node-simple-metric key="Mean" value="{{ ('' + ((mean$ | async) ?? '')) | bytesToHumanSize }}"></app-kubernetes-node-simple-metric>
+        <app-kubernetes-node-simple-metric key="Maximum" value="{{ ('' + ((max$ | async) ?? '')) | bytesToHumanSize }}"></app-kubernetes-node-simple-metric>
       </div>
     </div>
   }

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node-metrics/kubernetes-node-metric-stats-card/kubernetes-node-metric-stats-card.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node-metrics/kubernetes-node-metric-stats-card/kubernetes-node-metric-stats-card.component.ts
@@ -42,7 +42,7 @@ export class KubernetesNodeMetricStatsCardComponent
   period = "Hour";
 
   @Input()
-  unit!: string;
+  unit?: string;
 
   max$!: Observable<number>;
   mean$!: Observable<number>;

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node-metrics/kubernetes-node-simple-metric/kubernetes-node-simple-metric.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node-metrics/kubernetes-node-simple-metric/kubernetes-node-simple-metric.component.ts
@@ -13,13 +13,14 @@ export class KubernetesNodeSimpleMetricComponent {
   @Input()
   key!: string;
 
-  // strict: required @Input, set by Angular before the template reads it
+  // strict: required @Input, set by Angular before the template reads it.
+  // Callers bind interpolated (already formatted) values, so this is a string.
   @Input()
-  value!: number;
+  value!: string;
 
-  // strict: required @Input, set by Angular before the template reads it
+  // Optional - callers may omit the unit; formatValue() falls back to ''
   @Input()
-  unit!: string;
+  unit?: string;
 
   public formatValue() {
     switch (this.unit) {

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-node/kubernetes-node.component.html
@@ -1,4 +1,4 @@
-<app-page-header tabsHeader="Node" [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks">
+<app-page-header tabsHeader="Node" [breadcrumbs]="(breadcrumbs$ | async) ?? []" [tabs]="tabLinks">
   <h1>{{ kubeNodeService.nodeName }}</h1>
   <div class="page-header-right">
   </div>

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-resource-viewer/kubernetes-resource-viewer.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-resource-viewer/kubernetes-resource-viewer.component.ts
@@ -29,6 +29,9 @@ import {
 } from '../../services/domain-data/kube-generic-resource-data.services';
 import { KubePodDataService } from '../../services/domain-data/kube-pod-data.service';
 import { KubeServiceDataService } from '../../services/domain-data/kube-service-data.service';
+import {
+  ResourceAlertViewComponent,
+} from '../analysis-report-viewer/resource-alert-preview/resource-alert-view/resource-alert-view.component';
 import { KUBERNETES_ENDPOINT_TYPE } from '../kubernetes-entity-factory';
 import { KubernetesEndpointService } from '../services/kubernetes-endpoint.service';
 import { BasicKubeAPIResource, KubeAPIResource, KubeResourceEntityDefinition } from '../store/kube.types';
@@ -76,6 +79,7 @@ selector: 'app-kubernetes-resource-viewer',
     SidepanelPreviewComponent,
     MetadataItemComponent,
     JsonViewerComponent,
+    ResourceAlertViewComponent,
   ]
 })
 export class KubernetesResourceViewerComponent implements PreviewableComponent, OnDestroy, AfterViewInit {

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-tab-base/kubernetes-tab-base.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-tab-base/kubernetes-tab-base.component.html
@@ -1,5 +1,5 @@
 <app-page-header [tabs]="tabLinks" [favorite]="favorite$ | async" tabsHeader="Kubernetes" [endpointIds$]="endpointIds$">
-  <h1>{{ (kubeEndpointService.endpoint$ | async)?.entity.name }}</h1>
+  <h1>{{ (kubeEndpointService.endpoint$ | async)?.entity?.name }}</h1>
   <div class="page-header-right">
   </div>
 </app-page-header>

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes/kubernetes.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes/kubernetes.component.html
@@ -1,7 +1,7 @@
 <app-page-header>
   <h1>Kubernetes</h1>
 </app-page-header>
-@if ((connectedEndpoints$ | async) > 1) {
+@if (((connectedEndpoints$ | async) ?? 0) > 1) {
   <app-signal-list [config]="endpointsSignalConfig.config" class="flex-1 min-h-0">
     <ng-template #cardTemplate let-row>
       <app-endpoint-card [row]="$any(row)"></app-endpoint-card>

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-condition-card/kubernetes-node-condition/kubernetes-node-condition.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-condition-card/kubernetes-node-condition/kubernetes-node-condition.component.ts
@@ -3,7 +3,7 @@ import {Component, Input, OnInit, inject, ChangeDetectionStrategy } from '@angul
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
-import { BooleanIndicatorComponent } from '@stratosui/core';
+import { BooleanIndicatorComponent, BooleanIndicatorTypeValue } from '@stratosui/core';
 import { KubernetesNodeService } from '../../../../../services/kubernetes-node.service';
 import { ConditionType, ConditionTypeLabels, KubernetesCondition } from '../../../../../store/kube.types';
 
@@ -18,7 +18,7 @@ export class KubernetesNodeConditionComponent implements OnInit {
 
 
   @Input()
-  condition!: ConditionType; // strict: required @Input, always bound by the template
+  condition!: ConditionType | `${ConditionType}`; // strict: required @Input, templates bind literal strings (condition="Ready")
   // boolean | undefined: an "Unknown" condition status renders as the indicator's unknown state
   condition$!: Observable<boolean | undefined>; // strict: assigned in ngOnInit before the template reads it
   hasCondition$!: Observable<boolean>; // strict: assigned in ngOnInit before the template reads it
@@ -27,7 +27,7 @@ export class KubernetesNodeConditionComponent implements OnInit {
   overrideCondition$?: Observable<boolean>;
 
   @Input()
-  type = 'yes-no';
+  type: BooleanIndicatorTypeValue = 'yes-no';
 
   @Input()
   inverse = false;

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-info-card/kubernetes-node-info-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-info-card/kubernetes-node-info-card.component.html
@@ -5,12 +5,12 @@
       </app-card-header>
       <app-card-content>
         <div class="kubernetes-node-info-card__content">
-          <app-metadata-item label="Operating System">{{ (kubeNodeService.nodeEntity$ | async)?.status.nodeInfo.operatingSystem }}</app-metadata-item>
-          <app-metadata-item label="Archtecture">{{ (kubeNodeService.nodeEntity$ | async)?.status.nodeInfo.architecture }}</app-metadata-item>
-          <app-metadata-item label="OS Image">{{ (kubeNodeService.nodeEntity$ | async)?.status.nodeInfo.osImage }}</app-metadata-item>
-          <app-metadata-item label="Kernel Version">{{ (kubeNodeService.nodeEntity$ | async)?.status.nodeInfo.kernelVersion }}</app-metadata-item>
-          <app-metadata-item label="Kubelet Version">{{ (kubeNodeService.nodeEntity$ | async)?.status.nodeInfo.kubeletVersion }}</app-metadata-item>
-          <app-metadata-item label="Kube Proxy Version">{{ (kubeNodeService.nodeEntity$ | async)?.status.nodeInfo.kubeProxyVersion }}</app-metadata-item>
+          <app-metadata-item label="Operating System">{{ (kubeNodeService.nodeEntity$ | async)?.status?.nodeInfo?.operatingSystem }}</app-metadata-item>
+          <app-metadata-item label="Archtecture">{{ (kubeNodeService.nodeEntity$ | async)?.status?.nodeInfo?.architecture }}</app-metadata-item>
+          <app-metadata-item label="OS Image">{{ (kubeNodeService.nodeEntity$ | async)?.status?.nodeInfo?.osImage }}</app-metadata-item>
+          <app-metadata-item label="Kernel Version">{{ (kubeNodeService.nodeEntity$ | async)?.status?.nodeInfo?.kernelVersion }}</app-metadata-item>
+          <app-metadata-item label="Kubelet Version">{{ (kubeNodeService.nodeEntity$ | async)?.status?.nodeInfo?.kubeletVersion }}</app-metadata-item>
+          <app-metadata-item label="Kube Proxy Version">{{ (kubeNodeService.nodeEntity$ | async)?.status?.nodeInfo?.kubeProxyVersion }}</app-metadata-item>
         </div>
       </app-card-content>
     </app-card>

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-summary-card/kubernetes-node-summary-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-summary-card/kubernetes-node-summary-card.component.html
@@ -6,11 +6,11 @@
     <div class="card-content">
       <div class="kubernetes-node-summary-card__content">
         <app-metadata-item icon="title" label="Name"
-          >{{ (kubeNodeService.nodeEntity$ | async)?.metadata.name }}
+          >{{ (kubeNodeService.nodeEntity$ | async)?.metadata?.name }}
         </app-metadata-item>
         <app-metadata-item icon="today" label="Created">
           {{
-            $safeNavigationMigration((kubeNodeService.nodeEntity$ | async)?.metadata.creationTimestamp) | date: "medium"
+            (kubeNodeService.nodeEntity$ | async)?.metadata?.creationTimestamp | date: "medium"
           }}</app-metadata-item
         >
         @if (caaspNode$ | async; as caaspNode) {

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-summary-card/kubernetes-node-summary-card.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-summary-card/kubernetes-node-summary-card.component.ts
@@ -9,11 +9,14 @@ import {
   KubernetesEndpointService,
 } from "../../../../services/kubernetes-endpoint.service";
 import { KubernetesNodeService } from "../../../../services/kubernetes-node.service";
+import {
+  KubernetesNodeConditionComponent,
+} from "../kubernetes-node-condition-card/kubernetes-node-condition/kubernetes-node-condition.component";
 
 @Component({
   selector: "app-kubernetes-node-summary-card",
   templateUrl: "./kubernetes-node-summary-card.component.html",
-  imports: [AsyncPipe, DatePipe, MetadataItemComponent],
+  imports: [AsyncPipe, DatePipe, MetadataItemComponent, KubernetesNodeConditionComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-tags-card/kubernetes-node-tags-card.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-nodes/kubernetes-node-summary/kubernetes-node-tags-card/kubernetes-node-tags-card.component.html
@@ -5,7 +5,7 @@
     </app-card-header>
     <app-card-content>
       <div class="kubernetes-node-tags-card__content">
-        <app-chips [chips]="(chipTags$ | async)" [stacked]="true" [orientation]="'rtl'"></app-chips>
+        <app-chips [chips]="(chipTags$ | async) ?? []" [stacked]="true" [orientation]="'rtl'"></app-chips>
         </div>
       </app-card-content>
   </app-card>

--- a/src/frontend/packages/kubernetes/src/kubernetes/pod-metrics/pod-metrics.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/pod-metrics/pod-metrics.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async">
+<app-page-header [breadcrumbs]="(breadcrumbs$ | async) ?? []">
   <h1>{{ podName }}</h1>
   <div class="page-header-right">
   </div>

--- a/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-analysis-tab/kubernetes-analysis-report/kubernetes-analysis-report.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-analysis-tab/kubernetes-analysis-report/kubernetes-analysis-report.component.html
@@ -1,9 +1,11 @@
-<app-page-sub-nav [breadcrumbs]="breadcrumbs$ | async"></app-page-sub-nav>
+<app-page-sub-nav [breadcrumbs]="(breadcrumbs$ | async) ?? []"></app-page-sub-nav>
 
 <app-loading-page [isLoading]="isLoading$" text="Loading Analysis Report">
   @if (errorMsg$ | async; as message) {
-    <app-no-content-message icon="warning" [hidden]="!message" [firstLine]="message.firstLine" [secondLine]="message.secondLine">
+    <app-no-content-message icon="warning" [hidden]="!message" [firstLine]="message.firstLine">
     </app-no-content-message>
   }
-  <app-analysis-report-viewer [report]="report$ | async"></app-analysis-report-viewer>
+  @if (report$ | async; as report) {
+    <app-analysis-report-viewer [report]="report"></app-analysis-report-viewer>
+  }
 </app-loading-page>

--- a/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-analysis-tab/kubernetes-analysis-report/kubernetes-analysis-report.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-analysis-tab/kubernetes-analysis-report/kubernetes-analysis-report.component.ts
@@ -8,6 +8,7 @@ import { catchError, map, startWith, take } from 'rxjs/operators';
 import {
   IHeaderBreadcrumbLink,
   LoadingPageComponent,
+  NoContentMessageComponent,
   PageHeaderModule,
   PageSubNavComponent,
 } from '@stratosui/core';
@@ -41,6 +42,7 @@ import { AnalysisReport } from '../../../../services/endpoint-data/kube-types';
     PageHeaderModule,
     PageSubNavComponent,
     LoadingPageComponent,
+    NoContentMessageComponent,
     AnalysisReportViewerComponent,
   ],
 })
@@ -50,8 +52,9 @@ export class KubernetesAnalysisReportComponent implements OnInit {
   report$!: Observable<AnalysisReport | false>;
   isLoading$!: Observable<boolean>;
 
-  private errorMsg = new Subject<{ firstLine: string; secondLine?: string } | string>();
-  errorMsg$ = this.errorMsg.pipe(startWith(''));
+  // null = no error to show; the template's @if guard filters it out
+  private errorMsg = new Subject<{ firstLine: string } | null>();
+  errorMsg$ = this.errorMsg.pipe(startWith(null));
 
   endpointID?: string;
   id: string;
@@ -87,7 +90,7 @@ export class KubernetesAnalysisReportComponent implements OnInit {
           this.error();
           return false;
         }
-        this.errorMsg.next('');
+        this.errorMsg.next(null);
         return report;
       }),
       catchError(() => {

--- a/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.html
@@ -16,7 +16,7 @@
 
   <app-loading-page [isLoading]="isLoading$" [text]="'Retrieving Kubernetes details'">
     @if (endpointDetails$ | async; as details) {
-      <app-entity-summary-title [imagePath]="details.imagePath"
+      <app-entity-summary-title [imagePath]="details.imagePath ?? null"
         [title]="details.name" [subTitle]="details.label">
         <app-tile-grid class="max-w-[350px]">
           <app-tile-group class="tile-group-3-cols">
@@ -55,10 +55,6 @@
                     <button class="btn btn-primary leading-normal m-0 min-w-0 p-0"
                     (click)="configureDashboard()">Configure</button>
                   }
-                  @if ((kubeEndpointService.kubeDashboardStatus$ | async) === false) {
-                    <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-brand-500">
-                    </div>
-                  }
                 </div>
               </app-metadata-item>
             </div>
@@ -94,46 +90,58 @@
       <div class="m-2.5">
         <div>
           <div class="inline-block pr-5 pb-5 w-[250px]">
-            <div class="card">
-              <app-simple-usage-chart chartTitle="Pod Usage" [data]="podCapacity$ | async" height="{{chartHeight}}">
-              </app-simple-usage-chart>
-            </div>
-          </div>
-          <div class="inline-block pr-5 pb-5 w-[250px]">
-            <div class="card">
-              <app-simple-usage-chart [thresholds]="pressureChartThresholds" chartTitle="Nodes With Disk Pressure"
-                [data]="diskPressure$ | async" height="{{chartHeight}}">
-              </app-simple-usage-chart>
-            </div>
-          </div>
-          <div class="inline-block pr-5 pb-5 w-[250px]">
-            <div class="card">
-              <app-simple-usage-chart [thresholds]="pressureChartThresholds" chartTitle="Nodes With Memory Pressure"
-                [data]="memoryPressure$ | async" height="{{chartHeight}}">
-              </app-simple-usage-chart>
-            </div>
-          </div>
-          <div class="inline-block pr-5 pb-5 w-[250px]">
-            <div class="card">
-              <app-simple-usage-chart chartTitle="Nodes Out Of Disk" [thresholds]="criticalPressureChartThresholds"
-                [data]="outOfDisk$ | async" height="{{chartHeight}}">
-              </app-simple-usage-chart>
-            </div>
-          </div>
-          <div class="inline-block pr-5 pb-5 w-[250px]">
-            <div class="card">
-              <app-simple-usage-chart [thresholds]="nominalPressureChartThresholds" chartTitle="Nodes Ready"
-                [data]="nodesReady$ | async" height="{{chartHeight}}">
-              </app-simple-usage-chart>
-            </div>
-          </div>
-          <div class="inline-block pr-5 pb-5 w-[250px]">
-            @if ((networkUnavailable$ | async)?.supported) {
+            @if (podCapacity$ | async; as podCapacity) {
               <div class="card">
-                <app-simple-usage-chart [thresholds]="criticalPressureChartThresholdsInverted"
-                  chartTitle="Nodes With Network Available" [data]="networkUnavailable$ | async" height="{{chartHeight}}">
+                <app-simple-usage-chart chartTitle="Pod Usage" [data]="podCapacity" height="{{chartHeight}}">
                 </app-simple-usage-chart>
               </div>
+            }
+          </div>
+          <div class="inline-block pr-5 pb-5 w-[250px]">
+            @if (diskPressure$ | async; as diskPressure) {
+              <div class="card">
+                <app-simple-usage-chart [thresholds]="pressureChartThresholds" chartTitle="Nodes With Disk Pressure"
+                  [data]="diskPressure" height="{{chartHeight}}">
+                </app-simple-usage-chart>
+              </div>
+            }
+          </div>
+          <div class="inline-block pr-5 pb-5 w-[250px]">
+            @if (memoryPressure$ | async; as memoryPressure) {
+              <div class="card">
+                <app-simple-usage-chart [thresholds]="pressureChartThresholds" chartTitle="Nodes With Memory Pressure"
+                  [data]="memoryPressure" height="{{chartHeight}}">
+                </app-simple-usage-chart>
+              </div>
+            }
+          </div>
+          <div class="inline-block pr-5 pb-5 w-[250px]">
+            @if (outOfDisk$ | async; as outOfDisk) {
+              <div class="card">
+                <app-simple-usage-chart chartTitle="Nodes Out Of Disk" [thresholds]="criticalPressureChartThresholds"
+                  [data]="outOfDisk" height="{{chartHeight}}">
+                </app-simple-usage-chart>
+              </div>
+            }
+          </div>
+          <div class="inline-block pr-5 pb-5 w-[250px]">
+            @if (nodesReady$ | async; as nodesReady) {
+              <div class="card">
+                <app-simple-usage-chart [thresholds]="nominalPressureChartThresholds" chartTitle="Nodes Ready"
+                  [data]="nodesReady" height="{{chartHeight}}">
+                </app-simple-usage-chart>
+              </div>
+            }
+          </div>
+          <div class="inline-block pr-5 pb-5 w-[250px]">
+            @if (networkUnavailable$ | async; as networkUnavailable) {
+              @if (networkUnavailable.supported) {
+                <div class="card">
+                  <app-simple-usage-chart [thresholds]="criticalPressureChartThresholdsInverted"
+                    chartTitle="Nodes With Network Available" [data]="networkUnavailable" height="{{chartHeight}}">
+                  </app-simple-usage-chart>
+                </div>
+              }
             }
           </div>
         </div>

--- a/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.ts
@@ -15,6 +15,14 @@ import {
 import { SimpleUsageChartComponent } from '../../../../../core/src/shared/components/simple-usage-chart/simple-usage-chart.component';
 import { PageSubNavComponent } from '../../../../../core/src/shared/components/page-sub-nav/page-sub-nav.component';
 import { LoadingPageComponent } from '../../../../../core/src/shared/components/loading-page/loading-page.component';
+import {
+  CardNumberMetricComponent,
+  EntitySummaryTitleComponent,
+  MetadataItemComponent,
+  TileComponent,
+  TileGridComponent,
+  TileGroupComponent,
+} from '@stratosui/core';
 import { entityCatalog } from '@stratosui/store';
 import { KubePodDataService } from '../../../services/domain-data/kube-pod-data.service';
 import { KubeNodeDataService } from '../../../services/domain-data/kube-node-data.service';
@@ -43,7 +51,13 @@ interface IEndpointDetails {
     RouterModule,
     SimpleUsageChartComponent,
     PageSubNavComponent,
-    LoadingPageComponent
+    LoadingPageComponent,
+    EntitySummaryTitleComponent,
+    TileGridComponent,
+    TileGroupComponent,
+    TileComponent,
+    CardNumberMetricComponent,
+    MetadataItemComponent
   ]
 })
 export class KubernetesSummaryTabComponent implements OnInit, OnDestroy {
@@ -104,7 +118,9 @@ export class KubernetesSummaryTabComponent implements OnInit, OnDestroy {
   public memoryPressure$!: Observable<ISimpleUsageChartData>;
   public outOfDisk$!: Observable<ISimpleUsageChartData>;
   public nodesReady$!: Observable<ISimpleUsageChartData>;
-  public networkUnavailable$!: Observable<ISimpleUsageChartData>;
+  // getNodeStatusCount decorates the chart data with a `supported` flag —
+  // NetworkUnavailable is only reported by some K8S versions.
+  public networkUnavailable$!: Observable<ISimpleUsageChartData & { supported?: boolean }>;
   public kubeNodeVersions$!: Observable<string>;
   public caaspData$!: Observable<CaaspNodesData | null>;
 

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.ts
@@ -4,7 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { AppProgressBarComponent } from '../../../../../../../core/src/shared/components/progress-bar/app-progress-bar.component';
 import { CustomIconComponent } from '../../../../../../../core/src/shared/components/custom-material/custom-material.component';
 import { CustomTooltipDirective } from '../../../../../../../core/src/shared/components/custom-tooltip/custom-tooltip.directive';
-import { Edge, NgxGraphModule } from '@swimlane/ngx-graph';
+import { Edge, NgxGraphModule, NgxGraphZoomOptions } from '@swimlane/ngx-graph';
 import { SidePanelService } from '@stratosui/core';
 import { combineLatest, Observable, Subject, Subscription } from 'rxjs';
 import { take, distinctUntilChanged, filter, map, publishReplay, refCount, startWith } from 'rxjs/operators';
@@ -90,7 +90,9 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
   private updateSignal: WritableSignal<boolean> = signal<boolean>(false);
   update$ = toObservable(this.updateSignal);
 
-  private fitSignal: WritableSignal<boolean> = signal<boolean>(false);
+  // ngx-graph zooms-to-fit on every emission; the options object matches
+  // the [zoomToFit$] input's Observable<NgxGraphZoomOptions> type.
+  private fitSignal: WritableSignal<NgxGraphZoomOptions> = signal<NgxGraphZoomOptions>({});
   fit$ = toObservable(this.fitSignal);
 
   public layout = 'dagre';
@@ -110,7 +112,7 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
     publishReplay(1),
     refCount()
   );
-  private helper = inject(HelmReleaseHelperService);
+  protected helper = inject(HelmReleaseHelperService);
   public analyzerService = inject(KubernetesAnalysisService);
   private previewPanel = inject(SidePanelService);
 
@@ -233,7 +235,7 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
   }
 
   public fitGraph() {
-    this.fitSignal.set(true);
+    this.fitSignal.set({});
   }
 
   public toggleLayout() {

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-summary-tab/helm-release-summary-tab.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-summary-tab/helm-release-summary-tab.component.html
@@ -29,7 +29,7 @@
           Upgrade available: {{ upgrade }}
         </div>
       }
-      <app-entity-summary-title [imagePath]="release.chart.metadata.icon" [title]="release.name"
+      <app-entity-summary-title [imagePath]="release.chart.metadata.icon ?? null" [title]="release.name"
         [subText]="release.chart.metadata.description" [subTitle]="release.chart.metadata.name"
         [fallBackIcon]="'workloads'" [fallBackIconFont]="'stratos-icons'">
         <div class="summary">

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/workload.types.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/workload.types.ts
@@ -23,6 +23,7 @@ export interface HelmRelease {
     metadata: {
       name: string;
       version: string;
+      appVersion?: string;
       icon?: string;
       description: string;
       sources: string[];

--- a/src/frontend/packages/shared/tsconfig.lib.json
+++ b/src/frontend/packages/shared/tsconfig.lib.json
@@ -8,6 +8,6 @@
     "**/*.spec.ts"
   ],
   "angularCompilerOptions": {
-    "strictTemplates": false
+    "strictTemplates": true
   }
 }

--- a/src/frontend/packages/store/src/public-api.ts
+++ b/src/frontend/packages/store/src/public-api.ts
@@ -150,7 +150,7 @@ export { SystemSharedUserGuid } from './types/endpoint.types';
 export { stratosEntityCatalog } from './stratos-entity-catalog';
 export { EntityCatalogHelper } from './entity-catalog/entity-catalog-entity/entity-catalog.service';
 export type { PermissionValues } from './types/current-user-roles.types';
-export type { SessionData, SessionDataConfig } from './types/auth.types';
+export type { SessionData, SessionDataConfig, Diagnostics } from './types/auth.types';
 export { APIKeysEnabled, UserEndpointsEnabled } from './types/auth.types';
 export type { RouterRedirect } from './types/auth.types';
 export { EntitySchema } from './helpers/entity-schema';

--- a/src/frontend/packages/store/src/types/auth.types.ts
+++ b/src/frontend/packages/store/src/types/auth.types.ts
@@ -142,6 +142,7 @@ export interface AuthTokenEnvelope {
 export interface Diagnostics {
   deploymentType?: string;
   gitClientVersion?: string;
+  databaseBackend?: string;
   databaseMigrations?: any;
   helmName?: string;
   helmRevision?: string;

--- a/src/frontend/packages/store/tsconfig.lib.json
+++ b/src/frontend/packages/store/tsconfig.lib.json
@@ -13,6 +13,6 @@
     "**/*.spec.ts"
   ],
   "angularCompilerOptions": {
-    "strictTemplates": false
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
Closes #5618.

## What

Turns on Angular `strictTemplates` for every frontend package and fixes the 557 template type errors that flipping the flag surfaced. `strictTemplates` was disabled during the Angular 22 + TypeScript 6.0 upgrade so the codebase would compile through the migration (cdaf000a60); this pays down that debt.

## Why

Template expressions have never been type-checked while the flag was off. That is exactly how the second defect on #5600 (a template reading the legacy v2 `entity.*` / `metadata.guid` shape over a stream now emitting flat v3 rows) compiled clean and survived several v2/ngrx removal sweeps — those scans key on imports, URLs and store APIs, none of which see plain HTML. With the flag on, that whole bug class can no longer compile silently.

## Shape of the change

Commits are grouped per package for review:

1. `core` — nullable inputs, widened setters that already guarded at runtime, missing standalone imports, `private`→`protected` for template-read members
2. `store` + `git`
3. `cloud-foundry`
4. `kubernetes`
5. `cf-autoscaler` — includes restoring the metric chart card broken by the earlier ngx-charts→Chart.js migration (gauge + combo-chart inputs reimplemented)
6. the flag flip itself (six package tsconfigs)

The per-package tsconfigs override the root, so each needed the flip; the app build compiles all packages from source, so `core/tsconfig.app.json` is what actually gates CI.

## Real defects the checker exposed (fixed here, not silenced)

The point of the flag is catching these, and it did:

- **application-delete** rendered blank service-instance names — a template reading `binding.serviceInstanceName` (never existed) instead of `binding.serviceInstance.name`. The #5600 v2-shape class.
- **endpoint name-uniqueness validation** was dead — a template typo (`existingEndpoinNames$`) that silently disabled the check.
- **deploy-application branch `<select>`** bound the whole `GitBranch` object with `[value]` (no `[ngValue]`), so the DOM value was `"[object Object]"` and overwrote the typed model — branch switching was broken.
- **kubedash config** bound raw booleans to a `busy` input piped through `| async`, so the busy overlay never worked.
- **cf-autoscaler combo-chart** read the old ngx-charts multi-series shape after the Chart.js rewrite and would have thrown once metric data arrived.
- **unique-name status icon** had rendered nothing since the StratosStatus migration (`done` stopped matching any state key).
- Latent null-crash on the home endpoint-card favourite star; several dead bindings removed.

## No `any`

Fixes are root-cause: correct the producer type, optional-chain, narrow with `@if`, or widen an input that genuinely accepts undefined. No `$any()` / `as any` / blanket non-null assertions were used to reach green.

## Verification

`make check gate` green (3094 tests pass, 0 fail); full `ng build` clean with the flag on.

## Draft

Draft pending live UI verification of the restored cf-autoscaler chart and the deploy branch select.