### PR TITLE
Reconnect snackbar action opens the connect dialog

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.spec.ts
@@ -2,18 +2,29 @@ import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { EndpointsSignalService } from '@stratosui/core';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { Router } from '@angular/router';
+import { ConnectEndpointDialogComponent, EndpointsSignalService, TailwindDialogService } from '@stratosui/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StratosDiagnostics } from '../services/diagnostics/stratos-diagnostics.service';
 import { cfApiInterceptor } from './cf-api-interceptor';
 
-// Minimal EndpointsSignalService stub — the interceptor only reads
-// `endpoints()` to look up a name for the 502 snackbar. An empty map is
-// enough for the existing tests; the snackbar-naming regression test below
-// pre-populates a single endpoint via the same stub.
+// Minimal EndpointsSignalService stub — the interceptor reads `endpoints()`
+// to name the 502 snackbar and to build the connect-dialog config for the
+// Reconnect action. An empty map is enough for the existing tests; the
+// snackbar-naming and reconnect tests pre-populate endpoints via the stub.
 const endpointsStub = {
-  endpoints: signal<Record<string, { name?: string }>>({}),
+  endpoints: signal<Record<string, {
+    name?: string;
+    guid?: string;
+    cnsi_type?: string;
+    sub_type?: string;
+    sso_allowed?: boolean;
+  }>>({}),
 };
+
+// TailwindDialogService stub — the Reconnect action opens the connect
+// dialog through it; the tests only assert the open() call.
+const dialogStub = { open: vi.fn() };
 
 describe('cfApiInterceptor', () => {
   let http: HttpClient;
@@ -22,11 +33,13 @@ describe('cfApiInterceptor', () => {
 
   beforeEach(() => {
     endpointsStub.endpoints.set({});
+    dialogStub.open.mockReset();
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(withInterceptors([cfApiInterceptor])),
         provideHttpClientTesting(),
         { provide: EndpointsSignalService, useValue: endpointsStub },
+        { provide: TailwindDialogService, useValue: dialogStub },
       ],
     });
     http = TestBed.inject(HttpClient);
@@ -80,13 +93,14 @@ describe('cfApiInterceptor', () => {
   //
   // Helper: capture banner messages and the action label passed alongside.
   const captureSnackbar = async () => {
-    const calls: { msg: string; action?: string }[] = [];
+    const calls: { msg: string; action?: string; ref: { dismissWithAction: () => void } }[] = [];
     const { TailwindSnackBarService } = await import('@stratosui/core');
     const snackbar = TestBed.inject(TailwindSnackBarService);
     const origError = snackbar.error.bind(snackbar);
     snackbar.error = (msg: string, action?: string) => {
-      calls.push({ msg, action });
-      return origError(msg, action);
+      const ref = origError(msg, action);
+      calls.push({ msg, action, ref });
+      return ref;
     };
     return calls;
   };
@@ -107,6 +121,57 @@ describe('cfApiInterceptor', () => {
     expect(calls[0].msg).not.toContain(cnsi); // GUID dropped from the banner
     expect(calls[0].msg).toContain('Authentication expired');
     expect(calls[0].action).toBe('Reconnect');
+  });
+
+  // #5621: the Reconnect action must actually reconnect — it opens the
+  // connect dialog for the affected endpoint in place instead of dumping
+  // the user on /endpoints to find the row themselves.
+  it('Reconnect action opens the connect dialog for the affected endpoint', async () => {
+    const cnsi = 'CSnSysOkvwBD6A-UQyQW6gmKPhI';
+    endpointsStub.endpoints.set({
+      [cnsi]: { name: 'Kevin', guid: cnsi, cnsi_type: 'cf', sub_type: '', sso_allowed: true },
+    });
+    const calls = await captureSnackbar();
+
+    http.get(`/pp/v1/cf/info/${cnsi}`).subscribe({ error: () => undefined });
+    ctrl.expectOne(`/pp/v1/cf/info/${cnsi}`).flush(
+      JSON.stringify({ reason: 'auth_expired', detail: 'token rejected' }),
+      { status: 502, statusText: 'Bad Gateway', headers: { 'X-Stratos-Error-Reason': 'auth_expired' } },
+    );
+
+    expect(calls).toHaveLength(1);
+    calls[0].ref.dismissWithAction(); // click "Reconnect"
+
+    expect(dialogStub.open).toHaveBeenCalledTimes(1);
+    const [component, config] = dialogStub.open.mock.calls[0];
+    expect(component).toBe(ConnectEndpointDialogComponent);
+    expect(config.data).toEqual({
+      name: 'Kevin',
+      guid: cnsi,
+      type: 'cf',
+      subType: '',
+      ssoAllowed: true,
+    });
+  });
+
+  it('Reconnect action falls back to /endpoints when the endpoint is unknown', async () => {
+    const cnsi = 'CSnSysOkvwBD6A-UQyQW6gmKPhI';
+    // No endpoint registered in the signal — nothing to hand the dialog.
+    const calls = await captureSnackbar();
+    const router = TestBed.inject(Router);
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    http.get(`/pp/v1/cf/info/${cnsi}`).subscribe({ error: () => undefined });
+    ctrl.expectOne(`/pp/v1/cf/info/${cnsi}`).flush(
+      JSON.stringify({ reason: 'auth_expired', detail: 'token rejected' }),
+      { status: 502, statusText: 'Bad Gateway', headers: { 'X-Stratos-Error-Reason': 'auth_expired' } },
+    );
+
+    expect(calls).toHaveLength(1);
+    calls[0].ref.dismissWithAction(); // click "Reconnect"
+
+    expect(dialogStub.open).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith(['/endpoints']);
   });
 
   it('unreachable reason → "unreachable" banner, no Reconnect, includes upstream status', async () => {

--- a/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
+++ b/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
@@ -2,7 +2,14 @@ import { HttpErrorResponse, HttpEventType, HttpInterceptorFn, HttpResponse } fro
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { tap } from 'rxjs/operators';
-import { EndpointAuthStateService, EndpointsSignalService, TailwindSnackBarService } from '@stratosui/core';
+import {
+  ConnectEndpointConfig,
+  ConnectEndpointDialogComponent,
+  EndpointAuthStateService,
+  EndpointsSignalService,
+  TailwindDialogService,
+  TailwindSnackBarService,
+} from '@stratosui/core';
 import { StratosDiagnostics } from '../services/diagnostics/stratos-diagnostics.service';
 
 // Stratos cnsi GUIDs come in two flavours: standard hex UUIDs from
@@ -79,6 +86,7 @@ export const cfApiInterceptor: HttpInterceptorFn = (req, next) => {
   const diagnostics = inject(StratosDiagnostics);
   const authState = inject(EndpointAuthStateService);
   const snackbar = inject(TailwindSnackBarService);
+  const dialog = inject(TailwindDialogService);
   const router = inject(Router);
   const endpointsSignal = inject(EndpointsSignalService);
   const start = performance.now();
@@ -141,7 +149,39 @@ export const cfApiInterceptor: HttpInterceptorFn = (req, next) => {
                   `${line1}\n${codePrefix}Authentication expired. Reconnect to refresh.`,
                   'Reconnect',
                 );
-                ref.onAction().subscribe(() => router.navigate(['/endpoints']));
+                // One-click reconnect: open the connect dialog in place for
+                // the affected endpoint. The user just clicked "Reconnect" on
+                // an error about the page they're on, so a modal here is the
+                // expected response — routing to /endpoints and making them
+                // find the row was the old behaviour this replaces (#5621).
+                // Re-read the signal at click time; fall back to the
+                // endpoints list when the endpoint is unknown (nothing to
+                // hand the dialog).
+                ref.onAction().subscribe(() => {
+                  const ep = endpointsSignal.endpoints()[cnsiGuid];
+                  if (!ep) {
+                    router.navigate(['/endpoints']);
+                    return;
+                  }
+                  const data: ConnectEndpointConfig = {
+                    name: ep.name,
+                    guid: ep.guid,
+                    // cnsi_type/sub_type are optional on EndpointModel; this
+                    // interceptor only sees CF traffic, so 'cf' is the only
+                    // possible fallback.
+                    type: ep.cnsi_type ?? 'cf',
+                    subType: ep.sub_type ?? '',
+                    ssoAllowed: ep.sso_allowed,
+                  };
+                  // Same dialog options the endpoints list uses.
+                  dialog.open(ConnectEndpointDialogComponent, {
+                    data,
+                    disableClose: true,
+                    width: '550px',
+                    maxWidth: '550px',
+                    panelClass: ['overflow-visible', 'p-6'],
+                  });
+                });
               }
             } else if (reason === 'unreachable') {
               // Endpoint is down — no stale mark (reconnect won't help).

--- a/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
+++ b/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
@@ -165,7 +165,9 @@ export const cfApiInterceptor: HttpInterceptorFn = (req, next) => {
                   }
                   const data: ConnectEndpointConfig = {
                     name: ep.name,
-                    guid: ep.guid,
+                    // cnsiGuid, not ep.guid: same value (it's the lookup key)
+                    // but non-optional, which the config type requires.
+                    guid: cnsiGuid,
                     // cnsi_type/sub_type are optional on EndpointModel; this
                     // interceptor only sees CF traffic, so 'cf' is the only
                     // possible fallback.

--- a/src/frontend/packages/core/src/public-api.ts
+++ b/src/frontend/packages/core/src/public-api.ts
@@ -250,6 +250,8 @@ export { HomePageCardLayout, HomePageEndpointCard, LinkMetadata } from './featur
 export * from './features/endpoints/create-endpoint/create-endpoint-helper';
 export { CreateEndpointModule } from './features/endpoints/create-endpoint/create-endpoint.module';
 export { CreateEndpointBaseStepComponent } from './features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component';
+export { ConnectEndpointDialogComponent } from './features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
+export { ConnectEndpointConfig } from './features/endpoints/connect.service';
 export { BaseEndpointAuth, EndpointAuthTypeNames } from './core/endpoint-auth';
 
 // List Types and Components


### PR DESCRIPTION
The auth-expired banner's **Reconnect** button only routed to `/endpoints`, leaving the user to find the endpoint in the list and click Connect themselves. The action was labelled for a one-click reconnect but didn't perform one.

This makes the action open the connect dialog for the affected endpoint in place. The interceptor already has everything the dialog needs (`EndpointsSignalService` lookup maps 1:1 to `ConnectEndpointConfig`), so the change is confined to the `auth_expired` branch. If the endpoint is unknown to the frontend at click time, it falls back to the old `/endpoints` navigation.

On the issue's open design question (in-place modal vs routing to `/endpoints` first): went with in-place. The snackbar only appears in response to a request the current page made, and the user explicitly clicked Reconnect on it — a modal there is the expected response, and it preserves the page the user was on so a retry lands back in context.

One correction to the issue text: `ConnectEndpointDialogComponent` was not actually exported from `@stratosui/core` — this adds that export (plus `ConnectEndpointConfig`) to the core public API.

Tests: two new interceptor specs — the Reconnect action opens the dialog with the endpoint's config, and the unknown-endpoint fallback navigates to `/endpoints`. 14/14 pass.

Closes #5621