### PR TITLE
refactor(core): name the CF quota unlimited sentinel

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/actions/quota-definitions.actions.ts
+++ b/src/frontend/packages/cloud-foundry/src/actions/quota-definitions.actions.ts
@@ -1,5 +1,7 @@
 import { HttpParams, HttpRequest } from '@angular/common/http';
 
+import { CF_QUOTA_UNLIMITED } from '@stratosui/core';
+
 import { PaginatedAction } from '../../../store/src/types/pagination.types';
 import { ICFAction } from '../../../store/src/types/request.types';
 import { IQuotaDefinition } from '../cf-api.types';
@@ -61,7 +63,6 @@ export const DELETE_SPACE_QUOTA_DEFINITION_FAILED = '[QuotaDefinitions] Delete s
 const quotaDefinitionEntitySchema = cfEntityFactory(quotaDefinitionEntityType);
 const spaceQuotaEntitySchema = cfEntityFactory(spaceQuotaEntityType);
 
-const UNLIMITED = -1;
 // Legacy ngrx action — write path now goes through QuotaDataService.
 // V3-shape form values can be number | string (UnlimitedInputComponent
 // emits '' for unlimited); coerce to number for the V2 wire body kept
@@ -69,7 +70,7 @@ const UNLIMITED = -1;
 // cf-entity-catalog wiring.
 function toNumber(v: number | string | undefined): number {
   const n = Number(v);
-  return isNaN(n) || v === '' || v == null ? UNLIMITED : n;
+  return isNaN(n) || v === '' || v == null ? CF_QUOTA_UNLIMITED : n;
 }
 function orgSpaceQuotaFormValuesToApiObject(formValues: QuotaFormValues, isOrg = true, orgGuid?: string): IQuotaDefinition {
   const res: IQuotaDefinition = {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
@@ -10,6 +10,7 @@ import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
   CurrentUserPermissionsService,
+  isUnlimited,
   ListSubNavAddAction,
   ListSubNavComponent,
   PageHeaderComponent,
@@ -462,8 +463,7 @@ export class ApplicationWallComponent implements OnInit {
 
   static formatMb(mb: number | null | undefined): string {
     if (mb == null || typeof mb !== 'number' || Number.isNaN(mb)) return '—';
-    // CF quota APIs encode 'unlimited' as -1
-    if (mb === -1) return '∞';
+    if (isUnlimited(mb)) return '∞';
     if (mb < 1024) return `${mb} MB`;
     const gb = mb / 1024;
     if (gb < 1024) return `${gb.toFixed(1)} GB`;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -8,6 +8,7 @@ import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
   CurrentUserPermissionsService,
+  isUnlimited,
   ListSubNavAddAction,
   ListSubNavComponent,
   SignalListCompoundSegment,
@@ -356,8 +357,7 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
 
   static formatMb(mb: number | null | undefined): string {
     if (mb == null || typeof mb !== 'number' || Number.isNaN(mb)) return '—';
-    // CF quota APIs encode 'unlimited' as -1
-    if (mb === -1) return '∞';
+    if (isUnlimited(mb)) return '∞';
     if (mb < 1024) return `${mb} MB`;
     const gb = mb / 1024;
     if (gb < 1024) return `${gb.toFixed(1)} GB`;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organization-space-quotas/cloud-foundry-organization-space-quotas.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organization-space-quotas/cloud-foundry-organization-space-quotas.component.ts
@@ -6,6 +6,7 @@ import { Router, RouterModule } from '@angular/router';
 import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
+  isUnlimited,
   ListSubNavAddAction,
   ListSubNavComponent,
   SignalListComponent,
@@ -246,10 +247,9 @@ export class CloudFoundryOrganizationSpaceQuotasComponent {
     ];
   }
 
-  // -1 on the wire signals "Unlimited" (the backend coerces null v3
-  // limits to -1 for a flat int wire shape).
+  // The backend coerces null v3 limits to -1 for a flat int wire shape.
   static formatLimit(value: number, unit?: string): string {
-    if (value === -1) return 'Unlimited';
+    if (isUnlimited(value)) return 'Unlimited';
     return unit ? `${value.toLocaleString()} ${unit}` : value.toLocaleString();
   }
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
@@ -8,6 +8,7 @@ import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
   CurrentUserPermissionsService,
+  isUnlimited,
   ListSubNavAddAction,
   ListSubNavComponent,
   SignalListComponent,
@@ -270,8 +271,7 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
 
   static formatMb(mb: number | null | undefined): string {
     if (mb == null || typeof mb !== 'number' || Number.isNaN(mb)) return '—';
-    // CF quota APIs encode 'unlimited' as -1
-    if (mb === -1) return '∞';
+    if (isUnlimited(mb)) return '∞';
     if (mb < 1024) return `${mb} MB`;
     const gb = mb / 1024;
     if (gb < 1024) return `${gb.toFixed(1)} GB`;

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-quotas/cloud-foundry-quotas.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-quotas/cloud-foundry-quotas.component.ts
@@ -6,6 +6,7 @@ import { Router, RouterModule } from '@angular/router';
 import {
   ConfirmationDialogConfig,
   ConfirmationDialogService,
+  isUnlimited,
   ListSubNavAddAction,
   ListSubNavComponent,
   SignalListComponent,
@@ -219,10 +220,9 @@ export class CloudFoundryQuotasComponent {
     ];
   }
 
-  // -1 on the wire signals "Unlimited" (the backend coerces null v3
-  // limits to -1 for a flat int wire shape).
+  // The backend coerces null v3 limits to -1 for a flat int wire shape.
   static formatLimit(value: number, unit?: string): string {
-    if (value === -1) return 'Unlimited';
+    if (isUnlimited(value)) return 'Unlimited';
     return unit ? `${value.toLocaleString()} ${unit}` : value.toLocaleString();
   }
 

--- a/src/frontend/packages/core/src/core/byte-formatters.pipe.ts
+++ b/src/frontend/packages/core/src/core/byte-formatters.pipe.ts
@@ -1,5 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+import { isUnlimited } from './cf-quota.types';
+
 @Pipe({
   name: 'bytesToHumanSize',
   standalone: true
@@ -18,8 +20,7 @@ export class BytesToHumanSize implements PipeTransform {
       return '';
     }
 
-    // Special case: unlimited
-    if (bytes === -1) {
+    if (isUnlimited(bytes)) {
       return '∞';
     }
 
@@ -75,8 +76,7 @@ export class MegaBytesToHumanSize implements PipeTransform {
       return '';
     }
 
-    // Special case: unlimited
-    if (mbs === -1) {
+    if (isUnlimited(mbs)) {
       return '∞';
     }
 

--- a/src/frontend/packages/core/src/core/cf-quota.types.ts
+++ b/src/frontend/packages/core/src/core/cf-quota.types.ts
@@ -1,0 +1,10 @@
+// CF quota APIs encode 'unlimited' as -1 (memory_limit, total_services, ...).
+// Values arrive as plain numbers off the API, so this stays a runtime guard
+// rather than a type-level union. Same shape as PAGE_SIZE_ALL in
+// signal-list/page-size.types.ts.
+export const CF_QUOTA_UNLIMITED = -1;
+
+/** True when a CF quota value means 'unlimited' rather than a literal limit. */
+export function isUnlimited(value: number): boolean {
+  return value === CF_QUOTA_UNLIMITED;
+}

--- a/src/frontend/packages/core/src/core/infinity.pipe.ts
+++ b/src/frontend/packages/core/src/core/infinity.pipe.ts
@@ -1,12 +1,13 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+import { isUnlimited } from './cf-quota.types';
+
 @Pipe({
   name: 'infinityPipe',
   standalone: true
 })
 export class InfinityPipe implements PipeTransform {
   transform(value: string): string {
-    // CF quota APIs encode 'unlimited' as -1
-    return (parseInt(value, 10) === -1) ? '∞' : value;
+    return isUnlimited(parseInt(value, 10)) ? '∞' : value;
   }
 }

--- a/src/frontend/packages/core/src/core/utils.service.ts
+++ b/src/frontend/packages/core/src/core/utils.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 
+import { isUnlimited } from './cf-quota.types';
+
 export function getIdFromRoute(activatedRoute: ActivatedRoute, id: string) {
   if (activatedRoute.snapshot.params[id]) {
     return activatedRoute.snapshot.params[id];
@@ -75,8 +77,7 @@ export class UtilsService {
       return '';
     }
 
-    // Special case: CF quota APIs encode 'unlimited' as -1
-    if (mb === -1) {
+    if (isUnlimited(mb)) {
       return '∞';
     }
 
@@ -107,8 +108,7 @@ export class UtilsService {
       return '';
     }
 
-    // Special case: CF quota APIs encode 'unlimited' as -1
-    if (bytes === -1) {
+    if (isUnlimited(bytes)) {
       return '∞';
     }
 

--- a/src/frontend/packages/core/src/public-api.ts
+++ b/src/frontend/packages/core/src/public-api.ts
@@ -9,6 +9,7 @@ export * from './core/extension/extension-service';
 
 // Utils
 export { getIdFromRoute, pathGet, safeStringToObj, urlValidationExpression, truthyIncludingZeroString } from './core/utils.service';
+export { CF_QUOTA_UNLIMITED, isUnlimited } from './core/cf-quota.types';
 export {
   naturalCollator,
   naturalCompare,

--- a/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 
 import { StratosStatus } from '@stratosui/store';
+import { isUnlimited } from '../../../../core/cf-quota.types';
 import { UtilsService } from '../../../../core/utils.service';
 import { CardStatusComponent, determineCardStatus } from '../card-status/card-status.component';
 
@@ -87,8 +88,7 @@ export class CardNumberMetricComponent implements OnInit, OnChanges {
   handleValue() {
     const value = parseInt(this.value, 10);
     this.isUnlimited = false;
-    // CF quota APIs encode 'unlimited' as -1
-    if (value === -1) {
+    if (isUnlimited(value)) {
       this.formattedValue = 'Unlimited';
       this.isUnlimited = true;
     } else {
@@ -103,8 +103,7 @@ export class CardNumberMetricComponent implements OnInit, OnChanges {
     this._status.set(status);
 
     const limit = parseInt(this.limit, 10);
-    // CF quota APIs encode 'unlimited' as -1
-    if (limit === -1) {
+    if (isUnlimited(limit)) {
       this.formattedLimit = '∞';
       this.usage = '';
     } else {

--- a/src/frontend/packages/core/src/shared/components/cards/card-status/card-status.component.ts
+++ b/src/frontend/packages/core/src/shared/components/cards/card-status/card-status.component.ts
@@ -4,10 +4,12 @@ import { Observable } from 'rxjs';
 
 import { StratosStatus } from '@stratosui/store';
 
+import { isUnlimited } from '../../../../core/cf-quota.types';
+
 
 export function determineCardStatus(value: number, limit: number): StratosStatus {
-  // -1 is the CF quota 'unlimited' sentinel, so there is no meaningful usage fraction
-  if ((limit !== 0 && !limit) || limit === -1) {
+  // An unlimited quota has no meaningful usage fraction
+  if ((limit !== 0 && !limit) || isUnlimited(limit)) {
     return StratosStatus.NONE;
   }
 

--- a/src/frontend/packages/core/src/shared/components/unlimited-input/unlimited-input.component.ts
+++ b/src/frontend/packages/core/src/shared/components/unlimited-input/unlimited-input.component.ts
@@ -20,8 +20,7 @@ import {
   AppInputDirective,
   CustomFormFieldComponent,
 } from "../custom-form-field/custom-form-field.component";
-
-const UNLIMITED = -1;
+import { CF_QUOTA_UNLIMITED } from "../../../core/cf-quota.types";
 
 @Component({
   selector: "app-unlimited-input",
@@ -69,7 +68,7 @@ export class UnlimitedInputComponent implements OnInit {
       this.formControl.disable();
     } else {
       this.formControl.enable();
-      if (this.initialValue !== UNLIMITED && this.initialValue != null) {
+      if (this.initialValue !== CF_QUOTA_UNLIMITED && this.initialValue != null) {
         this.formControl.patchValue(this.initialValue);
       } else {
         this.formControl.setValue("");
@@ -88,7 +87,7 @@ export class UnlimitedInputComponent implements OnInit {
 
   setInitialValues(value: any) {
     this.initialValue = value;
-    this.unlimited = value === UNLIMITED;
+    this.unlimited = value === CF_QUOTA_UNLIMITED;
     this.onChange();
   }
 }


### PR DESCRIPTION
CF quota APIs encode 'unlimited' as -1, and twelve call sites compared against the bare literal — two of them re-declaring their own private `UNLIMITED = -1` constant.

This adds one exported `CF_QUOTA_UNLIMITED` constant and an `isUnlimited()` guard in core (following the existing `PAGE_SIZE_ALL` shape in `page-size.types.ts`) and converts all twelve sites: the infinity/byte-formatter pipes, `UtilsService`, the status/metric cards, `UnlimitedInputComponent`, the org and space quota tabs, and the app-wall memory columns. The shared write path (`toNumber` in the quota actions) uses the constant too, so org and space quotas are both covered.

The `-1` in profile-settings is deliberately untouched — there it means "size could not be determined", a different sentinel that must not be folded into the unlimited constant.

All sites are read-only comparisons, so the change is mechanical with no behavior change. Part of the sentinel-hardening work in #5613 (step 3).