### PR TITLE
feat(release): publish cf-pushable zip; fix deprecated build hint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,12 @@ jobs:
       - name: Package release archives
         env:
           VERSION: ${{ needs.validate-version.outputs.version }}
-        run: make release github VERSION="$VERSION"
+        run: |
+          # cf first (writes dist/stratos-cf-*.zip), then github (rebuilds
+          # dist/release/); stage the cf-pushable zip into dist/release so it
+          # is checksummed and published alongside the platform archives.
+          make release cf github VERSION="$VERSION"
+          cp dist/stratos-cf-*.zip dist/release/
 
       - name: Generate checksums
         env:

--- a/build/release-cf.sh
+++ b/build/release-cf.sh
@@ -47,7 +47,15 @@ else
 fi
 
 # Backend binary — CF requires a Linux ELF binary (amd64 or arm64)
+# Prefer an explicit dist/bin/jetstream (from `make build PLATFORM=linux/amd64`
+# or `make build korifi`); for cf mode, fall back to the cross-compiled
+# artifact from a plain `make build`, so `make build release cf github`
+# composes in one pass. korifi keeps requiring its own static build below.
+CF_ARCH="${CF_ARCH:-amd64}"
 jetstream_bin="${BIN_DIR}/jetstream"
+if [[ ! -f "${jetstream_bin}" && "${MODE}" == "cf" && -f "${BIN_DIR}/jetstream-linux-${CF_ARCH}" ]]; then
+  jetstream_bin="${BIN_DIR}/jetstream-linux-${CF_ARCH}"
+fi
 
 if [[ ! -f "${jetstream_bin}" ]]; then
   error "Backend binary not found at dist/bin/jetstream"

--- a/build/release-github.sh
+++ b/build/release-github.sh
@@ -57,7 +57,7 @@ check_prerequisites() {
 
   # Check backend binaries
   if [ ! -d "${BIN_DIR}" ]; then
-    error "Backend binaries not found. Run: make build backend-all"
+    error "Backend binaries not found. Run: make build backend"
   fi
 
   local missing_binaries=()
@@ -73,7 +73,7 @@ check_prerequisites() {
   done
 
   if [ ${#missing_binaries[@]} -gt 0 ]; then
-    error "Missing binaries: ${missing_binaries[*]}. Run: make build backend-all"
+    error "Missing binaries: ${missing_binaries[*]}. Run: make build backend"
   fi
 
   success "Prerequisites OK"


### PR DESCRIPTION
Two related fixes to the release packaging path, both surfaced while cutting v5.0.0-rc.1.

### 1. Missing-binary hint pointed at a deprecated target (closes #5657)

`release-github.sh` told the operator to run `make build backend-all` when binaries were absent. That target was renamed to `make build backend` (`deprecated.mk` maps the old spelling to a `RENAMED:` warning). Following the message therefore hit the deprecation notice instead of building. Corrected both occurrences.

### 2. GitHub releases shipped no cf-pushable artifact

The release published six standalone-binary tarballs plus source — none of them `cf push`-able. An operator wanting to deploy to Cloud Foundry had to clone and build the zip themselves, despite CF being the primary deployment story.

Root cause of why it wasn't already wired in: `release-cf.sh` looked only for an unqualified `dist/bin/jetstream`, but the release workflow runs `make build all`, which cross-compiles to suffixed names (`jetstream-linux-amd64`, …) and produces no plain binary. So `make build release cf github` failed at the cf step:

```
ERROR: Backend binary not found at dist/bin/jetstream
```

Fix: cf mode now falls back to `dist/bin/jetstream-linux-${CF_ARCH}` (amd64 default) when the unqualified binary is absent. korifi is unchanged — it still requires its own static build, and its existing static-linkage guard rejects anything else. With the fallback, `make build release cf github` composes in a single pass.

The release workflow now runs `make release cf github` and stages the cf zip into `dist/release/` before checksumming, so it is checksummed, uploaded, and attached to the GitHub release alongside the platform archives.

### Verified locally

- `make release cf` against a cross-compiled `dist/` now produces `stratos-cf-<version>.zip` — statically-linked linux/amd64 `jetstream` at root, `Procfile`, `manifest.yml`, `config.properties`, `plugins.yaml`, `ui/`.
- The full workflow packaging sequence (`make release cf github` → stage → `create-checksums.sh`) lands the cf zip in `dist/release/` and includes it in `SHA256SUMS`.

CF zip is single-arch (amd64). Override with `CF_ARCH=arm64`; publishing both arches would be a follow-up.
