### PR TITLE
fix(jetstream): surface close error on unarchive open-failure path

### DIFF
--- a/src/jetstream/plugins/cfapppush/unarchive.go
+++ b/src/jetstream/plugins/cfapppush/unarchive.go
@@ -2,6 +2,7 @@ package cfapppush
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -64,8 +65,9 @@ func unarchive(src, dst string) error {
 			}
 			in, err := entry.Open()
 			if err != nil {
-				out.Close()
-				return err
+				// Join rather than drop the close error - the open failure
+				// matters more, but a failed close is still worth surfacing
+				return errors.Join(err, out.Close())
 			}
 			defer in.Close()
 			_, err = io.Copy(out, in)


### PR DESCRIPTION
Clears the last open Code Quality warning (go/unhandled-writable-file-close, unarchive.go).

The entry.Open error path in cfapppush's unarchive discarded the error from out.Close(). Now the close error is joined with the open error via errors.Join, so a failed close is surfaced instead of silently dropped while the more significant open failure still leads the chain.

Verified: cfapppush build and tests pass, make lint clean on both modules, full check gate green.