### PR TITLE
chore(make): split version.mk into vendorable core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,40 @@
 #
 # See docs/build-and-packaging.md for full documentation.
 
+# ── Version (repo settings + shared core) ─────────────────────
+# Stratos versions from package.json — the current version, not the
+# core's next-tag default. `make bump` edits package.json at recipe
+# time; the core keeps version resolution lazy so chains stay correct.
+VERSION_CMD := node -p "require('./package.json').version" 2>/dev/null
+
 include version.mk
+
+# Stratos-specific build metadata and stamps — the per-repo config the
+# vendorable core deliberately excludes.
+$(_HIDE)BUILD_NODE_VERSION := $(shell node --version 2>/dev/null || echo "unknown")
+$(_HIDE)BUILD_TS_VERSION   := $(shell npx tsc --version 2>/dev/null | awk '{print $$2}' || echo "unknown")
+$(_HIDE)BUILD_BUN_VERSION  := $(shell bun --version 2>/dev/null || echo "unknown")
+
+# Lazy (=) so the backend binary's baked-in version reflects the post-bump
+# value when `bump` and `build` chain in a single Make invocation.
+$(_HIDE)GO_LDFLAGS = -X main.appVersion=$($(_HIDE)SEMVER_VERSION) -X main.buildDate=$($(_HIDE)BUILD_DATE) -X main.gitCommit=$($(_HIDE)BUILD_VCS_ID) -X main.gitBranch=$($(_HIDE)BUILD_VCS_BRANCH)
+
+# ── Frontend build info path ─────────────────────────────────
+$(_HIDE)BUILD_INFO_TS := src/frontend/packages/core/src/environments/build-info.ts
+
+# ── Stamp action ─────────────────────────────────────────────
+define stamp.frontend
+	@mkdir -p $(dir $($(_HIDE)BUILD_INFO_TS))
+	@printf "export const BUILD_INFO = {\n  version: '%s',\n  gitProject: '%s',\n  gitCommit: '%s',\n  gitBranch: '%s',\n  buildDate: '%s',\n  nodeVersion: '%s',\n  typescriptVersion: '%s',\n  bunVersion: '%s',\n};\n" \
+		"$($(_HIDE)SEMVER_VERSION)" "$($(_HIDE)BUILD_VCS_URL)" "$($(_HIDE)BUILD_VCS_ID)" "$($(_HIDE)BUILD_VCS_BRANCH)" "$($(_HIDE)BUILD_DATE)" \
+		"$($(_HIDE)BUILD_NODE_VERSION)" "$($(_HIDE)BUILD_TS_VERSION)" "$($(_HIDE)BUILD_BUN_VERSION)" \
+		> $($(_HIDE)BUILD_INFO_TS)
+	@echo "Generated $($(_HIDE)BUILD_INFO_TS)"
+endef
+
+define dump.version.extra
+	@echo "GO_LDFLAGS        $($(_HIDE)GO_LDFLAGS)"
+endef
 
 # ── Directories ───────────────────────────────────────────────
 $(_HIDE)DIST_DIR    := dist
@@ -305,7 +338,7 @@ define dev.frontend
 endef
 $(call register, dev, frontend)
 
-# stamp.frontend recipe is defined in version.mk (shared library)
+# stamp.frontend recipe is defined in the version block near the top
 $(call register, stamp, frontend)
 
 # ── Backend ───────────────────────────────────────────────────

--- a/version.mk
+++ b/version.mk
@@ -1,90 +1,108 @@
-# version.mk — shared semver resolution and build metadata
+# version.mk — shared semver resolution and build metadata (vendorable)
 #
-# Public variables (user-settable):
-#   VERSION            Override version from package.json
+# Drop this file into a repo unchanged and `include` it. Per-repo settings:
+#   VERSION       Override the version string entirely (user-settable).
+#   VERSION_CMD   Shell command that prints the version string. Default:
+#                 nearest git tag, leading 'v' stripped, patch incremented
+#                 ("the next release"). Repos with their own source set it
+#                 before or after the include, e.g.:
+#                   VERSION_CMD := node -p "require('./package.json').version"
+#   BUILD_TZ      Timezone for BUILD_DATE_TZ: 'local' (default) or a zone
+#                 name (e.g. UTC, America/New_York).
+#   _HIDE         Internal-name prefix, default '_' (hides internals from
+#                 tab completion). Set `_HIDE :=` (empty) before the include
+#                 for plain names, or run `make _HIDE= <target>` to expose
+#                 everything for debugging.
 #
-# Hidden variables (internal, toggle with: make _HIDE= ...):
+# Derived variables (prefixed with $(_HIDE)):
 #   SEMVER_VERSION, SEMVER_MAJOR, SEMVER_MINOR, SEMVER_PATCH,
-#   SEMVER_PRERELEASE, SEMVER_BUILDMETA
-#   BUILD_DATE, BUILD_VCS_URL, BUILD_VCS_ID, BUILD_VCS_ID_DATE
-#   GO_LDFLAGS, BUILD_INFO_TS
+#   SEMVER_PRERELEASE, SEMVER_BUILDMETA, SEMVER_VALID
+#   BUILD_DATE, BUILD_DATE_SEMVER, BUILD_DATE_TZ
+#   BUILD_VCS_URL, BUILD_VCS_ID, BUILD_VCS_ID_FULL, BUILD_VCS_ID_DATE,
+#   BUILD_VCS_BRANCH
+#
+# An unresolvable or malformed version soft-fails to 0.0.0-unknown and
+# leaves SEMVER_VALID empty. Repos wanting a hard failure test the flag:
+#   check-version:
+#   	$(if $($(_HIDE)SEMVER_VALID),,$(error VERSION is unusable))
+#
+# Recipes: dump.version prints everything above; if the including Makefile
+# defines dump.version.extra, its lines are appended to the dump.
 
-# ── Hidden prefix ────────────────────────────────────────────
-# Prefixes internal names with _ to hide from tab completion.
-# Debug mode: make _HIDE= <target>  (exposes all variables)
-_HIDE := _
+_HIDE ?= _
 
 # ── Version ───────────────────────────────────────────────────
-VERSION       ?= $(shell node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0-unknown")
-# Lazy (=) rather than immediate (:=) so consumers re-evaluate at recipe
+# Default source: nearest tag, 'v' stripped, patch+1 ("next release").
+# Only plain x.y.z tags qualify; a prerelease/buildmeta tag produces no
+# output and falls through to 0.0.0-unknown — set VERSION or VERSION_CMD
+# for anything richer.
+VERSION_CMD ?= git describe --tags --abbrev=0 2>/dev/null | sed -e 's/^v//' | awk -F. 'NF==3 && $$3 ~ /^[0-9]+$$/ {print $$1"."$$2"."$$3+1}'
+
+# Lazy (=/?=) rather than immediate (:=) so consumers re-evaluate at recipe
 # execution time. Important for chains like `make bump dev build ...` where
-# `bump` edits package.json at recipe time — if SEMVER_VERSION were :=, it'd
+# `bump` edits the version source at recipe time — if these were :=, they'd
 # capture the pre-bump value at parse time and the build would stamp the
-# wrong version into build-info.ts and the Go binary. Preserves the two
-# interfaces: VERSION is user-settable input; SEMVER_VERSION is the internal
-# canonical value derived from it.
-$(_HIDE)SEMVER_VERSION = $(VERSION)
+# wrong version. Preserves the two interfaces: VERSION is user-settable
+# input; SEMVER_* are the internal canonical values derived from it.
+VERSION ?= $(shell v=$$($(VERSION_CMD)); echo "$${v:-0.0.0-unknown}")
 
-# Strip leading 'v' for parsing
-$(_HIDE)V := $(patsubst v%,%,$($(_HIDE)SEMVER_VERSION))
+# Strip leading 'v' for parsing; remember it so SEMVER_VERSION reassembles
+# byte-identical to the input.
+$(_HIDE)SEMVER_IN     = $(patsubst v%,%,$(VERSION))
+$(_HIDE)SEMVER_PREFIX = $(if $(filter v%,$(VERSION)),v,)
 
-# Split on '-' to separate core from prerelease+buildmeta
-$(_HIDE)CORE       := $(firstword $(subst -, ,$($(_HIDE)V)))
-$(_HIDE)PRE_BUILD  := $(word 2,$(subst -, ,$($(_HIDE)V)))
+# Split buildmeta off first (everything after '+'), then prerelease
+# (everything after the first '-' of what remains), leaving the x.y.z core.
+$(_HIDE)SEMVER_NOMETA  = $(firstword $(subst +, ,$($(_HIDE)SEMVER_IN)))
+$(_HIDE)SEMVER_CORE    = $(firstword $(subst -, ,$($(_HIDE)SEMVER_NOMETA)))
+$(_HIDE)SEMVER_PRE_RAW = $(patsubst $($(_HIDE)SEMVER_CORE)-%,%,$($(_HIDE)SEMVER_NOMETA))
 
-$(_HIDE)SEMVER_MAJOR      := $(word 1,$(subst ., ,$($(_HIDE)CORE)))
-$(_HIDE)SEMVER_MINOR      := $(word 2,$(subst ., ,$($(_HIDE)CORE)))
-$(_HIDE)SEMVER_PATCH      := $(word 3,$(subst ., ,$($(_HIDE)CORE)))
+# Parts are ?= so the command line (or the including Makefile) can override
+# any of them individually; unset ones derive from VERSION.
+$(_HIDE)SEMVER_MAJOR      ?= $(word 1,$(subst ., ,$($(_HIDE)SEMVER_CORE)))
+$(_HIDE)SEMVER_MINOR      ?= $(word 2,$(subst ., ,$($(_HIDE)SEMVER_CORE)))
+$(_HIDE)SEMVER_PATCH      ?= $(word 3,$(subst ., ,$($(_HIDE)SEMVER_CORE)))
+$(_HIDE)SEMVER_PRERELEASE ?= $(if $(filter-out $($(_HIDE)SEMVER_NOMETA),$($(_HIDE)SEMVER_PRE_RAW)),$($(_HIDE)SEMVER_PRE_RAW),)
+$(_HIDE)SEMVER_BUILDMETA  ?= $(word 2,$(subst +, ,$($(_HIDE)SEMVER_IN)))
 
-# Prerelease: everything after first '-', before any '+'
-$(_HIDE)SEMVER_PRERELEASE := $(firstword $(subst +, ,$(patsubst $($(_HIDE)CORE)-%,%,$($(_HIDE)V))))
-ifeq ($($(_HIDE)SEMVER_PRERELEASE),$($(_HIDE)V))
-  $(_HIDE)SEMVER_PRERELEASE :=
-endif
+# Reassembled from the parts (lazy) so part overrides — including
+# target-specific ones like `build: $(_HIDE)SEMVER_PRERELEASE := dev` —
+# flow into everything downstream.
+$(_HIDE)SEMVER_VERSION = $($(_HIDE)SEMVER_PREFIX)$($(_HIDE)SEMVER_MAJOR).$($(_HIDE)SEMVER_MINOR).$($(_HIDE)SEMVER_PATCH)$(if $($(_HIDE)SEMVER_PRERELEASE),-$($(_HIDE)SEMVER_PRERELEASE))$(if $($(_HIDE)SEMVER_BUILDMETA),+$($(_HIDE)SEMVER_BUILDMETA))
 
-# Build metadata: everything after '+'
-$(_HIDE)SEMVER_BUILDMETA  := $(word 2,$(subst +, ,$($(_HIDE)V)))
+# Soft validation flag: 'yes' when major.minor.patch are present and
+# numeric and the version isn't the 0.0.0-unknown fallback; empty otherwise.
+$(_HIDE)SEMVER_VALID = $(if $(filter 0.0.0-unknown,$($(_HIDE)SEMVER_IN)),,$(if $(and $($(_HIDE)SEMVER_MAJOR),$($(_HIDE)SEMVER_MINOR),$($(_HIDE)SEMVER_PATCH)),$(if $(shell echo "$($(_HIDE)SEMVER_MAJOR).$($(_HIDE)SEMVER_MINOR).$($(_HIDE)SEMVER_PATCH)" | tr -d '0-9.'),,yes),))
 
 # ── Build metadata ────────────────────────────────────────────
+# BUILD_DATE is canonical zulu; BUILD_DATE_SEMVER is the same instant in a
+# colon-free form legal inside semver build-metadata identifiers;
+# BUILD_DATE_TZ carries the builder-local (or BUILD_TZ-forced) time.
+BUILD_TZ ?= local
 $(_HIDE)BUILD_DATE        := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+$(_HIDE)BUILD_DATE_SEMVER := $(shell date -u +"%Y%m%dT%H%M%SZ")
+$(_HIDE)BUILD_DATE_TZ     := $(shell $(if $(filter local,$(BUILD_TZ)),,TZ='$(BUILD_TZ)' )date +"%Y-%m-%dT%H:%M:%S%z")
 $(_HIDE)BUILD_VCS_URL     := $(shell git remote get-url origin 2>/dev/null || echo "unknown")
 $(_HIDE)BUILD_VCS_ID      := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 $(_HIDE)BUILD_VCS_ID_FULL := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
-$(_HIDE)BUILD_VCS_ID_DATE := $(shell git log -1 --format=%cI 2>/dev/null || echo "unknown")
+$(_HIDE)BUILD_VCS_ID_DATE := $(shell TZ=UTC0 git log -1 --date=format-local:"%Y-%m-%dT%H:%M:%SZ" --format=%cd 2>/dev/null || echo "unknown")
 $(_HIDE)BUILD_VCS_BRANCH  := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-$(_HIDE)BUILD_NODE_VERSION := $(shell node --version 2>/dev/null || echo "unknown")
-$(_HIDE)BUILD_TS_VERSION   := $(shell npx tsc --version 2>/dev/null | awk '{print $$2}' || echo "unknown")
-$(_HIDE)BUILD_BUN_VERSION  := $(shell bun --version 2>/dev/null || echo "unknown")
-
-# ── Go ldflags ────────────────────────────────────────────────
-# Lazy (=) so the backend binary's baked-in version reflects the post-bump
-# value when `bump` and `build` chain in a single Make invocation.
-$(_HIDE)GO_LDFLAGS = -X main.appVersion=$($(_HIDE)SEMVER_VERSION) -X main.buildDate=$($(_HIDE)BUILD_DATE) -X main.gitCommit=$($(_HIDE)BUILD_VCS_ID) -X main.gitBranch=$($(_HIDE)BUILD_VCS_BRANCH)
-
-# ── Frontend build info path ─────────────────────────────────
-$(_HIDE)BUILD_INFO_TS := src/frontend/packages/core/src/environments/build-info.ts
-
-# ── Stamp action ─────────────────────────────────────────────
-define stamp.frontend
-	@mkdir -p $(dir $($(_HIDE)BUILD_INFO_TS))
-	@printf "export const BUILD_INFO = {\n  version: '%s',\n  gitProject: '%s',\n  gitCommit: '%s',\n  gitBranch: '%s',\n  buildDate: '%s',\n  nodeVersion: '%s',\n  typescriptVersion: '%s',\n  bunVersion: '%s',\n};\n" \
-		"$($(_HIDE)SEMVER_VERSION)" "$($(_HIDE)BUILD_VCS_URL)" "$($(_HIDE)BUILD_VCS_ID)" "$($(_HIDE)BUILD_VCS_BRANCH)" "$($(_HIDE)BUILD_DATE)" \
-		"$($(_HIDE)BUILD_NODE_VERSION)" "$($(_HIDE)BUILD_TS_VERSION)" "$($(_HIDE)BUILD_BUN_VERSION)" \
-		> $($(_HIDE)BUILD_INFO_TS)
-	@echo "Generated $($(_HIDE)BUILD_INFO_TS)"
-endef
 
 # ── Dump action ──────────────────────────────────────────────
 define dump.version
+	@echo "VERSION           $(VERSION)"
 	@echo "SEMVER_VERSION    $($(_HIDE)SEMVER_VERSION)"
 	@echo "SEMVER_MAJOR      $($(_HIDE)SEMVER_MAJOR)"
 	@echo "SEMVER_MINOR      $($(_HIDE)SEMVER_MINOR)"
 	@echo "SEMVER_PATCH      $($(_HIDE)SEMVER_PATCH)"
 	@echo "SEMVER_PRERELEASE $($(_HIDE)SEMVER_PRERELEASE)"
 	@echo "SEMVER_BUILDMETA  $($(_HIDE)SEMVER_BUILDMETA)"
+	@echo "SEMVER_VALID      $($(_HIDE)SEMVER_VALID)"
 	@echo "BUILD_DATE        $($(_HIDE)BUILD_DATE)"
+	@echo "BUILD_DATE_SEMVER $($(_HIDE)BUILD_DATE_SEMVER)"
+	@echo "BUILD_DATE_TZ     $($(_HIDE)BUILD_DATE_TZ)"
 	@echo "BUILD_VCS_URL     $($(_HIDE)BUILD_VCS_URL)"
 	@echo "BUILD_VCS_ID      $($(_HIDE)BUILD_VCS_ID)"
 	@echo "BUILD_VCS_ID_DATE $($(_HIDE)BUILD_VCS_ID_DATE)"
-	@echo "GO_LDFLAGS        $($(_HIDE)GO_LDFLAGS)"
+	$(dump.version.extra)
 endef


### PR DESCRIPTION
version.mk previously mixed reusable semver/build-metadata logic with
Stratos-specific configuration, which blocked dropping the file into
other repos (one already carries an unused verbatim copy for exactly
this reason).

The file is now a generic, vendorable core:

- Version source is a `VERSION_CMD` hook. The default resolves the
  nearest git tag, strips a leading `v`, and increments the patch
  number ("the next release") — the behavior several candidate consumer
  repos already implement inline. Stratos overrides it with its
  package.json read.
- Semver parts (`SEMVER_MAJOR/MINOR/PATCH/PRERELEASE/BUILDMETA`) are
  individually overridable (`?=`), and `SEMVER_VERSION` is reassembled
  from them, preserving any leading `v` byte-for-byte. This also fixes
  a latent parse bug: `1.2.3+meta` (build metadata without prerelease)
  previously corrupted the patch field.
- Unresolvable or malformed versions soft-fail to `0.0.0-unknown` and
  leave a `SEMVER_VALID` flag empty, so a repo that wants a hard error
  can test the flag with one line.
- `BUILD_DATE` is canonical zulu; new `BUILD_DATE_SEMVER` is the same
  instant in a colon-free form legal inside semver build-metadata
  identifiers; new `BUILD_DATE_TZ` carries builder-local time, or a
  forced zone via `BUILD_TZ`.
- `dump.version` gains a `dump.version.extra` hook so the including
  Makefile can append its own lines.
- The `_HIDE` prefix convention and the lazy-vs-immediate evaluation
  notes (bump/build chaining) survive. A repo preferring plain variable
  names sets `_HIDE :=` (empty) before the include.

Stratos-specific pieces move to a version block in the Makefile:
the package.json `VERSION_CMD`, node/tsc/bun tool-version stamps, the
jetstream `GO_LDFLAGS` symbol map, the build-info.ts path with the
`stamp.frontend` recipe, and the `GO_LDFLAGS` dump line.

Verification: `make dump version`, `make -n stamp frontend`, and
`make -n build backend` outputs differ from the pre-change baseline
only by timestamps, the new fields, and `BUILD_VCS_ID_DATE` now being
zulu. The core was exercised as-is from two external repos (a BOSH
release repo and a cf CLI plugin repo): next-patch tag resolution
(4.0.1→4.0.2, 2.2.0→2.2.1), plain-name mode, per-part overrides,
meta-only versions, and the no-git soft fallback all behave. Full
check gate passes (frontend 3135 tests, backend suites green).

Closes #5652
