### PR TITLE
Document numeric sentinel values at their definitions

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
@@ -462,6 +462,7 @@ export class ApplicationWallComponent implements OnInit {
 
   static formatMb(mb: number | null | undefined): string {
     if (mb == null || typeof mb !== 'number' || Number.isNaN(mb)) return '—';
+    // CF quota APIs encode 'unlimited' as -1
     if (mb === -1) return '∞';
     if (mb < 1024) return `${mb} MB`;
     const gb = mb / 1024;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -356,6 +356,7 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
 
   static formatMb(mb: number | null | undefined): string {
     if (mb == null || typeof mb !== 'number' || Number.isNaN(mb)) return '—';
+    // CF quota APIs encode 'unlimited' as -1
     if (mb === -1) return '∞';
     if (mb < 1024) return `${mb} MB`;
     const gb = mb / 1024;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organization-space-quotas/cloud-foundry-organization-space-quotas.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organization-space-quotas/cloud-foundry-organization-space-quotas.component.ts
@@ -246,6 +246,8 @@ export class CloudFoundryOrganizationSpaceQuotasComponent {
     ];
   }
 
+  // -1 on the wire signals "Unlimited" (the backend coerces null v3
+  // limits to -1 for a flat int wire shape).
   static formatLimit(value: number, unit?: string): string {
     if (value === -1) return 'Unlimited';
     return unit ? `${value.toLocaleString()} ${unit}` : value.toLocaleString();

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
@@ -270,6 +270,7 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
 
   static formatMb(mb: number | null | undefined): string {
     if (mb == null || typeof mb !== 'number' || Number.isNaN(mb)) return '—';
+    // CF quota APIs encode 'unlimited' as -1
     if (mb === -1) return '∞';
     if (mb < 1024) return `${mb} MB`;
     const gb = mb / 1024;

--- a/src/frontend/packages/core/src/core/infinity.pipe.ts
+++ b/src/frontend/packages/core/src/core/infinity.pipe.ts
@@ -6,6 +6,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class InfinityPipe implements PipeTransform {
   transform(value: string): string {
+    // CF quota APIs encode 'unlimited' as -1
     return (parseInt(value, 10) === -1) ? '∞' : value;
   }
 }

--- a/src/frontend/packages/core/src/core/utils.service.ts
+++ b/src/frontend/packages/core/src/core/utils.service.ts
@@ -75,7 +75,7 @@ export class UtilsService {
       return '';
     }
 
-    // Special case: unlimited
+    // Special case: CF quota APIs encode 'unlimited' as -1
     if (mb === -1) {
       return '∞';
     }
@@ -107,7 +107,7 @@ export class UtilsService {
       return '';
     }
 
-    // Special case: unlimited
+    // Special case: CF quota APIs encode 'unlimited' as -1
     if (bytes === -1) {
       return '∞';
     }

--- a/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.ts
@@ -87,6 +87,7 @@ export class CardNumberMetricComponent implements OnInit, OnChanges {
   handleValue() {
     const value = parseInt(this.value, 10);
     this.isUnlimited = false;
+    // CF quota APIs encode 'unlimited' as -1
     if (value === -1) {
       this.formattedValue = 'Unlimited';
       this.isUnlimited = true;
@@ -102,6 +103,7 @@ export class CardNumberMetricComponent implements OnInit, OnChanges {
     this._status.set(status);
 
     const limit = parseInt(this.limit, 10);
+    // CF quota APIs encode 'unlimited' as -1
     if (limit === -1) {
       this.formattedLimit = '∞';
       this.usage = '';

--- a/src/frontend/packages/core/src/shared/components/cards/card-status/card-status.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-status/card-status.component.ts
@@ -6,6 +6,7 @@ import { StratosStatus } from '@stratosui/store';
 
 
 export function determineCardStatus(value: number, limit: number): StratosStatus {
+  // -1 is the CF quota 'unlimited' sentinel, so there is no meaningful usage fraction
   if ((limit !== 0 && !limit) || limit === -1) {
     return StratosStatus.NONE;
   }

--- a/src/frontend/packages/core/src/shared/components/profile-settings/profile-settings.component.ts
+++ b/src/frontend/packages/core/src/shared/components/profile-settings/profile-settings.component.ts
@@ -90,6 +90,7 @@ export class ProfileSettingsComponent {
   public allowGravatar$ = toObservable(this.dashboardSignals.gravatarEnabled);
 
   public localStorageSize$ = this.sessionData$.pipe(
+    // -1 means the size could not be determined (no user session or storage unavailable)
     map(sessionData => sessionData && sessionData.user ? LocalStorageService.localStorageSize(sessionData) : -1),
     filter(bytes => bytes !== -1),
   );

--- a/src/jetstream/authlocal.go
+++ b/src/jetstream/authlocal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -189,7 +188,7 @@ func (a *localAuth) generateLoginSuccessResponse(c echo.Context, userGUID string
 	log.Debug("generateLoginResponse")
 
 	var err error
-	var expiry int64 = math.MaxInt64
+	var expiry int64 = sessionNeverExpires
 
 	sessionValues := make(map[string]interface{})
 	sessionValues["user_id"] = userGUID

--- a/src/jetstream/authnone.go
+++ b/src/jetstream/authnone.go
@@ -16,6 +16,11 @@ import (
 
 const (
 	noAuthUserID = "10000000-1111-2222-3333-444444444444"
+
+	// sessionNeverExpires marks sessions that have no expiry (no-auth and
+	// local-auth logins); session validation treats any future exp as valid,
+	// so MaxInt64 means the session never expires.
+	sessionNeverExpires int64 = math.MaxInt64
 )
 
 // More fields will be moved into here as global portalProxy struct is phased out
@@ -62,7 +67,7 @@ func (a *noAuth) GetUser(userGUID string) (*api.ConnectedUser, error) {
 
 func (a *noAuth) BeforeVerifySession(c echo.Context) {
 	var err error
-	var expiry int64 = math.MaxInt64
+	var expiry int64 = sessionNeverExpires
 
 	session, err := a.p.GetSession(c)
 	if err != nil {
@@ -94,7 +99,7 @@ func (a *noAuth) generateLoginSuccessResponse(c echo.Context, userGUID string, u
 	log.Debug("generateLoginResponse")
 
 	var err error
-	var expiry int64 = math.MaxInt64
+	var expiry int64 = sessionNeverExpires
 
 	sessionValues := make(map[string]interface{})
 	sessionValues["user_id"] = userGUID

--- a/src/jetstream/middleware_wiresize.go
+++ b/src/jetstream/middleware_wiresize.go
@@ -127,6 +127,8 @@ func (w *bufferingResponseWriter) flushStatus() {
 		return
 	}
 	status := w.statusCode
+	// 0 means the handler never called WriteHeader; net/http defaults
+	// that to 200, so mirror it here.
 	if status == 0 {
 		status = http.StatusOK
 	}

--- a/src/jetstream/plugins/cfapppush/unarchive.go
+++ b/src/jetstream/plugins/cfapppush/unarchive.go
@@ -53,6 +53,8 @@ func unarchive(src, dst string) error {
 				return err
 			}
 			mode := entry.Mode().Perm()
+			// A zero mode means the archive entry recorded no permission
+			// bits; fall back to owner read/write.
 			if mode == 0 {
 				mode = 0600
 			}

--- a/src/jetstream/setup_console.go
+++ b/src/jetstream/setup_console.go
@@ -92,6 +92,8 @@ func (p *portalProxy) setupGetAvailableScopes(c echo.Context) error {
 	if err != nil {
 		errInfo, ok := err.(api.ErrHTTPRequest)
 		if ok {
+			// Status 0 means no HTTP response was received (transport or
+			// certificate failure), not a real HTTP status code.
 			if errInfo.Status == 0 {
 				var certError *x509.CertificateInvalidError
 				if errors.As(err, certError) {


### PR DESCRIPTION
Step 1 of #5613: numbers acting as flags or sentinels read as plain quantities without a comment where they're defined. This documents the confirmed cases — comment/naming pass only, no behavior change.

- **CF quota `-1` = unlimited** — commented at every branch that renders it (infinity pipe, size formatters, metric/status cards, quota tabs, app-wall memory columns).
- **`profile-settings` `-1`** turns out to be a *different* sentinel — "size could not be determined", not the quota convention. Its comment states that explicitly so the two don't get conflated by a future consolidation.
- **jetstream**: the no-auth/local-auth session expiry sentinel is now a named package constant (`sessionNeverExpires = math.MaxInt64`) instead of a bare literal at three sites; documented `status == 0` = no HTTP response in `setup_console`, the WriteHeader-never-called → 200 default in the wiresize middleware, and the zero-mode → 0600 fallback in cfapppush unarchive.

The convert-vs-document triage list (which of these deserve a shared constant or type beyond a comment) is posted on #5613 for discussion.

Part of #5613