### PR TITLE
fix(release): build via 'make build', not removed 'make build all'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           NODE_ENV: production
           VERSION: ${{ needs.validate-version.outputs.version }}
-        run: make build all VERSION="$VERSION"
+        run: make build VERSION="$VERSION"
 
       - name: Verify binaries
         run: |


### PR DESCRIPTION
The Release Automation workflow has failed on every run — `v5.0.0-dev.8`, `v5.0.0-dev.10`, and now `v5.0.0-rc.1` (run 29781102832).

Root cause: the build step runs `make build all`. `all` is not a registered build modifier, so make builds everything for the `build` goal, then processes the second goal `all`, which no target defines — it falls through `deprecated.mk`'s catch-all and exits 2. The cross-compile succeeds first, which is why the failure looks late in the log:

```
✓ Cross-compilation complete!
make: *** No rule to make target 'all'. Stop.
make: *** [deprecated.mk:10: all] Error 2
```

Fix: drop `all`. `make build` already builds the frontend and cross-compiles all backend platforms — exactly what the release needs. One-word change; the only caller of `make build all` in the repo.

This unblocks the v5.0.0-rc.1 release, which will be re-cut once this lands.
