### PR TITLE
refactor(home): name endpoint-card status enum in template

### DIFF
--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.html
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.html
@@ -22,12 +22,12 @@
         <div class="flex items-center space-x-2">
           @if ((status$ | async); as status) {
             <div>
-              @if (status === 1) {
+              @if (status === Status.Loading) {
                 <div class="animate-spin">
                   <div class="h-5 w-5 border-2 border-brand-600 border-t-transparent rounded-full"></div>
                 </div>
               }
-              @if (status === 2) {
+              @if (status === Status.Error) {
                 <div class="text-warning-shade-500" title="Data for this endpoint took too long to load">
                   <span class="material-icons">warning</span>
                 </div>

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
@@ -109,6 +109,8 @@ export class HomePageEndpointCardComponent implements OnInit, OnChanges, OnDestr
   private _status = signal<Status>(Status.OK);
   public statusSignal = this._status.asReadonly();
   public status$: Observable<Status>;
+  // Expose the Status enum so the template can name values instead of magic numbers
+  public readonly Status = Status;
 
   // strict: assigned by createCard (ngAfterViewInit) before any card-instance read; reads are guarded with if (this.ref)
   private ref!: ComponentRef<HomePageEndpointCard>;


### PR DESCRIPTION
Replaces the magic numbers in the home endpoint-card status check
(`status === 1` / `status === 2`) with the named values of the existing
`Status` enum, and exposes that enum on the component so the template can
reference it.

Supersedes #5625 (the code-quality autofix suggestion), which referenced
a non-existent `EndpointCardStatus.LOADING`/`.TIMEOUT` enum and would not
have compiled under strictTemplates. This uses the component's real
`Status` enum (`OK`/`Loading`/`Error`) instead.
