### PR TITLE
CF section navigation fixes; transient connect/disconnect states; modeless endpoint dialogs

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.spec.ts
@@ -1,9 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
+import { Signal, WritableSignal, computed, importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
+import { Router, provideRouter } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { of } from 'rxjs';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { TabNavService } from '@stratosui/core';
+import { EndpointRowActionsService, TabNavService } from '@stratosui/core';
+import type { EndpointModel } from '@stratosui/store';
+import { EndpointsDataService } from '../../../../../store/src/services/endpoints-data.service';
 import { EntityCatalogHelper, EntityCatalogHelpers, EntityCatalogTestModule, generateStratosEntities, TEST_CATALOGUE_ENTITIES } from '@stratosui/store';
 import { createBasicStoreModule, STORE_TEST_PROVIDERS, testSCFEndpointGuid, populateStoreWithTestEndpoint } from '@stratosui/store/testing';
 import { CF_BASE_TEST_PROVIDERS, generateCfActiveRouteMock } from '@test-framework/cf';
@@ -64,5 +68,93 @@ describe('CloudFoundryComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+// The single-CF shortcut is a one-shot decision taken once the endpoint list
+// has hydrated. It used to sample connectedCFEndpoints$ with take(1) in the
+// constructor, which on a cold load reads the empty pre-fetch list, sees zero
+// endpoints and never looks again — so the picker it exists to skip was shown
+// to every single-CF user who reloaded or followed a bookmark. See #5638.
+describe('CloudFoundryComponent single-CF shortcut', () => {
+  const endpoint = (guid: string): EndpointModel =>
+    ({ guid, name: guid, cnsi_type: 'cf', connectionStatus: 'connected' }) as EndpointModel;
+
+  let endpoints: WritableSignal<EndpointModel[]>;
+  let resolveReady: () => void;
+  let ready: Promise<void>;
+  let navigate: ReturnType<typeof vi.fn>;
+
+  // Reproduces a cold load: the component is constructed while the endpoint
+  // list is still empty and the first /pp/v1/info call is in flight, and the
+  // list only fills as hydration completes. `hydrate` runs in that window, so
+  // any implementation that reads the list at construction time sees zero.
+  const createComponent = async (hydrate: () => void = () => undefined): Promise<void> => {
+    TestBed.createComponent(CloudFoundryComponent);
+    hydrate();
+    resolveReady();
+    await ready;
+    // Let the whenReady().then() callback run.
+    await Promise.resolve();
+  };
+
+  beforeEach(async () => {
+    endpoints = signal<EndpointModel[]>([]);
+    ready = new Promise<void>(resolve => { resolveReady = resolve; });
+    navigate = vi.fn().mockResolvedValue(true);
+
+    const availableCFEndpoints: Signal<EndpointModel[]> = computed(() => endpoints());
+    const cfService = {
+      // The picker + shortcut read the "available" set (connected/expired/
+      // connecting); the connected/expired filtering itself is covered in the
+      // CloudFoundryService spec. Here it's a passthrough so the shortcut's
+      // count logic can be exercised directly.
+      availableCFEndpoints,
+      // The duplicate-URL banner in the template resolves CloudFoundryService
+      // through this same component-level provider. It plays no part in the
+      // shortcut, so an empty list keeps it inert.
+      connectedCFEndpoints$: of([] as EndpointModel[]),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CloudFoundryComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        { provide: EndpointsDataService, useValue: { whenReady: () => ready, isConnecting: () => false } },
+        { provide: EndpointRowActionsService, useValue: { buildEndpointActions: () => [] } },
+      ],
+    })
+      // CloudFoundryService is a component-level provider, so it has to be
+      // replaced on the component rather than in the testing module.
+      .overrideComponent(CloudFoundryComponent, { set: { providers: [{ provide: CloudFoundryService, useValue: cfService }] } })
+      .compileComponents();
+
+    vi.spyOn(TestBed.inject(Router), 'navigate').mockImplementation(navigate);
+  });
+
+  it('routes into the only connected CF once the endpoint list has hydrated', async () => {
+    await createComponent(() => endpoints.set([endpoint('cf-only')]));
+
+    expect(navigate).toHaveBeenCalledWith(['cloud-foundry', 'cf-only']);
+  });
+
+  it('routes into a lone expired CF — the user never disconnected it, so it is still theirs', async () => {
+    const expired = { guid: 'cf-expired', name: 'cf-expired', cnsi_type: 'cf', connectionStatus: 'expired' } as EndpointModel;
+    await createComponent(() => endpoints.set([expired]));
+
+    expect(navigate).toHaveBeenCalledWith(['cloud-foundry', 'cf-expired']);
+  });
+
+  it('leaves the picker up when several CFs are connected', async () => {
+    await createComponent(() => endpoints.set([endpoint('cf-1'), endpoint('cf-2')]));
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('leaves the picker up when no CF is connected', async () => {
+    await createComponent();
+
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.ts
@@ -90,7 +90,11 @@ export class CloudFoundryComponent {
     // overlays the wire status while a connect/reconnect is in flight, tracking
     // the isConnecting signal so the row updates when the operation resolves.
     const rowStatus = (e: EndpointModel): string =>
-      withConnectingOverlay(e.connectionStatus, this.endpointsData.isConnecting(e.guid ?? ''));
+      withConnectingOverlay(
+        e.connectionStatus,
+        this.endpointsData.isConnecting(e.guid ?? ''),
+        this.endpointsData.isDisconnecting(e.guid ?? ''),
+      );
 
     const sortState: WritableSignal<SignalListSort> = signal({ field: 'name', direction: 'asc' });
     const sortExtractors: Record<string, (e: EndpointModel) => unknown> = {
@@ -128,7 +132,7 @@ export class CloudFoundryComponent {
     const statusColor = (e: EndpointModel): SignalListPillColor => {
       const s = rowStatus(e);
       if (s === 'connected') return 'success';
-      if (s === 'expired' || s === 'connecting') return 'warning';
+      if (s === 'expired' || s === 'connecting' || s === 'disconnecting') return 'warning';
       return 'neutral';
     };
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry/cloud-foundry.component.ts
@@ -8,18 +8,19 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { take } from 'rxjs/operators';
 
 import {
   EndpointRowActionsService,
   PageHeaderComponent,
   SignalListComponent,
   SignalListConfig,
+  SignalListPillColor,
   SignalListSort,
   naturalCompare,
 } from '@stratosui/core';
+import { EndpointsDataService } from '../../../../../store/src/services/endpoints-data.service';
+import { withConnectingOverlay } from '@stratosui/store';
 import type { EndpointModel } from '@stratosui/store';
 
 import { CfEndpointsMissingComponent } from '../../../shared/components/cf-endpoints-missing/cf-endpoints-missing.component';
@@ -42,6 +43,7 @@ import { CloudFoundryService } from '../../../shared/data-services/cloud-foundry
 })
 export class CloudFoundryComponent {
   cloudFoundryService = inject(CloudFoundryService);
+  private endpointsData = inject(EndpointsDataService);
   private router = inject(Router);
   // The CF picker is a projection of the Endpoints page onto its CF subset -
   // rows carry the same management kebab (Connect / Disconnect / Edit /
@@ -52,14 +54,24 @@ export class CloudFoundryComponent {
   public readonly connectedCount: Signal<number>;
 
   constructor() {
-    const connected: Signal<EndpointModel[]> = toSignal(
-      this.cloudFoundryService.connectedCFEndpoints$,
-      { initialValue: [] as EndpointModel[] },
-    );
-    this.connectedCount = computed(() => connected().length);
+    // The picker lists every CF that belongs to the user — connected, expired
+    // (theirs, needs reconnect), or mid-connect — not just the ones with a live
+    // token. A disconnected CF the user dropped is reconnected from the
+    // Endpoints page, not here.
+    const available: Signal<EndpointModel[]> = this.cloudFoundryService.availableCFEndpoints;
+    this.connectedCount = computed(() => available().length);
 
-    // Single connected CF — skip the picker and route straight in.
-    this.cloudFoundryService.connectedCFEndpoints$.pipe(take(1)).subscribe(endpoints => {
+    // Single CF — skip the picker and route straight in. The decision waits on
+    // whenReady() because the endpoint list is empty while the first
+    // /pp/v1/info call is in flight: on a cold load (reload, bookmark, first
+    // navigation after login) reading it at construction always sees zero and
+    // the shortcut never fires. whenReady() also triggers that fetch if nothing
+    // else has yet, and resolves on failure too — a list that never arrives
+    // leaves the picker up, which is the right fallback. At this hydration point
+    // no user connect is in flight, so the set holds only settled connected/
+    // expired CFs; routing into a lone expired one lands on its reconnect prompt.
+    void this.endpointsData.whenReady().then(() => {
+      const endpoints = available();
       if (endpoints.length === 1) {
         void this.router.navigate(['cloud-foundry', endpoints[0].guid]);
       }
@@ -68,15 +80,24 @@ export class CloudFoundryComponent {
     const nameFilter: WritableSignal<string> = signal('');
     const filtered: Signal<EndpointModel[]> = computed(() => {
       const q = nameFilter().trim().toLowerCase();
-      const all = connected();
+      const all = available();
       if (!q) return all;
       return all.filter(e => (e.name ?? '').toLowerCase().includes(q));
     });
+    // Status the picker renders per row. The set now holds mixed states —
+    // connected, expired (needs reconnect), mid-connect — so the row must say
+    // which, else an expired CF looks identical to a live one. 'connecting'
+    // overlays the wire status while a connect/reconnect is in flight, tracking
+    // the isConnecting signal so the row updates when the operation resolves.
+    const rowStatus = (e: EndpointModel): string =>
+      withConnectingOverlay(e.connectionStatus, this.endpointsData.isConnecting(e.guid ?? ''));
+
     const sortState: WritableSignal<SignalListSort> = signal({ field: 'name', direction: 'asc' });
     const sortExtractors: Record<string, (e: EndpointModel) => unknown> = {
       name: e => e.name ?? '',
       address: e => e.api_endpoint?.Host ?? '',
       user: e => e.user?.name ?? '',
+      status: e => rowStatus(e),
     };
     const sorted: Signal<EndpointModel[]> = computed(() => {
       const items = filtered();
@@ -99,6 +120,17 @@ export class CloudFoundryComponent {
       const i = pageIndex();
       return items.slice(i * sz, (i + 1) * sz);
     });
+
+    const statusLabel = (e: EndpointModel): string => {
+      const s = rowStatus(e);
+      return s.charAt(0).toUpperCase() + s.slice(1);
+    };
+    const statusColor = (e: EndpointModel): SignalListPillColor => {
+      const s = rowStatus(e);
+      if (s === 'connected') return 'success';
+      if (s === 'expired' || s === 'connecting') return 'warning';
+      return 'neutral';
+    };
 
     this.listConfig = signal<SignalListConfig<EndpointModel>>({
       pagedItems: paged,
@@ -129,6 +161,14 @@ export class CloudFoundryComponent {
           widthHint: '12rem',
         },
         {
+          header: 'Status', key: 'status',
+          kind: 'dot',
+          pillColor: statusColor,
+          sortField: (e: EndpointModel) => rowStatus(e),
+          render: statusLabel,
+          widthHint: '10rem',
+        },
+        {
           header: '', key: 'actions',
           kind: 'actions',
           actions: (e: EndpointModel) => this.endpointRowActions.buildEndpointActions(e, { unregister: false }),
@@ -137,7 +177,7 @@ export class CloudFoundryComponent {
         },
       ],
       getRowKey: (e: EndpointModel) => e.guid ?? e.name,
-      emptyMessage: 'There are no Cloud Foundry endpoints connected',
+      emptyMessage: 'There are no connected or expired Cloud Foundry endpoints',
       emptyFilterMessage: 'No Cloud Foundry endpoints match the current filters',
       loadingMessage: 'Loading…',
       nameFilter,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.spec.ts
@@ -1,21 +1,27 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideRouter } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { TEST_CATALOGUE_ENTITIES, generateStratosEntities, EntityCatalogTestModule, EntityCatalogHelper, EntityCatalogHelpers } from '@stratosui/store';
 import { STORE_TEST_PROVIDERS, testSCFEndpointGuid, populateStoreWithTestEndpoint } from '@stratosui/store/testing';
 import { generateCFEntities, generateTestCfEndpointServiceProvider, ActiveRouteCfOrgSpace } from '@test-framework/cf';
+import { CfAppsSignalConfigService } from '../../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
 import { CloudFoundrySummaryTabComponent } from './cloud-foundry-summary-tab.component';
 
 describe('CloudFoundrySummaryTabComponent', () => {
   let component: CloudFoundrySummaryTabComponent;
   let fixture: ComponentFixture<CloudFoundrySummaryTabComponent>;
+  let appsConfig: { selectedOrg: ReturnType<typeof signal<string | null>>; selectedSpace: ReturnType<typeof signal<string | null>> };
 
   beforeEach(async () => {
+    appsConfig = {
+      selectedOrg: signal<string | null>(null),
+      selectedSpace: signal<string | null>(null),
+    };
     await TestBed.configureTestingModule({
       imports: [
         CloudFoundrySummaryTabComponent,
@@ -45,6 +51,7 @@ describe('CloudFoundrySummaryTabComponent', () => {
             spaceGuid: testSCFEndpointGuid
           }
         },
+        { provide: CfAppsSignalConfigService, useValue: appsConfig },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
@@ -64,5 +71,31 @@ describe('CloudFoundrySummaryTabComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // The Applications tile must stay inside the CF section — it used to call
+  // goToAppWall(), landing on the global /applications wall and dropping the
+  // CF context (the side nav reverted to the global menu). See #5638.
+  describe('Applications tile link', () => {
+    it('opens this CF Applications tab, not the application wall', () => {
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      component.appLink();
+
+      expect(navigate).toHaveBeenCalledWith(['/cloud-foundry', testSCFEndpointGuid, 'applications']);
+    });
+
+    it('clears any org/space scope left on the shared apps config', () => {
+      vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+      // Seed the scope a previous app-wall or org visit would have left behind:
+      // the tab self-scopes to the CNSI but deliberately keeps org/space.
+      appsConfig.selectedOrg.set('stale-org');
+      appsConfig.selectedSpace.set('stale-space');
+
+      component.appLink();
+
+      expect(appsConfig.selectedOrg()).toBeNull();
+      expect(appsConfig.selectedSpace()).toBeNull();
+    });
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.ts
@@ -13,7 +13,6 @@ import {
   LoadingPageComponent,
   CardNumberMetricComponent
 } from '@stratosui/core';
-import { goToAppWall } from '../../cf.helpers';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import { CfAppsSignalConfigService } from '../../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
 import { CardCfInfoComponent } from '../../../../shared/components/cards/card-cf-info/card-cf-info.component';
@@ -60,7 +59,13 @@ export class CloudFoundrySummaryTabComponent {
 
   constructor() {
     this.appLink = () => {
-      goToAppWall(this.appsConfig, this.router, this.cfEndpointService.cfGuid);
+      // The tile means "every app in this CF", so drop any org/space scope a
+      // previous mount left on the root-singleton config. The Applications tab
+      // can't do this itself: it keeps the existing org/space so that returning
+      // from an app detail page preserves the filter the user set there.
+      this.appsConfig.selectedOrg.set(null);
+      this.appsConfig.selectedSpace.set(null);
+      this.router.navigate(['/cloud-foundry', this.cfEndpointService.cfGuid, 'applications']);
     };
 
     const endpointData = this.registry.acquire(this.cfEndpointService.cfGuid);

--- a/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
+++ b/src/frontend/packages/cloud-foundry/src/interceptors/cf-api-interceptor.ts
@@ -3,6 +3,7 @@ import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { tap } from 'rxjs/operators';
 import {
+  CONNECT_ENDPOINT_DIALOG_OPTIONS,
   ConnectEndpointConfig,
   ConnectEndpointDialogComponent,
   EndpointAuthStateService,
@@ -178,10 +179,7 @@ export const cfApiInterceptor: HttpInterceptorFn = (req, next) => {
                   // Same dialog options the endpoints list uses.
                   dialog.open(ConnectEndpointDialogComponent, {
                     data,
-                    disableClose: true,
-                    width: '550px',
-                    maxWidth: '550px',
-                    panelClass: ['overflow-visible', 'p-6'],
+                    ...CONNECT_ENDPOINT_DIALOG_OPTIONS,
                   });
                 });
               }

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.spec.ts
@@ -15,6 +15,7 @@ import { CloudFoundryService } from './cloud-foundry.service';
 describe('CloudFoundryService endpoint sets', () => {
   let list: WritableSignal<EndpointModel[]>;
   let connecting: Set<string>;
+  let disconnecting: Set<string>;
   let service: CloudFoundryService;
 
   const ep = (guid: string, connectionStatus: string, cnsi_type = 'cf'): EndpointModel =>
@@ -23,12 +24,17 @@ describe('CloudFoundryService endpoint sets', () => {
   beforeEach(() => {
     list = signal<EndpointModel[]>([]);
     connecting = new Set<string>();
+    disconnecting = new Set<string>();
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
         {
           provide: EndpointsDataService,
-          useValue: { endpointsList: list, isConnecting: (g: string) => connecting.has(g) },
+          useValue: {
+            endpointsList: list,
+            isConnecting: (g: string) => connecting.has(g),
+            isDisconnecting: (g: string) => disconnecting.has(g),
+          },
         },
         CloudFoundryService,
       ],
@@ -67,5 +73,17 @@ describe('CloudFoundryService endpoint sets', () => {
     // fan-out set (still no usable token).
     expect(service.availableCFEndpoints().map(e => e.guid)).toEqual(['a', 'c']);
     expect(service.connectedCFEndpoints().map(e => e.guid)).toEqual(['a']);
+  });
+
+  it('availableCFEndpoints keeps a CF visible while it is mid-disconnect (disconnecting overlay)', () => {
+    disconnecting.add('a');
+    list.set([ep('a', 'connected'), ep('b', 'connected')]);
+
+    // 'a' is mid-disconnect: the picker keeps it visible (as Disconnecting)
+    // until the operation settles. Fan-out still includes it — the token
+    // remains valid until the DELETE lands, and the wire status only flips
+    // once it does.
+    expect(service.availableCFEndpoints().map(e => e.guid)).toEqual(['a', 'b']);
+    expect(service.connectedCFEndpoints().map(e => e.guid)).toEqual(['a', 'b']);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.spec.ts
@@ -1,0 +1,71 @@
+import { WritableSignal, provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { EndpointsDataService } from '../../../../store/src/services/endpoints-data.service';
+import { EndpointModel } from '../../../../store/src/types/endpoint.types';
+import { CloudFoundryService } from './cloud-foundry.service';
+
+// The two CF endpoint sets deliberately diverge:
+//   connectedCFEndpoints — connected-only, feeds request fan-out (a request to
+//     an expired or mid-connect token would 401 / isn't usable yet).
+//   availableCFEndpoints — connected + expired + connecting, feeds the picker
+//     (an expired CF the user never disconnected is still theirs; a mid-connect
+//     one should show). Excludes disconnected — the user dropped it.
+describe('CloudFoundryService endpoint sets', () => {
+  let list: WritableSignal<EndpointModel[]>;
+  let connecting: Set<string>;
+  let service: CloudFoundryService;
+
+  const ep = (guid: string, connectionStatus: string, cnsi_type = 'cf'): EndpointModel =>
+    ({ guid, name: guid, cnsi_type, connectionStatus } as unknown as EndpointModel);
+
+  beforeEach(() => {
+    list = signal<EndpointModel[]>([]);
+    connecting = new Set<string>();
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: EndpointsDataService,
+          useValue: { endpointsList: list, isConnecting: (g: string) => connecting.has(g) },
+        },
+        CloudFoundryService,
+      ],
+    });
+    service = TestBed.inject(CloudFoundryService);
+  });
+
+  it('connectedCFEndpoints is connected-only, CF-typed', () => {
+    list.set([
+      ep('a', 'connected'),
+      ep('b', 'expired'),
+      ep('c', 'disconnected'),
+      ep('k', 'connected', 'metrics'),
+    ]);
+
+    expect(service.connectedCFEndpoints().map(e => e.guid)).toEqual(['a']);
+  });
+
+  it('availableCFEndpoints includes connected + expired, excludes disconnected and non-CF', () => {
+    list.set([
+      ep('a', 'connected'),
+      ep('b', 'expired'),
+      ep('c', 'disconnected'),
+      ep('k', 'connected', 'metrics'),
+    ]);
+
+    expect(service.availableCFEndpoints().map(e => e.guid)).toEqual(['a', 'b']);
+  });
+
+  it('availableCFEndpoints includes a disconnected CF while it is mid-connect (connecting overlay)', () => {
+    connecting.add('c');
+    list.set([ep('a', 'connected'), ep('c', 'disconnected')]);
+
+    // 'c' has a disconnected wire status but a connect is in flight, so the
+    // overlay makes it 'connecting' — visible in the picker, but NOT in the
+    // fan-out set (still no usable token).
+    expect(service.availableCFEndpoints().map(e => e.guid)).toEqual(['a', 'c']);
+    expect(service.connectedCFEndpoints().map(e => e.guid)).toEqual(['a']);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, Signal, computed, inject } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { EndpointsDataService } from '../../../../store/src/services/endpoints-data.service';
 import { APIResource, EntityInfo } from '../../../../store/src/types/api.types';
-import { EndpointModel } from '../../../../store/src/types/endpoint.types';
+import { EndpointModel, withConnectingOverlay } from '../../../../store/src/types/endpoint.types';
 
 @Injectable({
   providedIn: 'root'
@@ -17,6 +17,38 @@ export class CloudFoundryService {
   // signal is the authoritative source.
   private endpointsData = inject(EndpointsDataService);
 
+  // Signal form of the CF endpoint set. Callers that need to read a list at a
+  // known point in time — rather than react to it — must use these: the
+  // observables below are driven by toObservable(), which republishes on the
+  // next effect flush, so reading one immediately after
+  // EndpointsDataService.whenReady() still sees the pre-hydration value.
+  readonly cfEndpoints: Signal<EndpointModel[]> = computed(() =>
+    this.endpointsData.endpointsList().filter(e => e.cnsi_type === 'cf')
+  );
+
+  // Endpoints whose token can serve a request right now. Request fan-out (the
+  // app/service walls, the "have a connected CF" gates) reads this. 'expired'
+  // is excluded — a dead token 401s — and so is 'connecting': a token mid-
+  // connect isn't usable yet. Only genuinely connected CFs qualify.
+  readonly connectedCFEndpoints: Signal<EndpointModel[]> = computed(() =>
+    this.cfEndpoints().filter(endpoint => endpoint.connectionStatus === 'connected')
+  );
+
+  // Endpoints that belong to the user and should appear in the /cloud-foundry
+  // picker: a live connection, an expired one they never disconnected (still
+  // theirs, needs reconnect), or one mid-connect (shows the transient state).
+  // 'disconnected' is excluded — the user dropped it; reconnect from the
+  // Endpoints page. Broader than connectedCFEndpoints, which is fan-out only.
+  readonly availableCFEndpoints: Signal<EndpointModel[]> = computed(() =>
+    this.cfEndpoints().filter(endpoint => {
+      const status = withConnectingOverlay(
+        endpoint.connectionStatus,
+        this.endpointsData.isConnecting(endpoint.guid ?? ''),
+      );
+      return status === 'connected' || status === 'expired' || status === 'connecting';
+    })
+  );
+
   hasRegisteredCFEndpoints$: Observable<boolean>;
   hasConnectedCFEndpoints$: Observable<boolean>;
   connectedCFEndpoints$: Observable<EndpointModel[]>;
@@ -24,17 +56,8 @@ export class CloudFoundryService {
   waitForAppEntity$!: Observable<EntityInfo<APIResource>>;
 
   constructor() {
-    const endpoints$ = toObservable(this.endpointsData.endpointsList);
-
-    this.cFEndpoints$ = endpoints$.pipe(
-      map(endpoints => endpoints.filter(e => e.cnsi_type === 'cf'))
-    );
-
-    this.connectedCFEndpoints$ = this.cFEndpoints$.pipe(
-      map(endpoints => endpoints.filter(
-        endpoint => endpoint.connectionStatus === 'connected' || endpoint.connectionStatus === 'checking'
-      ))
-    );
+    this.cFEndpoints$ = toObservable(this.cfEndpoints);
+    this.connectedCFEndpoints$ = toObservable(this.connectedCFEndpoints);
 
     this.hasConnectedCFEndpoints$ = this.connectedCFEndpoints$.pipe(
       map(endpoints => !!endpoints.length)

--- a/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/data-services/cloud-foundry.service.ts
@@ -36,16 +36,18 @@ export class CloudFoundryService {
 
   // Endpoints that belong to the user and should appear in the /cloud-foundry
   // picker: a live connection, an expired one they never disconnected (still
-  // theirs, needs reconnect), or one mid-connect (shows the transient state).
-  // 'disconnected' is excluded — the user dropped it; reconnect from the
-  // Endpoints page. Broader than connectedCFEndpoints, which is fan-out only.
+  // theirs, needs reconnect), or one mid-connect/mid-disconnect (shows the
+  // transient state until the operation settles). 'disconnected' is excluded —
+  // the user dropped it; reconnect from the Endpoints page. Broader than
+  // connectedCFEndpoints, which is fan-out only.
   readonly availableCFEndpoints: Signal<EndpointModel[]> = computed(() =>
     this.cfEndpoints().filter(endpoint => {
       const status = withConnectingOverlay(
         endpoint.connectionStatus,
         this.endpointsData.isConnecting(endpoint.guid ?? ''),
+        this.endpointsData.isDisconnecting(endpoint.guid ?? ''),
       );
-      return status === 'connected' || status === 'expired' || status === 'connecting';
+      return status === 'connected' || status === 'expired' || status === 'connecting' || status === 'disconnecting';
     })
   );
 

--- a/src/frontend/packages/core/src/app.module.ts
+++ b/src/frontend/packages/core/src/app.module.ts
@@ -206,7 +206,7 @@ export class AppModule {
     //     selector: (state: AppState) => state.requestData.endpoint,
     //     eventTriggered: (state: IRequestEntityTypeState<EndpointModel>) => {
     //       return Object.values(state).reduce((events, endpoint) => {
-    //         if (endpoint.connectionStatus === 'checking') {
+    //         if (endpoint.connectionStatus === 'connecting') {
     //           events.push(new GlobalEventData(true, endpoint));
     //         }
     //         return events;

--- a/src/frontend/packages/core/src/core/signals/endpoints-signal.service.ts
+++ b/src/frontend/packages/core/src/core/signals/endpoints-signal.service.ts
@@ -81,7 +81,7 @@ function isConnected(endpoint: EndpointModel): boolean {
     return (
       epType.definition.unConnectable ||
       endpoint.connectionStatus === 'connected' ||
-      endpoint.connectionStatus === 'checking'
+      endpoint.connectionStatus === 'connecting'
     );
   } catch {
     return false;

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.html
@@ -1,11 +1,11 @@
-<div class="connection-dialog__loading-wrapper">
-  <app-progress-bar class="connection-dialog__loading"
-    [color]="(connectService.connectingError$ | async) && (connectService.isBusy$ | async) === false ? 'warn' : 'primary'"
-    [mode]="(connectService.isBusy$ | async) ? 'indeterminate' : 'solid'">
-  </app-progress-bar>
-</div>
+@if (connectService.isBusy$ | async) {
+  <div class="connection-dialog__loading-wrapper">
+    <app-progress-bar class="connection-dialog__loading" color="primary" mode="indeterminate">
+    </app-progress-bar>
+  </div>
+}
 <div class="connection-dialog">
-  <div class="connection-dialog__title">
+  <div class="connection-dialog__title" data-dialog-drag-handle>
     <h2 class="dialog-title">
       Connect to {{ data.name }}
     </h2>
@@ -20,8 +20,14 @@
   <app-dialog-error message="{{connectService.connectingError$ | async}}"
     [show]="!!(connectService.connectingError$ | async) && (connectService.isBusy$ | async) === false">
   </app-dialog-error>
+  @if (!!(connectService.connectingError$ | async) && (connectService.isBusy$ | async) === false && stillConnected) {
+    <div class="flex items-center gap-2 text-xs text-content-muted">
+      <span class="material-icons text-base">info</span>
+      <span>Your existing connection is unaffected and remains active.</span>
+    </div>
+  }
   <div class="dialog-actions connection-dialog__actions">
-    <button (click)="dialogRef.close()" class="btn btn-warn">Cancel</button>
+    <button (click)="dialogRef.close()" class="btn btn-secondary">Cancel</button>
     <button (click)="connect()" [disabled]="(connectService.isBusy$ | async) || !valid" class="btn btn-primary">Connect</button>
   </div>
 </div>

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.scss
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.scss
@@ -23,9 +23,7 @@
   &__actions {
     display: flex;
     justify-content: flex-end;
-    gap: 12px;
-    padding-top: 16px;
-    border-top: 1px solid var(--content-border);
+    gap: 8px;
     margin-top: auto;
   }
 
@@ -42,13 +40,13 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    margin-bottom: 8px;
 
+    // Match the confirmation-dialog header (text-lg font-semibold)
     h2 {
       flex: 1;
       margin: 0;
-      font-size: 20px;
-      font-weight: 500;
+      font-size: 18px;
+      font-weight: 600;
     }
   }
 

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnDestroy, signal, Injector, inject } from '@angular/core';
 import { AppProgressBarComponent } from '../../../shared/components/progress-bar/app-progress-bar.component';
-import { MAT_DIALOG_DATA, TailwindDialogRef } from '../../../shared/services/tailwind-dialog.service';
+import { MAT_DIALOG_DATA, TailwindDialogConfig, TailwindDialogRef } from '../../../shared/services/tailwind-dialog.service';
 import { Observable, Subscription } from 'rxjs';
 import { take, defaultIfEmpty, delay, startWith } from 'rxjs/operators';
 import { toObservable } from '@angular/core/rxjs-interop';
@@ -16,6 +16,22 @@ import { SidePanelService } from '../../../shared/services/side-panel.service';
 import { TailwindSnackBarService } from '../../../shared/services/tailwind-snackbar.service';
 import { ConnectEndpointComponent } from '../connect-endpoint/connect-endpoint.component';
 import { ConnectEndpointConfig, ConnectEndpointService } from '../connect.service';
+
+/** Shared open() options for the connect dialog — every call site spreads
+ *  this (adding its own `data`) so the dialog looks and behaves the same
+ *  everywhere. Modeless + draggable so the endpoint card behind stays
+ *  visible while connecting (its status pill reads "Connecting") and the
+ *  panel can be dragged off the card. */
+export const CONNECT_ENDPOINT_DIALOG_OPTIONS: TailwindDialogConfig = {
+  disableClose: true,
+  // Same footprint as the ConfirmationDialogService dialogs (e.g. the
+  // Disconnect confirm) so all endpoint dialogs read as one family.
+  width: '400px',
+  maxWidth: '400px',
+  panelClass: ['overflow-visible', 'p-6'],
+  draggable: true,
+  modeless: true,
+};
 
 @Component({
   selector: 'app-connect-endpoint-dialog',
@@ -48,11 +64,21 @@ export class ConnectEndpointDialogComponent implements OnDestroy {
   public helpDocument = this._helpDocument.asReadonly();
   public helpDocument$: Observable<string | null>;
 
+  private endpointsData!: EndpointsDataService;
+
+  // A failed reconnect does not touch the stored token, so if the endpoint
+  // was already connected it still is. Read alongside the error message to
+  // reassure the user their session survived the failed attempt.
+  get stillConnected(): boolean {
+    return this.endpointsData.endpoints().get(this.data.guid)?.connectionStatus === 'connected';
+  }
+
   constructor() {
     const data = this.data;
     const endpointsService = inject(EndpointsService);
 
     const endpointsData = inject(EndpointsDataService);
+    this.endpointsData = endpointsData;
     this.connectService = new ConnectEndpointService(endpointsService, data, endpointsData, this.injector);
 
     this.hasConnected = this.connectService.hasConnected$.subscribe(() => {

--- a/src/frontend/packages/core/src/features/endpoints/endpoint-row-actions.service.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-row-actions.service.ts
@@ -9,7 +9,7 @@ import { SignalListRowAction } from '../../shared/components/signal-list/signal-
 import { EndpointAuthStateService } from '../../shared/services/endpoint-auth-state.service';
 import { TailwindDialogService } from '../../shared/services/tailwind-dialog.service';
 import { TailwindSnackBarService } from '../../shared/services/tailwind-snackbar.service';
-import { ConnectEndpointDialogComponent } from './connect-endpoint-dialog/connect-endpoint-dialog.component';
+import { CONNECT_ENDPOINT_DIALOG_OPTIONS, ConnectEndpointDialogComponent } from './connect-endpoint-dialog/connect-endpoint-dialog.component';
 import { EndpointsSignalConfigService } from './endpoints-page/endpoints-signal-config.service';
 
 /**
@@ -125,10 +125,7 @@ export class EndpointRowActionsService {
         // Prefills the Reconnect dialog with the live connection's user
         username: ep.user?.name,
       },
-      disableClose: true,
-      width: '550px',
-      maxWidth: '550px',
-      panelClass: ['overflow-visible', 'p-6'],
+      ...CONNECT_ENDPOINT_DIALOG_OPTIONS,
     });
   }
 

--- a/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.ts
@@ -146,6 +146,9 @@ export class EndpointsSignalListComponent {
       if (this.endpointsData.isConnecting(ep.guid ?? '')) {
         return 'Connecting';
       }
+      if (this.endpointsData.isDisconnecting(ep.guid ?? '')) {
+        return 'Disconnecting';
+      }
       // 'expired' arrives computed on connectionStatus (Task 3, from wire
       // data); the authState overlay catches 401s the interceptor witnessed
       // THIS session, before the next info refetch reflects the
@@ -159,7 +162,7 @@ export class EndpointsSignalListComponent {
     };
 
     const statusColor = (ep: EndpointModel): SignalListPillColor => {
-      if (this.endpointsData.isConnecting(ep.guid ?? '')) {
+      if (this.endpointsData.isConnecting(ep.guid ?? '') || this.endpointsData.isDisconnecting(ep.guid ?? '')) {
         return 'warning';
       }
       if (isEndpointExpired(ep, this.authState.stale())) {

--- a/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoints-page/endpoints-signal-list.component.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 
 import {
   EndpointModel,
+  EndpointsDataService,
   MenuItem,
   UserFavorite,
   UserFavoriteManager,
@@ -58,6 +59,7 @@ export class EndpointsSignalListComponent {
   private userFavoriteManager = inject(UserFavoriteManager);
   private rowActions = inject(EndpointRowActionsService);
   private authState = inject(EndpointAuthStateService);
+  private endpointsData = inject(EndpointsDataService);
 
   /**
    * Primary "Register Endpoint" action surfaced on the L5 sub-nav row above
@@ -138,6 +140,12 @@ export class EndpointsSignalListComponent {
     const userLabel = (ep: EndpointModel): string => ep.user?.name ?? '';
 
     const statusLabel = (ep: EndpointModel): string => {
+      // 'connecting' is a transient overlay held while a connect/reconnect is in
+      // flight (EndpointsDataService.isConnecting); it outranks the settled
+      // states because an active operation is what the user most wants to see.
+      if (this.endpointsData.isConnecting(ep.guid ?? '')) {
+        return 'Connecting';
+      }
       // 'expired' arrives computed on connectionStatus (Task 3, from wire
       // data); the authState overlay catches 401s the interceptor witnessed
       // THIS session, before the next info refetch reflects the
@@ -151,13 +159,16 @@ export class EndpointsSignalListComponent {
     };
 
     const statusColor = (ep: EndpointModel): SignalListPillColor => {
+      if (this.endpointsData.isConnecting(ep.guid ?? '')) {
+        return 'warning';
+      }
       if (isEndpointExpired(ep, this.authState.stale())) {
         return 'warning';
       }
       const s = ep.connectionStatus;
       if (s === 'connected') return 'success';
-      if (s === 'checking') return 'warning';
-      // disconnected / unknown / undefined all collapse to neutral.
+      // disconnected / unknown / undefined all collapse to neutral. 'connecting'
+      // never reaches here — it's the overlay handled above, not a wire status.
       return 'neutral';
     };
 

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.ts
@@ -14,7 +14,7 @@ import { EntityFavoriteStarComponent } from '../../../../core/entity-favorite-st
 import { MultilineTitleComponent } from '../../../../shared/components/multiline-title/multiline-title.component';
 import { SidePanelMode, SidePanelService } from '../../../../shared/services/side-panel.service';
 import { TailwindDialogService } from '../../../../shared/services/tailwind-dialog.service';
-import { ConnectEndpointDialogComponent } from '../../../endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
+import { CONNECT_ENDPOINT_DIALOG_OPTIONS, ConnectEndpointDialogComponent } from '../../../endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
 import { isEndpointConnected } from '../../../endpoints/endpoint-helpers';
 import { FavoritesSidePanelComponent } from '../favorites-side-panel/favorites-side-panel.component';
 import { FavoritesMetaCardComponent } from '../favorites-meta-card/favorites-meta-card.component';
@@ -188,10 +188,7 @@ export class HomePageEndpointCardComponent implements OnInit, OnChanges, OnDestr
         subType: this.endpoint.sub_type,
         ssoAllowed: this.endpoint.sso_allowed,
       },
-      disableClose: true,
-      width: '550px',
-      maxWidth: '550px',
-      panelClass: ['overflow-visible', 'p-6'],
+      ...CONNECT_ENDPOINT_DIALOG_OPTIONS,
     });
   }
 

--- a/src/frontend/packages/core/src/public-api.ts
+++ b/src/frontend/packages/core/src/public-api.ts
@@ -250,7 +250,7 @@ export { HomePageCardLayout, HomePageEndpointCard, LinkMetadata } from './featur
 export * from './features/endpoints/create-endpoint/create-endpoint-helper';
 export { CreateEndpointModule } from './features/endpoints/create-endpoint/create-endpoint.module';
 export { CreateEndpointBaseStepComponent } from './features/endpoints/create-endpoint/create-endpoint-base-step/create-endpoint-base-step.component';
-export { ConnectEndpointDialogComponent } from './features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
+export { CONNECT_ENDPOINT_DIALOG_OPTIONS, ConnectEndpointDialogComponent } from './features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
 export { ConnectEndpointConfig } from './features/endpoints/connect.service';
 export { EndpointRowActionsService } from './features/endpoints/endpoint-row-actions.service';
 export { BaseEndpointAuth, EndpointAuthTypeNames } from './core/endpoint-auth';

--- a/src/frontend/packages/core/src/shared/components/confirmation-dialog.service.ts
+++ b/src/frontend/packages/core/src/shared/components/confirmation-dialog.service.ts
@@ -21,7 +21,12 @@ export class ConfirmationDialogService {
 
     const dialogRef = this.dialog.open(DialogConfirmComponent, {
       maxWidth: '400px',
-      data: dialog
+      data: dialog,
+      // Same behaviour as the connect dialog: the dim backdrop lets pointer
+      // events through so the page behind stays live (e.g. an endpoint's
+      // status pill during disconnect), and the panel drags by its title.
+      draggable: true,
+      modeless: true,
     });
 
     dialogRef.afterClosed().pipe(take(1)).subscribe(result => {

--- a/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html
+++ b/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html
@@ -1,5 +1,5 @@
 <div class="p-6">
-  <h1 class="confirm-dialog__header text-lg font-semibold mb-4 flex items-center justify-between text-content-text">
+  <h1 class="confirm-dialog__header text-lg font-semibold mb-4 flex items-center justify-between text-content-text" data-dialog-drag-handle>
     <span class="confirm-dialog__header-title">{{data.title}}</span>
     @if (data.critical || textToMatch) {
       <span class="material-icons confirm-dialog__warn-icon text-warning-shade-500">warning</span>

--- a/src/frontend/packages/core/src/shared/components/dialog-error/dialog-error.component.html
+++ b/src/frontend/packages/core/src/shared/components/dialog-error/dialog-error.component.html
@@ -1,12 +1,6 @@
-<div>
-  <div class="dialog-error">
-    <div class="dialog-error__content-outer">
-      @if (show) {
-        <div class="dialog-error__content flex items-center gap-2 p-4 bg-danger-shade-50 text-danger-shade-700 rounded-md border border-danger-shade-200">
-          <span class="material-icons text-danger-shade-500">warning</span>
-          <span>{{message}}</span>
-        </div>
-      }
-    </div>
+@if (show) {
+  <div class="dialog-error flex items-center gap-2 p-4 bg-danger-shade-50 text-danger-shade-700 rounded-md border border-danger-shade-200">
+    <span class="material-icons text-danger-shade-500">warning</span>
+    <span>{{message}}</span>
   </div>
-</div>
+}

--- a/src/frontend/packages/core/src/shared/components/dialog-error/dialog-error.component.scss
+++ b/src/frontend/packages/core/src/shared/components/dialog-error/dialog-error.component.scss
@@ -1,17 +1,3 @@
 .dialog-error {
   font-size: 12px;
-  margin: 0 -24px -10px;
-  height: 35px;
-  &__content {
-    height: 100%;
-    padding: 0 24px;
-    display: flex;
-    align-items: center;
-    mat-icon {
-      margin-right: 10px;
-    }
-    &-outer {
-      width: 300px;
-    }
-  }
 }

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
@@ -5,7 +5,7 @@
      dimming the card would work against that - it should stay as noticeable as
      connected. -->
 <app-meta-card class="endpoint-card" [routerLink]="endpointLink" [appDisableRouterLink]="!endpointLink"
-  [ngClass]="{'endpoint-card--no-link': !endpointLink, 'endpoint-card--disconnected': connectionStatus === 'disconnected', 'endpoint-card--connecting': connectionStatus === 'connecting'}"
+  [ngClass]="{'endpoint-card--no-link': !endpointLink, 'endpoint-card--disconnected': connectionStatus === 'disconnected'}"
   [favorite]="favorite" [actionMenu]="actionMenu" [status$]="cardStatus$" [statusIcon]="false" [statusBackground]="true">
   <app-meta-card-title>
     <div class="endpoint-card__title">

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.html
@@ -5,7 +5,7 @@
      dimming the card would work against that - it should stay as noticeable as
      connected. -->
 <app-meta-card class="endpoint-card" [routerLink]="endpointLink" [appDisableRouterLink]="!endpointLink"
-  [ngClass]="{'endpoint-card--no-link': !endpointLink, 'endpoint-card--disconnected': connectionStatus === 'disconnected', 'endpoint-card--checking': connectionStatus === 'checking'}"
+  [ngClass]="{'endpoint-card--no-link': !endpointLink, 'endpoint-card--disconnected': connectionStatus === 'disconnected', 'endpoint-card--connecting': connectionStatus === 'connecting'}"
   [favorite]="favorite" [actionMenu]="actionMenu" [status$]="cardStatus$" [statusIcon]="false" [statusBackground]="true">
   <app-meta-card-title>
     <div class="endpoint-card__title">

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.scss
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.scss
@@ -26,10 +26,6 @@
     }
   }
 
-  &--connecting {
-    opacity: 0.65;
-  }
-
   &--no-link {
     cursor: default;
   }

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.scss
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.scss
@@ -26,7 +26,7 @@
     }
   }
 
-  &--checking {
+  &--connecting {
     opacity: 0.65;
   }
 

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-list.helpers.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-list.helpers.ts
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators';
 import { TailwindDialogService } from '../../services/tailwind-dialog.service';
 import { CurrentUserPermissionsService } from '../../../core/permissions/current-user-permissions.service';
 import { StratosCurrentUserPermissions } from '../../../core/permissions/stratos-user-permissions.checker';
-import { ConnectEndpointDialogComponent } from '../../../features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
+import { CONNECT_ENDPOINT_DIALOG_OPTIONS, ConnectEndpointDialogComponent } from '../../../features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
 import { SessionService } from '../../../shared/services/session.service';
 import { UserProfileService } from '../../../core/user-profile.service';
 import { TailwindSnackBarService } from '../../services/tailwind-snackbar.service';
@@ -130,10 +130,7 @@ export class EndpointListHelper {
               subType: item.sub_type,
               ssoAllowed: item.sso_allowed
             },
-            disableClose: true,
-            width: '550px',
-            maxWidth: '550px',
-            panelClass: ['overflow-visible', 'p-6']
+            ...CONNECT_ENDPOINT_DIALOG_OPTIONS,
           });
         },
         label: 'Connect',

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.html
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.html
@@ -32,6 +32,12 @@
       }
       <app-spinner [diameter]="20"></app-spinner>
     }
+    @if (status === 'disconnecting') {
+      @if (config?.showLabel) {
+        <span class="mr-2">Disconnecting </span>
+      }
+      <app-spinner [diameter]="20"></app-spinner>
+    }
     @if (status === 'unknown') {
       @if (config?.showLabel) {
         <span class="mr-2">Unknown </span>

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.html
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.html
@@ -1,6 +1,6 @@
 <div class="flex items-center">
   @if (connectable) {
-    @if (row.connectionStatus === 'connected' ) {
+    @if (status === 'connected' ) {
       @if (config?.showLabel) {
         <span class="mr-2">Connected @if (row.local) {
           <span class="mr-2">(local)</span>
@@ -8,7 +8,7 @@
       }
       <app-custom-icon fontSet="stratos-icons">endpoints_connected</app-custom-icon>
     }
-    @if (row.connectionStatus === 'disconnected') {
+    @if (status === 'disconnected') {
       @if (config?.showLabel) {
         <span class="mr-2">Disconnected @if (row.local) {
           <span class="mr-2">(local)</span>
@@ -16,7 +16,7 @@
       }
       <app-custom-icon fontSet="stratos-icons">endpoints_disconnected</app-custom-icon>
     }
-    @if (row.connectionStatus === 'expired') {
+    @if (status === 'expired') {
       @if (config?.showLabel) {
         <span class="mr-2 text-warning-shade-600 dark:text-warning-shade-300">Expired @if (row.local) {
           <span class="mr-2">(local)</span>
@@ -26,13 +26,13 @@
            reuse endpoints_disconnected rather than add a new font entry. -->
       <app-custom-icon fontSet="stratos-icons" class="text-warning-shade-600 dark:text-warning-shade-300">endpoints_disconnected</app-custom-icon>
     }
-    @if (row.connectionStatus === 'checking') {
+    @if (status === 'connecting') {
       @if (config?.showLabel) {
-        <span class="mr-2">Updating </span>
+        <span class="mr-2">Connecting </span>
       }
       <app-spinner [diameter]="20"></app-spinner>
     }
-    @if (!row.connectionStatus || row.connectionStatus === 'unknown') {
+    @if (status === 'unknown') {
       @if (config?.showLabel) {
         <span class="mr-2">Unknown </span>
       }

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
@@ -30,11 +30,16 @@ export class TableCellEndpointStatusComponent extends TableCellCustom<EndpointMo
   }
 
   // Displayed status = the wire-derived connectionStatus overlaid with the
-  // transient 'connecting' while a connect/reconnect is in flight. Reading
-  // isConnecting() here tracks the connecting-state signal, so the zoneless
-  // OnPush template re-renders when the operation starts and finishes.
+  // transient 'connecting' / 'disconnecting' while the operation is in
+  // flight. Reading isConnecting()/isDisconnecting() here tracks the state
+  // signals, so the zoneless OnPush template re-renders when the operation
+  // starts and finishes.
   get status(): endpointConnectionStatus {
-    return withConnectingOverlay(this.row?.connectionStatus, this.endpointsData.isConnecting(this.row?.guid ?? ''));
+    return withConnectingOverlay(
+      this.row?.connectionStatus,
+      this.endpointsData.isConnecting(this.row?.guid ?? ''),
+      this.endpointsData.isDisconnecting(this.row?.guid ?? ''),
+    );
   }
 
   constructor() {

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-status/table-cell-endpoint-status.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit  } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 
-import { entityCatalog, EndpointModel } from '@stratosui/store';
+import { EndpointModel, EndpointsDataService, endpointConnectionStatus, entityCatalog, withConnectingOverlay } from '@stratosui/store';
 
 import { TableCellCustom } from '../../signal-list/cell-base';
 import { CustomIconComponent } from '../../../../shared/components/custom-material/custom-material.component';
@@ -19,6 +19,7 @@ import { AppSpinnerComponent } from '../../progress-spinner/app-spinner.componen
 export class TableCellEndpointStatusComponent extends TableCellCustom<EndpointModel, { showLabel: boolean; }> implements OnInit {
 
   public connectable = true;
+  private endpointsData = inject(EndpointsDataService);
 
   @Input()
   get row(): EndpointModel {
@@ -26,6 +27,14 @@ export class TableCellEndpointStatusComponent extends TableCellCustom<EndpointMo
   }
   set row(row: EndpointModel) {
     super.row = row;
+  }
+
+  // Displayed status = the wire-derived connectionStatus overlaid with the
+  // transient 'connecting' while a connect/reconnect is in flight. Reading
+  // isConnecting() here tracks the connecting-state signal, so the zoneless
+  // OnPush template re-renders when the operation starts and finishes.
+  get status(): endpointConnectionStatus {
+    return withConnectingOverlay(this.row?.connectionStatus, this.endpointsData.isConnecting(this.row?.guid ?? ''));
   }
 
   constructor() {

--- a/src/frontend/packages/core/src/shared/components/progress-bar/progress-bar.component.ts
+++ b/src/frontend/packages/core/src/shared/components/progress-bar/progress-bar.component.ts
@@ -47,9 +47,7 @@ import { CommonModule } from "@angular/common";
           class="absolute h-full animate-progress-indeterminate-primary z-20 opacity-70"
           [ngClass]="progressBarPrimaryClass"
         ></div>
-        , changeDetection: ChangeDetectionStrategy.OnPush
       }
-      )
 
       <!-- Determinate progress -->
       @if (mode === "determinate") {

--- a/src/frontend/packages/core/src/shared/components/progress-spinner/progress-spinner.component.ts
+++ b/src/frontend/packages/core/src/shared/components/progress-spinner/progress-spinner.component.ts
@@ -37,9 +37,7 @@ import {
           aria-valuemin="0"
           aria-valuemax="100"
         ></div>
-        , changeDetection: ChangeDetectionStrategy.OnPush
       }
-      )
 
       <!-- Determinate spinner (arc showing progress) -->
       @if (mode === "determinate") {

--- a/src/frontend/packages/core/src/shared/services/endpoint-reauth-report.service.ts
+++ b/src/frontend/packages/core/src/shared/services/endpoint-reauth-report.service.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { EndpointsDataService } from '@stratosui/store';
 
 import { ConnectEndpointConfig } from '../../features/endpoints/connect.service';
-import { ConnectEndpointDialogComponent } from '../../features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
+import { CONNECT_ENDPOINT_DIALOG_OPTIONS, ConnectEndpointDialogComponent } from '../../features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component';
 import { TailwindDialogService } from './tailwind-dialog.service';
 import { TailwindSnackBarService } from './tailwind-snackbar.service';
 
@@ -49,10 +49,7 @@ export class EndpointReauthReportService {
         };
         this.dialog.open(ConnectEndpointDialogComponent, {
           data,
-          disableClose: true,
-          width: '550px',
-          maxWidth: '550px',
-          panelClass: ['overflow-visible', 'p-6'],
+          ...CONNECT_ENDPOINT_DIALOG_OPTIONS,
         });
       });
     } else {

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.spec.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.spec.ts
@@ -476,6 +476,39 @@ describe('TailwindDialogService', () => {
     });
   });
 
+  describe('Modeless', () => {
+    it('should let pointer events pass through the backdrop but not the panel when modeless', async () => {
+      vi.useFakeTimers();
+      const dialogRef = service.open(TestDialogComponent, { modeless: true });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const overlay = document.querySelector('.fixed.inset-0') as HTMLElement;
+      const panel = document.querySelector('.rounded-lg') as HTMLElement;
+      expect(overlay.style.pointerEvents).toBe('none');
+      expect(panel.style.pointerEvents).toBe('auto');
+      expect(panel.getAttribute('aria-modal')).toBe('false');
+
+      dialogRef.close();
+      await vi.advanceTimersByTimeAsync(300);
+      vi.useRealTimers();
+    });
+
+    it('should keep a blocking backdrop and aria-modal by default', async () => {
+      vi.useFakeTimers();
+      const dialogRef = service.open(TestDialogComponent);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const overlay = document.querySelector('.fixed.inset-0') as HTMLElement;
+      const panel = document.querySelector('.rounded-lg') as HTMLElement;
+      expect(overlay.style.pointerEvents).toBe('');
+      expect(panel.getAttribute('aria-modal')).toBe('true');
+
+      dialogRef.close();
+      await vi.advanceTimersByTimeAsync(300);
+      vi.useRealTimers();
+    });
+  });
+
   describe('Data Injection', () => {
     it('should inject data into dialog component', async () => {
 

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
@@ -38,6 +38,10 @@ export interface TailwindDialogConfig<D = any> {
   /** Let the user move the panel by dragging an element marked with
    *  `data-dialog-drag-handle` (e.g. the dialog header). */
   draggable?: boolean;
+  /** Keep the dim backdrop visually but let pointer events pass through it,
+   *  so the page behind stays visible AND interactive while the dialog is
+   *  open. The panel itself remains interactive. */
+  modeless?: boolean;
   position?: DialogPosition;
   customPosition?: DialogPositionConfig;
   ariaLabel?: string;
@@ -238,6 +242,12 @@ export class TailwindDialogService {
     overlay.className = backdropClasses.join(' ');
     overlay.style.zIndex = zIndex.toString();
 
+    // Modeless: the dim stays, but clicks fall through to the page beneath.
+    // The panel re-enables pointer events for itself below.
+    if (config?.modeless) {
+      overlay.style.pointerEvents = 'none';
+    }
+
     // Start with transparent backdrop for fade-in animation
     overlay.style.backgroundColor = 'rgba(0, 0, 0, 0)';
 
@@ -284,7 +294,10 @@ export class TailwindDialogService {
 
     // Accessibility attributes
     dialog.setAttribute('role', 'dialog');
-    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-modal', config?.modeless ? 'false' : 'true');
+    if (config?.modeless) {
+      dialog.style.pointerEvents = 'auto';
+    }
 
     if (config?.id) {
       dialog.setAttribute('id', config.id);

--- a/src/frontend/packages/kubernetes/src/services/endpoint-data/kube-endpoint-registry.hook.spec.ts
+++ b/src/frontend/packages/kubernetes/src/services/endpoint-data/kube-endpoint-registry.hook.spec.ts
@@ -14,7 +14,7 @@ import { KubeEndpointRegistryHook } from './kube-endpoint-registry.hook';
 
 type EndpointMap = { [guid: string]: EndpointModel };
 
-function kubeEp(guid: string, status: 'connected' | 'disconnected' | 'checking' = 'connected'): EndpointModel {
+function kubeEp(guid: string, status: 'connected' | 'disconnected' | 'connecting' = 'connected'): EndpointModel {
   return {
     guid,
     name: guid,

--- a/src/frontend/packages/store/src/public-api.ts
+++ b/src/frontend/packages/store/src/public-api.ts
@@ -151,8 +151,8 @@ export { PaginationEntityState, isPaginatedAction } from './types/pagination.typ
 export { MAX_RECENT_COUNT, RecentlyVisitedDataService } from './services/recently-visited-data.service';
 export type { ActionState, RequestInfoState } from './types/entity-pipeline.types';
 export { getDefaultActionState, rootUpdatingKey } from './types/entity-pipeline.types';
-export type { EndpointModel, EndpointUser, INewlyConnectedEndpointInfo } from './types/endpoint.types';
-export { SystemSharedUserGuid } from './types/endpoint.types';
+export type { EndpointModel, EndpointUser, INewlyConnectedEndpointInfo, endpointConnectionStatus } from './types/endpoint.types';
+export { SystemSharedUserGuid, withConnectingOverlay } from './types/endpoint.types';
 export { stratosEntityCatalog } from './stratos-entity-catalog';
 export { EntityCatalogHelper } from './entity-catalog/entity-catalog-entity/entity-catalog.service';
 export type { PermissionValues } from './types/current-user-roles.types';

--- a/src/frontend/packages/store/src/services/endpoints-data.service.spec.ts
+++ b/src/frontend/packages/store/src/services/endpoints-data.service.spec.ts
@@ -216,6 +216,10 @@ describe('EndpointsDataService', () => {
       systemShared: false,
     });
     expect(svc.connectingState('cf-2')().busy).toBe(true);
+    // isConnecting drives the transient 'connecting' overlay; it tracks the
+    // same busy window.
+    expect(svc.isConnecting('cf-2')).toBe(true);
+    expect(svc.isConnecting('cf-1')).toBe(false);
 
     httpMock.expectOne('/api/v1/tokens').flush({ guid: 'cf-2' });
     // Yield enough microtasks so the .then() handler runs and dispatches
@@ -226,6 +230,7 @@ describe('EndpointsDataService', () => {
 
     expect(state.error).toBe(false);
     expect(svc.connectingState('cf-2')().busy).toBe(false);
+    expect(svc.isConnecting('cf-2')).toBe(false);
 
     // Successful connect emits on the connectedSignal delta queue.
     expect(svc.connectedSignal()).toHaveLength(1);

--- a/src/frontend/packages/store/src/services/endpoints-data.service.ts
+++ b/src/frontend/packages/store/src/services/endpoints-data.service.ts
@@ -195,6 +195,15 @@ export class EndpointsDataService {
     return computed(() => this._connectingStates().get(guid) ?? getDefaultActionState());
   }
 
+  // True while a connect or reconnect is in flight for this guid — the busy
+  // window connect() holds from before the token POST until it resolves. Read
+  // inside a computed/render to drive the transient 'connecting' overlay (see
+  // withConnectingOverlay); reads the state map directly so a caller filtering
+  // many endpoints doesn't spin up one computed per guid.
+  isConnecting(guid: string): boolean {
+    return !!this._connectingStates().get(guid)?.busy;
+  }
+
   disconnectingState(guid: string): Signal<ActionState> {
     return computed(() => this._disconnectingStates().get(guid) ?? getDefaultActionState());
   }

--- a/src/frontend/packages/store/src/services/endpoints-data.service.ts
+++ b/src/frontend/packages/store/src/services/endpoints-data.service.ts
@@ -208,6 +208,12 @@ export class EndpointsDataService {
     return computed(() => this._disconnectingStates().get(guid) ?? getDefaultActionState());
   }
 
+  // Mirror of isConnecting() for the disconnect window disconnect() holds —
+  // drives the transient 'disconnecting' overlay (see withConnectingOverlay).
+  isDisconnecting(guid: string): boolean {
+    return !!this._disconnectingStates().get(guid)?.busy;
+  }
+
   // ---- readiness primitive (used by pipeline) ----------------------------
 
   /**

--- a/src/frontend/packages/store/src/types/endpoint.types.spec.ts
+++ b/src/frontend/packages/store/src/types/endpoint.types.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeConnectionStatus } from './endpoint.types';
+import { computeConnectionStatus, withConnectingOverlay } from './endpoint.types';
 
 describe('computeConnectionStatus', () => {
   const future = Math.floor(Date.now() / 1000) + 3600;
@@ -24,5 +24,21 @@ describe('computeConnectionStatus', () => {
   });
   it('connected when token_expiry is 0 (documented no-expiry value), even if not renewable', () => {
     expect(computeConnectionStatus({ user, token_expiry: 0, token_renewable: false })).toBe('connected');
+  });
+});
+
+describe('withConnectingOverlay', () => {
+  it('overlays connecting onto any settled status while a connect is in flight', () => {
+    expect(withConnectingOverlay('connected', true)).toBe('connecting');
+    expect(withConnectingOverlay('expired', true)).toBe('connecting');
+    expect(withConnectingOverlay('disconnected', true)).toBe('connecting');
+  });
+  it('passes the settled status through when nothing is in flight', () => {
+    expect(withConnectingOverlay('connected', false)).toBe('connected');
+    expect(withConnectingOverlay('expired', false)).toBe('expired');
+    expect(withConnectingOverlay('disconnected', false)).toBe('disconnected');
+  });
+  it('falls back to unknown for an absent status', () => {
+    expect(withConnectingOverlay(undefined, false)).toBe('unknown');
   });
 });

--- a/src/frontend/packages/store/src/types/endpoint.types.ts
+++ b/src/frontend/packages/store/src/types/endpoint.types.ts
@@ -22,7 +22,7 @@ export interface IApiEndpointInfo {
   // Go url.Userinfo pointer: serializes to JSON null when no userinfo is present.
   User: object | null;
 }
-export type endpointConnectionStatus = 'connected' | 'expired' | 'disconnected' | 'unknown' | 'checking';
+export type endpointConnectionStatus = 'connected' | 'expired' | 'disconnected' | 'unknown' | 'connecting';
 
 // 'expired' = connected but past the connection time: a stored token exists
 // but is known-dead — past token_expiry with no refresh token to renew from.
@@ -30,6 +30,11 @@ export type endpointConnectionStatus = 'connected' | 'expired' | 'disconnected' 
 // (refresh cleared, expiry floored), so one computation covers both the
 // predictable death and the witnessed one. A renewable token past expiry is
 // still 'connected' — jetstream mints a fresh one on use.
+//
+// 'connecting' is never returned here: it is a transient overlay applied while
+// a connect/reconnect is in flight (see withConnectingOverlay), not a state
+// derivable from the wire payload. The wire only ever yields the three settled
+// values below.
 export function computeConnectionStatus(info: {
   user?: unknown; token_renewable?: boolean; token_expiry?: number;
 }): endpointConnectionStatus {
@@ -40,6 +45,20 @@ export function computeConnectionStatus(info: {
     return 'expired';
   }
   return 'connected';
+}
+
+// Overlay the transient 'connecting' state onto a wire-derived status while a
+// connect or reconnect is in flight for the endpoint. The operation owns no
+// stored status of its own — EndpointsDataService.connect() (also the reconnect
+// path) holds a busy connecting-state for the duration, and this folds that
+// signal onto the last settled status so display surfaces can show it without
+// the value being written into the endpoint model (which getAll() would clobber
+// on its next wholesale refresh).
+export function withConnectingOverlay(
+  status: endpointConnectionStatus | undefined,
+  isConnecting: boolean,
+): endpointConnectionStatus {
+  return isConnecting ? 'connecting' : (status ?? 'unknown');
 }
 export interface EndpointModel {
   api_endpoint?: IApiEndpointInfo;

--- a/src/frontend/packages/store/src/types/endpoint.types.ts
+++ b/src/frontend/packages/store/src/types/endpoint.types.ts
@@ -22,7 +22,7 @@ export interface IApiEndpointInfo {
   // Go url.Userinfo pointer: serializes to JSON null when no userinfo is present.
   User: object | null;
 }
-export type endpointConnectionStatus = 'connected' | 'expired' | 'disconnected' | 'unknown' | 'connecting';
+export type endpointConnectionStatus = 'connected' | 'expired' | 'disconnected' | 'unknown' | 'connecting' | 'disconnecting';
 
 // 'expired' = connected but past the connection time: a stored token exists
 // but is known-dead — past token_expiry with no refresh token to renew from.
@@ -47,18 +47,21 @@ export function computeConnectionStatus(info: {
   return 'connected';
 }
 
-// Overlay the transient 'connecting' state onto a wire-derived status while a
-// connect or reconnect is in flight for the endpoint. The operation owns no
-// stored status of its own — EndpointsDataService.connect() (also the reconnect
-// path) holds a busy connecting-state for the duration, and this folds that
-// signal onto the last settled status so display surfaces can show it without
-// the value being written into the endpoint model (which getAll() would clobber
-// on its next wholesale refresh).
+// Overlay the transient 'connecting' / 'disconnecting' states onto a
+// wire-derived status while the operation is in flight for the endpoint. The
+// operation owns no stored status of its own — EndpointsDataService.connect()
+// (also the reconnect path) and disconnect() hold a busy state for the
+// duration, and this folds that signal onto the last settled status so display
+// surfaces can show it without the value being written into the endpoint model
+// (which getAll() would clobber on its next wholesale refresh).
 export function withConnectingOverlay(
   status: endpointConnectionStatus | undefined,
   isConnecting: boolean,
+  isDisconnecting = false,
 ): endpointConnectionStatus {
-  return isConnecting ? 'connecting' : (status ?? 'unknown');
+  if (isConnecting) return 'connecting';
+  if (isDisconnecting) return 'disconnecting';
+  return status ?? 'unknown';
 }
 export interface EndpointModel {
   api_endpoint?: IApiEndpointInfo;


### PR DESCRIPTION
Closes #5638

## What this fixes

**Defect 1 — Applications tile leaves the CF section.** The tile now routes to `/cloud-foundry/{guid}/applications`, keeping the CF header and side nav, with org/space filters reset.

**Defect 2 — single-CF shortcut never fires on cold load.** The CF section now reads the picker set after `EndpointsDataService.whenReady()` instead of sampling `connectedCFEndpoints$` with `take(1)`, which on a cold load always saw the empty pre-hydration list.

## Transient connection states

The dormant `'checking'` status is renamed to `'connecting'` and given a producer: `EndpointsDataService` holds a busy state for the duration of a connect/reconnect, and a matching `'disconnecting'` state covers the disconnect window. Both are overlays (`withConnectingOverlay`) computed at display time — never written to the endpoint model, so `getAll()`'s wholesale refresh cannot clobber them.

While an operation is in flight the status pill shows Connecting/Disconnecting (table label, card word + spinner, CF picker warning dot) and nothing else on the row or card changes. The CF picker also gained a Status column and now lists connected, expired, and mid-transition endpoints, so an expired CF no longer looks identical to a live one.

## Dialog behaviour

To make the transient states actually observable, the endpoint dialogs no longer hide the page behind them:

- `TailwindDialogService` gains a `modeless` option — the dim backdrop remains but passes pointer events through, so the endpoint card stays visible and live while the dialog is open. Dialogs are draggable by their title bar.
- The connect dialog is resized and restyled to match the confirmation dialogs (shared 400px config used by all five call sites), its progress bar only renders while a connect is in flight, and the error area only occupies space when an error exists.
- A failed reconnect now states that the existing connection is unaffected — the stored token survives a failed attempt, which is easy to misread as a contradiction when the card still says Connected.
- Confirmation dialogs (Disconnect, Unregister, and the rest of the family) get the same modeless + draggable behaviour. Note: backdrop clicks no longer dismiss these dialogs; Cancel and Escape still do.

Also fixes a template corruption in the rewritten progress bar/spinner: a fragment of decorator source rendered as literal text next to every indeterminate spinner.

## Verification

- Frontend suite green; new unit tests for the modeless dialog option and the picker's disconnecting behaviour.
- Live-verified against a real CF: card pill flips to Connecting/Disconnecting during the operations and reverts or settles correctly on failure/success; dialogs drag correctly; failed reconnect leaves the existing session working (confirmed with a live API call through the stored token).
