### PR TITLE
Add golangci-lint gate and expand audit tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,12 +154,24 @@ endif
 
 $(_HIDE)WANT_PACKAGES :=
 $(_HIDE)WANT_SECRETS  :=
+$(_HIDE)WANT_TREE     :=
+$(_HIDE)WANT_HISTORY  :=
+$(_HIDE)WANT_LICENSES :=
 
 ifneq ($(filter packages,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_PACKAGES := yes
 endif
 ifneq ($(filter secrets,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_SECRETS := yes
+endif
+ifneq ($(filter tree,$(MAKECMDGOALS)),)
+  $(_HIDE)WANT_TREE := yes
+endif
+ifneq ($(filter history,$(MAKECMDGOALS)),)
+  $(_HIDE)WANT_HISTORY := yes
+endif
+ifneq ($(filter licenses,$(MAKECMDGOALS)),)
+  $(_HIDE)WANT_LICENSES := yes
 endif
 
 # cf modifier defaults to linux/amd64 unless PLATFORM is set
@@ -224,7 +236,7 @@ endif
 endif
 # Default: all scanners for audit when no modifier given
 ifneq ($(filter audit,$(MAKECMDGOALS)),)
-ifeq ($($(_HIDE)WANT_FRONTEND)$($(_HIDE)WANT_BACKEND)$($(_HIDE)WANT_SUMMARY)$($(_HIDE)WANT_ACTIONS)$($(_HIDE)WANT_PACKAGES)$($(_HIDE)WANT_SECRETS),)
+ifeq ($($(_HIDE)WANT_FRONTEND)$($(_HIDE)WANT_BACKEND)$($(_HIDE)WANT_SUMMARY)$($(_HIDE)WANT_ACTIONS)$($(_HIDE)WANT_PACKAGES)$($(_HIDE)WANT_SECRETS)$($(_HIDE)WANT_TESTS)$($(_HIDE)WANT_TREE)$($(_HIDE)WANT_HISTORY)$($(_HIDE)WANT_LICENSES),)
   $(_HIDE)WANT_FRONTEND := yes
   $(_HIDE)WANT_BACKEND  := yes
   $(_HIDE)WANT_ACTIONS  := yes
@@ -242,8 +254,8 @@ endif
 
 # No-op targets so modifiers don't error
 # Note: lint has its own standalone recipe — not listed here.
-.PHONY: frontend backend website booklets cf korifi github pages dist version e2e actions packages secrets gate tests coverage summary dependabot
-frontend backend website booklets cf korifi github pages dist version e2e actions packages secrets gate tests coverage summary dependabot:
+.PHONY: frontend backend website booklets cf korifi github pages dist version e2e actions packages secrets gate tests coverage summary dependabot tree history licenses
+frontend backend website booklets cf korifi github pages dist version e2e actions packages secrets gate tests coverage summary dependabot tree history licenses:
 	@:
 
 # No-op targets for bump modifiers (consumed by BUMP_MOD filter).
@@ -394,6 +406,9 @@ E2E_TRACE       ?=
 E2E_VIDEO       ?=
 E2E_SCREENSHOTS ?=
 
+# Extra zizmor flags for `make audit actions` (e.g. --persona=auditor)
+ZIZMOR_FLAGS    ?=
+
 # Helpers — translate the variables above into Playwright CLI flags.
 
 # Convert "a,b,c" → "--project=a --project=b --project=c"
@@ -487,12 +502,17 @@ endef
 $(call register, check, e2e)
 
 # ── Audit (security scanning) ────────────────────────────────
-# make audit              — all scanners below
+# make audit              — default scanners (frontend backend actions packages secrets)
 # make audit frontend     — bun audit (npm advisory DB)
-# make audit backend      — gosec + trivy + govulncheck
+# make audit backend      — gosec + trivy + govulncheck (both Go modules)
 # make audit actions      — zizmor (GitHub Actions workflow SAST)
+#                           ZIZMOR_FLAGS="--persona=auditor" for the strict rule set
 # make audit packages     — osv-scanner (all lockfiles + go.mods, one pass)
 # make audit secrets      — gitleaks (working-tree secret scan)
+# make audit tests        — gosec including _test.go files + #nosec suppression report
+# make audit tree         — trivy over the whole tree (deploy/ Dockerfiles, helm, manifests)
+# make audit history      — gitleaks full git-history secret scan (slow)
+# make audit licenses     — osv-scanner dependency license report
 # make audit summary      — high/moderate/low counts only
 
 define audit.frontend
@@ -508,10 +528,12 @@ define audit.backend
 	@which govulncheck > /dev/null 2>&1 || (echo "govulncheck not installed. Run: go install golang.org/x/vuln/cmd/govulncheck@latest" >&2 && exit 1)
 	@echo "── gosec ──"
 	cd src/jetstream && gosec -quiet ./... || true
+	cd src/jetstream/api && gosec -quiet ./... || true
 	@echo "── trivy ──"
-	trivy fs --security-checks vuln,config src/jetstream || true
+	trivy fs --scanners vuln,misconfig src/jetstream || true
 	@echo "── govulncheck ──"
 	cd src/jetstream && govulncheck ./... || true
+	cd src/jetstream/api && govulncheck ./... || true
 endef
 $(call register, audit, backend)
 
@@ -519,9 +541,9 @@ define audit.actions
 	@echo "Running GitHub Actions workflow audit (zizmor)..."
 	@which zizmor > /dev/null 2>&1 || (echo "zizmor not installed. Run: brew install zizmor" >&2 && exit 1)
 	@if command -v gh > /dev/null 2>&1 && gh auth token > /dev/null 2>&1; then \
-		GH_TOKEN=$$(gh auth token) zizmor .github/workflows/ || true; \
+		GH_TOKEN=$$(gh auth token) zizmor $(ZIZMOR_FLAGS) .github/workflows/ || true; \
 	else \
-		zizmor --offline .github/workflows/ || true; \
+		zizmor --offline $(ZIZMOR_FLAGS) .github/workflows/ || true; \
 	fi
 endef
 $(call register, audit, actions)
@@ -539,6 +561,35 @@ define audit.secrets
 	@gitleaks dir . --no-banner --redact || true
 endef
 $(call register, audit, secrets)
+
+define audit.tests
+	@echo "Running gosec including test files..."
+	@which gosec > /dev/null 2>&1 || (echo "gosec not installed. Run: go install github.com/securego/gosec/v2/cmd/gosec@latest" >&2 && exit 1)
+	cd src/jetstream && gosec -quiet -tests -track-suppressions ./... || true
+	cd src/jetstream/api && gosec -quiet -tests -track-suppressions ./... || true
+endef
+$(call register, audit, tests)
+
+define audit.tree
+	@echo "Running full-tree scan (trivy)..."
+	@which trivy > /dev/null 2>&1 || (echo "trivy not installed. See https://github.com/aquasecurity/trivy" >&2 && exit 1)
+	trivy fs --scanners vuln,misconfig --skip-dirs '**/node_modules' --skip-dirs '**/dist' . || true
+endef
+$(call register, audit, tree)
+
+define audit.history
+	@echo "Running full git-history secret scan (gitleaks)..."
+	@which gitleaks > /dev/null 2>&1 || (echo "gitleaks not installed. Run: brew install gitleaks" >&2 && exit 1)
+	gitleaks git . --no-banner --redact || true
+endef
+$(call register, audit, history)
+
+define audit.licenses
+	@echo "Running dependency license report (osv-scanner)..."
+	@which osv-scanner > /dev/null 2>&1 || (echo "osv-scanner not installed. Run: brew install osv-scanner" >&2 && exit 1)
+	osv-scanner scan source --licenses -r . || true
+endef
+$(call register, audit, licenses)
 
 define audit.summary
 	@echo "── Frontend (bun audit) ──"
@@ -710,7 +761,7 @@ $(_HIDE)finalize-and-reexec:
 	@./build/version-bump.sh bump release
 	@echo "Re-running: $(MAKE) $(MAKECMDGOALS)"
 	@$(MAKE) FINAL= $(MAKECMDGOALS)
-$(filter-out frontend backend cf korifi github dist version e2e actions packages secrets lint gate tests coverage,$(MAKECMDGOALS)): $(_HIDE)finalize-and-reexec ; @:
+$(filter-out frontend backend cf korifi github dist version e2e actions packages secrets lint gate tests coverage tree history licenses,$(MAKECMDGOALS)): $(_HIDE)finalize-and-reexec ; @:
 else ifneq ($(FINAL),)
 $(error Unknown FINAL value '$(FINAL)' — supported: strip)
 endif
@@ -873,12 +924,16 @@ help:
 	@echo "  make clean dist           Remove everything (including node_modules)"
 	@echo ""
 	@echo "Security & dependencies:"
-	@echo "  make audit                Run all security scanners"
+	@echo "  make audit                Run default security scanners"
 	@echo "  make audit frontend       bun audit (npm advisory DB)"
-	@echo "  make audit backend        gosec + trivy + govulncheck"
-	@echo "  make audit actions        zizmor (GitHub Actions workflow SAST)"
+	@echo "  make audit backend        gosec + trivy + govulncheck (both Go modules)"
+	@echo "  make audit actions        zizmor (ZIZMOR_FLAGS=\"--persona=auditor\" for strict)"
 	@echo "  make audit packages       osv-scanner (all lockfiles + go.mods)"
 	@echo "  make audit secrets        gitleaks (working-tree secret scan)"
+	@echo "  make audit tests          gosec incl. test files + #nosec suppressions"
+	@echo "  make audit tree           trivy full-tree scan (deploy/, helm, manifests)"
+	@echo "  make audit history        gitleaks full git-history scan (slow)"
+	@echo "  make audit licenses       osv-scanner dependency license report"
 	@echo "  make audit summary        High/moderate/low counts only"
 	@echo "  make outdated             List outdated direct deps (frontend + backend)"
 	@echo "  make outdated frontend    bun outdated"

--- a/Makefile
+++ b/Makefile
@@ -440,7 +440,7 @@ $(call register, test, e2e)
 
 # ── Check (quality gates) ────────────────────────────────────
 # make check          — lint + gate (default)
-# make check lint     — ESLint + go vet only
+# make check lint     — ESLint + go vet + golangci-lint
 # make check gate     — lint + unit tests + production build (= bun run gate-check)
 # make check tests    — unit tests only
 # make check coverage — unit tests with coverage
@@ -448,8 +448,11 @@ $(call register, test, e2e)
 
 define check.lint
 	@echo "Running lint checks..."
+	@which golangci-lint > /dev/null 2>&1 || (echo "golangci-lint not installed. See https://golangci-lint.run/welcome/install/ (macOS: brew install golangci-lint)" >&2 && exit 1)
 	bun run lint
 	cd src/jetstream && go fmt ./... && go vet ./...
+	cd src/jetstream && golangci-lint run ./...
+	cd src/jetstream/api && golangci-lint run ./...
 endef
 $(call register, check, lint)
 
@@ -796,8 +799,7 @@ install:
 # lint: standalone verb, but no-op when used as check modifier
 ifeq ($(filter check,$(MAKECMDGOALS)),)
 lint:
-	bun run lint
-	cd src/jetstream && go fmt ./... && go vet ./...
+	$(check.lint)
 else
 lint: ;@:
 endif

--- a/actions.mk
+++ b/actions.mk
@@ -35,9 +35,12 @@ $(_HIDE)FLAG_tests       := $($(_HIDE)WANT_TESTS)
 $(_HIDE)FLAG_coverage    := $($(_HIDE)WANT_COVERAGE)
 $(_HIDE)FLAG_summary     := $($(_HIDE)WANT_SUMMARY)
 $(_HIDE)FLAG_dependabot  := $($(_HIDE)WANT_DEPENDABOT)
+$(_HIDE)FLAG_tree        := $($(_HIDE)WANT_TREE)
+$(_HIDE)FLAG_history     := $($(_HIDE)WANT_HISTORY)
+$(_HIDE)FLAG_licenses    := $($(_HIDE)WANT_LICENSES)
 
 # Known modifiers — the set checked during validation in declare_verb
-$(_HIDE)KNOWN_MODS := frontend backend website booklets cf korifi github pages e2e dist version actions packages secrets lint gate tests coverage summary dependabot
+$(_HIDE)KNOWN_MODS := frontend backend website booklets cf korifi github pages e2e dist version actions packages secrets lint gate tests coverage summary dependabot tree history licenses
 
 # Known verbs — populated by declare_verb, checked for collisions
 $(_HIDE)KNOWN_VERBS :=

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -49,8 +49,8 @@ when deployed as a Cloud Foundry application.
 
 | Command | What it does |
 |---------|-------------|
-| `make check` | Lint + gate (default — ESLint + go fmt/vet + Vitest) |
-| `make check lint` | Lint checks (ESLint + `go fmt` + `go vet`). Note: `go fmt` may modify files. |
+| `make check` | Lint + gate (default — ESLint + go fmt/vet + golangci-lint + Vitest) |
+| `make check lint` | Lint checks (ESLint + `go fmt` + `go vet` + `golangci-lint` on both Go modules). Requires `golangci-lint` installed. Note: `go fmt` may modify files. |
 | `make check gate` | Full pre-push quality gate — mirrors what CI runs on each PR (ESLint + Vitest frontend tests + Go unit tests). Run this before every push. |
 | `make check tests` | Unit tests only |
 | `make check coverage` | Frontend unit tests with coverage (Vitest). No Go coverage. |

--- a/docs/developer-environment.md
+++ b/docs/developer-environment.md
@@ -34,23 +34,58 @@ configuration. For step-by-step setup, see the
 | OpenSSL | Generate dev certs and encryption keys | Included on macOS/Linux | First-time setup |
 | `zip` | Release packaging | `brew install zip` | `make release` |
 | `swag` | OpenAPI doc generation | `go install github.com/swaggo/swag/cmd/swag@latest` | API docs |
-| `gosec` | Go security scanner | `go install github.com/securego/gosec/v2/cmd/gosec@latest` | `make audit backend` |
-| `trivy` | Vulnerability scanner | [aquasecurity/trivy](https://github.com/aquasecurity/trivy) | `make audit backend` |
+| `golangci-lint` | Go meta-linter (staticcheck, errcheck, unused, ineffassign) | [golangci-lint.run](https://golangci-lint.run/welcome/install/) | `make lint`, `make check` — lint hard-fails without it |
+| `gosec` | Go security scanner | `go install github.com/securego/gosec/v2/cmd/gosec@latest` | `make audit backend`, `make audit tests` |
+| `trivy` | Vulnerability + misconfig scanner | [aquasecurity/trivy](https://github.com/aquasecurity/trivy) | `make audit backend`, `make audit tree` |
 | `govulncheck` | Go vuln database | `go install golang.org/x/vuln/cmd/govulncheck@latest` | `make audit backend`, `make audit summary` |
+| `zizmor` | GitHub Actions workflow SAST | `brew install zizmor` | `make audit actions` |
+| `osv-scanner` | Multi-lockfile dependency scanner | `brew install osv-scanner` | `make audit packages`, `make audit licenses` |
+| `gitleaks` | Secret scanner | `brew install gitleaks` | `make audit secrets`, `make audit history` |
 | `gh` | GitHub CLI | [cli.github.com](https://cli.github.com/) | `make deps dependabot` |
 
 ### Audit & dependency commands
 
 | Command | Purpose |
 |---------|---------|
-| `make audit` | Run `bun audit` + backend scans |
+| `make audit` | Default scanner set: frontend + backend + actions + packages + secrets |
 | `make audit frontend` | `bun audit` (npm advisory DB) |
-| `make audit backend` | gosec + trivy + govulncheck |
+| `make audit backend` | gosec + trivy + govulncheck on both Go modules (`src/jetstream`, `src/jetstream/api`) |
+| `make audit actions` | zizmor SAST over `.github/workflows/`; `ZIZMOR_FLAGS="--persona=auditor"` enables the strict rule set |
+| `make audit packages` | osv-scanner over every lockfile and `go.mod` in one pass |
+| `make audit secrets` | gitleaks scan of the working tree |
 | `make audit summary` | High/moderate/low totals only — fast triage |
+| `make audit tests` | gosec including `_test.go` files, plus a `#nosec` suppression report |
+| `make audit tree` | trivy over the whole repo — covers the Dockerfiles, helm chart, and manifests under `deploy/` |
+| `make audit history` | gitleaks over the full git history (~14k commits) |
+| `make audit licenses` | osv-scanner dependency license report |
 | `make outdated` | List outdated direct deps in both stacks |
 | `make outdated frontend` | `bun outdated` |
 | `make outdated backend` | `go list -m -u all` (filtered to upgradable) |
 | `make deps dependabot` | List open dependency PRs (requires `gh` auth) |
+
+#### Non-default audit modes
+
+`make audit` runs the five default scanners only. Four modes are deliberately
+kept off the default path:
+
+- **`tests`** — gosec findings inside `_test.go` files are advisory (test code
+  doesn't ship), so they would add triage noise to every default run. Run it
+  when auditing test hygiene or reviewing `#nosec` suppressions.
+- **`tree`** — scans the entire repository instead of `src/jetstream`. It
+  exists for the deployment surface (`deploy/` Dockerfiles, helm chart, CF
+  manifests) which the backend scan doesn't reach. It is slower than the
+  default set and its misconfig findings change rarely — run it when touching
+  anything under `deploy/` or before a release.
+- **`history`** — walks all ~14k commits (roughly 15 seconds, vs instant for
+  the working-tree scan). Historical findings are almost entirely pre-2020
+  test fixtures; this is a forensic tool, not an everyday guard. The default
+  `secrets` mode already catches anything you are about to commit.
+- **`licenses`** — a compliance report, not a vulnerability source. Nothing
+  in it is actionable on a normal development day.
+
+All audit recipes are report-only (`|| true`): they never fail the build, so
+scanner exit codes are informational. The lint/test gates are where failures
+block.
 
 ## Container Runtimes
 

--- a/src/jetstream/.golangci.yml
+++ b/src/jetstream/.golangci.yml
@@ -1,0 +1,25 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      # Defaults, plus ST1005 disabled: error-string style (capitalization,
+      # punctuation). Jetstream error strings are user-facing surface — they
+      # flow into API responses and logs that clients and tests match on —
+      # so mass-rewording them is behavioral churn, not cleanup.
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        - -ST1005
+  exclusions:
+    rules:
+      # Teardown calls in tests (db.Close and friends) — checking their
+      # error returns adds noise, not safety.
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/src/jetstream/api/config/config.go
+++ b/src/jetstream/api/config/config.go
@@ -17,8 +17,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const secretsDir = "/etc/secrets"
-
 // APIKeysConfigValue - special type for configuring whether API keys feature is enabled
 type APIKeysConfigValue string
 
@@ -232,20 +230,6 @@ func NewSecretsDirLookup(secretsDir string) env.Lookup {
 		// File does not exist
 		return "", false
 	}
-}
-
-type notFoundErr string
-
-func isNotFoundErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := err.(notFoundErr)
-	return ok
-}
-
-func (n notFoundErr) Error() string {
-	return fmt.Sprintf("could not find secret file: %s", string(n))
 }
 
 // NewConfigFileLookup - Load the configuration values in the specified config file if it exists

--- a/src/jetstream/api/config/config.go
+++ b/src/jetstream/api/config/config.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -190,11 +189,12 @@ func SetStructFieldValue(value reflect.Value, field reflect.Value, val string) e
 	case reflect.String:
 		apiKeysConfigType := reflect.TypeOf((*APIKeysConfigValue)(nil)).Elem()
 		userEndpointsConfigType := reflect.TypeOf((*UserEndpointsConfigValue)(nil)).Elem()
-		if typ == apiKeysConfigType {
+		switch typ {
+		case apiKeysConfigType:
 			newVal, err = parseAPIKeysConfigValue(val)
-		} else if typ == userEndpointsConfigType {
+		case userEndpointsConfigType:
 			newVal, err = parseUserEndpointsConfigValue(val)
-		} else {
+		default:
 			newVal = val
 		}
 	default:
@@ -218,11 +218,11 @@ func SetStructFieldValue(value reflect.Value, field reflect.Value, val string) e
 // in /etc/secrets/hello-there
 func NewSecretsDirLookup(secretsDir string) env.Lookup {
 	return func(name string) (string, bool) {
-		name = strings.ToLower(strings.Replace(name, "_", "-", -1))
+		name = strings.ToLower(strings.ReplaceAll(name, "_", "-"))
 		filename := filepath.Join(secretsDir, name)
 
 		if _, err := os.Stat(filename); err == nil {
-			contents, err := ioutil.ReadFile(filename)
+			contents, err := os.ReadFile(filename)
 			if err != nil {
 				log.Warnf("Error reading secrets file: %s, %s", filename, err)
 				return "", false

--- a/src/jetstream/api/config/config.go
+++ b/src/jetstream/api/config/config.go
@@ -261,7 +261,9 @@ func NewConfigFileLookup(path string) env.Lookup {
 		log.Warn("Error reading configuration file, ignoring this file: ", err)
 		return env.NoopLookup
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	loadedConfig := make(map[string]string)
 	scanner := bufio.NewScanner(file)

--- a/src/jetstream/api/errors.go
+++ b/src/jetstream/api/errors.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -67,7 +67,7 @@ func LogHTTPError(r *http.Response, innerErr error) error {
 		defer func() {
 			_ = r.Body.Close()
 		}()
-		if bb, err := ioutil.ReadAll(r.Body); err == nil {
+		if bb, err := io.ReadAll(r.Body); err == nil {
 			b = bb
 		}
 		status = r.StatusCode

--- a/src/jetstream/api/errors.go
+++ b/src/jetstream/api/errors.go
@@ -64,7 +64,9 @@ func LogHTTPError(r *http.Response, innerErr error) error {
 	b := []byte("No request body")
 	status := 0
 	if r != nil {
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 		if bb, err := ioutil.ReadAll(r.Body); err == nil {
 			b = bb
 		}

--- a/src/jetstream/api/websocket.go
+++ b/src/jetstream/api/websocket.go
@@ -42,17 +42,20 @@ func UpgradeToWebSocket(echoContext echo.Context) (*websocket.Conn, *time.Ticker
 	log.Debugf("Successfully upgraded to a WebSocket connection")
 
 	// HSC-1276 - handle pong messages and reset the read deadline
-	clientWebSocket.SetReadDeadline(time.Now().Add(pongWait))
+	if err := clientWebSocket.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+		log.Warnf("Unable to set read deadline on the WebSocket connection: %v", err)
+	}
 	clientWebSocket.SetPongHandler(func(string) error {
-		clientWebSocket.SetReadDeadline(time.Now().Add(pongWait))
-		return nil
+		return clientWebSocket.SetReadDeadline(time.Now().Add(pongWait))
 	})
 
 	// HSC-1276 - send regular Pings to prevent the WebSocket being closed on us
 	ticker := time.NewTicker(pingPeriod)
 	go func() {
 		for range ticker.C {
-			clientWebSocket.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(pingWriteTimeout))
+			if err := clientWebSocket.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(pingWriteTimeout)); err != nil {
+				log.Errorf("Web socket ping error: %+v", err)
+			}
 		}
 	}()
 

--- a/src/jetstream/apikeys.go
+++ b/src/jetstream/apikeys.go
@@ -10,10 +10,11 @@ import (
 )
 
 func (p *portalProxy) checkIfAPIKeysEnabled(userGUID string) error {
-	if p.Config.APIKeysEnabled == config.APIKeysConfigEnum.Disabled {
+	switch p.Config.APIKeysEnabled {
+	case config.APIKeysConfigEnum.Disabled:
 		log.Info("API keys are disabled")
 		return errors.New("API keys are disabled")
-	} else if p.Config.APIKeysEnabled == config.APIKeysConfigEnum.AdminOnly {
+	case config.APIKeysConfigEnum.AdminOnly:
 		user, err := p.StratosAuthService.GetUser(userGUID)
 		if err != nil {
 			return err

--- a/src/jetstream/apikeys_test.go
+++ b/src/jetstream/apikeys_test.go
@@ -30,7 +30,7 @@ func Test_addAPIKey(t *testing.T) {
 		mockStratosAuth := mock_api.NewMockStratosAuth(ctrl)
 		pp := makeMockServer(mockAPIRepo, mockStratosAuth)
 		defer ctrl.Finish()
-		defer pp.DatabaseConnectionPool.Close()
+		defer func() { _ = pp.DatabaseConnectionPool.Close() }()
 
 		Convey("when API keys are disabled", func() {
 			pp.Config.APIKeysEnabled = config.APIKeysConfigEnum.Disabled
@@ -231,7 +231,7 @@ func Test_listAPIKeys(t *testing.T) {
 	mockStratosAuth := mock_api.NewMockStratosAuth(ctrl)
 	pp := makeMockServer(mockAPIRepo, mockStratosAuth)
 	defer ctrl.Finish()
-	defer pp.DatabaseConnectionPool.Close()
+	defer func() { _ = pp.DatabaseConnectionPool.Close() }()
 
 	Convey("Given a request to list API keys", t, func() {
 		userID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
@@ -320,7 +320,7 @@ func Test_deleteAPIKeys(t *testing.T) {
 	mockStratosAuth := mock_api.NewMockStratosAuth(ctrl)
 	pp := makeMockServer(mockAPIRepo, mockStratosAuth)
 	defer ctrl.Finish()
-	defer pp.DatabaseConnectionPool.Close()
+	defer func() { _ = pp.DatabaseConnectionPool.Close() }()
 
 	userID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	keyID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"

--- a/src/jetstream/auth_test.go
+++ b/src/jetstream/auth_test.go
@@ -829,10 +829,14 @@ func TestLogout(t *testing.T) {
 			}
 		}
 
-		pp.StratosAuthService.Logout(ctx)
+		err = pp.StratosAuthService.Logout(ctx)
 
 		header := res.Header()
 		setCookie := header.Get("Set-Cookie")
+
+		Convey("Should not return an error", func() {
+			So(err, ShouldBeNil)
+		})
 
 		Convey("Should unset Cookie", func() {
 			So(setCookie, ShouldNotStartWith, "console-session=")

--- a/src/jetstream/authcnsi.go
+++ b/src/jetstream/authcnsi.go
@@ -61,8 +61,7 @@ func (p *portalProxy) ssoLoginToCNSI(c echo.Context) error {
 		returnURL := getSSORedirectURI(state, state, endpointGUID)
 		redirectURL := fmt.Sprintf("%s/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s",
 			cnsiRecord.AuthorizationEndpoint, cnsiRecord.ClientId, url.QueryEscape(returnURL))
-		c.Redirect(http.StatusTemporaryRedirect, redirectURL)
-		return nil
+		return c.Redirect(http.StatusTemporaryRedirect, redirectURL)
 	}
 
 	// Callback
@@ -74,8 +73,7 @@ func (p *portalProxy) ssoLoginToCNSI(c echo.Context) error {
 
 	// Take the user back to Stratos on the endpoints page
 	redirect := fmt.Sprintf("/endpoints?cnsi_guid=%s&status=%s", endpointGUID, status)
-	c.Redirect(http.StatusTemporaryRedirect, redirect)
-	return nil
+	return c.Redirect(http.StatusTemporaryRedirect, redirect)
 }
 
 // Connect to the given Endpoint
@@ -131,8 +129,8 @@ func (p *portalProxy) loginToCNSI(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 func (p *portalProxy) DoLoginToCNSI(c echo.Context, cnsiGUID string, systemSharedToken bool) (*api.LoginRes, error) {
@@ -173,7 +171,9 @@ func (p *portalProxy) DoLoginToCNSI(c echo.Context, cnsiGUID string, systemShare
 			if (cnsi.Creator == userID || len(cnsi.Creator) == 0) && cnsi.GUID != cnsiGUID {
 				_, ok := p.GetCNSITokenRecord(cnsi.GUID, userID)
 				if ok {
-					p.ClearCNSIToken(*cnsi, userID)
+					if clearErr := p.ClearCNSIToken(*cnsi, userID); clearErr != nil {
+						log.Warnf("Unable to clear token for endpoint %s: %v", cnsi.GUID, clearErr)
+					}
 				}
 			}
 		}
@@ -229,7 +229,9 @@ func (p *portalProxy) DoLoginToCNSI(c echo.Context, cnsiGUID string, systemShare
 			err = endpointPlugin.Validate(userID, cnsiRecord, *tokenRecord)
 			if err != nil {
 				// Clear the token
-				p.ClearCNSIToken(cnsiRecord, userID)
+				if clearErr := p.ClearCNSIToken(cnsiRecord, userID); clearErr != nil {
+					log.Warnf("Unable to clear token for endpoint %s: %v", cnsiGUID, clearErr)
+				}
 				return nil, api.NewHTTPShadowError(
 					http.StatusBadRequest,
 					"Could not connect to the endpoint",
@@ -299,7 +301,9 @@ func (p *portalProxy) DoLoginToCNSIwithConsoleUAAtoken(c echo.Context, theCNSIre
 			repo, dbErr := p.GetStoreFactory().EndpointStore()
 			if dbErr == nil {
 				theCNSIrecord.SSOAllowed = true
-				repo.Update(theCNSIrecord, p.Config.EncryptionKeyInBytes)
+				if updateErr := repo.Update(theCNSIrecord, p.Config.EncryptionKeyInBytes); updateErr != nil {
+					log.Warnf("Unable to update endpoint %s to allow SSO login: %v", theCNSIrecord.GUID, updateErr)
+				}
 			}
 			// Return error from the login
 			return err

--- a/src/jetstream/authcnsi.go
+++ b/src/jetstream/authcnsi.go
@@ -489,7 +489,6 @@ func (p *portalProxy) GetCNSIUserFromBasicToken(cnsiGUID string, cfTokenRecord *
 
 func (p *portalProxy) GetCNSIUserFromOAuthToken(cnsiGUID string, cfTokenRecord *api.TokenRecord) (*api.ConnectedUser, bool) {
 	var cnsiUser *api.ConnectedUser
-	var scope = []string{}
 
 	// get the scope out of the JWT token data
 	userTokenInfo, err := p.GetUserTokenInfo(cfTokenRecord.AuthToken)
@@ -505,7 +504,7 @@ func (p *portalProxy) GetCNSIUserFromOAuthToken(cnsiGUID string, cfTokenRecord *
 		Name:   userTokenInfo.UserName,
 		Scopes: userTokenInfo.Scope,
 	}
-	scope = userTokenInfo.Scope
+	scope := userTokenInfo.Scope
 
 	// is the user an CF admin?
 	cnsiRecord, err := p.GetCNSIRecord(cnsiGUID)

--- a/src/jetstream/authlocal.go
+++ b/src/jetstream/authlocal.go
@@ -188,7 +188,7 @@ func (a *localAuth) generateLoginSuccessResponse(c echo.Context, userGUID string
 	log.Debug("generateLoginResponse")
 
 	var err error
-	var expiry int64 = sessionNeverExpires
+	expiry := sessionNeverExpires
 
 	sessionValues := make(map[string]interface{})
 	sessionValues["user_id"] = userGUID

--- a/src/jetstream/authlocal.go
+++ b/src/jetstream/authlocal.go
@@ -22,7 +22,6 @@ import (
 type localAuth struct {
 	databaseConnectionPool *sql.DB
 	localUserScope         string
-	consoleAdminScope      string
 	p                      *portalProxy
 }
 

--- a/src/jetstream/authlocal.go
+++ b/src/jetstream/authlocal.go
@@ -217,7 +217,9 @@ func (a *localAuth) generateLoginSuccessResponse(c echo.Context, userGUID string
 		// Add XSRF Token
 		a.p.ensureXSRFToken(c)
 		c.Response().Header().Set("Content-Type", "application/json")
-		c.Response().Write(jsonString)
+		if _, err := c.Response().Write(jsonString); err != nil {
+			return err
+		}
 	}
 
 	return err
@@ -230,7 +232,9 @@ func (a *localAuth) logout(c echo.Context) error {
 	a.p.removeEmptyCookie(c)
 
 	// Remove the XSRF Token from the session
-	a.p.unsetSessionValue(c, XSRFTokenSessionName)
+	if err := a.p.unsetSessionValue(c, XSRFTokenSessionName); err != nil {
+		log.Warnf("Unable to remove XSRF token from session: %v", err)
+	}
 
 	err := a.p.clearSession(c)
 	if err != nil {

--- a/src/jetstream/authnone.go
+++ b/src/jetstream/authnone.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"math"
 	"net/http"
@@ -26,8 +25,6 @@ const (
 // More fields will be moved into here as global portalProxy struct is phased out
 type noAuth struct {
 	databaseConnectionPool *sql.DB
-	localUserScope         string
-	consoleAdminScope      string
 	p                      *portalProxy
 }
 
@@ -66,14 +63,14 @@ func (a *noAuth) GetUser(userGUID string) (*api.ConnectedUser, error) {
 }
 
 func (a *noAuth) BeforeVerifySession(c echo.Context) {
-	var err error
 	expiry := sessionNeverExpires
 
-	session, err := a.p.GetSession(c)
-	if err != nil {
+	if _, err := a.p.GetSession(c); err != nil {
 		// No session, so create one
-		session, err = a.p.NewSession(c)
-		if saveErr := a.p.SaveSession(c, session); saveErr != nil {
+		session, newErr := a.p.NewSession(c)
+		if newErr != nil {
+			log.Warnf("Unable to create session: %v", newErr)
+		} else if saveErr := a.p.SaveSession(c, session); saveErr != nil {
 			log.Warnf("Unable to save session: %v", saveErr)
 		}
 	}
@@ -85,9 +82,9 @@ func (a *noAuth) BeforeVerifySession(c echo.Context) {
 	// Ensure that login disregards cookies from the request
 	req := c.Request()
 	req.Header.Set("Cookie", "")
-	if err = a.p.setSessionValues(c, sessionValues); err == nil {
+	if err := a.p.setSessionValues(c, sessionValues); err == nil {
 		//Makes sure the client gets the right session expiry time
-		if err = a.p.handleSessionExpiryHeader(c); err != nil {
+		if err := a.p.handleSessionExpiryHeader(c); err != nil {
 			log.Warnf("Unable to set session expiry header: %v", err)
 		}
 	}
@@ -96,48 +93,6 @@ func (a *noAuth) BeforeVerifySession(c echo.Context) {
 // VerifySession for no authentication - always passes
 func (a *noAuth) VerifySession(c echo.Context, sessionUser string, sessionExpireTime int64) error {
 	return nil
-}
-
-// generateLoginSuccessResponse
-func (a *noAuth) generateLoginSuccessResponse(c echo.Context, userGUID string, username string) error {
-	log.Debug("generateLoginResponse")
-
-	var err error
-	expiry := sessionNeverExpires
-
-	sessionValues := make(map[string]interface{})
-	sessionValues["user_id"] = userGUID
-	sessionValues["exp"] = expiry
-
-	// Ensure that login disregards cookies from the request
-	req := c.Request()
-	req.Header.Set("Cookie", "")
-	if err = a.p.setSessionValues(c, sessionValues); err != nil {
-		return err
-	}
-
-	//Makes sure the client gets the right session expiry time
-	if err = a.p.handleSessionExpiryHeader(c); err != nil {
-		return err
-	}
-
-	resp := &api.LoginRes{
-		Account:     username,
-		TokenExpiry: expiry,
-		APIEndpoint: nil,
-		Admin:       true,
-	}
-
-	if jsonString, err := json.Marshal(resp); err == nil {
-		// Add XSRF Token
-		a.p.ensureXSRFToken(c)
-		c.Response().Header().Set("Content-Type", "application/json")
-		if _, err := c.Response().Write(jsonString); err != nil {
-			return err
-		}
-	}
-
-	return err
 }
 
 // logout

--- a/src/jetstream/authnone.go
+++ b/src/jetstream/authnone.go
@@ -67,7 +67,7 @@ func (a *noAuth) GetUser(userGUID string) (*api.ConnectedUser, error) {
 
 func (a *noAuth) BeforeVerifySession(c echo.Context) {
 	var err error
-	var expiry int64 = sessionNeverExpires
+	expiry := sessionNeverExpires
 
 	session, err := a.p.GetSession(c)
 	if err != nil {
@@ -103,7 +103,7 @@ func (a *noAuth) generateLoginSuccessResponse(c echo.Context, userGUID string, u
 	log.Debug("generateLoginResponse")
 
 	var err error
-	var expiry int64 = sessionNeverExpires
+	expiry := sessionNeverExpires
 
 	sessionValues := make(map[string]interface{})
 	sessionValues["user_id"] = userGUID

--- a/src/jetstream/authnone.go
+++ b/src/jetstream/authnone.go
@@ -73,7 +73,9 @@ func (a *noAuth) BeforeVerifySession(c echo.Context) {
 	if err != nil {
 		// No session, so create one
 		session, err = a.p.NewSession(c)
-		a.p.SaveSession(c, session)
+		if saveErr := a.p.SaveSession(c, session); saveErr != nil {
+			log.Warnf("Unable to save session: %v", saveErr)
+		}
 	}
 
 	sessionValues := make(map[string]interface{})
@@ -85,7 +87,9 @@ func (a *noAuth) BeforeVerifySession(c echo.Context) {
 	req.Header.Set("Cookie", "")
 	if err = a.p.setSessionValues(c, sessionValues); err == nil {
 		//Makes sure the client gets the right session expiry time
-		a.p.handleSessionExpiryHeader(c)
+		if err = a.p.handleSessionExpiryHeader(c); err != nil {
+			log.Warnf("Unable to set session expiry header: %v", err)
+		}
 	}
 }
 
@@ -128,7 +132,9 @@ func (a *noAuth) generateLoginSuccessResponse(c echo.Context, userGUID string, u
 		// Add XSRF Token
 		a.p.ensureXSRFToken(c)
 		c.Response().Header().Set("Content-Type", "application/json")
-		c.Response().Write(jsonString)
+		if _, err := c.Response().Write(jsonString); err != nil {
+			return err
+		}
 	}
 
 	return err
@@ -141,7 +147,9 @@ func (a *noAuth) logout(c echo.Context) error {
 	a.p.removeEmptyCookie(c)
 
 	// Remove the XSRF Token from the session
-	a.p.unsetSessionValue(c, XSRFTokenSessionName)
+	if err := a.p.unsetSessionValue(c, XSRFTokenSessionName); err != nil {
+		log.Warnf("Unable to remove XSRF token from session: %v", err)
+	}
 
 	err := a.p.clearSession(c)
 	if err != nil {

--- a/src/jetstream/authuaa.go
+++ b/src/jetstream/authuaa.go
@@ -24,7 +24,6 @@ const UAAAdminIdentifier = "stratos.admin"
 type uaaAuth struct {
 	databaseConnectionPool *sql.DB
 	p                      *portalProxy
-	skipSSLValidation      bool
 }
 
 func (a *uaaAuth) ShowConfig(config *api.ConsoleConfig) {

--- a/src/jetstream/authuaa.go
+++ b/src/jetstream/authuaa.go
@@ -61,9 +61,9 @@ func (a *uaaAuth) Login(c echo.Context) error {
 	a.p.ensureXSRFToken(c)
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
+	_, err = c.Response().Write(jsonString)
 
-	return nil
+	return err
 }
 
 // Logout provides UAA-auth specific Stratos login
@@ -170,7 +170,9 @@ func (a *uaaAuth) logout(c echo.Context) error {
 	a.p.removeEmptyCookie(c)
 
 	// Remove the XSRF Token from the session
-	a.p.unsetSessionValue(c, XSRFTokenSessionName)
+	if err := a.p.unsetSessionValue(c, XSRFTokenSessionName); err != nil {
+		log.Warnf("Unable to remove XSRF token from session: %v", err)
+	}
 
 	err := a.p.clearSession(c)
 	if err != nil {
@@ -374,7 +376,7 @@ func (p *portalProxy) getUAAToken(body url.Values, skipSSLValidation bool, clien
 		return nil, api.LogHTTPError(res, err)
 	}
 
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	var response api.UAAResponse
 
@@ -529,8 +531,7 @@ func (p *portalProxy) initSSOlogin(c echo.Context) error {
 	}
 
 	redirectURL := fmt.Sprintf("%s/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s", p.Config.ConsoleConfig.AuthorizationEndpoint, p.Config.ConsoleConfig.ConsoleClient, url.QueryEscape(getSSORedirectURI(state, state, "")))
-	c.Redirect(http.StatusTemporaryRedirect, redirectURL)
-	return nil
+	return c.Redirect(http.StatusTemporaryRedirect, redirectURL)
 }
 
 func validateSSORedirectState(state string, allowListStr string) error {

--- a/src/jetstream/cnsi.go
+++ b/src/jetstream/cnsi.go
@@ -96,8 +96,7 @@ func (p *portalProxy) RegisterEndpoint(c echo.Context, fetchInfo api.InfoFunc) e
 		return err
 	}
 
-	c.JSON(http.StatusCreated, newCNSI)
-	return nil
+	return c.JSON(http.StatusCreated, newCNSI)
 }
 
 func (p *portalProxy) DoRegisterEndpoint(cnsiName string, apiEndpoint string, skipSSLValidation bool, clientId string, clientSecret string, userId string, ssoAllowed bool, subType string, createSystemEndpoint bool, caCert string, fetchInfo api.InfoFunc) (api.CNSIRecord, error) {
@@ -213,13 +212,18 @@ func (p *portalProxy) unregisterCluster(c echo.Context) error {
 func (p *portalProxy) doUnregisterCluster(cnsiGUID string) error {
 	log.Debug("doUnregisterCluster")
 
-	// Should check for errors?
-	p.unsetCNSIRecord(cnsiGUID)
+	if err := p.unsetCNSIRecord(cnsiGUID); err != nil {
+		return err
+	}
 
-	p.unsetCNSITokenRecords(cnsiGUID)
+	if err := p.unsetCNSITokenRecords(cnsiGUID); err != nil {
+		log.Warnf("Unable to remove tokens for unregistered endpoint %s: %v", cnsiGUID, err)
+	}
 
 	ufe := userfavoritesendpoints.Constructor(p, cnsiGUID)
-	ufe.RemoveFavorites()
+	if err := ufe.RemoveFavorites(); err != nil {
+		log.Warnf("Unable to remove favorites for unregistered endpoint %s: %v", cnsiGUID, err)
+	}
 
 	return nil
 }
@@ -376,8 +380,8 @@ func (p *portalProxy) listCNSIs(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 func (p *portalProxy) listRegisteredCNSIs(c echo.Context) error {
@@ -415,8 +419,8 @@ func (p *portalProxy) listRegisteredCNSIs(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 func marshalCNSIlist(cnsiList []*api.CNSIRecord) ([]byte, error) {

--- a/src/jetstream/cnsi.go
+++ b/src/jetstream/cnsi.go
@@ -384,45 +384,6 @@ func (p *portalProxy) listCNSIs(c echo.Context) error {
 	return err
 }
 
-func (p *portalProxy) listRegisteredCNSIs(c echo.Context) error {
-	log.Debug("listRegisteredCNSIs")
-	userGUIDIntf, err := p.GetSessionValue(c, "user_id")
-	if err != nil {
-		return api.NewHTTPShadowError(
-			http.StatusBadRequest,
-			"User session could not be found",
-			"User session could not be found: %v", err,
-		)
-	}
-	userGUID := userGUIDIntf.(string)
-
-	cnsiRepo, err := p.GetStoreFactory().EndpointStore()
-	if err != nil {
-		return fmt.Errorf("listRegisteredCNSIs: %s", err)
-	}
-
-	var jsonString []byte
-	var clusterList []*api.ConnectedEndpoint
-
-	clusterList, err = cnsiRepo.ListByUser(userGUID)
-	if err != nil {
-		return api.NewHTTPShadowError(
-			http.StatusBadRequest,
-			"Failed to retrieve list of clusters",
-			"Failed to retrieve list of clusters: %v", err,
-		)
-	}
-
-	jsonString, err = marshalClusterList(clusterList)
-	if err != nil {
-		return err
-	}
-
-	c.Response().Header().Set("Content-Type", "application/json")
-	_, err = c.Response().Write(jsonString)
-	return err
-}
-
 func marshalCNSIlist(cnsiList []*api.CNSIRecord) ([]byte, error) {
 	log.Debug("marshalCNSIlist")
 	jsonString, err := json.Marshal(cnsiList)
@@ -431,19 +392,6 @@ func marshalCNSIlist(cnsiList []*api.CNSIRecord) ([]byte, error) {
 			http.StatusBadRequest,
 			"Failed to retrieve list of CNSIs",
 			"Failed to retrieve list of CNSIs: %v", err,
-		)
-	}
-	return jsonString, nil
-}
-
-func marshalClusterList(clusterList []*api.ConnectedEndpoint) ([]byte, error) {
-	log.Debug("marshalClusterList")
-	jsonString, err := json.Marshal(clusterList)
-	if err != nil {
-		return nil, api.NewHTTPShadowError(
-			http.StatusBadRequest,
-			"Failed to retrieve list of clusters",
-			"Failed to retrieve list of clusters: %v", err,
 		)
 	}
 	return jsonString, nil
@@ -510,13 +458,6 @@ func (p *portalProxy) GetAdminCNSIRecordByEndpoint(endpoint string) (api.CNSIRec
 	rec.APIEndpoint.Path = strings.TrimRight(rec.APIEndpoint.Path, "/")
 
 	return *rec, nil
-}
-
-func (p *portalProxy) adminCNSIRecordExists(apiEndpoint string) bool {
-	log.Debug("adminCNSIRecordExists")
-
-	_, err := p.GetAdminCNSIRecordByEndpoint(apiEndpoint)
-	return err == nil
 }
 
 func (p *portalProxy) setCNSIRecord(guid string, c api.CNSIRecord) error {

--- a/src/jetstream/crypto/aes.go
+++ b/src/jetstream/crypto/aes.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -35,7 +35,10 @@ func Encrypt(key, text []byte) (ciphertext []byte, err error) {
 		return
 	}
 
-	cfb := cipher.NewCFBEncrypter(block, iv)
+	// CFB is deprecated upstream, but all persisted ciphertexts (endpoint
+	// tokens, client secrets) are CFB-encrypted; switching modes requires a
+	// versioned re-encryption migration, not a drop-in replacement.
+	cfb := cipher.NewCFBEncrypter(block, iv) //nolint:staticcheck
 	cfb.XORKeyStream(ciphertext[aes.BlockSize:], text)
 
 	return
@@ -63,7 +66,8 @@ func Decrypt(key, ciphertext []byte) (plaintext []byte, err error) {
 	iv := ciphertext[:aes.BlockSize]
 	ciphertext = ciphertext[aes.BlockSize:]
 
-	cfb := cipher.NewCFBDecrypter(block, iv)
+	// See Encrypt: CFB retained for compatibility with persisted ciphertexts.
+	cfb := cipher.NewCFBDecrypter(block, iv) //nolint:staticcheck
 	cfb.XORKeyStream(ciphertext, ciphertext)
 
 	plaintext = ciphertext
@@ -79,7 +83,7 @@ func ReadEncryptionKey(v, f string) ([]byte, error) {
 	if string(f[0]) == "/" {
 		encryptionKey = fmt.Sprintf("%s/%s", v, f)
 	}
-	key64chars, err := ioutil.ReadFile(encryptionKey)
+	key64chars, err := os.ReadFile(encryptionKey)
 	if err != nil {
 		log.Errorf("Unable to read encryption key file: %+v\n", err)
 		return nil, err

--- a/src/jetstream/crypto/crypto_test.go
+++ b/src/jetstream/crypto/crypto_test.go
@@ -2,7 +2,6 @@ package crypto
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -92,13 +91,13 @@ func writeFakeEncryptionKey() error {
 	var err error
 
 	// create a temporary volume
-	FakeVolumeName, err = ioutil.TempDir("", "fake-volume")
+	FakeVolumeName, err = os.MkdirTemp("", "fake-volume")
 	if err != nil {
 		return err
 	}
 
 	key := filepath.Join(FakeVolumeName, FakeKeyName)
-	if err = ioutil.WriteFile(key, FakeKey, 0666); err != nil {
+	if err = os.WriteFile(key, FakeKey, 0666); err != nil {
 		return err
 	}
 

--- a/src/jetstream/crypto/crypto_test.go
+++ b/src/jetstream/crypto/crypto_test.go
@@ -52,7 +52,7 @@ func TestAESEncryptDecrypt(t *testing.T) {
 		})
 
 		Reset(func() {
-			os.RemoveAll(FakeVolumeName)
+			_ = os.RemoveAll(FakeVolumeName)
 		})
 
 	})

--- a/src/jetstream/datastore/20190930092500_LocalUsersTriggerFix.go
+++ b/src/jetstream/datastore/20190930092500_LocalUsersTriggerFix.go
@@ -27,7 +27,7 @@ func Up20190930092500(txn *sql.Tx) error {
 		// MYSQL
 		dropTrigger = "DROP TRIGGER IF EXISTS update_last_updated;"
 		// Ignore error - most likely permission bug issue on Mysql
-		txn.Exec(dropTrigger)
+		_, _ = txn.Exec(dropTrigger)
 		return nil
 	}
 

--- a/src/jetstream/datastore/datastore.go
+++ b/src/jetstream/datastore/datastore.go
@@ -143,14 +143,15 @@ func NewDatabaseConnectionParametersFromConfig(dc DatabaseConfig) (DatabaseConfi
 		return dc, err
 	}
 
-	if dc.DatabaseProvider == PGSQL {
+	switch dc.DatabaseProvider {
+	case PGSQL:
 		if dc.SSLMode == string(SSLDisabled) || dc.SSLMode == string(SSLRequired) ||
 			dc.SSLMode == string(SSLVerifyCA) || dc.SSLMode == string(SSLVerifyFull) {
 			return dc, nil
 		}
 		// Invalid SSL mode
 		return dc, fmt.Errorf("invalid SSL mode: %s", dc.SSLMode)
-	} else if dc.DatabaseProvider == MYSQL {
+	case MYSQL:
 		// Map default of disabled to false for MySQL
 		if dc.SSLMode == "disable" {
 			dc.SSLMode = "false"
@@ -218,13 +219,14 @@ func NewGooseDBConf(dc DatabaseConfig, env *env.VarSet) (*sql.DB, error) {
 
 	var openStr, name string
 
-	if dc.DatabaseProvider == PGSQL {
+	switch dc.DatabaseProvider {
+	case PGSQL:
 		name = "postgres"
 		openStr = buildConnectionString(dc)
-	} else if dc.DatabaseProvider == MYSQL {
+	case MYSQL:
 		name = "mysql"
 		openStr = buildConnectionStringForMysql(dc)
-	} else {
+	default:
 		name = "sqlite3"
 		sqlDbDir := env.String("SQLITE_DB_DIR", ".")
 		openStr = path.Join(sqlDbDir, SQLiteDatabaseFile)
@@ -249,7 +251,7 @@ func NewGooseDBConf(dc DatabaseConfig, env *env.VarSet) (*sql.DB, error) {
 func buildConnectionString(dc DatabaseConfig) string {
 	log.Debug("buildConnectionString")
 	escapeStr := func(in string) string {
-		return strings.Replace(in, `'`, `\'`, -1)
+		return strings.ReplaceAll(in, `'`, `\'`)
 	}
 
 	connStr := fmt.Sprintf("user='%s' password='%s' dbname='%s' host='%s' port=%d connect_timeout=%d",
@@ -288,7 +290,7 @@ func buildConnectionString(dc DatabaseConfig) string {
 func buildConnectionStringForMysql(dc DatabaseConfig) string {
 	log.Debug("buildConnectionStringForMysql")
 	escapeStr := func(in string) string {
-		return strings.Replace(in, `'`, `\'`, -1)
+		return strings.ReplaceAll(in, `'`, `\'`)
 	}
 
 	connStr := fmt.Sprintf("%s:%%s@tcp(%s:%d)/%s?parseTime=true",

--- a/src/jetstream/datastore/datastore.go
+++ b/src/jetstream/datastore/datastore.go
@@ -201,7 +201,9 @@ func GetInMemorySQLLiteConnection() (*sql.DB, error) {
 		return nil, err
 	}
 
-	goose.SetDialect("sqlite3")
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		return nil, err
+	}
 
 	err = ApplyMigrations(db)
 	if err != nil {
@@ -230,11 +232,15 @@ func NewGooseDBConf(dc DatabaseConfig, env *env.VarSet) (*sql.DB, error) {
 		log.Infof("SQLite Database file: %s", openStr)
 
 		if !sqliteKeepDB {
-			os.Remove(openStr)
+			if err := os.Remove(openStr); err != nil && !os.IsNotExist(err) {
+				log.Warnf("Unable to remove SQLite database file %s: %v", openStr, err)
+			}
 		}
 	}
 
-	goose.SetDialect(name)
+	if err := goose.SetDialect(name); err != nil {
+		return nil, err
+	}
 	db, err := sql.Open(name, openStr)
 
 	return db, err

--- a/src/jetstream/datastore/datastore_test.go
+++ b/src/jetstream/datastore/datastore_test.go
@@ -49,7 +49,7 @@ func TestDatastore(t *testing.T) {
 		if err != nil {
 			t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
 		}
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 
 		Convey("when the database config is valid", func() {
 
@@ -255,7 +255,7 @@ func TestDatastore(t *testing.T) {
 		if err != nil {
 			t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
 		}
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 
 		Convey("when the database config is valid", func() {
 
@@ -437,7 +437,7 @@ func TestDatastore(t *testing.T) {
 		if err != nil {
 			t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
 		}
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 
 		Convey("when the cloudfoundry database config is present", func() {
 

--- a/src/jetstream/http_client.go
+++ b/src/jetstream/http_client.go
@@ -23,7 +23,6 @@ var (
 	defaultHTTPClientTimeout           int64
 	defaultHTTPClientMutatingTimeout   int64
 	defaultHTTPClientConnectionTimeout int64
-	defaultDialer                      net.Dialer
 )
 
 func initializeHTTPClients(timeout int64, timeoutMutating int64, connectionTimeout int64) {

--- a/src/jetstream/info.go
+++ b/src/jetstream/info.go
@@ -161,7 +161,9 @@ func (p *portalProxy) getInfo(c echo.Context) (*api.Info, error) {
 func marshalEndpointMetadata(metadata string) interface{} {
 	if len(metadata) > 2 && strings.Index(metadata, "{") == 0 {
 		var anyJSON map[string]interface{}
-		json.Unmarshal([]byte(metadata), &anyJSON)
+		if err := json.Unmarshal([]byte(metadata), &anyJSON); err != nil {
+			return metadata
+		}
 		return anyJSON
 	} else {
 		return metadata

--- a/src/jetstream/localusers_test.go
+++ b/src/jetstream/localusers_test.go
@@ -15,10 +15,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const (
-	insertLocalUserSQL = `INSERT INTO local_users (user_guid, password_hash, user_name, user_email, user_scope) VALUES ($1, $2, $3, $4, $5)`
-)
-
 func TestAddLocalUser(t *testing.T) {
 	t.Parallel()
 
@@ -34,6 +30,7 @@ func TestAddLocalUser(t *testing.T) {
 
 		mock.ExpectExec(addLocalUser).WillReturnResult(sqlmock.NewResult(1, 1))
 		guid, err := pp.AddLocalUser(ctx)
+		So(err, ShouldBeNil)
 
 		expectedGUIDRow := sqlmock.NewRows([]string{"user_guid"}).AddRow(guid)
 		mock.ExpectQuery(findUserGUID).WillReturnRows(expectedGUIDRow)
@@ -118,6 +115,7 @@ func TestAddLocalUserDuplicate(t *testing.T) {
 
 		mock.ExpectExec(addLocalUser).WillReturnResult(sqlmock.NewResult(1, 1))
 		guid, err := pp.AddLocalUser(ctx)
+		So(err, ShouldBeNil)
 
 		//Check that the new local user has been added correctly before we try to add a duplicate
 		expectedGUIDRow := sqlmock.NewRows([]string{"user_guid"}).AddRow(guid)
@@ -182,6 +180,7 @@ func TestFindPasswordHash(t *testing.T) {
 		expectedHashRow := sqlmock.NewRows([]string{"password_hash"}).AddRow(generatedPasswordHash)
 		mock.ExpectQuery(findPasswordHash).WillReturnRows(expectedHashRow)
 		fetchedPasswordHash, err := localUsersRepo.FindPasswordHash(userGUID)
+		So(err, ShouldBeNil)
 
 		Convey("Password hashes should match", func() {
 			So(fetchedPasswordHash, ShouldResemble, generatedPasswordHash)

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -156,7 +156,9 @@ func main() {
 
 	if isUpgrading {
 		log.Info("Upgrade in progress (lock file detected) ... waiting for lock file to be removed ...")
-		start(portalConfig, &portalProxy{env: envLookup}, false, true, envLookup)
+		if err := start(portalConfig, &portalProxy{env: envLookup}, false, true, envLookup); err != nil {
+			log.Warnf("Unable to start upgrade web server instance: %v", err)
+		}
 	}
 	// Grab the Console Version from the executable
 	portalConfig.ConsoleVersion = appVersion
@@ -200,7 +202,7 @@ func main() {
 	}
 	defer func() {
 		log.Info(`... Closing database connection pool`)
-		databaseConnectionPool.Close()
+		_ = databaseConnectionPool.Close()
 	}()
 	log.Info("Database connection pool created.")
 
@@ -301,7 +303,7 @@ func main() {
 
 		// Database connection pool
 		log.Info(`... Closing database connection pool`)
-		databaseConnectionPool.Close()
+		_ = databaseConnectionPool.Close()
 
 		// Session store
 		log.Info(`... Closing session store`)
@@ -675,7 +677,7 @@ func newPortalProxy(pc api.PortalConfig, dcp *sql.DB, ss HttpSessionStore, sessi
 	domain := pc.CookieDomain
 	if len(domain) > 0 && domain != "-" {
 		h := sha1.New()
-		io.WriteString(h, domain)
+		_, _ = io.WriteString(h, domain)
 		hash := fmt.Sprintf("%x", h.Sum(nil))
 		cookieName = fmt.Sprintf("%s-%s", jetstreamSessionName, hash[0:10])
 	}
@@ -1143,7 +1145,9 @@ func getUICustomHTTPErrorHandler(staticDir string, defaultHandler echo.HTTPError
 
 		// If this was not a back-end request and the error code is 404, serve the app and let it route
 		if strings.Index(c.Request().RequestURI, "/pp") != 0 && code == 404 {
-			c.File(path.Join(staticDir, "index.html"))
+			if fileErr := c.File(path.Join(staticDir, "index.html")); fileErr != nil {
+				log.Warnf("Unable to serve index.html: %v", fileErr)
+			}
 			// Let the default handler handle it
 			defaultHandler(err, c)
 		} else {
@@ -1173,10 +1177,14 @@ func echoV2DefaultHTTPErrorHandler(err error, c echo.Context) {
 
 	// Send response
 	if !c.Response().Committed {
+		var writeErr error
 		if c.Request().Method == http.MethodHead { // Issue #608
-			c.NoContent(code)
+			writeErr = c.NoContent(code)
 		} else {
-			c.String(code, msg)
+			writeErr = c.String(code, msg)
+		}
+		if writeErr != nil {
+			c.Logger().Error(writeErr)
 		}
 	}
 
@@ -1224,7 +1232,9 @@ func stopEchoWhenUpgraded(e *echo.Echo, env *env.VarSet) {
 		time.Sleep(1 * time.Second)
 	}
 	log.Info("Upgrade has completed! Shutting down Upgrade web server instance")
-	e.Close()
+	if err := e.Close(); err != nil {
+		log.Warnf("Unable to shut down Upgrade web server instance: %v", err)
+	}
 }
 
 // GetStoreFactory gets the store factory

--- a/src/jetstream/middleware.go
+++ b/src/jetstream/middleware.go
@@ -391,8 +391,8 @@ func (p *portalProxy) apiKeyMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 
 		apiKey, err := p.APIKeysRepository.GetAPIKeyBySecret(apiKeySecret)
 		if err != nil {
-			switch {
-			case err == sql.ErrNoRows:
+			switch err {
+			case sql.ErrNoRows:
 				log.Debug("apiKeyMiddleware: Invalid API key supplied")
 			default:
 				log.Errorf("apiKeyMiddleware: %v", err)

--- a/src/jetstream/middleware.go
+++ b/src/jetstream/middleware.go
@@ -421,7 +421,9 @@ func (p *portalProxy) apiKeyMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 		// some endpoints check not only the context store, but also the contents of the session store
 		sessionValues := make(map[string]interface{})
 		sessionValues["user_id"] = apiKey.UserGUID
-		p.setSessionValues(c, sessionValues)
+		if err := p.setSessionValues(c, sessionValues); err != nil {
+			log.Errorf("apiKeyMiddleware: %v", err)
+		}
 
 		err = p.APIKeysRepository.UpdateAPIKeyLastUsed(apiKey.GUID)
 		if err != nil {

--- a/src/jetstream/middleware.go
+++ b/src/jetstream/middleware.go
@@ -20,8 +20,6 @@ import (
 	"github.com/cloudfoundry/stratos/src/jetstream/api/config"
 )
 
-const cfSessionCookieName = "JSESSIONID"
-
 // Header to communicate the configured Cookie Domain
 const StratosDomainHeader = "x-stratos-domain"
 

--- a/src/jetstream/middleware_wiresize_test.go
+++ b/src/jetstream/middleware_wiresize_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// fakeProxy satisfies the *portalProxy shape wireSizeMiddleware needs —
-// only GetConfig() is exercised. Keeps the test self-contained so it can
-// run without the full DI graph.
-type fakeProxyForWireSize struct {
-	*portalProxy
-	diagEnabled bool
-}
-
 func newTestPortalProxy(diagEnabled bool) *portalProxy {
 	cfg := &api.PortalConfig{DiagnosticsEnabled: diagEnabled}
 	return &portalProxy{Config: *cfg}

--- a/src/jetstream/middleware_wiresize_test.go
+++ b/src/jetstream/middleware_wiresize_test.go
@@ -52,7 +52,7 @@ func TestWireSizeMiddleware_EmitsHeaderForJSONResponse(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
-	if string(rec.Body.Bytes()) != string(body) {
+	if rec.Body.String() != string(body) {
 		t.Errorf("body mismatch: got %q, want %q", rec.Body.String(), string(body))
 	}
 	h := rec.Header().Get("X-Stratos-Wire-Sizes")

--- a/src/jetstream/mock_server_test.go
+++ b/src/jetstream/mock_server_test.go
@@ -194,20 +194,10 @@ func expectCFRow() *sqlmock.Rows {
 		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, cipherClientSecret, true, "", "", "", "")
 }
 
-func expectCERow() *sqlmock.Rows {
-	return sqlmock.NewRows(datastore.GetColumnNamesForCSNIs()).
-		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, cipherClientSecret, true, "", "", "", "")
-}
-
 func expectCFAndCERows() *sqlmock.Rows {
 	return sqlmock.NewRows(datastore.GetColumnNamesForCSNIs()).
 		AddRow(mockCFGUID, "Some fancy CF Cluster", "cf", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, mockDopplerEndpoint, true, mockClientId, cipherClientSecret, false, "", "", "", "").
 		AddRow(mockCEGUID, "Some fancy HCE Cluster", "hce", mockAPIEndpoint, mockAuthEndpoint, mockAuthEndpoint, "", true, mockClientId, cipherClientSecret, false, "", "", "", "")
-}
-
-func expectTokenRow() *sqlmock.Rows {
-	return sqlmock.NewRows(datastore.GetColumnNamesForTokens()).
-		AddRow(mockTokenGUID, mockUAAToken, mockUAAToken, mockTokenExpiry, false, "OAuth2", "", mockUserGUID, nil, false)
 }
 
 func expectEncryptedTokenRow(mockEncryptionKey []byte) *sqlmock.Rows {
@@ -388,14 +378,6 @@ func setupMockServer(t *testing.T, modifiers ...mockServerFunc) *httptest.Server
 	return server
 }
 
-func urlMust(i string) *url.URL {
-	b, err := url.Parse(i)
-	if err != nil {
-		panic(err)
-	}
-	return b
-}
-
 const mockUAAToken = `eyJhbGciOiJSUzI1NiIsImtpZCI6ImxlZ2FjeS10b2tlbi1rZXkiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiI2ZGIyYTI5NGYyYWE0OGNlYjI1NDgzMDk4ZDNjY2Q3YyIsInN1YiI6Ijg4YmNlYWE1LWJkY2UtNDdiOC04MmYzLTRhZmMxNGYyNjZmOSIsInNjb3BlIjpbIm9wZW5pZCIsInNjaW0ucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIuYWRtaW4iLCJ1YWEudXNlciIsImNsb3VkX2NvbnRyb2xsZXIucmVhZCIsInBhc3N3b3JkLndyaXRlIiwicm91dGluZy5yb3V0ZXJfZ3JvdXBzLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLndyaXRlIiwiZG9wcGxlci5maXJlaG9zZSIsInNjaW0ud3JpdGUiXSwiY2xpZW50X2lkIjoiY2YiLCJjaWQiOiJjZiIsImF6cCI6ImNmIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9pZCI6Ijg4YmNlYWE1LWJkY2UtNDdiOC04MmYzLTRhZmMxNGYyNjZmOSIsIm9yaWdpbiI6InVhYSIsInVzZXJfbmFtZSI6ImFkbWluIiwiZW1haWwiOiJhZG1pbiIsImF1dGhfdGltZSI6MTQ2Nzc2OTgxNiwicmV2X3NpZyI6IjE0MGUwMjZiIiwiaWF0IjoxNDY3NzY5ODE2LCJleHAiOjE0Njc3NzA0MTYsImlzcyI6Imh0dHBzOi8vdWFhLmV4YW1wbGUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiYXVkIjpbImNmIiwib3BlbmlkIiwic2NpbSIsImNsb3VkX2NvbnRyb2xsZXIiLCJ1YWEiLCJwYXNzd29yZCIsInJvdXRpbmcucm91dGVyX2dyb3VwcyIsImRvcHBsZXIiXX0.q2u0JX42Qiwr0ZsBU5Y6bF74_0URWmmBYTLf8l7of_6huFoMkyqvirEYcbYbATt6Hz2zcN6xlXcInALxQ6nt6Jk01kZHRNYfuu6QziLHHw2o_dJWk9iipiermUze7BvSGtU_JXx45BSBNVFxvRxG9Yv54Lwa9FvyhMSmK3CI5S8NtVDchzrsH3sMsIjlTAb-L7sch-OOQ7ncWH1JoGMtw8sTbiaHvfNJQclSq8Ro11NUtRHiWeGFFxYIerzKO-TrSpDojFJrYVuK1m0YPmBDa_dY3cneRuppagRIn8oI0VFHF8BckrIqNCHvOMoVz6uzHebo9LK7H5z5SluxJ2vYUgPiHE_Tyo-7gELnNSy8qL4Bk9yTxNseeGiq13TSTGOtNnbrv1eq4ZeW7eafseLceKIZH2QZlXVzwd_aWbuKRv9ApDwy4AcSbpM0XtU89IjUEDoOf3IDWV2YZTZkEaXZ52Mhztb1O_IVpHyyks88P67RoANFt83MnCai9U3stCX45LEsg9oz2djrVnfHDzRNQVlg9hKJYbxsa2R5tpnftjhz-hfpsoPRxBkJDKM2islyd-gLqHtsERiZEoifu93VRE0Jvk6vaCNdStw7y4mq73Co6ykNUYA78SlT9lCwDJRQHTJiDWg33EeKpXne8joZbElwrKNcv93X1qxxvmp1wXQ bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImxlZ2FjeS10b2tlbi1rZXkiLCJ0eXAiOiJKV1QifQ.eyJqdGkiOiI2ZGIyYTI5NGYyYWE0OGNlYjI1NDgzMDk4ZDNjY2Q3Yy1yIiwic3ViIjoiODhiY2VhYTUtYmRjZS00N2I4LTgyZjMtNGFmYzE0ZjI2NmY5Iiwic2NvcGUiOlsib3BlbmlkIiwic2NpbS5yZWFkIiwiY2xvdWRfY29udHJvbGxlci5hZG1pbiIsInVhYS51c2VyIiwiY2xvdWRfY29udHJvbGxlci5yZWFkIiwicGFzc3dvcmQud3JpdGUiLCJyb3V0aW5nLnJvdXRlcl9ncm91cHMucmVhZCIsImNsb3VkX2NvbnRyb2xsZXIud3JpdGUiLCJkb3BwbGVyLmZpcmVob3NlIiwic2NpbS53cml0ZSJdLCJpYXQiOjE0Njc3Njk4MTYsImV4cCI6MTQ3MDM2MTgxNiwiY2lkIjoiY2YiLCJjbGllbnRfaWQiOiJjZiIsImlzcyI6Imh0dHBzOi8vdWFhLmV4YW1wbGUuY29tL29hdXRoL3Rva2VuIiwiemlkIjoidWFhIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9uYW1lIjoiYWRtaW4iLCJvcmlnaW4iOiJ1YWEiLCJ1c2VyX2lkIjoiODhiY2VhYTUtYmRjZS00N2I4LTgyZjMtNGFmYzE0ZjI2NmY5IiwicmV2X3NpZyI6IjE0MGUwMjZiIiwiYXVkIjpbImNmIiwib3BlbmlkIiwic2NpbSIsImNsb3VkX2NvbnRyb2xsZXIiLCJ1YWEiLCJwYXNzd29yZCIsInJvdXRpbmcucm91dGVyX2dyb3VwcyIsImRvcHBsZXIiXX0.K5M_isGkEBAN_MaXqkVvJfHG86rGIUkDgsHaFnoKOA1x5FNC4APDvhImWJZ8zbFHhXT3PYHTyeSf_HQaFDFUHFvGZUhSSry2ID4kdU5kRyZ-y3ydkv2mq32BlUQBSC9ap0r5vFTv7BY1yf2EcDaKGe4v4ODMhTm2SIkdTyk2ZcLXHIucS0xgSZdjgxNqh3pnKtmcFkw72-CyREW4_2Nbvn_7U2UNUCb2SeAuWmYaNAOkuGveB8jAhg9ftTrxn5GNtNe1sdVycm51X1O0dGPt_rLbwkRDCdNpm0La_xzLqZEl60_YUqwo33eOChFgqXB5y_0Pzs9gD__uExrIXYIgMsltFELXryyRUDKTTHZEEw1bnLTbQfF-GAnS0E0CaTU_kcDVqDYcqfh0TCcr7nGCEozExMPm3J0OGUSP3FQAD5mDICsKKcSIi_kIjggkJ87tuNAY6QOW1WzBoRizXJVS4jb3QOnrii2LmH786qBYJMX0nH__JRYEU-HWLi_OGXVTo03Pe9QcB8qJvbu2DGRfQdBfjhvgt2AItY4voJnZcjwT29q144C5wvJ2_W8cUzNY-Xw_tN_fWK4LWCu6KRNLVLO2MNbl0aOfkvb1U5NZJUpUUC2jG3cZM2c8232YNFKVjdjbf-Mlx17OxOYQ5XtG5BiSEj7BA6s5hWftUXEUchg`
 
 var mockTokenExpiry = time.Now().AddDate(0, 0, 1).Unix()
@@ -414,8 +396,6 @@ const (
 	mockClientSecret    = "big_secret"
 	mockProxyVersion    = 20161117141922
 	mockLogCache        = "https://log-cache.127.0.0.1"
-
-	stringCFType = "cf"
 
 	selectAnyFromTokens    = `SELECT (.+) FROM tokens WHERE (.+)`
 	insertIntoTokens       = `INSERT INTO tokens`
@@ -451,9 +431,4 @@ var mockApiRootResponse = api.ApiRoot{
 			Href: mockLogCache,
 		},
 	},
-}
-
-var mockInfoResponse = api.V2Info{
-	AuthorizationEndpoint: mockAuthEndpoint,
-	TokenEndpoint:         mockTokenEndpoint,
 }

--- a/src/jetstream/mock_server_test.go
+++ b/src/jetstream/mock_server_test.go
@@ -336,20 +336,21 @@ func setupMockEndpointServer(t *testing.T) *httptest.Server {
 		var responseBody []byte
 		var err error
 
-		if r.URL.Path == "/" {
+		switch r.URL.Path {
+		case "/":
 			responseBody, err = json.Marshal(mockApiRootResponse)
 
-		} else if r.URL.Path == "/v2/info" {
+		case "/v2/info":
 			responseBody, err = json.Marshal(mockV2InfoResponse)
 
-		} else if r.URL.Path == "/v3/info" {
+		case "/v3/info":
 			// CF plugin (e238c315b0) now probes /v3/info during capability detection.
 			// Return 404 silently so supportsV3 resolves to false in the tests that use
 			// this mock — they only care about v2-era registration behavior.
 			w.WriteHeader(http.StatusNotFound)
 			return
 
-		} else {
+		default:
 			t.Errorf("No API Setup path / or /v1/info, got path '%s'", r.URL.Path)
 		}
 

--- a/src/jetstream/oauth_requests.go
+++ b/src/jetstream/oauth_requests.go
@@ -44,8 +44,7 @@ func (p *portalProxy) OAuthHandlerFunc(cnsiRequest *api.CNSIRequest, req *http.R
 			}
 			req.Header.Set("Authorization", "bearer "+tokenRec.AuthToken)
 
-			var client http.Client
-			client = p.GetHttpClientForRequest(req, cnsi.SkipSSLValidation, cnsi.CACert)
+			client := p.GetHttpClientForRequest(req, cnsi.SkipSSLValidation, cnsi.CACert)
 			res, err := client.Do(req)
 			if err != nil {
 				return nil, fmt.Errorf("request failed: %v", err)

--- a/src/jetstream/oauth_requests_test.go
+++ b/src/jetstream/oauth_requests_test.go
@@ -43,16 +43,15 @@ func TestDoOauthFlowRequestWithValidToken(t *testing.T) {
 				return
 			}
 
-			if "/v2/info" != r.URL.Path {
+			if r.URL.Path != "/v2/info" {
 				t.Errorf("Wanted path '/v2/info', got path '%s'", r.URL.Path)
 			}
-			if "GET" != r.Method {
+			if r.Method != "GET" {
 				t.Errorf("Wanted method 'GET', got method '%s'", r.Method)
 			}
 			w.WriteHeader(http.StatusOK)
 			io.WriteString(w, "hi")
 			numReqs++
-			return
 		})) // end of mockCF
 
 		defer mockCF.Close()
@@ -156,16 +155,15 @@ func TestDoOauthFlowRequestWithExpiredToken(t *testing.T) {
 				return
 			}
 
-			if "/v2/info" != r.URL.Path {
+			if r.URL.Path != "/v2/info" {
 				t.Errorf("Wanted path '/v2/info', got path '%s'", r.URL.Path)
 			}
-			if "GET" != r.Method {
+			if r.Method != "GET" {
 				t.Errorf("Wanted method 'GET', got method '%s'", r.Method)
 			}
 			w.WriteHeader(http.StatusOK)
 			io.WriteString(w, "hi")
 			numReqs++
-			return
 		})) // end of mockCF
 
 		// close this explicitly here so we can thread-safely check the bool
@@ -288,16 +286,15 @@ func TestDoOauthFlowRequestWithFailedRefreshMethod(t *testing.T) {
 				return
 			}
 
-			if "/v2/info" != r.URL.Path {
+			if r.URL.Path != "/v2/info" {
 				t.Errorf("Wanted path '/v2/info', got path '%s'", r.URL.Path)
 			}
-			if "GET" != r.Method {
+			if r.Method != "GET" {
 				t.Errorf("Wanted method 'GET', got method '%s'", r.Method)
 			}
 			w.WriteHeader(http.StatusOK)
 			io.WriteString(w, "hi")
 			numReqs++
-			return
 		})) // end of mockCF
 
 		// do a GET against the CF mock server
@@ -420,16 +417,15 @@ func TestDoOauthFlowRequestWithInvalidCNSIRequest(t *testing.T) {
 				return
 			}
 
-			if "/v2/info" != r.URL.Path {
+			if r.URL.Path != "/v2/info" {
 				t.Errorf("Wanted path '/v2/info', got path '%s'", r.URL.Path)
 			}
-			if "GET" != r.Method {
+			if r.Method != "GET" {
 				t.Errorf("Wanted method 'GET', got method '%s'", r.Method)
 			}
 			w.WriteHeader(http.StatusOK)
 			io.WriteString(w, "hi")
 			numReqs++
-			return
 		})) // end of mockCF
 
 		req, _ := http.NewRequest("GET", mockCF.URL+"/v2/info", nil)
@@ -516,16 +512,15 @@ func TestRefreshTokenWithDatabaseErrorOnSave(t *testing.T) {
 				return
 			}
 
-			if "/v2/info" != r.URL.Path {
+			if r.URL.Path != "/v2/info" {
 				t.Errorf("Wanted path '/v2/info', got path '%s'", r.URL.Path)
 			}
-			if "GET" != r.Method {
+			if r.Method != "GET" {
 				t.Errorf("Wanted method 'GET', got method '%s'", r.Method)
 			}
 			w.WriteHeader(http.StatusOK)
 			io.WriteString(w, "hi")
 			numReqs++
-			return
 		})) // end of mockCF
 
 		// do a GET against the CF mock server

--- a/src/jetstream/passthrough.go
+++ b/src/jetstream/passthrough.go
@@ -538,7 +538,7 @@ func (p *portalProxy) doRequest(cnsiRequest *api.CNSIRequest, done chan<- *api.C
 		cnsiRequest.StatusCode = res.StatusCode
 		cnsiRequest.Status = res.Status
 		cnsiRequest.Response, cnsiRequest.Error = io.ReadAll(res.Body)
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 	}
 
 	// If Status Code >=400, log this as a warning

--- a/src/jetstream/plugins/analysis/list.go
+++ b/src/jetstream/plugins/analysis/list.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -171,13 +171,12 @@ func (c *Analysis) deleteReports(ec echo.Context) error {
 	userID := ec.Get("user_id").(string)
 
 	defer func() { _ = ec.Request().Body.Close() }()
-	body, err := ioutil.ReadAll(ec.Request().Body)
+	body, err := io.ReadAll(ec.Request().Body)
 	if err != nil {
 		return err
 	}
 
-	var ids []string
-	ids = make([]string, 0)
+	ids := make([]string, 0)
 	if err = json.Unmarshal(body, &ids); err != nil {
 		return err
 	}
@@ -221,7 +220,7 @@ func (c *Analysis) getReportFile(userID, endpointID, ID, name string) ([]byte, e
 	}
 
 	defer func() { _ = rsp.Body.Close() }()
-	response, err := ioutil.ReadAll(rsp.Body)
+	response, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Could not read response: %v", err)
 	}

--- a/src/jetstream/plugins/analysis/list.go
+++ b/src/jetstream/plugins/analysis/list.go
@@ -170,7 +170,7 @@ func (c *Analysis) deleteReports(ec echo.Context) error {
 	// Need to get a config object for the target endpoint
 	userID := ec.Get("user_id").(string)
 
-	defer ec.Request().Body.Close()
+	defer func() { _ = ec.Request().Body.Close() }()
 	body, err := ioutil.ReadAll(ec.Request().Body)
 	if err != nil {
 		return err
@@ -200,7 +200,9 @@ func (c *Analysis) deleteReports(ec echo.Context) error {
 				log.Warnf("Could not delete analysis report for: %s", job.ID)
 			}
 		}
-		dbStore.Delete(userID, id)
+		if err := dbStore.Delete(userID, id); err != nil {
+			log.Warnf("Could not delete analysis report %s from store: %v", id, err)
+		}
 	}
 
 	return ec.JSON(200, ids)
@@ -218,7 +220,7 @@ func (c *Analysis) getReportFile(userID, endpointID, ID, name string) ([]byte, e
 		return nil, fmt.Errorf("Failed getting report from Analyzer service: %d", rsp.StatusCode)
 	}
 
-	defer rsp.Body.Close()
+	defer func() { _ = rsp.Body.Close() }()
 	response, err := ioutil.ReadAll(rsp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Could not read response: %v", err)

--- a/src/jetstream/plugins/analysis/main.go
+++ b/src/jetstream/plugins/analysis/main.go
@@ -115,7 +115,9 @@ func (analysis *Analysis) OnEndpointNotification(action api.EndpointAction, endp
 		// An endpoint was unregistered, so remove all reports
 		dbStore, err := store.NewAnalysisDBStore(analysis.portalProxy.GetDatabaseConnection())
 		if err == nil {
-			dbStore.DeleteForEndpoint(endpoint.GUID)
+			if err := dbStore.DeleteForEndpoint(endpoint.GUID); err != nil {
+				log.Errorf("Failed deleting reports for endpoint %s: %v", endpoint.GUID, err)
+			}
 
 			// Now ask the analysis engine to to delete all files on disk
 			deleteURL := fmt.Sprintf("%s/api/v1/report/%s", analysis.analysisServer, endpoint.GUID)
@@ -132,7 +134,7 @@ func (analysis *Analysis) OnEndpointNotification(action api.EndpointAction, endp
 			}
 
 			if rsp.Body != nil {
-				defer rsp.Body.Close()
+				defer func() { _ = rsp.Body.Close() }()
 				_, err = ioutil.ReadAll(rsp.Body)
 				if err != nil {
 					log.Errorf("Could not read response: %v", err)

--- a/src/jetstream/plugins/analysis/main.go
+++ b/src/jetstream/plugins/analysis/main.go
@@ -3,7 +3,7 @@ package analysis
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -135,7 +135,7 @@ func (analysis *Analysis) OnEndpointNotification(action api.EndpointAction, endp
 
 			if rsp.Body != nil {
 				defer func() { _ = rsp.Body.Close() }()
-				_, err = ioutil.ReadAll(rsp.Body)
+				_, err = io.ReadAll(rsp.Body)
 				if err != nil {
 					log.Errorf("Could not read response: %v", err)
 				}

--- a/src/jetstream/plugins/analysis/run.go
+++ b/src/jetstream/plugins/analysis/run.go
@@ -18,7 +18,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type popeyeConfig struct {
+// Referenced only by the parked sonobuoy analyzer (container/sonobuoy.go_);
+// kept so that file compiles if re-enabled.
+type popeyeConfig struct { //nolint:unused
 	Namespace string `json:"namespace"`
 	App       string `json:"app"`
 }

--- a/src/jetstream/plugins/analysis/run.go
+++ b/src/jetstream/plugins/analysis/run.go
@@ -63,13 +63,17 @@ func (c *Analysis) runReport(ec echo.Context) error {
 	}
 
 	report.Name = fmt.Sprintf("Analysis report %s", analyzer)
-	dbStore.Save((report))
+	if _, err := dbStore.Save(report); err != nil {
+		return err
+	}
 
 	err = c.doRunReport(ec, analyzer, endpointID, userID, dbStore, &report)
 	if err != nil {
 		report.Status = "error"
 		report.Result = err.Error()
-		dbStore.UpdateReport(userID, &report)
+		if updateErr := dbStore.UpdateReport(userID, &report); updateErr != nil {
+			log.Warnf("Could not update analysis report %s: %v", report.ID, updateErr)
+		}
 	}
 
 	return err
@@ -105,12 +109,12 @@ func (c *Analysis) doRunReport(ec echo.Context, analyzer, endpointID, userID str
 	metadataHeader.Set("Content-Type", "application/yaml")
 	metadataHeader.Set("Content-ID", "kubeconfig")
 	part, _ := writer.CreatePart(metadataHeader)
-	part.Write([]byte(config))
+	_, _ = part.Write([]byte(config))
 
 	requestBody := make([]byte, 0)
 
 	// Read body
-	defer ec.Request().Body.Close()
+	defer func() { _ = ec.Request().Body.Close() }()
 	if b, err := ioutil.ReadAll((ec.Request().Body)); err == nil {
 		requestBody = b
 	}
@@ -120,7 +124,7 @@ func (c *Analysis) doRunReport(ec echo.Context, analyzer, endpointID, userID str
 	postHeader.Set("Content-Type", "application/json")
 	postHeader.Set("Content-ID", "body")
 	part, _ = writer.CreatePart(postHeader)
-	part.Write(requestBody)
+	_, _ = part.Write(requestBody)
 
 	// Report config
 	reportHeader := textproto.MIMEHeader{}
@@ -131,8 +135,10 @@ func (c *Analysis) doRunReport(ec echo.Context, analyzer, endpointID, userID str
 	if err != nil {
 		return errors.New("Could not serialize job")
 	}
-	part.Write(job)
-	writer.Close()
+	_, _ = part.Write(job)
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("Could not close multipart writer: %v", err)
+	}
 
 	// Post this to the Analyzer API
 	contentType := fmt.Sprintf("multipart/form-data; boundary=%s", writer.Boundary())
@@ -154,7 +160,7 @@ func (c *Analysis) doRunReport(ec echo.Context, analyzer, endpointID, userID str
 	// Job submitted okay
 	// Updated job is in the response
 
-	defer rsp.Body.Close()
+	defer func() { _ = rsp.Body.Close() }()
 	response, err := ioutil.ReadAll(rsp.Body)
 	if err != nil {
 		return errors.New("Could not read response")

--- a/src/jetstream/plugins/analysis/run.go
+++ b/src/jetstream/plugins/analysis/run.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -115,7 +115,7 @@ func (c *Analysis) doRunReport(ec echo.Context, analyzer, endpointID, userID str
 
 	// Read body
 	defer func() { _ = ec.Request().Body.Close() }()
-	if b, err := ioutil.ReadAll((ec.Request().Body)); err == nil {
+	if b, err := io.ReadAll(ec.Request().Body); err == nil {
 		requestBody = b
 	}
 
@@ -161,7 +161,7 @@ func (c *Analysis) doRunReport(ec echo.Context, analyzer, endpointID, userID str
 	// Updated job is in the response
 
 	defer func() { _ = rsp.Body.Close() }()
-	response, err := ioutil.ReadAll(rsp.Body)
+	response, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return errors.New("Could not read response")
 	}

--- a/src/jetstream/plugins/analysis/status.go
+++ b/src/jetstream/plugins/analysis/status.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -76,7 +76,7 @@ func (c *Analysis) checkStatus() error {
 	}
 
 	defer func() { _ = rsp.Body.Close() }()
-	response, err := ioutil.ReadAll(rsp.Body)
+	response, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		log.Errorf("Could not read response: %v", err)
 		return fmt.Errorf("Could not read response: %v", err)

--- a/src/jetstream/plugins/analysis/status.go
+++ b/src/jetstream/plugins/analysis/status.go
@@ -75,7 +75,7 @@ func (c *Analysis) checkStatus() error {
 		return fmt.Errorf("Failed getting status from Analyzer service: %d", rsp.StatusCode)
 	}
 
-	defer rsp.Body.Close()
+	defer func() { _ = rsp.Body.Close() }()
 	response, err := ioutil.ReadAll(rsp.Body)
 	if err != nil {
 		log.Errorf("Could not read response: %v", err)

--- a/src/jetstream/plugins/analysis/store/analysis_store_db.go
+++ b/src/jetstream/plugins/analysis/store/analysis_store_db.go
@@ -52,7 +52,7 @@ func (p *AnalysisDBStore) List(userGUID, endpointID string) ([]*AnalysisRecord, 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve Analysis Reports records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	return list(rows)
 }
@@ -63,7 +63,7 @@ func (p *AnalysisDBStore) ListCompletedByPath(userGUID, endpointID, path string)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve Analysis Reports records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	return list(rows)
 }
@@ -74,7 +74,7 @@ func (p *AnalysisDBStore) ListRunning() ([]*AnalysisRecord, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve Analysis Reports records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	return list(rows)
 }

--- a/src/jetstream/plugins/backup/backup_restore.go
+++ b/src/jetstream/plugins/backup/backup_restore.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"golang.org/x/crypto/pbkdf2"
@@ -32,8 +31,8 @@ type ConnectionType string
 
 const (
 	BACKUP_CONNECTION_NONE    ConnectionType = "NONE"
-	BACKUP_CONNECTION_CURRENT                = "CURRENT"
-	BACKUP_CONNECTION_ALL                    = "ALL"
+	BACKUP_CONNECTION_CURRENT ConnectionType = "CURRENT"
+	BACKUP_CONNECTION_ALL     ConnectionType = "ALL"
 )
 
 // BackupEndpointsState - For a given endpoint define what's backed up
@@ -72,7 +71,7 @@ func (ctb *cnsiTokenBackup) BackupEndpoints(c echo.Context) error {
 	log.Debug("BackupEndpoints")
 
 	// Create the backup request struct from the body
-	body, err := ioutil.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		return api.NewHTTPShadowError(http.StatusBadRequest, "Invalid request body", "Invalid request body: %+v", err)
 	}
@@ -82,7 +81,7 @@ func (ctb *cnsiTokenBackup) BackupEndpoints(c echo.Context) error {
 		return api.NewHTTPShadowError(http.StatusBadRequest, "Invalid request body - could not parse JSON", "Invalid request body - could not parse JSON: %+v", err)
 	}
 
-	if data.State == nil || len(data.State) == 0 {
+	if len(data.State) == 0 {
 		return api.NewHTTPError(http.StatusBadRequest, "Invalid request body - no endpoints to backup")
 	}
 
@@ -191,7 +190,7 @@ func (ctb *cnsiTokenBackup) RestoreEndpoints(c echo.Context) error {
 	log.Debug("RestoreEndpoints")
 
 	// Create the restore request struct from the body
-	body, err := ioutil.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		return api.NewHTTPShadowError(http.StatusBadRequest, "Invalid request body", "Invalid request body: %+v", err)
 	}
@@ -219,7 +218,7 @@ func (ctb *cnsiTokenBackup) restoreBackup(backup *RestoreRequest) error {
 	}
 
 	// Check that the db version of backup file matches the stratos db version
-	if backup.IgnoreDbVersion == false {
+	if !backup.IgnoreDbVersion {
 		if ctb.dbVersion != data.DBVersion {
 			errorStr := fmt.Sprintf("Incompatible database versions. Expected %+v but got %+v", ctb.dbVersion, data.DBVersion)
 			return api.NewHTTPError(http.StatusBadRequest, errorStr)

--- a/src/jetstream/plugins/backup/backup_restore.go
+++ b/src/jetstream/plugins/backup/backup_restore.go
@@ -268,7 +268,7 @@ func serializeEndpoint(endpoint *api.CNSIRecord) map[string]interface{} {
 	// Convert struct to generic map
 	m, _ := json.Marshal(endpoint)
 	var a interface{}
-	json.Unmarshal(m, &a)
+	_ = json.Unmarshal(m, &a)
 	newEndpoint := a.(map[string]interface{})
 
 	// Apply the correct client secret
@@ -282,7 +282,7 @@ func deSerializeEndpoint(endpoint map[string]interface{}) api.CNSIRecord {
 	// Convert struct to endpoint
 	m, _ := json.Marshal(endpoint)
 	var cnsi api.CNSIRecord
-	json.Unmarshal(m, &cnsi)
+	_ = json.Unmarshal(m, &cnsi)
 
 	// Apply the correct client secret
 	cnsi.ClientSecret = fmt.Sprintf("%v", endpoint["client_secret"])

--- a/src/jetstream/plugins/backup/backup_restore.go
+++ b/src/jetstream/plugins/backup/backup_restore.go
@@ -99,8 +99,8 @@ func (ctb *cnsiTokenBackup) BackupEndpoints(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 func (ctb *cnsiTokenBackup) createBackup(data *BackupRequest) (*BackupContent, error) {

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -133,14 +133,14 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 		return fmt.Errorf("Failed to create session: %s", err)
 	}
 
-	defer connection.Close()
+	defer func() { _ = connection.Close() }()
 
 	// Upgrade the web socket
 	ws, pingTicker, err := api.UpgradeToWebSocket(c)
 	if err != nil {
 		return err
 	}
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 	defer pingTicker.Stop()
 
 	modes := ssh.TerminalModes{
@@ -150,7 +150,7 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 
 	// NB: rows, cols
 	if err := session.RequestPty("xterm", 84, 80, modes); err != nil {
-		session.Close()
+		_ = session.Close()
 		return fmt.Errorf("request for pseudo terminal failed: %s", err)
 	}
 
@@ -164,11 +164,15 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 		return fmt.Errorf("Unable to setup stdout for session: %v", err)
 	}
 
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	stdoutDone := make(chan struct{})
 	go pumpStdout(ws, stdout, stdoutDone)
-	go session.Shell()
+	go func() {
+		if err := session.Shell(); err != nil {
+			log.Errorf("App SSH failed to start shell: %v", err)
+		}
+	}()
 
 	// Read the input from the web socket and pipe it to the SSH client
 	for {
@@ -180,10 +184,15 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 		}
 
 		res := KeyCode{}
-		json.Unmarshal(r, &res)
+		if err := json.Unmarshal(r, &res); err != nil {
+			log.Warnf("App SSH: could not parse message from web socket: %+v", err)
+			continue
+		}
 
 		if res.Cols == 0 {
-			stdin.Write([]byte(res.Key))
+			if _, err := stdin.Write([]byte(res.Key)); err != nil {
+				log.Errorf("App SSH: error writing to session stdin: %v", err)
+			}
 		} else {
 			// Terminal resize request
 			if err := windowChange(session, res.Rows, res.Cols); err != nil {
@@ -251,15 +260,15 @@ func pumpStdout(ws *websocket.Conn, r io.Reader, done chan struct{}) {
 			if err != io.EOF {
 				log.Errorf("App SSH encountered an error reading from stdout; %v", err)
 			}
-			ws.Close()
+			_ = ws.Close()
 			break
 		}
 
-		ws.SetWriteDeadline(time.Now().Add(writeWait))
+		_ = ws.SetWriteDeadline(time.Now().Add(writeWait))
 		bytes := fmt.Sprintf("% x\n", buffer[:len])
 		if err := ws.WriteMessage(websocket.TextMessage, []byte(bytes)); err != nil {
 			log.Error("App SSH Failed to write nessage")
-			ws.Close()
+			_ = ws.Close()
 			break
 		}
 	}
@@ -293,7 +302,7 @@ func getWebProcessGUID(apiEndpoint, appGUID, token string, skipSSLValidation boo
 	if err != nil {
 		return "", fmt.Errorf("failed to get processes: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("processes API returned status %d", resp.StatusCode)

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -26,17 +26,9 @@ const (
 	// Time allowed to write a message to the peer.
 	writeWait = 10 * time.Second
 
-	// Inactivity timeout
-	inActivityTimeout = 10 * time.Second
-
 	md5FingerprintLength          = 47 // inclusive of space between bytes
 	base64Sha256FingerprintLength = 43
 )
-
-// Allow connections from any Origin
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
 
 // KeyCode - JSON object that is passed from the front-end to notify of a key press or a term resize
 type KeyCode struct {

--- a/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
+++ b/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
@@ -22,19 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// Time allowed to read the next pong message from the peer
-	pongWait = 30 * time.Second
-
-	// Send ping messages to peer with this period (must be less than pongWait)
-	pingPeriod = (pongWait * 9) / 10
-)
-
-// Allow connections from any Origin
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
-
 func (c *CloudFoundrySpecification) appStream(echoContext echo.Context) error {
 	return c.commonStreamHandler(echoContext, appStreamHandler)
 }

--- a/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
+++ b/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
@@ -48,13 +48,13 @@ func (c *CloudFoundrySpecification) commonStreamHandler(echoContext echo.Context
 	if err != nil {
 		return err
 	}
-	defer ac.consumer.Close()
+	defer func() { _ = ac.consumer.Close() }()
 
 	clientWebSocket, pingTicker, err := api.UpgradeToWebSocket(echoContext)
 	if err != nil {
 		return err
 	}
-	defer clientWebSocket.Close()
+	defer func() { _ = clientWebSocket.Close() }()
 	defer pingTicker.Stop()
 
 	if err := bespokeStreamHandler(echoContext, ac, clientWebSocket); err != nil {

--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -210,7 +210,9 @@ func (c *CloudFoundrySpecification) Init() error {
 
 func (c *CloudFoundrySpecification) cfLoginHook(context echo.Context) error {
 
-	cfAPI, cfCnsi, err := c.fetchAutoRegisterEndpoint()
+	// Error is ignored: it is also set when no record exists, which is handled
+	// below via the empty CNSIType
+	cfAPI, cfCnsi, _ := c.fetchAutoRegisterEndpoint()
 	// CF auto reg url missing, continue as normal
 	if cfAPI == "" {
 		return nil

--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -148,7 +148,7 @@ func (c *CloudFoundrySpecification) confirmCapabilityMetadata(cnsiRecord api.CNS
 	v2Uri := *uri
 	v2Uri.Path = "v2/info"
 	if res, err := h.Get(v2Uri.String()); err == nil {
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 		if res.StatusCode == 200 {
 			var v2 api.V2Info
 			if json.NewDecoder(res.Body).Decode(&v2) == nil && v2.AuthorizationEndpoint != "" {
@@ -160,7 +160,7 @@ func (c *CloudFoundrySpecification) confirmCapabilityMetadata(cnsiRecord api.CNS
 	v3Uri := *uri
 	v3Uri.Path = "v3/info"
 	if res, err := h.Get(v3Uri.String()); err == nil {
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 		if res.StatusCode == 200 {
 			var v3 api.V3Info
 			if json.NewDecoder(res.Body).Decode(&v3) == nil && v3.Links.Self.Href != "" {
@@ -185,7 +185,9 @@ func (c *CloudFoundrySpecification) confirmCapabilityMetadata(cnsiRecord api.CNS
 
 func (c *CloudFoundrySpecification) Init() error {
 	// Add login hook to automatically register and connect to the Cloud Foundry when the user logs in
-	c.portalProxy.AddLoginHook(0, c.cfLoginHook)
+	if err := c.portalProxy.AddLoginHook(0, c.cfLoginHook); err != nil {
+		return err
+	}
 
 	// Wire into the stratosjobs contract. Plugin load order isn't
 	// guaranteed — if stratosjobs didn't register yet we log + skip, and
@@ -328,8 +330,8 @@ func (c *CloudFoundrySpecification) Info(apiEndpoint string, skipSSLValidation b
 	}
 	if res.StatusCode != 200 {
 		buf := &bytes.Buffer{}
-		io.Copy(buf, res.Body)
-		res.Body.Close()
+		_, _ = io.Copy(buf, res.Body)
+		_ = res.Body.Close()
 		return newCNSI, nil, fmt.Errorf("%s endpoint returned %d\n%s", uri.String(), res.StatusCode, buf)
 	}
 	dec := json.NewDecoder(res.Body)
@@ -353,7 +355,7 @@ func (c *CloudFoundrySpecification) Info(apiEndpoint string, skipSSLValidation b
 	v2Uri := *uri
 	v2Uri.Path = "v2/info"
 	if res, err := h.Get(v2Uri.String()); err == nil {
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 		if res.StatusCode == 200 {
 			var v2 api.V2Info
 			if json.NewDecoder(res.Body).Decode(&v2) == nil && v2.AuthorizationEndpoint != "" {
@@ -370,7 +372,7 @@ func (c *CloudFoundrySpecification) Info(apiEndpoint string, skipSSLValidation b
 	v3Uri := *uri
 	v3Uri.Path = "v3/info"
 	if res, err := h.Get(v3Uri.String()); err == nil {
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 		if res.StatusCode == 200 {
 			var v3 api.V3Info
 			if json.NewDecoder(res.Body).Decode(&v3) == nil && v3.Links.Self.Href != "" {

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
@@ -341,15 +341,6 @@ func composeStAppSummary(app capi.App, cnsiGUID string, process *capi.Process, s
 	return s
 }
 
-// toStAppSummary is retained as a two-argument convenience for the tests +
-// the subset of callers that don't need org / route resolution. Delegates
-// to composeStAppSummary with space=nil and routes=[] so orgGuid is
-// always unavailable in this path; routes default to empty so the absence
-// is treated as "no routes" rather than "routes fetch failed".
-func toStAppSummary(app capi.App, cnsiGUID string, process *capi.Process) StApp {
-	return composeStAppSummary(app, cnsiGUID, process, nil, "", []StAppRoute{})
-}
-
 // envelopeMetaForCompositionErrors builds the envelope-level _meta.errors
 // entries for any composition sub-fetch that failed. Returns nil (so the
 // envelope's _meta stays absent) when no errors occurred. Supports

--- a/src/jetstream/plugins/cloudfoundry/native_identity_providers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_identity_providers.go
@@ -65,7 +65,7 @@ func (cf *CloudFoundrySpecification) getIdentityProviders(ctx echo.Context) erro
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadGateway, "UAA request failed: "+err.Error())
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Pass UAA 403 through so the frontend can degrade to free-text origin input.
 	if resp.StatusCode == http.StatusForbidden {

--- a/src/jetstream/plugins/cloudfoundry/native_service_bindings_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_bindings_reads_test.go
@@ -31,10 +31,10 @@ func newBindingsTestServer(t *testing.T) *bindingsTestServer {
 	s := &bindingsTestServer{}
 	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/v3":
+		switch r.URL.Path {
+		case "/v3":
 			_, _ = w.Write([]byte(`{"links":{}}`))
-		case r.URL.Path == "/v3/service_credential_bindings":
+		case "/v3/service_credential_bindings":
 			s.listHits++
 			s.lastListQuery = r.URL.RawQuery
 			body := map[string]interface{}{
@@ -200,10 +200,10 @@ func TestGetAppServiceBindings_SoftFallbackWhenIncludedMissing(t *testing.T) {
 	// is forwarded — simulates an upstream gap.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/v3":
+		switch r.URL.Path {
+		case "/v3":
 			_, _ = w.Write([]byte(`{"links":{}}`))
-		case r.URL.Path == "/v3/service_credential_bindings":
+		case "/v3/service_credential_bindings":
 			_, _ = w.Write([]byte(`{
 				"pagination": {"total_results": 1, "total_pages": 1, "next": null},
 				"resources": [
@@ -242,10 +242,10 @@ func TestGetAppServiceBindings_SoftFallbackWhenIncludedMissing(t *testing.T) {
 func TestGetAppServiceBindings_EmptyReturnsEmptyArray(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/v3":
+		switch r.URL.Path {
+		case "/v3":
 			_, _ = w.Write([]byte(`{"links":{}}`))
-		case r.URL.Path == "/v3/service_credential_bindings":
+		case "/v3/service_credential_bindings":
 			_, _ = w.Write([]byte(`{"pagination":{"total_results":0,"total_pages":1,"next":null},"resources":[]}`))
 		default:
 			http.NotFound(w, r)

--- a/src/jetstream/plugins/cloudfoundry/native_service_offerings_reads_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_offerings_reads_test.go
@@ -30,10 +30,10 @@ func newServiceOfferingTestServer(t *testing.T) *serviceOfferingTestServer {
 	s := &serviceOfferingTestServer{}
 	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/v3":
+		switch r.URL.Path {
+		case "/v3":
 			_, _ = w.Write([]byte(`{"links":{}}`))
-		case r.URL.Path == "/v3/service_offerings":
+		case "/v3/service_offerings":
 			s.listHits++
 			s.lastListQuery = r.URL.RawQuery
 			// v3 emits the `included` block only when the request asked
@@ -92,7 +92,7 @@ func newServiceOfferingTestServer(t *testing.T) *serviceOfferingTestServer {
 				}
 			}
 			_ = json.NewEncoder(w).Encode(body)
-		case r.URL.Path == "/v3/service_offerings/offering-1":
+		case "/v3/service_offerings/offering-1":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"guid":              "offering-1",
 				"name":              "redis",
@@ -116,7 +116,7 @@ func newServiceOfferingTestServer(t *testing.T) *serviceOfferingTestServer {
 					},
 				},
 			})
-		case r.URL.Path == "/v3/service_brokers":
+		case "/v3/service_brokers":
 			s.brokerHits++
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"pagination": map[string]interface{}{"total_results": 2, "total_pages": 1},

--- a/src/jetstream/plugins/cloudfoundry/native_uri_probe.go
+++ b/src/jetstream/plugins/cloudfoundry/native_uri_probe.go
@@ -116,7 +116,7 @@ func probeURITargetLen(client *http.Client, apiBase string, targetLen int) (bool
 	if err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode != http.StatusRequestURITooLong, nil
 }
 

--- a/src/jetstream/plugins/cloudfoundryhosting/main.go
+++ b/src/jetstream/plugins/cloudfoundryhosting/main.go
@@ -288,7 +288,9 @@ func (ch *CFHosting) SessionEchoMiddleware(h echo.HandlerFunc) echo.HandlerFunc 
 			if err != nil || guid == nil {
 				guid = uuid.NewV4().String()
 				session.Values[cfSessionCookieName] = guid
-				ch.portalProxy.SaveSession(c, session)
+				if err := ch.portalProxy.SaveSession(c, session); err != nil {
+					log.Warnf("Unable to save session for Cloud Foundry session affinity: %v", err)
+				}
 			}
 			sessionGUID := fmt.Sprintf("%s", guid)
 			// Set the JSESSIONID coolie for Cloud Foundry session affinity

--- a/src/jetstream/plugins/cloudfoundryhosting/main.go
+++ b/src/jetstream/plugins/cloudfoundryhosting/main.go
@@ -37,8 +37,7 @@ func init() {
 
 // CFHosting is a plugin to configure Stratos when hosted in Cloud Foundry
 type CFHosting struct {
-	portalProxy  api.PortalProxy
-	endpointType string
+	portalProxy api.PortalProxy
 }
 
 // Package initialization

--- a/src/jetstream/plugins/metrics/cloud_foundry.go
+++ b/src/jetstream/plugins/metrics/cloud_foundry.go
@@ -184,6 +184,9 @@ func (m *MetricsSpecification) makePrometheusRequest(c echo.Context, cnsiList []
 	// Construct the metadata for proxying
 	requests := makePrometheusRequestInfos(c, userGUID, metrics, prometheusOp, queries, true)
 	responses, err := m.portalProxy.DoProxyRequest(requests)
+	if err != nil {
+		return err
+	}
 	return m.portalProxy.SendProxiedResponse(c, responses)
 }
 

--- a/src/jetstream/plugins/metrics/kubernetes.go
+++ b/src/jetstream/plugins/metrics/kubernetes.go
@@ -33,5 +33,8 @@ func (m *MetricsSpecification) getPodMetrics(c echo.Context) error {
 	// Construct the metadata for proxying
 	requests := makePrometheusRequestInfos(c, userGUID, metrics, prometheusOp, "", false)
 	responses, err := m.portalProxy.DoProxyRequest(requests)
+	if err != nil {
+		return err
+	}
 	return m.portalProxy.SendProxiedResponse(c, responses)
 }

--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -195,7 +195,7 @@ func (m *MetricsSpecification) Connect(ec echo.Context, cnsiRecord api.CNSIRecor
 			"Could not connect to the endpoint: %s", err)
 	}
 
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	// If we got anything other than a 200, then we did not find the Stratos Metrics metadata file
 	if res.StatusCode != http.StatusOK {
@@ -218,7 +218,7 @@ func (m *MetricsSpecification) Connect(ec echo.Context, cnsiRecord api.CNSIRecor
 			return nil, false, api.LogHTTPError(res, err)
 		}
 
-		defer response.Body.Close()
+		defer func() { _ = response.Body.Close() }()
 		if response.StatusCode != http.StatusOK {
 			log.Errorf("Error fetching /api/v1/status/config - response: %v, error: %v", response, err)
 			return nil, false, api.LogHTTPError(res, err)
@@ -256,7 +256,7 @@ func (m *MetricsSpecification) createMetadata(metricEndpoint *url.URL, httpClien
 		log.Errorf("Error performing http request: %v", err)
 		return "", api.LogHTTPError(res, err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		log.Errorf("Error performing http request - response: %v", res)
 		return "", api.LogHTTPError(res, err)

--- a/src/jetstream/plugins/metrics/main.go
+++ b/src/jetstream/plugins/metrics/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -229,7 +229,7 @@ func (m *MetricsSpecification) Connect(ec echo.Context, cnsiRecord api.CNSIRecor
 	}
 
 	// We read the Stratos Metadata file ok
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 	// Put the body in the token metadata
 	tr.Metadata = string(body)
 
@@ -261,7 +261,7 @@ func (m *MetricsSpecification) createMetadata(metricEndpoint *url.URL, httpClien
 		log.Errorf("Error performing http request - response: %v", res)
 		return "", api.LogHTTPError(res, err)
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Errorf("Unexpected response: %v", err)
 		return "", api.LogHTTPError(res, err)
@@ -466,9 +466,7 @@ func (m *MetricsSpecification) getMetricsEndpoints(userGUID string, cnsiList []s
 	if err != nil {
 		return nil, err
 	}
-	for _, endpoint := range systemSharedEndpoints {
-		allUserAccessibleEndpoints = append(allUserAccessibleEndpoints, endpoint)
-	}
+	allUserAccessibleEndpoints = append(allUserAccessibleEndpoints, systemSharedEndpoints...)
 
 	if err != nil {
 		return nil, err

--- a/src/jetstream/plugins/stratosjobs/tracker_test.go
+++ b/src/jetstream/plugins/stratosjobs/tracker_test.go
@@ -29,11 +29,6 @@ func (s *stubTranslator) Kind() string {
 	return s.kind
 }
 
-// constantClock gives tests deterministic timestamps.
-func constantClock(ts time.Time) func() time.Time {
-	return func() time.Time { return ts }
-}
-
 func newTestTracker(t *testing.T, clock func() time.Time) *InMemoryTracker {
 	t.Helper()
 	// Very long sweep interval so tests drive eviction deterministically by

--- a/src/jetstream/plugins/userfavorites/favorites.go
+++ b/src/jetstream/plugins/userfavorites/favorites.go
@@ -40,8 +40,8 @@ func (uf *UserFavorites) getAll(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 func (uf *UserFavorites) delete(c echo.Context) error {
@@ -62,8 +62,8 @@ func (uf *UserFavorites) delete(c echo.Context) error {
 		return err
 	}
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write([]byte("{\"response\": \"User Favorite deleted okay\"}"))
-	return nil
+	_, err = c.Response().Write([]byte("{\"response\": \"User Favorite deleted okay\"}"))
+	return err
 }
 
 func (uf *UserFavorites) create(c echo.Context) error {
@@ -120,8 +120,8 @@ func (uf *UserFavorites) create(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 // RemoveEndpointFavorites removes favorites form an endpoint using the given endpoint guid

--- a/src/jetstream/plugins/userfavorites/favorites.go
+++ b/src/jetstream/plugins/userfavorites/favorites.go
@@ -3,7 +3,7 @@ package userfavorites
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -79,7 +79,7 @@ func (uf *UserFavorites) create(c echo.Context) error {
 	userGUID := c.Get("user_id").(string)
 
 	req := c.Request()
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 
 	favorite := userfavoritesstore.UserFavoriteRecord{}
 	err = json.Unmarshal(body, &favorite)

--- a/src/jetstream/plugins/userfavorites/userfavoritesstore/favorites-store-db.go
+++ b/src/jetstream/plugins/userfavorites/userfavoritesstore/favorites-store-db.go
@@ -43,7 +43,7 @@ func (p *FavoritesDBStore) List(userGUID string) ([]*UserFavoriteRecord, error) 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve User Favorite records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var favoritesList []*UserFavoriteRecord
 	favoritesList = make([]*UserFavoriteRecord, 0)

--- a/src/jetstream/plugins/userinfo/main.go
+++ b/src/jetstream/plugins/userinfo/main.go
@@ -3,7 +3,7 @@ package userinfo
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -128,7 +128,7 @@ func (userInfo *UserInfo) updateUserInfo(c echo.Context) error {
 
 	provider := userInfo.getProvider(c)
 
-	body, err := ioutil.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		log.Errorf("Unexpected response: %v", err)
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid message body")
@@ -168,7 +168,7 @@ func (userInfo *UserInfo) updateUserPassword(c echo.Context) error {
 
 	provider := userInfo.getProvider(c)
 
-	body, err := ioutil.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		log.Errorf("Unexpected response: %v", err)
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid message body")

--- a/src/jetstream/plugins/userinfo/uaa_user.go
+++ b/src/jetstream/plugins/userinfo/uaa_user.go
@@ -3,7 +3,7 @@ package userinfo
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -152,7 +152,7 @@ func (userInfo *UaaUserInfo) doAPIRequest(sessionUser string, url string, echoRe
 		return 0, nil, nil, fmt.Errorf("Request failed: %v", err)
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	defer func() { _ = res.Body.Close() }()
 
 	log.Debug("User profile request completed OK")

--- a/src/jetstream/plugins/userinfo/uaa_user.go
+++ b/src/jetstream/plugins/userinfo/uaa_user.go
@@ -153,7 +153,7 @@ func (userInfo *UaaUserInfo) doAPIRequest(sessionUser string, url string, echoRe
 	}
 
 	data, err := ioutil.ReadAll(res.Body)
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	log.Debug("User profile request completed OK")
 	return res.StatusCode, data, &res.Header, err

--- a/src/jetstream/plugins/userinvite/admin.go
+++ b/src/jetstream/plugins/userinvite/admin.go
@@ -59,8 +59,8 @@ func (invite *UserInvite) status(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 // Configure
@@ -96,8 +96,8 @@ func (invite *UserInvite) configure(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write([]byte("{\"status\": \"ok\"}"))
-	return nil
+	_, err = c.Response().Write([]byte("{\"status\": \"ok\"}"))
+	return err
 }
 
 // arrayContainsString checks the string array to see if it contains the specifed value
@@ -131,6 +131,6 @@ func (invite *UserInvite) remove(c echo.Context) error {
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write([]byte("{\"status\": \"ok\"}"))
-	return nil
+	_, err = c.Response().Write([]byte("{\"status\": \"ok\"}"))
+	return err
 }

--- a/src/jetstream/plugins/userinvite/auth.go
+++ b/src/jetstream/plugins/userinvite/auth.go
@@ -80,7 +80,7 @@ func (invite *UserInvite) refreshToken(clientID, clientSecret string, endpoint a
 		)
 	}
 
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	// Check error code
 	if res.StatusCode != http.StatusOK {

--- a/src/jetstream/plugins/userinvite/auth.go
+++ b/src/jetstream/plugins/userinvite/auth.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -86,7 +86,7 @@ func (invite *UserInvite) refreshToken(clientID, clientSecret string, endpoint a
 	if res.StatusCode != http.StatusOK {
 		errMessage := "Error validating Client ID and Client Secret"
 		authError := &api.UAAErrorResponse{}
-		uaaResponse, _ := ioutil.ReadAll(res.Body)
+		uaaResponse, _ := io.ReadAll(res.Body)
 		if err := json.Unmarshal([]byte(uaaResponse), authError); err == nil {
 			errMessage = errMessage + " - " + authError.ErrorDescription
 		}

--- a/src/jetstream/plugins/userinvite/invite.go
+++ b/src/jetstream/plugins/userinvite/invite.go
@@ -144,8 +144,8 @@ func (invite *UserInvite) invite(c echo.Context) error {
 		return api.NewHTTPError(http.StatusInternalServerError, "Failed to serialize response")
 	}
 	c.Response().Header().Set("Content-Type", "application/json")
-	c.Response().Write(jsonString)
-	return nil
+	_, err = c.Response().Write(jsonString)
+	return err
 }
 
 func (invite *UserInvite) processUserInvites(c echo.Context, endpoint api.CNSIRecord, userInviteRequest *UserInviteReq) (*UserInviteResponse, error) {
@@ -273,7 +273,7 @@ func (invite *UserInvite) UAAUserInvite(c echo.Context, endpoint api.CNSIRecord,
 	}
 
 	// Read the response
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, api.NewHTTPShadowError(

--- a/src/jetstream/plugins/userinvite/invite.go
+++ b/src/jetstream/plugins/userinvite/invite.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -108,7 +108,7 @@ func (invite *UserInvite) invite(c echo.Context) error {
 	}
 
 	// Check we can unmarshall the request
-	body, err := ioutil.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		return api.NewHTTPError(http.StatusBadRequest, "Invalid request body")
 	}
@@ -167,7 +167,7 @@ func (invite *UserInvite) processUserInvites(c echo.Context, endpoint api.CNSIRe
 
 	for _, user := range inviteResponse.NewInvites {
 		userErr, err := invite.processUserInvite(cfGUID, userGUID, userInviteRequest, user, endpoint)
-		if err == true {
+		if err {
 			failedInvites = append(failedInvites, userErr)
 		} else {
 			newInvites = append(newInvites, user)
@@ -274,7 +274,7 @@ func (invite *UserInvite) UAAUserInvite(c echo.Context, endpoint api.CNSIRecord,
 
 	// Read the response
 	defer func() { _ = res.Body.Close() }()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, api.NewHTTPShadowError(
 			http.StatusInternalServerError,

--- a/src/jetstream/plugins/userinvite/main.go
+++ b/src/jetstream/plugins/userinvite/main.go
@@ -100,7 +100,9 @@ func (userinvite *UserInvite) Init() error {
 	}
 
 	userinvite.portalProxy.GetConfig().PluginConfig[UserInvitePluginConfigSetting] = "true"
-	userinvite.portalProxy.AddLoginHook(5, userinvite.initClientToken)
+	if err := userinvite.portalProxy.AddLoginHook(5, userinvite.initClientToken); err != nil {
+		return err
+	}
 	userinvite.portalProxy.AddAuthProvider(UAAClientAuthType, api.AuthProvider{
 		Handler:  userinvite.doUAAClientAuthFlow,
 		UserInfo: userinvite.getCNSIUserFromUAAClientToken,

--- a/src/jetstream/plugins/yamlgenerated/main.go
+++ b/src/jetstream/plugins/yamlgenerated/main.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
@@ -218,7 +218,7 @@ func MakePluginsFromConfig() {
 
 	var config []pluginConfig
 
-	yamlFile, err := ioutil.ReadFile("plugins.yaml")
+	yamlFile, err := os.ReadFile("plugins.yaml")
 	if err != nil {
 		log.Errorf("Can't generate plugins from YAML: %v ", err)
 		return

--- a/src/jetstream/repository/apikeys/psql_apikeys_test.go
+++ b/src/jetstream/repository/apikeys/psql_apikeys_test.go
@@ -108,6 +108,9 @@ func TestListAPIKeys(t *testing.T) {
 		defer db.Close()
 
 		repository, err := NewPgsqlAPIKeysRepository(db)
+		if err != nil {
+			t.Errorf("an error '%s' was not expected when creating the repository", err)
+		}
 
 		Convey("if no records exist in the DB", func() {
 			rs := sqlmock.NewRows(rowFields)
@@ -194,6 +197,9 @@ func TestGetAPIKeyBySecret(t *testing.T) {
 		defer db.Close()
 
 		repository, err := NewPgsqlAPIKeysRepository(db)
+		if err != nil {
+			t.Errorf("an error '%s' was not expected when creating the repository", err)
+		}
 
 		Convey("if no matching record exists in the DB", func() {
 			rs := sqlmock.NewRows(rowFields)

--- a/src/jetstream/repository/cnsis/pgsql_cnsis.go
+++ b/src/jetstream/repository/cnsis/pgsql_cnsis.go
@@ -76,7 +76,7 @@ func (p *PostgresCNSIRepository) List(encryptionKey []byte) ([]*api.CNSIRecord, 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve CNSI records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var cnsiList []*api.CNSIRecord
 	cnsiList = make([]*api.CNSIRecord, 0)
@@ -144,7 +144,7 @@ func (p *PostgresCNSIRepository) ListByUser(userGUID string) ([]*api.ConnectedEn
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve CNSI records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var clusterList []*api.ConnectedEndpoint
 	clusterList = make([]*api.ConnectedEndpoint, 0)
@@ -214,7 +214,7 @@ func (p *PostgresCNSIRepository) listBy(query string, match string, encryptionKe
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve CNSI records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var cnsiList []*api.CNSIRecord
 	cnsiList = make([]*api.CNSIRecord, 0)

--- a/src/jetstream/repository/cnsis/pgsql_cnsis.go
+++ b/src/jetstream/repository/cnsis/pgsql_cnsis.go
@@ -351,8 +351,8 @@ func (p *PostgresCNSIRepository) Save(guid string, cnsi api.CNSIRecord, encrypti
 	if err != nil {
 		return err
 	}
-	if _, err := p.db.Exec(saveCNSI, guid, cnsi.Name, fmt.Sprintf("%s", cnsi.CNSIType),
-		fmt.Sprintf("%s", cnsi.APIEndpoint), cnsi.AuthorizationEndpoint, cnsi.TokenEndpoint, cnsi.DopplerLoggingEndpoint, cnsi.SkipSSLValidation,
+	if _, err := p.db.Exec(saveCNSI, guid, cnsi.Name, cnsi.CNSIType,
+		cnsi.APIEndpoint.String(), cnsi.AuthorizationEndpoint, cnsi.TokenEndpoint, cnsi.DopplerLoggingEndpoint, cnsi.SkipSSLValidation,
 		cnsi.ClientId, cipherTextClientSecret, cnsi.SSOAllowed, cnsi.SubType, cnsi.Metadata, cnsi.Creator, cnsi.CACert); err != nil {
 		return fmt.Errorf("Unable to Save CNSI record: %v", err)
 	}

--- a/src/jetstream/repository/console_config/env_lookup.go
+++ b/src/jetstream/repository/console_config/env_lookup.go
@@ -132,7 +132,7 @@ func MigrateSetupData(portal api.PortalProxy, configStore Repository) error {
 
 func migrateConfigSetting(envLookup *env.VarSet, configStore Repository, envVarName, value, defaultValue string) error {
 
-	var shouldStore = true
+	var shouldStore bool
 
 	// Get the current value from the environment
 	if currentValue, ok := envLookup.Lookup(envVarName); ok {

--- a/src/jetstream/repository/console_config/env_lookup.go
+++ b/src/jetstream/repository/console_config/env_lookup.go
@@ -107,7 +107,7 @@ func MigrateSetupData(portal api.PortalProxy, configStore Repository) error {
 	// SSO_LOGIN was incorrectly being set in previous console config table, this was then transferred over here where the console expects
 	// previous values to have been explicitly set by user (and as such should take precedents over env vars)
 	// See https://github.com/cloudfoundry/stratos/issues/4013
-	if config.UseSSO == true {
+	if config.UseSSO {
 		if err := migrateConfigSetting(portal.Env(), configStore, "SSO_LOGIN", strconv.FormatBool(config.UseSSO), "false"); err != nil {
 			return err
 		}

--- a/src/jetstream/repository/console_config/psql_console_config.go
+++ b/src/jetstream/repository/console_config/psql_console_config.go
@@ -120,7 +120,7 @@ func (c *ConsoleConfigRepository) GetValues(group string) (map[string]string, er
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve config records: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var values = make(map[string]string)
 
@@ -152,7 +152,7 @@ func (c *ConsoleConfigRepository) GetConsoleConfig() (*api.ConsoleConfig, error)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve console config record: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	rowCount := 0
 

--- a/src/jetstream/repository/goose-db-version/pgsql_goose_db_version.go
+++ b/src/jetstream/repository/goose-db-version/pgsql_goose_db_version.go
@@ -56,7 +56,11 @@ func (p *PostgresGooseDBVersionRepository) List() ([]*api.GooseDBVersionRecord, 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve Goose Version records: %v", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Warnf("Unable to close rows: %v", err)
+		}
+	}()
 
 	var versionList []*api.GooseDBVersionRecord
 	versionList = make([]*api.GooseDBVersionRecord, 0)

--- a/src/jetstream/repository/localusers/psql_localusers.go
+++ b/src/jetstream/repository/localusers/psql_localusers.go
@@ -263,7 +263,8 @@ func (p *PgsqlLocalUsersRepository) AddLocalUser(user api.LocalUser) error {
 
 	if err == nil {
 		//Validate that 1 row has been updated
-		rowsUpdates, err := result.RowsAffected()
+		var rowsUpdates int64
+		rowsUpdates, err = result.RowsAffected()
 		if err != nil {
 			err = errors.New("unable to INSERT local user: could not determine number of rows that were updated")
 		} else if rowsUpdates < 1 {
@@ -312,7 +313,8 @@ func (p *PgsqlLocalUsersRepository) UpdateLocalUser(user api.LocalUser) error {
 
 	if err == nil {
 		//Validate that 1 row has been updated
-		rowsUpdates, err := result.RowsAffected()
+		var rowsUpdates int64
+		rowsUpdates, err = result.RowsAffected()
 		if err != nil {
 			err = errors.New("unable to UPDATE local user: could not determine number of rows that were updated")
 		} else if rowsUpdates < 1 {

--- a/src/jetstream/repository/sessiondata/psql_sessiondata.go
+++ b/src/jetstream/repository/sessiondata/psql_sessiondata.go
@@ -55,7 +55,11 @@ func (c *SessionDataRepository) GetValues(session, group string) (map[string]str
 	if err != nil {
 		return nil, fmt.Errorf("Unable to retrieve session data records: %v", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Warnf("Unable to close rows: %v", err)
+		}
+	}()
 
 	var values = make(map[string]string)
 	for rows.Next() {

--- a/src/jetstream/repository/tokens/pgsql_tokens.go
+++ b/src/jetstream/repository/tokens/pgsql_tokens.go
@@ -342,7 +342,7 @@ func (p *PgsqlTokenRepository) ListAllEnabledConnectedCNSITokens(encryptionKey [
 		return make([]api.BackupTokenRecord, 0), fmt.Errorf(msg, err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	btrs := make([]api.BackupTokenRecord, 0)
 
@@ -434,7 +434,7 @@ func (p *PgsqlTokenRepository) FindAllCNSITokenBackup(cnsiGUID string, encryptio
 		return make([]api.BackupTokenRecord, 0), fmt.Errorf(msg, err)
 	}
 
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	btrs := make([]api.BackupTokenRecord, 0)
 	for rows.Next() {

--- a/src/jetstream/repository/tokens/pgsql_tokens_test.go
+++ b/src/jetstream/repository/tokens/pgsql_tokens_test.go
@@ -52,7 +52,7 @@ func TestSaveUAATokens(t *testing.T) {
 			db, _, repository := initialiseRepo(t)
 
 			Convey("should fail to save token with an invalid user GUID", func() {
-				var userGuid string = ""
+				userGuid := ""
 				err := repository.SaveAuthToken(userGuid, tokenRecord, mockEncryptionKey)
 				So(err, ShouldNotBeNil)
 
@@ -408,7 +408,7 @@ func TestDeleteCNSIToken(t *testing.T) {
 		db, mock, repository := initialiseRepo(t)
 
 		Convey("should fail to delete token with an invalid CNSI GUID", func() {
-			var cnsiGuid string = ""
+			cnsiGuid := ""
 			err := repository.DeleteCNSIToken(cnsiGuid, mockUserGuid)
 			So(err, ShouldNotBeNil)
 		})
@@ -453,7 +453,7 @@ func TestDeleteCNSITokens(t *testing.T) {
 		db, mock, repository := initialiseRepo(t)
 
 		Convey("should fail to delete token with an invalid CNSI GUID", func() {
-			var cnsiGuid string = ""
+			cnsiGuid := ""
 			err := repository.DeleteCNSITokens(cnsiGuid)
 			So(err, ShouldNotBeNil)
 		})

--- a/src/jetstream/session.go
+++ b/src/jetstream/session.go
@@ -244,7 +244,9 @@ func (p *portalProxy) ensureXSRFToken(c echo.Context) {
 		}
 		sessionValues := make(map[string]interface{})
 		sessionValues[XSRFTokenSessionName] = token
-		p.setSessionValues(c, sessionValues)
+		if err := p.setSessionValues(c, sessionValues); err != nil {
+			log.Warnf("Unable to save XSRF token to session: %v", err)
+		}
 	}
 
 	if len(token) > 0 {

--- a/src/jetstream/session.go
+++ b/src/jetstream/session.go
@@ -27,8 +27,6 @@ const (
 	sessionExpiresOnHeader = "X-Cap-Session-Expires-On"
 	// ClientRequestDateHeader Custom header for getting date form client
 	clientRequestDateHeader = "X-Cap-Request-Date"
-	// XSRFTokenCookie - XSRF Token Cookie name
-	xSRFTokenCookie = "XSRF-TOKEN"
 	// Default cookie name/cookie name prefix
 	jetstreamSessionName              = "console-session"
 	jetStreamSessionContextKey        = "jetstream-session"

--- a/src/jetstream/session_test.go
+++ b/src/jetstream/session_test.go
@@ -11,10 +11,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-type sessionTestPortalProxy struct {
-	portalProxy
-}
-
 type testEchoContext struct {
 	echo.Context
 }
@@ -25,10 +21,6 @@ func (s *testEchoContext) Request() *http.Request {
 
 func (s *testEchoContext) Get(key string) interface{} {
 	return nil
-}
-
-func (p *sessionTestPortalProxy) GetSession(c echo.Context) (*sessions.Session, error) {
-	return nil, errors.New("Test error")
 }
 
 type testSessionStore struct {

--- a/src/jetstream/setup_console.go
+++ b/src/jetstream/setup_console.go
@@ -263,15 +263,16 @@ func (p *portalProxy) initialiseConsoleConfig(envLookup *env.VarSet) (*api.Conso
 
 	val, endpointTypeSupported := api.AuthEndpointTypes[consoleConfig.AuthEndpointType]
 	if endpointTypeSupported {
-		if val == api.AuthNone {
+		switch val {
+		case api.AuthNone:
 			return consoleConfig, nil
-		} else if val == api.Local {
+		case api.Local:
 			//Auth endpoint type is set to "local", so load the local user config
 			err := initialiseLocalUsersConfiguration(consoleConfig, p)
 			if err != nil {
 				return consoleConfig, err
 			}
-		} else if val == api.Remote {
+		case api.Remote:
 			// Auth endpoint type is set to "remote", so need to load local user config vars
 			// Default authorization endpoint to be UAA endpoint
 			if consoleConfig.AuthorizationEndpoint == nil {
@@ -279,7 +280,7 @@ func (p *portalProxy) initialiseConsoleConfig(envLookup *env.VarSet) (*api.Conso
 				consoleConfig.AuthorizationEndpoint = consoleConfig.UAAEndpoint
 				log.Debugf("Using UAA Endpoint for Auth Endpoint: %s", consoleConfig.AuthorizationEndpoint)
 			}
-		} else {
+		default:
 			//Auth endpoint type has been set to an invalid value
 			return consoleConfig, errors.New("AUTH_ENDPOINT_TYPE must be set to either \"local\" or \"remote\"")
 		}
@@ -394,7 +395,7 @@ func (p *portalProxy) SetupMiddleware() echo.MiddlewareFunc {
 			// Request is not a setup request, refuse backend requests and allow all others
 			isBackendRequest, _ := regexp.MatchString(backendRequestRegex, requestURLPath)
 			isAPIRequest, _ := regexp.MatchString(apiRequestRegex, requestURLPath)
-			if !(isBackendRequest || isAPIRequest) {
+			if !isBackendRequest && !isAPIRequest {
 				return h(c)
 			}
 

--- a/src/jetstream/setup_console.go
+++ b/src/jetstream/setup_console.go
@@ -122,8 +122,7 @@ func (p *portalProxy) setupGetAvailableScopes(c echo.Context) error {
 			"Failed to authenticate with UAA due to %s", err)
 	}
 
-	c.JSON(http.StatusOK, userTokenInfo)
-	return nil
+	return c.JSON(http.StatusOK, userTokenInfo)
 }
 
 func saveConsoleConfig(consoleRepo console_config.Repository, consoleConfig *api.ConsoleConfig) error {
@@ -232,17 +231,20 @@ func (p *portalProxy) setupSaveConfig(c echo.Context) error {
 		consoleConfig.LocalUser = "admin"
 		if consoleConfig.IsSetupComplete() {
 			p.GetConfig().ConsoleConfig.AuthEndpointType = "local"
-			p.InitStratosAuthService(api.Local)
+			if err := p.InitStratosAuthService(api.Local); err != nil {
+				return err
+			}
 			c.Request().Form.Add("username", "admin")
 			c.Request().Form.Add("password", consoleConfig.LocalUserPassword)
 			c.Request().RequestURI = "/pp/v1/login"
-			setupInitialiseLocalUsersConfiguration(consoleConfig, p)
+			if err := setupInitialiseLocalUsersConfiguration(consoleConfig, p); err != nil {
+				return err
+			}
 			return p.consoleLogin(c)
 		}
 	}
 
-	c.NoContent(http.StatusOK)
-	return nil
+	return c.NoContent(http.StatusOK)
 }
 
 func (p *portalProxy) initialiseConsoleConfig(envLookup *env.VarSet) (*api.ConsoleConfig, error) {
@@ -412,7 +414,9 @@ func checkSetupComplete(portalProxy *portalProxy) bool {
 	}
 
 	// This will reload the env config
-	console_config.InitializeConfEnvProvider(consoleRepo)
+	if err := console_config.InitializeConfEnvProvider(consoleRepo); err != nil {
+		log.Warnf("Unable to initialize config environment provider: %v", err)
+	}
 
 	// Now that the config DB is an env provider, we can just use the env to fetch the setup values
 	consoleConfig, err := portalProxy.initialiseConsoleConfig(portalProxy.Env())
@@ -427,7 +431,9 @@ func checkSetupComplete(portalProxy *portalProxy) bool {
 		portalProxy.Config.ConsoleConfig = consoleConfig
 		portalProxy.Config.SSOLogin = consoleConfig.UseSSO
 		portalProxy.Config.AuthEndpointType = consoleConfig.AuthEndpointType
-		portalProxy.InitStratosAuthService(api.AuthEndpointTypes[consoleConfig.AuthEndpointType])
+		if err := portalProxy.InitStratosAuthService(api.AuthEndpointTypes[consoleConfig.AuthEndpointType]); err != nil {
+			log.Errorf("Unable to initialise Stratos auth service: %v", err)
+		}
 	}
 
 	return consoleConfig.IsSetupComplete()


### PR DESCRIPTION
## What

- `make check lint` (and the standalone `lint` verb) now run golangci-lint (errcheck, staticcheck, unused, ineffassign) over both Go modules — `src/jetstream` and the nested `src/jetstream/api`, which no scanner covered before.
- Audit tooling updates:
  - trivy: replace the deprecated `--security-checks vuln,config` with `--scanners vuln,misconfig`
  - `make audit backend` also scans the `api` module (gosec + govulncheck)
  - new opt-in modes, deliberately off the default path: `audit tests` (gosec incl. test files + #nosec report), `audit tree` (trivy over the whole tree, covering the deploy/ Dockerfiles and helm chart), `audit history` (gitleaks over full git history), `audit licenses` (osv-scanner license report)
  - `ZIZMOR_FLAGS` passthrough for `audit actions` (e.g. `--persona=auditor`)
- Docs refreshed: tool and command tables in `docs/developer-environment.md` and an explanation of why the new modes stay off the default path.
- The new gate merges green: every golangci-lint finding in both modules is resolved.

## Lint findings resolved

The uncapped baseline was 705 findings. Two policy exclusions are set in `src/jetstream/.golangci.yml` with reasons in the file: errcheck skips `_test.go` (teardown-call noise, 289 findings), and staticcheck's ST1005 error-string style rule is off (error text is user-facing API/log surface, 230 findings). The remaining 186 were fixed:

- **errcheck (74)** — echo handler results returned to echo, logout/cleanup paths log-and-continue, setup prerequisites propagate, cleanup calls explicitly acknowledged.
- **staticcheck (66)** — io/ioutil modernized, if/else chains to tagged switches, redundant conversions dropped. Two documented suppressions on the CFB cipher calls: persisted tokens and client secrets are CFB-encrypted, so changing modes needs a versioned re-encryption migration (possible follow-up), not a drop-in swap.
- **unused (33)** — 32 dead symbols deleted (~213 lines), each verified by repo-wide search; one kept with a comment (referenced by the parked sonobuoy analyzer file).
- **ineffassign (15)** — including three real bugs: shadowed errors in local-user INSERT/UPDATE made zero-row writes return success; metrics proxy handlers swallowed request-build errors and forwarded nil responses; a failed session creation still attempted the session save. Three test assertions that could never fail are also unmasked.

Verified with the full gate: frontend lint + 3094 unit tests + production build + all backend Go tests green.