### PR TITLE
feat(dialogs): make every dialog movable by default

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/variables-tab/variables-tab.component.ts
@@ -217,7 +217,6 @@ export class VariablesTabComponent implements OnInit {
       maxWidth: '92vw',
       maxHeight: '90vh',
       resizable: true,
-      draggable: true,
       data: { mode, name: row?.name, value: row?.value, existingNames },
     });
 

--- a/src/frontend/packages/cloud-foundry/src/features/cf/user-invites/configuration-dialog/user-invite-configuration-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/user-invites/configuration-dialog/user-invite-configuration-dialog.component.html
@@ -5,7 +5,7 @@
   </app-progress-bar>
 </div>
 <div class="connection-dialog">
-  <h2 class="dialog-title">
+  <h2 class="dialog-title" data-dialog-drag-handle>
     Configure User Invite Client
   </h2>
   <p>In order to allow user invites for this Cloud Foundry, you must

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
@@ -1,6 +1,6 @@
 <div class="p-6 flex flex-col gap-4">
   <!-- Dialog header -->
-  <h2 id="add-user-dialog-title" class="text-lg font-semibold text-content-text">Add User</h2>
+  <h2 id="add-user-dialog-title" class="text-lg font-semibold text-content-text" data-dialog-drag-handle>Add User</h2>
 
   <!-- Mode tabs: Associate (username/origin) vs Invite (email) -->
   @if (inviteTabVisible()) {

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-plans/service-plans.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-plans/service-plans.component.ts
@@ -124,7 +124,6 @@ export class ServicePlansComponent implements OnInit {
                 maxWidth: '92vw',
                 maxHeight: '90vh',
                 resizable: true,
-                draggable: true,
                 data: {
                   cnsiGuid: p.cnsiGuid,
                   planGuid: p.guid,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/event-detail/event-detail.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-3 min-w-[24rem] max-w-[48rem]">
-  <h2 class="dialog-title break-all">{{ data.type }}</h2>
+  <h2 class="dialog-title break-all" data-dialog-drag-handle>{{ data.type }}</h2>
   <div class="dialog-content max-h-[60vh] overflow-auto">
     <pre class="text-xs whitespace-pre-wrap break-all bg-content-secondary text-content-text p-3 rounded border border-content-border">{{ data.metadata | json }}</pre>
   </div>

--- a/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.html
+++ b/src/frontend/packages/core/src/core/log-out-dialog/log-out-dialog.component.html
@@ -2,7 +2,7 @@
   <app-progress-bar class="absolute inset-x-0 top-0" mode="determinate" [value]="percentage">
   </app-progress-bar>
   <div class="dialog-content p-5">
-    <div class="flex flex-row items-center">
+    <div class="flex flex-row items-center" data-dialog-drag-handle>
       <i class="material-icons">pan_tool</i>
       <div class="flex-1 text-lg font-bold">
         Are you still there?

--- a/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.html
+++ b/src/frontend/packages/core/src/features/api-keys/add-api-key-dialog/add-api-key-dialog.component.html
@@ -5,7 +5,7 @@
   </app-progress-bar>
 </div>
 <div class="key-dialog">
-  <div class="key-dialog__title">
+  <div class="key-dialog__title" data-dialog-drag-handle>
     <h2 class="text-xl font-semibold mb-4">
       Create an API Key
     </h2>

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint-dialog/connect-endpoint-dialog.component.ts
@@ -29,7 +29,6 @@ export const CONNECT_ENDPOINT_DIALOG_OPTIONS: TailwindDialogConfig = {
   width: '400px',
   maxWidth: '400px',
   panelClass: ['overflow-visible', 'p-6'],
-  draggable: true,
   modeless: true,
 };
 

--- a/src/frontend/packages/core/src/shared/components/confirmation-dialog.service.ts
+++ b/src/frontend/packages/core/src/shared/components/confirmation-dialog.service.ts
@@ -24,8 +24,7 @@ export class ConfirmationDialogService {
       data: dialog,
       // Same behaviour as the connect dialog: the dim backdrop lets pointer
       // events through so the page behind stays live (e.g. an endpoint's
-      // status pill during disconnect), and the panel drags by its title.
-      draggable: true,
+      // status pill during disconnect). Drags by its title (service default).
       modeless: true,
     });
 

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.spec.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.spec.ts
@@ -474,6 +474,46 @@ describe('TailwindDialogService', () => {
       await vi.advanceTimersByTimeAsync(300);
       vi.useRealTimers();
     });
+
+    it('should be draggable by default (no config)', async () => {
+      vi.useFakeTimers();
+      const dialogRef = service.open(TestDraggableDialogComponent);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const panel = document.querySelector('.rounded-lg') as HTMLElement;
+      const handle = panel.querySelector('[data-dialog-drag-handle]') as HTMLElement;
+      expect(handle.style.cursor).toBe('move');
+
+      handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 100, clientY: 100 }));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 130, clientY: 120 }));
+      expect(panel.style.left).toBe('30px');
+      expect(panel.style.top).toBe('20px');
+
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      dialogRef.close();
+      await vi.advanceTimersByTimeAsync(300);
+      vi.useRealTimers();
+    });
+
+    it('should NOT be draggable when draggable is false', async () => {
+      vi.useFakeTimers();
+      const dialogRef = service.open(TestDraggableDialogComponent, { draggable: false });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const panel = document.querySelector('.rounded-lg') as HTMLElement;
+      const handle = panel.querySelector('[data-dialog-drag-handle]') as HTMLElement;
+      expect(handle.style.cursor).not.toBe('move');
+
+      handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 100, clientY: 100 }));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 160, clientY: 140 }));
+      expect(panel.style.left).toBe('');
+      expect(panel.style.top).toBe('');
+
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      dialogRef.close();
+      await vi.advanceTimersByTimeAsync(300);
+      vi.useRealTimers();
+    });
   });
 
   describe('Modeless', () => {

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
@@ -36,7 +36,9 @@ export interface TailwindDialogConfig<D = any> {
    *  (a flex-centered panel would re-center and grow at half speed). */
   resizable?: boolean;
   /** Let the user move the panel by dragging an element marked with
-   *  `data-dialog-drag-handle` (e.g. the dialog header). */
+   *  `data-dialog-drag-handle` (e.g. the dialog header). Defaults to true —
+   *  every dialog is movable; pass false to opt out. A template with no
+   *  drag-handle element simply isn't movable. */
   draggable?: boolean;
   /** Keep the dim backdrop visually but let pointer events pass through it,
    *  so the page behind stays visible AND interactive while the dialog is
@@ -167,8 +169,8 @@ export class TailwindDialogService {
       this.focusFirstElement(dialogContainer);
       // Resize/drag are wired here (after first layout) so the panel can be
       // measured and pinned to a fixed viewport position.
-      if (config?.resizable || config?.draggable) {
-        this.setupResizableDraggable(dialogContainer, config);
+      if (config?.resizable || config?.draggable !== false) {
+        this.setupResizableDraggable(dialogContainer, config ?? {});
       }
       dialogRef._emitOpened();
       // ZONELESS: Trigger change detection after dialog is fully opened
@@ -416,6 +418,14 @@ export class TailwindDialogService {
     const panel = dialogContainer.querySelector('[role="dialog"]') as HTMLElement;
     if (!panel) return;
 
+    // Drag is on unless explicitly disabled, but only takes effect when the
+    // template marks a handle. A dialog with neither resize nor a handle is
+    // left flex-centered (pinning it would cost re-centering for nothing).
+    const handle = config.draggable !== false
+      ? panel.querySelector('[data-dialog-drag-handle]') as HTMLElement
+      : null;
+    if (!config.resizable && !handle) return;
+
     // Pin to current position so resize/drag have a stable origin. The panel
     // was flex-centered; reuse that measured rect as the fixed start point.
     const rect = panel.getBoundingClientRect();
@@ -461,36 +471,33 @@ export class TailwindDialogService {
 
     clampSizeToViewport();
 
-    if (config.draggable) {
-      const handle = panel.querySelector('[data-dialog-drag-handle]') as HTMLElement;
-      if (handle) {
-        handle.style.cursor = 'move';
-        handle.style.userSelect = 'none';
-        handle.addEventListener('mousedown', (e: MouseEvent) => {
-          const start = panel.getBoundingClientRect();
-          const startX = e.clientX;
-          const startY = e.clientY;
-          const onMove = (m: MouseEvent) => {
-            // Clamp to the viewport so the panel (and its action buttons) can
-            // never be dragged off-screen — it's position:fixed/overflow:hidden,
-            // so anything past the edge would be unreachable.
-            const maxLeft = Math.max(0, window.innerWidth - panel.offsetWidth);
-            const maxTop = Math.max(0, window.innerHeight - panel.offsetHeight);
-            const left = Math.min(Math.max(0, start.left + m.clientX - startX), maxLeft);
-            const top = Math.min(Math.max(0, start.top + m.clientY - startY), maxTop);
-            panel.style.left = `${left}px`;
-            panel.style.top = `${top}px`;
-            clampSizeToViewport();
-          };
-          const onUp = () => {
-            document.removeEventListener('mousemove', onMove);
-            document.removeEventListener('mouseup', onUp);
-          };
-          document.addEventListener('mousemove', onMove);
-          document.addEventListener('mouseup', onUp);
-          e.preventDefault();
-        });
-      }
+    if (handle) {
+      handle.style.cursor = 'move';
+      handle.style.userSelect = 'none';
+      handle.addEventListener('mousedown', (e: MouseEvent) => {
+        const start = panel.getBoundingClientRect();
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const onMove = (m: MouseEvent) => {
+          // Clamp to the viewport so the panel (and its action buttons) can
+          // never be dragged off-screen — it's position:fixed/overflow:hidden,
+          // so anything past the edge would be unreachable.
+          const maxLeft = Math.max(0, window.innerWidth - panel.offsetWidth);
+          const maxTop = Math.max(0, window.innerHeight - panel.offsetHeight);
+          const left = Math.min(Math.max(0, start.left + m.clientX - startX), maxLeft);
+          const top = Math.min(Math.max(0, start.top + m.clientY - startY), maxTop);
+          panel.style.left = `${left}px`;
+          panel.style.top = `${top}px`;
+          clampSizeToViewport();
+        };
+        const onUp = () => {
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+        };
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+        e.preventDefault();
+      });
     }
   }
 


### PR DESCRIPTION
Four dialogs were draggable (connect endpoint, the confirm family, variable edit, plan parameters preview) while the other five (Add User, event detail, user invite configuration, add API key, session expiry) were fixed in place. This makes movability the default for all of them.

- `TailwindDialogService`: drag wiring now runs unless `draggable: false` is passed, so the option reads as opt-out. A panel is only pinned to fixed coordinates when it is resizable or actually has a drag handle — a handle-less dialog keeps its flex-centered behavior exactly as before.
- The five previously fixed dialogs get a `data-dialog-drag-handle` on their title/header.
- The four already-movable dialogs needed no functional change; their now-redundant `draggable: true` lines are removed.

Two new service specs pin the contract (draggable by default, opt-out honored). Verified live: previously fixed dialogs now pin, show a move cursor on the title, and track the pointer 1:1, clamped to the viewport.