### PR TITLE
Tiered e2e execution: runner, impact selection, make dispatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 #   make clean dist             Remove everything (including node_modules)
 #   make check                  Run all quality gates (lint + gate)
 #   make check e2e              Run Playwright E2E tests
+#   make test e2e TIER=acceptance PR=1234   Tiered E2E run (see TESTING.md)
 #   make stamp frontend         Generate build-info.ts with version metadata
 #   make dump version           Print resolved version variables
 #
@@ -406,6 +407,13 @@ E2E_TRACE       ?=
 E2E_VIDEO       ?=
 E2E_SCREENSHOTS ?=
 
+# Tiered selection (see TESTING.md "Tiered E2E runs"). Comma lists.
+# TIER/GROUP set → recipe delegates to scripts/e2e-run.mjs and the
+# browser default becomes all three (E2E_BROWSERS still overrides).
+TIER            ?=
+GROUP           ?=
+PR              ?=
+
 # Extra zizmor flags for `make audit actions` (e.g. --persona=auditor)
 ZIZMOR_FLAGS    ?=
 
@@ -445,11 +453,18 @@ endef
 
 define test.e2e
 	$(_ensure_host_backend)
-	@echo "Running Playwright E2E tests..."
-	@$(if $(E2E_VIDEO),E2E_VIDEO=$(E2E_VIDEO) )$(if $(E2E_SCREENSHOTS),E2E_SCREENSHOTS=$(E2E_SCREENSHOTS) )npx playwright test \
-		$(call _e2e_browsers,$(E2E_BROWSERS)) \
-		$(call _e2e_flag,trace,$(E2E_TRACE)) \
-		$(call _e2e_toggle,list,$(DRYRUN))
+	@if [ -n "$(TIER)$(GROUP)" ]; then \
+		echo "Running tiered E2E tests..."; \
+		$(if $(E2E_VIDEO),E2E_VIDEO=$(E2E_VIDEO) )$(if $(E2E_SCREENSHOTS),E2E_SCREENSHOTS=$(E2E_SCREENSHOTS) )node scripts/e2e-run.mjs \
+			$(if $(TIER),--tier $(TIER) )$(if $(GROUP),--group $(GROUP) )--browsers $(or $(E2E_BROWSERS),all) \
+			$(if $(PR),--pr $(PR) )$(call _e2e_toggle,dry-run,$(DRYRUN)); \
+	else \
+		echo "Running Playwright E2E tests..."; \
+		$(if $(E2E_VIDEO),E2E_VIDEO=$(E2E_VIDEO) )$(if $(E2E_SCREENSHOTS),E2E_SCREENSHOTS=$(E2E_SCREENSHOTS) )npx playwright test \
+			$(call _e2e_browsers,$(E2E_BROWSERS)) \
+			$(call _e2e_flag,trace,$(E2E_TRACE)) \
+			$(call _e2e_toggle,list,$(DRYRUN)); \
+	fi
 endef
 $(call register, test, e2e)
 

--- a/e2e/tests/application/application-wall.spec.ts
+++ b/e2e/tests/application/application-wall.spec.ts
@@ -19,7 +19,7 @@ const customOrgSpacesLabel = createCustomName('app-wall-tests');
 test.describe('Application Wall Tests', () => {
 
   test.describe('Basic Wall View', () => {
-    test('should display applications wall', async ({ connectedEndpointsUserPage }) => {
+    test('should display applications wall', { tag: '@smoke' }, async ({ connectedEndpointsUserPage }) => {
       const appsPage = new ApplicationsPage(connectedEndpointsUserPage);
 
       // Navigate to applications

--- a/e2e/tests/cloud-foundry/cloud-foundry-list.spec.ts
+++ b/e2e/tests/cloud-foundry/cloud-foundry-list.spec.ts
@@ -9,7 +9,7 @@ import { test, expect } from '../../fixtures/test-base';
 
 test.describe('Cloud Foundry List', () => {
 
-  test('should display CF endpoints on endpoints page', async ({ connectedEndpointsAdminPage }) => {
+  test('should display CF endpoints on endpoints page', { tag: '@smoke' }, async ({ connectedEndpointsAdminPage }) => {
     const { page } = connectedEndpointsAdminPage;
 
     // Navigate to endpoints page
@@ -26,7 +26,7 @@ test.describe('Cloud Foundry List', () => {
     expect(count).toBeGreaterThanOrEqual(1);
   });
 
-  test('should navigate to CF from endpoints list', async ({ connectedEndpointsAdminPage, secrets }) => {
+  test('should navigate to CF from endpoints list', { tag: '@smoke' }, async ({ connectedEndpointsAdminPage, secrets }) => {
     const { page } = connectedEndpointsAdminPage;
     const cfEndpoint = secrets.getCloudfoundryEndpoint(0);
 

--- a/e2e/tests/core/home.spec.ts
+++ b/e2e/tests/core/home.spec.ts
@@ -8,7 +8,7 @@ import { HomePage } from '../../pages/home.page';
  * Tests the home/dashboard page functionality
  */
 test.describe('Home', () => {
-  test('should reach home page', async ({ connectedEndpointsUserPage }) => {
+  test('should reach home page', { tag: '@smoke' }, async ({ connectedEndpointsUserPage }) => {
     // Page is already connected with endpoints as user
     const homePage = new HomePage(connectedEndpointsUserPage.page);
 

--- a/e2e/tests/core/login.spec.ts
+++ b/e2e/tests/core/login.spec.ts
@@ -11,7 +11,7 @@ import { LoginPage } from '../../pages/login.page';
  */
 test.describe('Login', () => {
 
-  test('should reach log in page', async ({ unauthenticatedPage, authType }) => {
+  test('should reach log in page', { tag: '@smoke' }, async ({ unauthenticatedPage, authType }) => {
     const loginPage = new LoginPage(unauthenticatedPage);
     await loginPage.navigateTo();
 

--- a/e2e/tests/marketplace/marketplace.spec.ts
+++ b/e2e/tests/marketplace/marketplace.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../../fixtures/test-base';
 
 test.describe('Marketplace', () => {
-  test('should navigate to marketplace', async ({ connectedEndpointsAdminPage }) => {
+  test('should navigate to marketplace', { tag: '@smoke' }, async ({ connectedEndpointsAdminPage }) => {
     const { page, cfGuid } = connectedEndpointsAdminPage;
     await page.goto(`/marketplace/${cfGuid}`);
     await page.waitForLoadState('networkidle');

--- a/e2e/tests/metrics/metrics-registration.spec.ts
+++ b/e2e/tests/metrics/metrics-registration.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../../fixtures/test-base';
 
 test.describe('Metrics Registration', () => {
-  test('should check metrics availability', async ({ connectedEndpointsAdminPage }) => {
+  test('should check metrics availability', { tag: '@smoke' }, async ({ connectedEndpointsAdminPage }) => {
     const { page } = connectedEndpointsAdminPage;
     await page.goto('/');
     const url = page.url();

--- a/scripts/e2e-impact.mjs
+++ b/scripts/e2e-impact.mjs
@@ -19,14 +19,14 @@ import { files, HOOK_DEFS, DATA_TEST_CONFIG } from './lib/e2e-hooks.mjs'
 
 process.chdir(fileURLToPath(new URL('..', import.meta.url)))
 
-if (process.argv.length <= 2 && process.stdin.isTTY) {
-  console.error('Usage: git diff --name-only develop...HEAD | node scripts/e2e-impact.mjs')
-  console.error('   or: node scripts/e2e-impact.mjs <changed-file> [...]')
+const FILES_ONLY = process.argv.includes('--files')
+const argFiles = process.argv.slice(2).filter((a) => a !== '--files')
+if (!argFiles.length && process.stdin.isTTY) {
+  console.error('Usage: git diff --name-only develop...HEAD | node scripts/e2e-impact.mjs [--files]')
+  console.error('   or: node scripts/e2e-impact.mjs [--files] <changed-file> [...]')
   process.exit(1)
 }
-const input = process.argv.length > 2
-  ? process.argv.slice(2)
-  : readFileSync(0, 'utf8').split('\n')
+const input = argFiles.length ? argFiles : readFileSync(0, 'utf8').split('\n')
 const changed = input.map((l) => l.trim()).filter(Boolean)
 
 const IMPACT_BASE = process.env.IMPACT_BASE ?? 'develop'
@@ -75,7 +75,7 @@ const changedStems = [...new Set(
 )]
 
 if (!changedStems.length) {
-  console.log('e2e impact: no frontend component changes.')
+  if (!FILES_ONLY) console.log('e2e impact: no frontend component changes.')
   process.exit(0)
 }
 
@@ -190,7 +190,10 @@ for (const stem of changedStems) {
   if (specs.size) report.push({ comp: stem, specs: [...specs].sort() })
 }
 
-if (!report.length) {
+if (FILES_ONLY) {
+  const all = [...new Set(report.flatMap((r) => r.specs))].sort()
+  if (all.length) console.log(all.join('\n'))
+} else if (!report.length) {
   console.log('e2e impact: changed components have no e2e references — no scoped specs to suggest.')
 } else {
   console.log('e2e impact — specs covering changed components (advisory):')

--- a/scripts/e2e-run.mjs
+++ b/scripts/e2e-run.mjs
@@ -8,7 +8,7 @@
 // Exits nonzero if any Playwright invocation fails.
 
 import { execFileSync, spawnSync } from 'node:child_process'
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync, readdirSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 
@@ -93,6 +93,7 @@ for (const run of runs) {
   const argv = ['playwright', 'test', ...run.args]
   console.log(`\n>>> ${run.label}\n    npx ${argv.join(' ')}`)
   if (opt.dryRun) continue
+  rmSync('e2e-reports/results.json', { force: true }) // a crashed run must not inherit the previous run's report
   const r = spawnSync('npx', argv, { stdio: 'inherit' })
   if (r.status !== 0) exitCode = 1
   try {

--- a/scripts/e2e-run.mjs
+++ b/scripts/e2e-run.mjs
@@ -27,6 +27,7 @@ for (let i = 0; i < args.length; i++) {
     case '--browsers': opt.browsers.push(...next().split(',').filter(Boolean)); break
     case '--base': opt.base = next(); break
     case '--dry-run': opt.dryRun = true; break
+    case '--pr': opt.pr = next(); break
     default: console.error(`unknown argument: ${args[i]}`); process.exit(2)
   }
 }
@@ -129,5 +130,12 @@ const verdict = [
   ...(failedTests.length ? ['', '### Failed', ...failedTests.map((t) => `- ${t}`)] : []),
 ].join('\n')
 console.log('\n' + verdict + '\n')
+
+if (opt.pr) {
+  const r = spawnSync('gh', ['pr', 'comment', opt.pr, '--repo', 'cloudfoundry/stratos', '--body-file', '-'],
+    { input: verdict, encoding: 'utf8' })
+  if (r.status === 0) console.log(`verdict posted to PR #${opt.pr}`)
+  else console.error(`could not post verdict to PR #${opt.pr} (gh exit ${r.status}) — run result above still stands`)
+}
 
 process.exit(exitCode)

--- a/scripts/e2e-run.mjs
+++ b/scripts/e2e-run.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Tiered e2e runner behind `make test e2e TIER=... GROUP=...` — see
+// TESTING.md "Tiered E2E runs". Selections are additive: tier-computed
+// spec sets (diff-driven, via e2e-impact.mjs) and group directories union
+// into one file list; browsers apply uniformly to the result. Tiers that
+// scope down (acceptance, broad) add a second pass running @smoke tests
+// over the UNSELECTED remainder, so every run keeps cross-surface cover.
+// Exits nonzero if any Playwright invocation fails.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+process.chdir(fileURLToPath(new URL('..', import.meta.url)))
+
+const opt = { tier: [], group: [], browsers: [], pr: null, base: process.env.IMPACT_BASE ?? 'develop', dryRun: false }
+const args = process.argv.slice(2)
+for (let i = 0; i < args.length; i++) {
+  const next = () => {
+    if (i + 1 >= args.length) { console.error(`${args[i]} needs a value`); process.exit(2) }
+    return args[++i]
+  }
+  switch (args[i]) {
+    case '--tier': opt.tier.push(...next().split(',').filter(Boolean)); break
+    case '--group': opt.group.push(...next().split(',').filter(Boolean)); break
+    case '--browsers': opt.browsers.push(...next().split(',').filter(Boolean)); break
+    case '--base': opt.base = next(); break
+    case '--dry-run': opt.dryRun = true; break
+    default: console.error(`unknown argument: ${args[i]}`); process.exit(2)
+  }
+}
+
+const TESTS_DIR = 'e2e/tests'
+const TIERS = ['acceptance', 'broad', 'full']
+const GROUPS = readdirSync(TESTS_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory()).map((d) => d.name).sort()
+for (const t of opt.tier) if (!TIERS.includes(t)) { console.error(`unknown tier '${t}' (tiers: ${TIERS.join(', ')})`); process.exit(2) }
+for (const g of opt.group) if (!GROUPS.includes(g)) { console.error(`unknown group '${g}' (groups: ${GROUPS.join(', ')})`); process.exit(2) }
+if (!opt.tier.length && !opt.group.length) { console.error('nothing selected: pass --tier and/or --group'); process.exit(2) }
+
+function specsUnder(dir) {
+  return readdirSync(dir, { withFileTypes: true, recursive: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.spec.ts'))
+    .map((e) => path.join(e.parentPath, e.name)).sort()
+}
+const allSpecs = specsUnder(TESTS_DIR)
+const groupOf = (spec) => spec.split(path.sep)[2] // e2e/tests/<group>/...
+
+function impactedSpecs() {
+  const diff = execFileSync('git', ['diff', '--name-only', `${opt.base}...HEAD`], { encoding: 'utf8' })
+  const r = spawnSync('node', ['scripts/e2e-impact.mjs', '--files'], { input: diff, encoding: 'utf8' })
+  if (r.status !== 0) { console.error('e2e-impact.mjs failed:\n' + r.stderr); process.exit(2) }
+  return r.stdout.split('\n').map((l) => l.trim()).filter(Boolean)
+}
+
+// Selection: union everything into one file-level set.
+const files = new Set()
+let smokeRest = false
+let impactEmpty = false
+for (const t of opt.tier) {
+  if (t === 'full') { for (const s of allSpecs) files.add(s) }
+  else {
+    const impacted = impactedSpecs()
+    if (!impacted.length) impactEmpty = true
+    if (t === 'acceptance') for (const s of impacted) files.add(s)
+    else for (const s of impacted) for (const f of specsUnder(path.join(TESTS_DIR, groupOf(s)))) files.add(f)
+    smokeRest = true
+  }
+}
+for (const g of opt.group) for (const f of specsUnder(path.join(TESTS_DIR, g))) files.add(f)
+
+const smokeFiles = allSpecs.filter((f) => readFileSync(f, 'utf8').includes("tag: '@smoke'"))
+// Playwright runs the `setup` dependency automatically for each selected
+// browser project; never pass --project=setup explicitly.
+const browserFlags = (!opt.browsers.length || opt.browsers.includes('all'))
+  ? [] : opt.browsers.map((b) => `--project=${b}`)
+
+const runs = []
+if (files.size) runs.push({ label: `selected specs (${files.size} files)`, args: [...browserFlags, ...[...files].sort()] })
+if (smokeRest) {
+  const rest = smokeFiles.filter((f) => !files.has(f))
+  if (rest.length) runs.push({ label: `smoke over the rest (${rest.length} files)`, args: [...browserFlags, '--grep', '@smoke', ...rest] })
+}
+if (impactEmpty) console.log(`impact scan against '${opt.base}' found no covered specs — running smoke only.`)
+if (!runs.length) { console.log('selection is empty — nothing to run.'); process.exit(0) }
+
+const t0 = Date.now()
+let failedTests = []
+let totals = { expected: 0, unexpected: 0, flaky: 0, skipped: 0 }
+let exitCode = 0
+for (const run of runs) {
+  const argv = ['playwright', 'test', ...run.args]
+  console.log(`\n>>> ${run.label}\n    npx ${argv.join(' ')}`)
+  if (opt.dryRun) continue
+  const r = spawnSync('npx', argv, { stdio: 'inherit' })
+  if (r.status !== 0) exitCode = 1
+  try {
+    const j = JSON.parse(readFileSync('e2e-reports/results.json', 'utf8'))
+    for (const k of Object.keys(totals)) totals[k] += j.stats?.[k] ?? 0
+    const walk = (suite, crumbs) => {
+      for (const sub of suite.suites ?? []) walk(sub, [...crumbs, sub.title])
+      for (const spec of suite.specs ?? []) if (!spec.ok) failedTests.push([...crumbs, spec.title].join(' › '))
+    }
+    for (const s of j.suites ?? []) walk(s, [s.title])
+  } catch {
+    console.error('could not read e2e-reports/results.json for this invocation')
+    exitCode = 1
+  }
+}
+
+if (opt.dryRun) { console.log('\n(dry run — nothing executed)'); process.exit(0) }
+
+const sha = execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim()
+const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' }).trim()
+const dirty = execFileSync('git', ['status', '--porcelain'], { encoding: 'utf8' }).trim()
+  ? ' — **DIRTY TREE**, results include uncommitted changes' : ''
+const mins = Math.floor((Date.now() - t0) / 60000)
+const secs = Math.round(((Date.now() - t0) % 60000) / 1000)
+const verdict = [
+  `## e2e verdict — ${exitCode === 0 ? 'PASS' : 'FAIL'}`,
+  `- selection: ${opt.tier.length ? `TIER=${opt.tier.join(',')}` : ''} ${opt.group.length ? `GROUP=${opt.group.join(',')}` : ''}`.trimEnd(),
+  `- browsers: ${opt.browsers.length ? opt.browsers.join(', ') : 'all'}`,
+  `- commit: ${sha} (${branch})${dirty}`,
+  `- runs: ${runs.map((r) => r.label).join('; ')}`,
+  `- results: ${totals.expected} passed, ${totals.unexpected} failed, ${totals.flaky} flaky, ${totals.skipped} skipped`,
+  `- wall-clock: ${mins}m ${secs}s`,
+  ...(failedTests.length ? ['', '### Failed', ...failedTests.map((t) => `- ${t}`)] : []),
+].join('\n')
+console.log('\n' + verdict + '\n')
+
+process.exit(exitCode)


### PR DESCRIPTION
Adds a tiered e2e execution path so CI and local runs can pick the amount of coverage that fits the change, instead of always paying for the full multi-hour suite.

What's in here:

- `scripts/e2e-run.mjs`: a runner that composes one or more playwright passes from a tier (`smoke`, `impact`, `acceptance`, `broad`, `full`), a group (test directory), or an explicit file list, unions the selections, runs them sequentially against a shared webserver, and prints a single verdict from `results.json`. Stale `results.json` is removed before each pass so a crashed pass can't report the previous pass's outcome.
- `scripts/e2e-impact.mjs --files`: machine-readable output (changed-file to spec mapping) so the runner can drive impact-based selection.
- `--pr <number>`: optionally posts the run verdict as a PR comment.
- Makefile: `TIER=` / `GROUP=` / `PR=` variables on the e2e target dispatch to the runner.
- Seven representative journeys tagged `@smoke` (login, home, endpoint registration, app wall, CF list, marketplace, metrics registration) as the smallest tier.

Docs (TESTING.md) and CI workflow wiring for the tiers are deliberately not in this PR: a full-suite measurement run showed the current suite's failure rate would contaminate any recorded tier budgets. Harness fixes are queued as a follow-up branch; the numbers land with them.
