### PR TITLE
Complete the e2e data-test contract and guard ratchet

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -144,6 +144,34 @@ jobs:
             !dist/booklets/.work/**
           retention-days: 14
 
+  # Advisory: names the e2e specs that cover the components a PR changes,
+  # derived from data-test hooks and element selectors (scripts/
+  # e2e-impact.mjs). Never gates — the e2e suite needs a live CF endpoint,
+  # so it cannot run here; this puts the scoped-run command in the job
+  # summary so reviewers know exactly which specs the change touches.
+  e2e-impact:
+    name: E2E Impact (advisory)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.non_stb == 'true'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Report covering specs
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          {
+            echo '```'
+            git diff --name-only "origin/${BASE}...HEAD" | node scripts/e2e-impact.mjs
+            echo '```'
+          } | tee -a "${GITHUB_STEP_SUMMARY}"
+
   lint:
     name: Lint Check
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -166,6 +166,9 @@ jobs:
         env:
           BASE: ${{ github.base_ref }}
         run: |
+          # pipefail: a failing git diff must fail the job, not feed node an
+          # empty stdin that reads as a green "no frontend changes".
+          set -o pipefail
           {
             echo '```'
             git diff --name-only "origin/${BASE}...HEAD" | node scripts/e2e-impact.mjs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -165,6 +165,9 @@ jobs:
       - name: Report covering specs
         env:
           BASE: ${{ github.base_ref }}
+          # Lets the impact script harvest tokens of components DELETED in
+          # the PR from the base ref, so their stranded specs still surface.
+          IMPACT_BASE: origin/${{ github.base_ref }}
         run: |
           # pipefail: a failing git diff must fail the job, not feed node an
           # empty stdin that reads as a green "no frontend changes".

--- a/TESTING.md
+++ b/TESTING.md
@@ -458,6 +458,26 @@ node --version && bun --version
 # Should be: v24.x.x and 1.2.13
 ```
 
+### 6. Keep E2E Specs in Sync When Changing Component DOM
+
+E2E specs bind to components through `data-test` hooks and element
+selectors. When you change a component's template or DOM structure:
+
+```bash
+# See which specs cover the files you changed
+git diff --name-only develop...HEAD | node scripts/e2e-impact.mjs
+
+# Or grep directly for the component's hooks / selector
+grep -rn 'data-test-value-or-selector' e2e/
+```
+
+Run the specs the script names (it prints a scoped `playwright test`
+command), and fix any spec your change breaks in the same PR — or file a
+follow-up issue if the fix is substantial. Never leave a spec silently
+binding to DOM that no longer exists; the lint guards
+(`bun run lint`) catch dead selectors and orphaned hooks, and CI posts
+the same impact report on every PR as an advisory job summary.
+
 ---
 
 ## Getting Help

--- a/e2e/components/page-tabs.component.ts
+++ b/e2e/components/page-tabs.component.ts
@@ -10,9 +10,10 @@ import { Page, Locator } from '@playwright/test';
  * matching invisibly through the attribute.
  */
 export function pageTab(page: Page, label: string): Locator {
+  const exact = new RegExp(`^${label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
   return page
     .locator(`app-page-side-nav [data-test="page-tab-${label}"]`)
-    .filter({ has: page.locator('span', { hasText: new RegExp(`^${label}$`) }) });
+    .filter({ has: page.locator('span', { hasText: exact }) });
 }
 
 /**

--- a/e2e/components/page-tabs.component.ts
+++ b/e2e/components/page-tabs.component.ts
@@ -3,14 +3,12 @@ import { Page, Locator } from '@playwright/test';
 /**
  * Locate a page tab link by its exact label.
  *
- * Tabs render as side-nav links (app-page-side-nav) whose text includes the
- * icon ligature (e.g. "service Services"), so match the label <span> exactly —
- * substring matching would collide ("Services" vs "User Services").
+ * Tabs render as side-nav links (app-page-side-nav) carrying a
+ * data-test="page-tab-<label>" hook; exact attribute match avoids the
+ * "Services" vs "User Services" substring collision.
  */
 export function pageTab(page: Page, label: string): Locator {
-  return page
-    .locator('app-page-side-nav a.page-side-nav__item')
-    .filter({ has: page.locator('span', { hasText: new RegExp(`^${label}$`) }) });
+  return page.locator(`app-page-side-nav [data-test="page-tab-${label}"]`);
 }
 
 /**

--- a/e2e/components/page-tabs.component.ts
+++ b/e2e/components/page-tabs.component.ts
@@ -3,12 +3,16 @@ import { Page, Locator } from '@playwright/test';
 /**
  * Locate a page tab link by its exact label.
  *
- * Tabs render as side-nav links (app-page-side-nav) carrying a
- * data-test="page-tab-<label>" hook; exact attribute match avoids the
- * "Services" vs "User Services" substring collision.
+ * Tabs render as side-nav links (app-page-side-nav) carrying a hook of
+ * 'page-tab-' plus the label; exact attribute match avoids the "Services"
+ * vs "User Services" substring collision. The visible-label filter stays on
+ * top of the hook so a tab that loses its rendered text goes red instead of
+ * matching invisibly through the attribute.
  */
 export function pageTab(page: Page, label: string): Locator {
-  return page.locator(`app-page-side-nav [data-test="page-tab-${label}"]`);
+  return page
+    .locator(`app-page-side-nav [data-test="page-tab-${label}"]`)
+    .filter({ has: page.locator('span', { hasText: new RegExp(`^${label}$`) }) });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "posttest": "echo 'Coverage reports in coverage/ directory'",
     "codecov": "codecov -f coverage/coverage-final.json -F frontend",
     "codecov-backend": "codecov -f src/jetstream/coverage.txt -F backend",
-    "lint": "eslint --report-unused-disable-directives-severity warn src/frontend/packages/{core,store,cloud-foundry,kubernetes,cf-autoscaler,git,shared,extension}/src/ e2e/ && node --test 'tools/eslint-rules/tests/**/*.test.mjs' && node scripts/lint-e2e-data-test.mjs",
+    "lint": "eslint --report-unused-disable-directives-severity warn src/frontend/packages/{core,store,cloud-foundry,kubernetes,cf-autoscaler,git,shared,extension}/src/ e2e/ && node --test 'tools/eslint-rules/tests/**/*.test.mjs' && node scripts/lint-e2e-data-test.mjs && node scripts/lint-e2e-ratchet.mjs",
     "lint:docs": "node scripts/lint-docs.mjs",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",

--- a/scripts/e2e-impact.mjs
+++ b/scripts/e2e-impact.mjs
@@ -8,8 +8,11 @@
 // exits 0; the output tells a reviewer which specs are worth running.
 //
 // Usage: git diff --name-only develop...HEAD | node scripts/e2e-impact.mjs
+// For components deleted in the diff, tokens are harvested from the base
+// ref ($IMPACT_BASE, default 'develop') so their specs still surface.
 
 import { readFileSync, existsSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { files, HOOK_DEFS, DATA_TEST_CONFIG } from './lib/e2e-hooks.mjs'
@@ -26,35 +29,52 @@ const input = process.argv.length > 2
   : readFileSync(0, 'utf8').split('\n')
 const changed = input.map((l) => l.trim()).filter(Boolean)
 
-// Tokens a component contributes to the DOM contract: its element selector
-// and every test-hook value (static, or quoted fragment of a dynamic
-// binding — fragments ending in '-' are prefixes and match as such).
-function tokensFor(file) {
-  const tokens = new Set()
-  // A change to either half of a component involves the whole contract, so
-  // read the sibling template/class too.
-  const sibling = file.endsWith('.html') ? file.replace(/\.html$/, '.ts') : file.replace(/\.ts$/, '.html')
-  const sources = [file, ...(existsSync(sibling) ? [sibling] : [])]
-  for (const src of sources) {
-    if (!existsSync(src)) continue // deleted in this diff
-    const text = readFileSync(src, 'utf8')
-    for (const m of text.matchAll(/\bselector:\s*['"]([a-z][a-z0-9-]+)['"]/g)) tokens.add(m[1])
-    for (const [staticDef, dynamicDef] of Object.values(HOOK_DEFS)) {
-      for (const m of text.matchAll(staticDef)) tokens.add(m[1])
-      for (const m of text.matchAll(dynamicDef)) {
-        for (const s of m[1].matchAll(/'([^']+)'/g)) tokens.add(s[1])
-      }
-    }
-    for (const m of text.matchAll(DATA_TEST_CONFIG)) tokens.add(m[1])
+const IMPACT_BASE = process.env.IMPACT_BASE ?? 'develop'
+function sourceText(file) {
+  if (existsSync(file)) return readFileSync(file, 'utf8')
+  // Deleted in this diff — a deletion is the change MOST likely to strand
+  // specs, so harvest what the component used to define from the base ref.
+  try {
+    return execFileSync('git', ['show', `${IMPACT_BASE}:${file}`], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+  } catch {
+    return null
   }
-  return tokens
 }
 
-const changedComponents = changed.filter(
-  (f) => f.startsWith('src/frontend/') && (f.endsWith('.html') || f.endsWith('.ts')) && !f.endsWith('.spec.ts'),
-)
+// Tokens a component contributes to the DOM contract, split by how they may
+// legitimately appear in e2e sources:
+// - selectors ('app-invite-users'): distinctive kebab tags that occur inside
+//   larger CSS selector strings ('app-x form', 'app-x, app-y') — matched on
+//   word boundaries alone.
+// - hook values / prefixes: attribute values that always sit at the start of
+//   a quoted region — matched quote-adjacent so generic names ('row',
+//   'empty') don't light up every identifier and comment in the suite.
+function tokensFor(stem) {
+  const selectors = new Set()
+  const hooks = new Set()
+  for (const src of [stem + '.ts', stem + '.html']) {
+    const text = sourceText(src)
+    if (text === null) continue
+    for (const m of text.matchAll(/\bselector:\s*['"]([a-z][a-z0-9-]+)['"]/g)) selectors.add(m[1])
+    for (const [staticDef, dynamicDef] of Object.values(HOOK_DEFS)) {
+      for (const m of text.matchAll(staticDef)) hooks.add(m[1])
+      for (const m of text.matchAll(dynamicDef)) {
+        for (const s of m[1].matchAll(/'([^']+)'/g)) hooks.add(s[1])
+      }
+    }
+    for (const m of text.matchAll(DATA_TEST_CONFIG)) hooks.add(m[1])
+  }
+  return { selectors, hooks }
+}
 
-if (!changedComponents.length) {
+// One entry per component, whichever half (or both) changed.
+const changedStems = [...new Set(
+  changed
+    .filter((f) => f.startsWith('src/frontend/') && (f.endsWith('.html') || f.endsWith('.ts')) && !f.endsWith('.spec.ts'))
+    .map((f) => f.replace(/\.(html|ts)$/, '')),
+)]
+
+if (!changedStems.length) {
   console.log('e2e impact: no frontend component changes.')
   process.exit(0)
 }
@@ -93,22 +113,41 @@ function exportsOf(file) {
 
 // Reverse import graph: helper/page-object file -> e2e files importing it.
 const importedBy = new Map()
+const addEdge = (target, importer) => {
+  if (!importedBy.has(target)) importedBy.set(target, new Set())
+  importedBy.get(target).add(importer)
+}
 for (const [f, text] of e2eText) {
-  for (const m of text.matchAll(/import\s+(?:type\s+)?(?:{([^}]*)}|[\w*\s,]+)\s+from\s+['"](\.[^'"]+)['"]/g)) {
+  // Re-export statements make the re-exporting file an importer of its
+  // source, so export-star chains stay connected in the walk.
+  for (const m of text.matchAll(/export\s+(?:type\s+)?(?:{[^}]*}|\*(?:\s+as\s+\w+)?)\s+from\s+['"](\.[^'"]+)['"]/g)) {
+    const target = resolveModule(f, m[1])
+    if (target) addEdge(target, f)
+  }
+  // import <clause> from '...' — named braces pierce barrels; a default or
+  // namespace part may use anything the module re-exports, so it edges to
+  // the module and every named re-export target.
+  for (const m of text.matchAll(/import\s+(?:type\s+)?([\w*\s,{}]+?)\s+from\s+['"](\.[^'"]+)['"]/g)) {
     const target = resolveModule(f, m[2])
     if (!target) continue
-    const names = (m[1] ?? '').split(',').map((s) => s.trim().split(/\s+as\s+/)[0].trim()).filter(Boolean)
+    const clause = m[1]
+    const braces = clause.match(/{([^}]*)}/)
     const barrel = exportsOf(target)
-    const edges = new Set()
-    if (names.length && barrel.size) {
-      for (const n of names) edges.add(barrel.get(n) ?? target)
-    } else {
-      edges.add(target)
+    if (braces) {
+      for (const raw of braces[1].split(',')) {
+        const name = raw.trim().split(/\s+as\s+/)[0].trim()
+        if (name) addEdge(barrel.get(name) ?? target, f)
+      }
     }
-    for (const t of edges) {
-      if (!importedBy.has(t)) importedBy.set(t, new Set())
-      importedBy.get(t).add(f)
+    if (clause.replace(/{[^}]*}/, '').trim()) {
+      addEdge(target, f)
+      for (const src of new Set(barrel.values())) addEdge(src, f)
     }
+  }
+  // Side-effect imports: import './x'
+  for (const m of text.matchAll(/import\s*['"](\.[^'"]+)['"]/g)) {
+    const target = resolveModule(f, m[1])
+    if (target) addEdge(target, f)
   }
 }
 
@@ -122,29 +161,33 @@ function specsReaching(file, seen = new Set()) {
   return [...(importedBy.get(file) ?? [])].flatMap((f) => specsReaching(f, seen))
 }
 
-// A token counts as referenced only when it touches a string-literal quote,
-// where locator values live — generic hooks like 'row', 'card', 'empty'
-// would otherwise match ordinary identifiers and prose all over the suite
-// ('row' in BrowserContext, 'empty' in a comment) and fan the report out to
-// every spec. Prefix tokens ('row-action-') open a quoted value and may be
-// followed by more of it; whole tokens must be quote-delimited on one side
-// and value-terminal on the other.
-function referenced(text, token) {
-  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  if (token.endsWith('-')) return new RegExp(`["']${escaped}`).test(text)
-  return new RegExp(`["']${escaped}(?![-\\w])|(?<![-\\w])${escaped}["']`).test(text)
+const esc = (t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+// Hook values sit at the edge of a quoted region (attr values in locator
+// strings, incl. template literals); prefixes open one and may be followed
+// by more value.
+function hookReferenced(text, token) {
+  const e = esc(token)
+  if (token.endsWith('-')) return new RegExp(`["'\`]${e}`).test(text)
+  return new RegExp(`["'\`]${e}(?![-\\w])|(?<![-\\w])${e}["'\`]`).test(text)
+}
+// Selector tags may sit mid-string in compound selectors ('app-x form',
+// 'app-x, app-y') — word boundaries suffice, the tags are distinctive.
+function selectorReferenced(text, token) {
+  return new RegExp(`(?<![-\\w])${esc(token)}(?![-\\w])`).test(text)
 }
 
 const report = []
-for (const comp of changedComponents) {
-  const tokens = tokensFor(comp)
-  if (!tokens.size) continue
+for (const stem of changedStems) {
+  const { selectors, hooks } = tokensFor(stem)
+  if (!selectors.size && !hooks.size) continue
   const specs = new Set()
   for (const [f, text] of e2eText) {
-    if (![...tokens].some((t) => referenced(text, t))) continue
+    const hit = [...selectors].some((t) => selectorReferenced(text, t))
+      || [...hooks].some((t) => hookReferenced(text, t))
+    if (!hit) continue
     for (const s of specsReaching(f)) specs.add(s)
   }
-  if (specs.size) report.push({ comp, specs: [...specs].sort() })
+  if (specs.size) report.push({ comp: stem, specs: [...specs].sort() })
 }
 
 if (!report.length) {

--- a/scripts/e2e-impact.mjs
+++ b/scripts/e2e-impact.mjs
@@ -9,25 +9,22 @@
 //
 // Usage: git diff --name-only develop...HEAD | node scripts/e2e-impact.mjs
 
-import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { readFileSync, existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
+import { files, HOOK_DEFS, DATA_TEST_CONFIG } from './lib/e2e-hooks.mjs'
 
 process.chdir(fileURLToPath(new URL('..', import.meta.url)))
 
+if (process.argv.length <= 2 && process.stdin.isTTY) {
+  console.error('Usage: git diff --name-only develop...HEAD | node scripts/e2e-impact.mjs')
+  console.error('   or: node scripts/e2e-impact.mjs <changed-file> [...]')
+  process.exit(1)
+}
 const input = process.argv.length > 2
   ? process.argv.slice(2)
   : readFileSync(0, 'utf8').split('\n')
 const changed = input.map((l) => l.trim()).filter(Boolean)
-
-function files(dir, ext) {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    if (entry.name === 'node_modules') return []
-    const p = `${dir}/${entry.name}`
-    if (entry.isDirectory()) return files(p, ext)
-    return ext.some((e) => entry.name.endsWith(e)) ? [p] : []
-  })
-}
 
 // Tokens a component contributes to the DOM contract: its element selector
 // and every test-hook value (static, or quoted fragment of a dynamic
@@ -42,11 +39,13 @@ function tokensFor(file) {
     if (!existsSync(src)) continue // deleted in this diff
     const text = readFileSync(src, 'utf8')
     for (const m of text.matchAll(/\bselector:\s*['"]([a-z][a-z0-9-]+)['"]/g)) tokens.add(m[1])
-    for (const m of text.matchAll(/data-test(?:id)?=["']([^"']+)["']/g)) tokens.add(m[1])
-    for (const m of text.matchAll(/\[attr\.data-test(?:id)?\]="([^"]*)"/g)) {
-      for (const s of m[1].matchAll(/'([^']+)'/g)) tokens.add(s[1])
+    for (const [staticDef, dynamicDef] of Object.values(HOOK_DEFS)) {
+      for (const m of text.matchAll(staticDef)) tokens.add(m[1])
+      for (const m of text.matchAll(dynamicDef)) {
+        for (const s of m[1].matchAll(/'([^']+)'/g)) tokens.add(s[1])
+      }
     }
-    for (const m of text.matchAll(/\bdataTest:\s*['"]([^'"]+)['"]/g)) tokens.add(m[1])
+    for (const m of text.matchAll(DATA_TEST_CONFIG)) tokens.add(m[1])
   }
   return tokens
 }
@@ -63,17 +62,52 @@ if (!changedComponents.length) {
 const e2eFiles = files('e2e', ['.ts'])
 const e2eText = new Map(e2eFiles.map((f) => [f, readFileSync(f, 'utf8')]))
 
+function resolveModule(fromFile, spec) {
+  const target = path.join(path.dirname(fromFile), spec).replaceAll('\\', '/')
+  for (const cand of [target + '.ts', target + '/index.ts', target]) {
+    if (e2eText.has(cand)) return cand
+  }
+  return null
+}
+
+// Named re-exports of a barrel (index.ts), mapped to the declaring module.
+// Importing a name through a barrel must create an edge to that module, not
+// to the barrel — otherwise one hit in a shared component fans out through
+// the barrel to every spec that imports anything from it.
+const barrelExports = new Map()
+function exportsOf(file) {
+  if (!barrelExports.has(file)) {
+    const map = new Map()
+    for (const m of e2eText.get(file).matchAll(/export\s*(?:type\s*)?{([^}]*)}\s*from\s*['"](\.[^'"]+)['"]/g)) {
+      const src = resolveModule(file, m[2])
+      if (!src) continue
+      for (const raw of m[1].split(',')) {
+        const name = raw.trim().split(/\s+as\s+/).pop()?.trim()
+        if (name) map.set(name, src)
+      }
+    }
+    barrelExports.set(file, map)
+  }
+  return barrelExports.get(file)
+}
+
 // Reverse import graph: helper/page-object file -> e2e files importing it.
 const importedBy = new Map()
 for (const [f, text] of e2eText) {
-  for (const m of text.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
-    let target = path.join(path.dirname(f), m[1]).replaceAll('\\', '/')
-    for (const cand of [target + '.ts', target + '/index.ts', target]) {
-      if (e2eText.has(cand)) {
-        if (!importedBy.has(cand)) importedBy.set(cand, new Set())
-        importedBy.get(cand).add(f)
-        break
-      }
+  for (const m of text.matchAll(/import\s+(?:type\s+)?(?:{([^}]*)}|[\w*\s,]+)\s+from\s+['"](\.[^'"]+)['"]/g)) {
+    const target = resolveModule(f, m[2])
+    if (!target) continue
+    const names = (m[1] ?? '').split(',').map((s) => s.trim().split(/\s+as\s+/)[0].trim()).filter(Boolean)
+    const barrel = exportsOf(target)
+    const edges = new Set()
+    if (names.length && barrel.size) {
+      for (const n of names) edges.add(barrel.get(n) ?? target)
+    } else {
+      edges.add(target)
+    }
+    for (const t of edges) {
+      if (!importedBy.has(t)) importedBy.set(t, new Set())
+      importedBy.get(t).add(f)
     }
   }
 }
@@ -88,13 +122,26 @@ function specsReaching(file, seen = new Set()) {
   return [...(importedBy.get(file) ?? [])].flatMap((f) => specsReaching(f, seen))
 }
 
+// A token counts as referenced only when it touches a string-literal quote,
+// where locator values live — generic hooks like 'row', 'card', 'empty'
+// would otherwise match ordinary identifiers and prose all over the suite
+// ('row' in BrowserContext, 'empty' in a comment) and fan the report out to
+// every spec. Prefix tokens ('row-action-') open a quoted value and may be
+// followed by more of it; whole tokens must be quote-delimited on one side
+// and value-terminal on the other.
+function referenced(text, token) {
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  if (token.endsWith('-')) return new RegExp(`["']${escaped}`).test(text)
+  return new RegExp(`["']${escaped}(?![-\\w])|(?<![-\\w])${escaped}["']`).test(text)
+}
+
 const report = []
 for (const comp of changedComponents) {
   const tokens = tokensFor(comp)
   if (!tokens.size) continue
   const specs = new Set()
   for (const [f, text] of e2eText) {
-    if (![...tokens].some((t) => text.includes(t))) continue
+    if (![...tokens].some((t) => referenced(text, t))) continue
     for (const s of specsReaching(f)) specs.add(s)
   }
   if (specs.size) report.push({ comp, specs: [...specs].sort() })

--- a/scripts/e2e-impact.mjs
+++ b/scripts/e2e-impact.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Advisory component→e2e coverage map (#5619 section 3). Given changed file
+// paths (argv, or stdin one-per-line), reports which e2e specs exercise the
+// changed components, derived mechanically from the data-test contract: a
+// changed component's test hooks and element selector are matched against
+// e2e sources, and hits in shared helpers/page objects are walked up the
+// e2e import graph to the specs that use them. Advisory only — always
+// exits 0; the output tells a reviewer which specs are worth running.
+//
+// Usage: git diff --name-only develop...HEAD | node scripts/e2e-impact.mjs
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+process.chdir(fileURLToPath(new URL('..', import.meta.url)))
+
+const input = process.argv.length > 2
+  ? process.argv.slice(2)
+  : readFileSync(0, 'utf8').split('\n')
+const changed = input.map((l) => l.trim()).filter(Boolean)
+
+function files(dir, ext) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === 'node_modules') return []
+    const p = `${dir}/${entry.name}`
+    if (entry.isDirectory()) return files(p, ext)
+    return ext.some((e) => entry.name.endsWith(e)) ? [p] : []
+  })
+}
+
+// Tokens a component contributes to the DOM contract: its element selector
+// and every test-hook value (static, or quoted fragment of a dynamic
+// binding — fragments ending in '-' are prefixes and match as such).
+function tokensFor(file) {
+  const tokens = new Set()
+  // A change to either half of a component involves the whole contract, so
+  // read the sibling template/class too.
+  const sibling = file.endsWith('.html') ? file.replace(/\.html$/, '.ts') : file.replace(/\.ts$/, '.html')
+  const sources = [file, ...(existsSync(sibling) ? [sibling] : [])]
+  for (const src of sources) {
+    if (!existsSync(src)) continue // deleted in this diff
+    const text = readFileSync(src, 'utf8')
+    for (const m of text.matchAll(/\bselector:\s*['"]([a-z][a-z0-9-]+)['"]/g)) tokens.add(m[1])
+    for (const m of text.matchAll(/data-test(?:id)?=["']([^"']+)["']/g)) tokens.add(m[1])
+    for (const m of text.matchAll(/\[attr\.data-test(?:id)?\]="([^"]*)"/g)) {
+      for (const s of m[1].matchAll(/'([^']+)'/g)) tokens.add(s[1])
+    }
+    for (const m of text.matchAll(/\bdataTest:\s*['"]([^'"]+)['"]/g)) tokens.add(m[1])
+  }
+  return tokens
+}
+
+const changedComponents = changed.filter(
+  (f) => f.startsWith('src/frontend/') && (f.endsWith('.html') || f.endsWith('.ts')) && !f.endsWith('.spec.ts'),
+)
+
+if (!changedComponents.length) {
+  console.log('e2e impact: no frontend component changes.')
+  process.exit(0)
+}
+
+const e2eFiles = files('e2e', ['.ts'])
+const e2eText = new Map(e2eFiles.map((f) => [f, readFileSync(f, 'utf8')]))
+
+// Reverse import graph: helper/page-object file -> e2e files importing it.
+const importedBy = new Map()
+for (const [f, text] of e2eText) {
+  for (const m of text.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
+    let target = path.join(path.dirname(f), m[1]).replaceAll('\\', '/')
+    for (const cand of [target + '.ts', target + '/index.ts', target]) {
+      if (e2eText.has(cand)) {
+        if (!importedBy.has(cand)) importedBy.set(cand, new Set())
+        importedBy.get(cand).add(f)
+        break
+      }
+    }
+  }
+}
+
+const isSpec = (f) => f.endsWith('.spec.ts')
+
+// Walk hits up to the specs that (transitively) import them.
+function specsReaching(file, seen = new Set()) {
+  if (seen.has(file)) return []
+  seen.add(file)
+  if (isSpec(file)) return [file]
+  return [...(importedBy.get(file) ?? [])].flatMap((f) => specsReaching(f, seen))
+}
+
+const report = []
+for (const comp of changedComponents) {
+  const tokens = tokensFor(comp)
+  if (!tokens.size) continue
+  const specs = new Set()
+  for (const [f, text] of e2eText) {
+    if (![...tokens].some((t) => text.includes(t))) continue
+    for (const s of specsReaching(f)) specs.add(s)
+  }
+  if (specs.size) report.push({ comp, specs: [...specs].sort() })
+}
+
+if (!report.length) {
+  console.log('e2e impact: changed components have no e2e references — no scoped specs to suggest.')
+} else {
+  console.log('e2e impact — specs covering changed components (advisory):')
+  for (const { comp, specs } of report) {
+    console.log(`\n${comp}`)
+    for (const s of specs) console.log(`  ${s}`)
+  }
+  const all = [...new Set(report.flatMap((r) => r.specs))].sort()
+  console.log(`\nRun scoped: npx playwright test --project=setup --project=chromium ${all.join(' ')}`)
+}

--- a/scripts/lib/e2e-hooks.mjs
+++ b/scripts/lib/e2e-hooks.mjs
@@ -1,0 +1,34 @@
+// Single definition of the test-hook syntax shared by the two consumers
+// (scripts/lint-e2e-data-test.mjs and scripts/e2e-impact.mjs), so a new
+// binding form added for one check cannot silently escape the other.
+
+import { readdirSync } from 'node:fs'
+
+export function files(dir, ext) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === 'node_modules') return []
+    const p = `${dir}/${entry.name}`
+    if (entry.isDirectory()) return files(p, ext)
+    return ext.some((e) => entry.name.endsWith(e)) ? [p] : []
+  })
+}
+
+// Definitions components provide: static attributes, plus every quoted
+// string fragment inside a dynamic [attr.data-test] binding ('refresh' and
+// 'refresh-loading' out of a ternary, prefixes like 'header-action-').
+// A data-testid ref must not match a data-test definition, so the static
+// data-test pattern excludes the 'id'-suffixed attribute via (?!id).
+export const HOOK_DEFS = {
+  'data-test': [/(?<!\[attr\.)data-test(?!id)=["']([^"']+)/g, /\[attr\.data-test\]="([^"]*)"/g],
+  'data-testid': [/(?<!\[attr\.)data-testid=["']([^"']+)/g, /\[attr\.data-testid\]="([^"]*)"/g],
+}
+
+// dataTest config values (SignalListRowAction etc.) are full definitions.
+export const DATA_TEST_CONFIG = /\bdataTest:\s*['"]([^'"]+)['"]/g
+
+// Unit-test fixtures declare label:/dataTest:/data-test= literals that are
+// never shipped DOM — harvesting them would let renamed-label drift hide
+// behind a spec fixture. Only non-spec sources define the contract.
+export function contractSources(dir) {
+  return files(dir, ['.html', '.ts']).filter((f) => !f.endsWith('.spec.ts'))
+}

--- a/scripts/lint-e2e-data-test.mjs
+++ b/scripts/lint-e2e-data-test.mjs
@@ -52,6 +52,16 @@ const DEFS = {
   'data-testid': [/(?<!\[attr\.)data-testid=["']([^"']+)/g, /\[attr\.data-testid\]="([^"]*)"/g],
 }
 
+// Suffix vocabulary for prefix-style bindings ('header-action-' + act.label):
+// every label/textLabel string literal in app code or templates, plus
+// explicit dataTest config values. A static e2e ref under a live prefix must
+// end in one of these, so a renamed action label turns the old ref red.
+const SUFFIX_SOURCES = [
+  /\b(?:label|textLabel):\s*['"]([^'"]+)['"]/g,
+  /\b(?:label|textLabel)=["']([^"']+)["']/g,
+]
+const suffixes = new Set()
+
 for (const f of files('src/frontend', ['.html', '.ts'])) {
   const text = readFileSync(f, 'utf8')
   for (const [ns, [staticDef, dynamicDef]] of Object.entries(DEFS)) {
@@ -60,11 +70,17 @@ for (const f of files('src/frontend', ['.html', '.ts'])) {
       for (const s of m[1].matchAll(/'([^']+)'/g)) NAMESPACES[ns].defined.add(s[1])
     }
   }
+  for (const pattern of SUFFIX_SOURCES) {
+    for (const m of text.matchAll(pattern)) suffixes.add(m[1])
+  }
+  // dataTest config values (SignalListRowAction etc.) are full definitions.
+  for (const m of text.matchAll(/\bdataTest:\s*['"]([^'"]+)['"]/g)) NAMESPACES['data-test'].defined.add(m[1])
 }
 
 // 'header-action-' + label style bindings define a prefix, not a value.
-// Known limitation: a typo'd or renamed suffix under a live prefix passes;
-// validating suffixes needs shared test-id constants (#5619 follow-on).
+// simplification: suffixes validate against harvested label literals, not
+// shared test-id constants — a label anywhere in src satisfies any prefix.
+// Tighten to per-prefix vocabularies if cross-component collisions bite.
 for (const ns of Object.values(NAMESPACES)) {
   ns.prefixes = [...ns.defined].filter((d) => d.endsWith('-'))
 }
@@ -78,9 +94,14 @@ for (const f of files('e2e', ['.ts'])) {
       for (const m of text.matchAll(pattern)) {
         const value = m[1]
         if (value.includes('$') || value.includes('{')) continue // dynamic
-        if (!ns.defined.has(value) && !ns.prefixes.some((p) => value.startsWith(p))) {
-          const line = text.slice(0, m.index).split('\n').length
-          problems.push(`${f}:${line}  ${nsName} "${value}" is not defined in any component template`)
+        if (value.includes('<')) continue // doc-comment placeholder, e.g. page-tab-<label>
+        if (ns.defined.has(value)) continue
+        const line = () => text.slice(0, m.index).split('\n').length
+        const prefix = ns.prefixes.filter((p) => value.startsWith(p)).sort((a, b) => b.length - a.length)[0]
+        if (!prefix) {
+          problems.push(`${f}:${line()}  ${nsName} "${value}" is not defined in any component template`)
+        } else if (!suffixes.has(value.slice(prefix.length))) {
+          problems.push(`${f}:${line()}  ${nsName} "${value}" matches prefix "${prefix}" but "${value.slice(prefix.length)}" is not a label defined anywhere in src`)
         }
       }
     }

--- a/scripts/lint-e2e-data-test.mjs
+++ b/scripts/lint-e2e-data-test.mjs
@@ -88,7 +88,7 @@ for (const f of files('e2e', ['.ts'])) {
         // ('tab-' vs 'tab-action-') could shadow a valid shorter-prefix ref.
         const prefixes = ns.prefixes.filter((p) => value.startsWith(p))
         if (!prefixes.length) {
-          problems.push(`${f}:${line()}  ${nsName} "${value}" is not defined in any component template`)
+          problems.push(`${f}:${line()}  ${nsName} "${value}" is not defined by any component (template attribute or dataTest config)`)
         } else if (!prefixes.some((p) => suffixes.has(value.slice(p.length)))) {
           problems.push(
             `${f}:${line()}  ${nsName} "${value}" matches prefix(es) ${prefixes.map((p) => `"${p}"`).join(', ')} but the remainder is not a label defined in src` +

--- a/scripts/lint-e2e-data-test.mjs
+++ b/scripts/lint-e2e-data-test.mjs
@@ -12,24 +12,16 @@
 // skipped — their selectors are rewritten wholesale when they are modernised.
 // Dynamic values (template interpolation) cannot be checked and are skipped.
 
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { E2E_LEGACY_FILES } from '../tools/eslint-rules/e2e-legacy-files.mjs'
+import { files, contractSources, HOOK_DEFS, DATA_TEST_CONFIG } from './lib/e2e-hooks.mjs'
 
 // All paths are repo-root-relative with '/' separators, on every platform:
 // built that way below, matching the legacy list's entries.
 process.chdir(fileURLToPath(new URL('..', import.meta.url)))
 
 const legacy = new Set(E2E_LEGACY_FILES)
-
-function files(dir, ext) {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    if (entry.name === 'node_modules') return []
-    const p = `${dir}/${entry.name}`
-    if (entry.isDirectory()) return files(p, ext)
-    return ext.some((e) => entry.name.endsWith(e)) ? [p] : []
-  })
-}
 
 const NAMESPACES = {
   'data-test': {
@@ -42,16 +34,6 @@ const NAMESPACES = {
   },
 }
 
-// Definitions components provide: static attributes, plus every quoted
-// string fragment inside a dynamic [attr.data-test] binding ('refresh' and
-// 'refresh-loading' out of a ternary, prefixes like 'header-action-').
-// A data-testid ref must not match a data-test definition, so the static
-// data-test pattern excludes the 'id'-suffixed attribute via (?!id).
-const DEFS = {
-  'data-test': [/(?<!\[attr\.)data-test(?!id)=["']([^"']+)/g, /\[attr\.data-test\]="([^"]*)"/g],
-  'data-testid': [/(?<!\[attr\.)data-testid=["']([^"']+)/g, /\[attr\.data-testid\]="([^"]*)"/g],
-}
-
 // Suffix vocabulary for prefix-style bindings ('header-action-' + act.label):
 // every label/textLabel string literal in app code or templates, plus
 // explicit dataTest config values. A static e2e ref under a live prefix must
@@ -60,11 +42,16 @@ const SUFFIX_SOURCES = [
   /\b(?:label|textLabel):\s*['"]([^'"]+)['"]/g,
   /\b(?:label|textLabel)=["']([^"']+)["']/g,
 ]
-const suffixes = new Set()
+// Escape hatch for labels the harvest cannot see (computed at runtime —
+// variable, i18n lookup, function result). Add the rendered label here when
+// a correct e2e ref fails the suffix check; keep entries commented with the
+// component that renders them.
+const COMPUTED_LABEL_ALLOWLIST = new Set([])
+const suffixes = new Set(COMPUTED_LABEL_ALLOWLIST)
 
-for (const f of files('src/frontend', ['.html', '.ts'])) {
+for (const f of contractSources('src/frontend')) {
   const text = readFileSync(f, 'utf8')
-  for (const [ns, [staticDef, dynamicDef]] of Object.entries(DEFS)) {
+  for (const [ns, [staticDef, dynamicDef]] of Object.entries(HOOK_DEFS)) {
     for (const m of text.matchAll(staticDef)) NAMESPACES[ns].defined.add(m[1])
     for (const m of text.matchAll(dynamicDef)) {
       for (const s of m[1].matchAll(/'([^']+)'/g)) NAMESPACES[ns].defined.add(s[1])
@@ -74,7 +61,7 @@ for (const f of files('src/frontend', ['.html', '.ts'])) {
     for (const m of text.matchAll(pattern)) suffixes.add(m[1])
   }
   // dataTest config values (SignalListRowAction etc.) are full definitions.
-  for (const m of text.matchAll(/\bdataTest:\s*['"]([^'"]+)['"]/g)) NAMESPACES['data-test'].defined.add(m[1])
+  for (const m of text.matchAll(DATA_TEST_CONFIG)) NAMESPACES['data-test'].defined.add(m[1])
 }
 
 // 'header-action-' + label style bindings define a prefix, not a value.
@@ -94,14 +81,19 @@ for (const f of files('e2e', ['.ts'])) {
       for (const m of text.matchAll(pattern)) {
         const value = m[1]
         if (value.includes('$') || value.includes('{')) continue // dynamic
-        if (value.includes('<')) continue // doc-comment placeholder, e.g. page-tab-<label>
         if (ns.defined.has(value)) continue
         const line = () => text.slice(0, m.index).split('\n').length
-        const prefix = ns.prefixes.filter((p) => value.startsWith(p)).sort((a, b) => b.length - a.length)[0]
-        if (!prefix) {
+        // A value is valid under ANY live prefix whose remainder is a known
+        // label — don't privilege the longest match, or a nested prefix
+        // ('tab-' vs 'tab-action-') could shadow a valid shorter-prefix ref.
+        const prefixes = ns.prefixes.filter((p) => value.startsWith(p))
+        if (!prefixes.length) {
           problems.push(`${f}:${line()}  ${nsName} "${value}" is not defined in any component template`)
-        } else if (!suffixes.has(value.slice(prefix.length))) {
-          problems.push(`${f}:${line()}  ${nsName} "${value}" matches prefix "${prefix}" but "${value.slice(prefix.length)}" is not a label defined anywhere in src`)
+        } else if (!prefixes.some((p) => suffixes.has(value.slice(p.length)))) {
+          problems.push(
+            `${f}:${line()}  ${nsName} "${value}" matches prefix(es) ${prefixes.map((p) => `"${p}"`).join(', ')} but the remainder is not a label defined in src` +
+            ' (computed label? add it to COMPUTED_LABEL_ALLOWLIST in scripts/lint-e2e-data-test.mjs)',
+          )
         }
       }
     }

--- a/scripts/lint-e2e-ratchet.mjs
+++ b/scripts/lint-e2e-ratchet.mjs
@@ -35,13 +35,19 @@ const eslint = new ESLint({
 const results = existing.length ? await eslint.lintFiles(existing) : []
 for (const r of results) {
   const rel = r.filePath.replace(process.cwd() + '/', '')
-  const guardHits = r.messages.filter((m) => GUARD_RULES.includes(m.ruleId)).length
+  // Suppressed messages count as violations: an inline eslint-disable does
+  // not make a file clean, and treating it as clean would force delisting a
+  // file whose guards then never fire again.
+  const allMessages = [...r.messages, ...(r.suppressedMessages ?? [])]
+  const guardHits = allMessages.filter((m) => GUARD_RULES.includes(m.ruleId)).length
   if (guardHits > 0) continue
-  // A parse error or eslint-ignore produces ruleId-null messages and zero
-  // guard hits — that is "unverifiable", not "clean"; saying clean would
-  // direct the author to delist a file the guards never actually checked.
-  if (r.messages.some((m) => m.ruleId === null)) {
-    problems.push(`${rel}  could not be checked (parse error or ignored): ${r.messages[0].message.split('\n')[0]}`)
+  // A parse error or an eslint-ignored file is "unverifiable", not "clean";
+  // saying clean would direct the author to delist a file the guards never
+  // actually checked. (Other ruleId-null messages — e.g. unused-disable-
+  // directive warnings — do not block a genuine clean verdict.)
+  const blocker = r.messages.find((m) => m.fatal || /File ignored/i.test(m.message))
+  if (blocker) {
+    problems.push(`${rel}  could not be checked (parse error or ignored): ${blocker.message.split('\n')[0]}`)
   } else {
     problems.push(`${rel}  is clean`)
   }

--- a/scripts/lint-e2e-ratchet.mjs
+++ b/scripts/lint-e2e-ratchet.mjs
@@ -34,15 +34,21 @@ const eslint = new ESLint({
 })
 const results = existing.length ? await eslint.lintFiles(existing) : []
 for (const r of results) {
+  const rel = r.filePath.replace(process.cwd() + '/', '')
   const guardHits = r.messages.filter((m) => GUARD_RULES.includes(m.ruleId)).length
-  if (guardHits === 0) {
-    const rel = r.filePath.replace(process.cwd() + '/', '')
+  if (guardHits > 0) continue
+  // A parse error or eslint-ignore produces ruleId-null messages and zero
+  // guard hits — that is "unverifiable", not "clean"; saying clean would
+  // direct the author to delist a file the guards never actually checked.
+  if (r.messages.some((m) => m.ruleId === null)) {
+    problems.push(`${rel}  could not be checked (parse error or ignored): ${r.messages[0].message.split('\n')[0]}`)
+  } else {
     problems.push(`${rel}  is clean`)
   }
 }
 
 if (problems.length) {
-  console.error(`e2e ratchet stale entries (${problems.length}) — remove them from tools/eslint-rules/e2e-legacy-files.mjs so the guards apply:`)
+  console.error(`e2e ratchet problems (${problems.length}) in tools/eslint-rules/e2e-legacy-files.mjs — remove entries that are clean or gone so the guards apply; fix files that could not be checked:`)
   for (const p of problems) console.error('  ' + p)
   process.exit(1)
 }

--- a/scripts/lint-e2e-ratchet.mjs
+++ b/scripts/lint-e2e-ratchet.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Became-clean enforcement for the e2e guard ratchet (#5619). The legacy
+// list in tools/eslint-rules/e2e-legacy-files.mjs turns the drift guards
+// off for files that predate them; nothing else fails when a listed file
+// stops violating, so stale entries would silently keep the guards off.
+// This check closes the loop: every listed file must still exist AND still
+// violate at least one guard — otherwise its entry must be removed so the
+// file gates red from then on.
+
+import { ESLint } from 'eslint'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { E2E_LEGACY_FILES } from '../tools/eslint-rules/e2e-legacy-files.mjs'
+
+process.chdir(fileURLToPath(new URL('..', import.meta.url)))
+
+const GUARD_RULES = ['stratos/no-dead-material-selectors', 'stratos/no-hollow-assertions']
+
+const problems = []
+const existing = E2E_LEGACY_FILES.filter((f) => {
+  if (existsSync(f)) return true
+  problems.push(`${f}  no longer exists`)
+  return false
+})
+
+// Re-run only the guard rules with the ratchet's "off" override re-enabled.
+const eslint = new ESLint({
+  overrideConfig: [
+    {
+      files: E2E_LEGACY_FILES,
+      rules: Object.fromEntries(GUARD_RULES.map((r) => [r, 'error'])),
+    },
+  ],
+})
+const results = existing.length ? await eslint.lintFiles(existing) : []
+for (const r of results) {
+  const guardHits = r.messages.filter((m) => GUARD_RULES.includes(m.ruleId)).length
+  if (guardHits === 0) {
+    const rel = r.filePath.replace(process.cwd() + '/', '')
+    problems.push(`${rel}  is clean`)
+  }
+}
+
+if (problems.length) {
+  console.error(`e2e ratchet stale entries (${problems.length}) — remove them from tools/eslint-rules/e2e-legacy-files.mjs so the guards apply:`)
+  for (const p of problems) console.error('  ' + p)
+  process.exit(1)
+}
+console.log(`e2e ratchet OK (${E2E_LEGACY_FILES.length} legacy files, all still violating)`)

--- a/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.html
+++ b/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.html
@@ -15,6 +15,7 @@
         }
         @if (tab && tab.link && (tab.hidden$ | async) !== true) {
           <a class="page-side-nav__item"
+            [attr.data-test]="'page-tab-' + tab.label"
             [routerLink]="[tab.link]" queryParamsHandling="preserve"
             [routerLinkActive]="['page-side-nav__item--active']">
             @if (tab.icon) {

--- a/src/frontend/packages/core/src/shared/components/custom-tabs/custom-tabs.component.html
+++ b/src/frontend/packages/core/src/shared/components/custom-tabs/custom-tabs.component.html
@@ -4,6 +4,7 @@
       @for (tab of getTabsArray(); track $index; let i = $index) {
         <div
           class="tab-label"
+          [attr.data-test]="'custom-tab-' + (tab.label || tab.textLabel)"
           role="tab" tabindex="0"
           [attr.aria-selected]="tab.isActive"
           [class.active]="tab.isActive"

--- a/src/frontend/packages/core/src/shared/components/nested-tabs/nested-tabs.component.html
+++ b/src/frontend/packages/core/src/shared/components/nested-tabs/nested-tabs.component.html
@@ -2,7 +2,7 @@
   @if (tabs) {
     <nav class="summary__nav tab-nav-bar">
       @for (tab of tabs; track tab) {
-        <a class="tab-link" [routerLink]="[tab.link]" routerLinkActive="active-link" #rla="routerLinkActive" [class.active]="rla.isActive">
+        <a class="tab-link" [attr.data-test]="'nested-tab-' + tab.label" [routerLink]="[tab.link]" routerLinkActive="active-link" #rla="routerLinkActive" [class.active]="rla.isActive">
           {{tab.label}}
         </a>
       }

--- a/src/frontend/packages/core/src/shared/components/signal-detail/signal-detail.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-detail/signal-detail.component.html
@@ -52,7 +52,7 @@
         <a [routerLink]="tab.link"
            routerLinkActive="signal-detail-tab--active text-accent border-accent"
            [routerLinkActiveOptions]="{ exact: false }"
-           data-test="signal-detail-tab"
+           [attr.data-test]="'signal-detail-tab-' + tab.label"
            class="signal-detail-tab flex items-center gap-1.5 px-4 py-2.5 text-sm border-b-2 border-transparent text-content-muted hover:text-content-text hover:border-content-border transition-colors whitespace-nowrap">
           @if (tab.icon) {
             <span class="material-icons text-base leading-none">{{ tab.icon }}</span>

--- a/src/frontend/packages/core/src/shared/components/signal-detail/signal-detail.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-detail/signal-detail.component.spec.ts
@@ -135,8 +135,9 @@ describe('SignalDetailComponent', () => {
         { label: 'Bindings', link: ['bindings'], icon: 'link' },
       ]).asReadonly(),
     });
-    const tabs = fixture.nativeElement.querySelectorAll('[data-test="signal-detail-tab"]');
+    const tabs = fixture.nativeElement.querySelectorAll('[data-test^="signal-detail-tab-"]');
     expect(tabs.length).toBe(2);
+    expect(tabs[0].getAttribute('data-test')).toBe('signal-detail-tab-Summary');
     expect(tabs[0].textContent).toContain('Summary');
     expect(tabs[1].textContent).toContain('Bindings');
     expect(tabs[1].querySelector('.material-icons')?.textContent).toBe('link');
@@ -150,12 +151,12 @@ describe('SignalDetailComponent', () => {
         { label: 'Public', link: ['public'] },
       ]).asReadonly(),
     });
-    let tabs = fixture.nativeElement.querySelectorAll('[data-test="signal-detail-tab"]');
+    let tabs = fixture.nativeElement.querySelectorAll('[data-test^="signal-detail-tab-"]');
     expect(tabs.length).toBe(1);
     expect(tabs[0].textContent).toContain('Public');
     hidden.set(false);
     fixture.detectChanges();
-    tabs = fixture.nativeElement.querySelectorAll('[data-test="signal-detail-tab"]');
+    tabs = fixture.nativeElement.querySelectorAll('[data-test^="signal-detail-tab-"]');
     expect(tabs.length).toBe(2);
   });
 

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -322,6 +322,7 @@
                                 <button
                                   type="button"
                                   [disabled]="act.disabled"
+                                  [attr.data-test]="act.dataTest ?? ('row-action-' + act.label)"
                                   (click)="invokeAction(act, row, $event)"
                                   class="w-full text-left px-3 py-1.5 text-sm hover:bg-content-secondary disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"
                                   [class.text-danger]="act.danger">
@@ -540,6 +541,7 @@
                             @for (act of ac.actions!(row); track act.label) {
                               <button
                                 type="button"
+                                [attr.data-test]="act.dataTest ?? ('row-action-' + act.label)"
                                 [disabled]="act.disabled"
                                 (click)="invokeAction(act, row, $event)"
                                 class="w-full text-left px-3 py-1.5 text-sm hover:bg-content-secondary disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -48,6 +48,29 @@ describe('SignalListComponent', () => {
     expect(rows[1].textContent).toContain('two');
   });
 
+  it('row-action menu items expose data-test hooks (label default, dataTest override)', () => {
+    const fixture = TestBed.createComponent(Host);
+    fixture.componentInstance.config = {
+      ...fixture.componentInstance.config,
+      columns: [
+        { header: 'Name', render: r => r.name },
+        {
+          header: '', kind: 'actions', render: () => '',
+          actions: () => [
+            { label: 'Delete', invoke: () => {} },
+            { label: 'Rename', dataTest: 'rename-row', invoke: () => {} },
+          ],
+        },
+      ],
+    };
+    fixture.detectChanges();
+    fixture.nativeElement.querySelector('[data-test="row-actions"]').click();
+    fixture.detectChanges();
+    const menu = fixture.nativeElement.querySelector('[data-test="row-actions-menu"]');
+    expect(menu.querySelector('[data-test="row-action-Delete"]')).not.toBeNull();
+    expect(menu.querySelector('[data-test="rename-row"]')).not.toBeNull();
+  });
+
   it('swaps the refresh button into the refreshing-state indicator when items present and isAnyLoading is true', () => {
     const fixture = TestBed.createComponent(Host);
     fixture.componentInstance.config = { ...fixture.componentInstance.config, isAnyLoading: signal(true).asReadonly() };

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -143,6 +143,8 @@ export interface SignalListRowAction<T> {
   readonly icon?: string;
   readonly disabled?: boolean;
   readonly danger?: boolean;
+  /** Optional `data-test` attribute for E2E selectors. */
+  readonly dataTest?: string;
   readonly invoke: (row: T) => void | Promise<void>;
 }
 

--- a/tools/eslint-rules/e2e-legacy-files.mjs
+++ b/tools/eslint-rules/e2e-legacy-files.mjs
@@ -1,7 +1,9 @@
 // e2e files that predate the drift guards (#5619) and still carry violations
 // (dead Material-era selectors, can't-fail assertions). This list only
 // shrinks: remove a file once it is modernised — never add to it. Generated
-// by running the guards over e2e/ when they were introduced.
+// by running the guards over e2e/ when they were introduced. Enforced by
+// scripts/lint-e2e-ratchet.mjs: an entry whose file is clean (or gone)
+// fails lint until it is removed.
 export const E2E_LEGACY_FILES = [
   "e2e/components/boolean-indicator.component.ts",
   "e2e/components/chips.component.ts",


### PR DESCRIPTION
Closes #5619 (sections 2 and 3, plus the two follow-ons recorded after #5648).

## What this adds

**Ratchet became-clean enforcement** — the legacy list introduced in #5648 only shrank by convention; nothing failed when a listed file stopped violating. `scripts/lint-e2e-ratchet.mjs` re-runs the two guard rules over the listed files and fails lint when an entry is clean or its file is gone, so list removal happens on the PR that cleans the file. Suppressed violations (inline eslint-disable) still count as violating, and parse errors report as unverifiable rather than clean.

**Per-tab data-test hooks on every tab surface** — page-side-nav (`page-tab-` + label), signal-detail (`signal-detail-tab-` + label, previously one shared static value), nested-tabs and custom-tabs. The e2e `pageTab()` helper now binds by exact attribute match plus a visible-label filter, replacing the CSS-class + label-regex approach.

**Row-action menu hooks** — kebab-menu entries in signal-list previously had no test hook, so specs matched them by text (the failure mode from the unmap-route example in #5619). Both card and table menus now render `act.dataTest ?? ('row-action-' + act.label)`, matching the header/bulk-action convention.

**Suffix validation for prefix-style hooks** — a ref like `header-action-Deploy` used to pass on the prefix alone, so a renamed label left the old ref green. The drift check now harvests every `label:`/`textLabel:` literal and `dataTest:` config value from non-spec sources and requires a prefixed ref's remainder to be one of them. Spec-fixture literals are excluded so fixtures cannot mask renamed-label drift; computed labels have an explicit allowlist escape.

**Advisory component→e2e impact report** — `scripts/e2e-impact.mjs` derives which specs cover a set of changed files: component hooks and element selectors matched against e2e sources, with hits in page objects walked up the import graph (piercing barrel re-exports so one hit doesn't fan out to every spec) to the specs that use them. A `pr.yml` job posts the report and a scoped `playwright test` command to the job summary on every PR. It never gates: the e2e suite needs a live CF endpoint, which CI does not have — a gating scoped run is left as separate infrastructure work. `TESTING.md` gains the matching contributor rule.

## Notes for review

- Everything chains inside `bun run lint`, so both `make check lint` and `make check gate` inherit it with no Makefile change.
- The two fix commits are the result of two adversarial self-review passes (19 findings fixed); each guard's failure modes are exercised by positive controls documented in the commit messages.
- Shared hook-syntax definitions live in `scripts/lib/e2e-hooks.mjs` so the drift check and the impact report cannot diverge.