### PR TITLE
chore(deps): switch dependabot to the bun ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,19 +4,16 @@ version: 2
 
 # Disable Dependabot during Angular
 updates:
-  - package-ecosystem: "npm"
+  # bun ecosystem, not npm: the lockfile is bun.lock (no package-lock.json),
+  # so npm-ecosystem PRs edit only package.json and every CI job then fails
+  # `bun install --frozen-lockfile` (see PR #5643).
+  - package-ecosystem: "bun"
     directory: "/"
-    schedule: 
+    schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0 # Angular v14 tree depracated, being updated to v20/v21
-  
-  - package-ecosystem: "npm"
-    directory: "/electron"
-    schedule: 
-      interval: "weekly"
-    open-pull-requests-limit: 0 # Electron app deprecated
-  
-  - package-ecosystem: "npm"
+    open-pull-requests-limit: 0 # version updates off; security updates still open PRs
+
+  - package-ecosystem: "bun"
     directory: "/website"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot's npm ecosystem edits only `package.json`, but the repo's lockfile is `bun.lock` (there is no `package-lock.json`). Every CI job starts with `bun install --frozen-lockfile`, which refuses the mismatched lockfile — so npm-ecosystem PRs like #5643 fail all checks in seconds without running a test.

This switches the `/` and `/website` entries to the `bun` package ecosystem so Dependabot regenerates `bun.lock` in its PRs, and drops the `/electron` entry since that directory no longer exists. PR limits are unchanged.

Notes: the config takes effect once merged to develop, and #5643 itself won't be adopted retroactively — it needs its `bun.lock` regenerated on-branch, or close it and let Dependabot refile under the bun ecosystem.