### PR TITLE
Surface deploy failure when source fetch fails

### DIFF
--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -145,6 +145,9 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 
 	if err != nil {
 		log.Errorf("Failed to fetch source: %v+", err)
+		// Tell the client the deploy is over — git getters send their own close
+		// events, but the file/folder path otherwise fails silently
+		sendErrorMessage(clientWebSocket, err, CLOSE_FAILURE)
 		return err
 	}
 


### PR DESCRIPTION
Follow-up to #5610 (merged as 590530dd7f).

## What

When the application source fetch fails on the file/folder deploy path, the backend logged the error and closed the deploy websocket without sending a close event. The client had nothing to react to, so the deploy UI stayed stuck on **Preparing…** with no failure shown.

This sends `CLOSE_FAILURE` on that error path — the same thing the git source getters already do — so the client renders **Deploy Failed!** and re-enables the controls.

```go
if err != nil {
    log.Errorf("Failed to fetch source: %v+", err)
    // Tell the client the deploy is over — git getters send their own close
    // events, but the file/folder path otherwise fails silently
    sendErrorMessage(clientWebSocket, err, CLOSE_FAILURE)
    return err
}
```

## Why separate from #5610

This was written and reviewed as part of the #5610 archiver work but the commit that carried it did not make it into the merge. Splitting it out so it lands on its own.

## Verification

Reproduced live: uploading a crafted archive that the new extractor rejects (Zip Slip) previously hung the deploy UI on Preparing…; with this change the UI shows **Deploy Failed!** and the deploy can be closed. `cfapppush` package builds and tests pass.