### PR TITLE
feat(cf): restore the full set of CF bulk operations with guard tests

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/cf/domains/share-domain-orgs-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/domains/share-domain-orgs-dialog.component.html
@@ -1,0 +1,49 @@
+<div class="p-6 flex flex-col gap-4 min-w-[420px]">
+  <!-- Dialog header -->
+  <h2 id="share-domain-orgs-dialog-title" class="text-lg font-semibold text-content-text" data-dialog-drag-handle>
+    Share to organizations
+  </h2>
+  <div class="text-sm text-content-muted">
+    Select the organizations that the private domain
+    <span class="font-medium text-content-text">{{ data.domainName }}</span> should be shared with.
+  </div>
+
+  <!-- Org picker -->
+  <section class="flex flex-col gap-1 border-t pt-3 max-h-[45vh] overflow-y-auto" aria-label="Organizations">
+    @if (loading() && orgs().length === 0) {
+      <div class="text-sm text-content-muted py-2">Loading organizations…</div>
+    } @else if (orgs().length === 0) {
+      <div class="text-sm text-content-muted py-2">There are no organizations in this Cloud Foundry.</div>
+    } @else {
+      @for (org of orgs(); track org.guid) {
+        <label class="flex items-center gap-2 py-1 cursor-pointer text-sm">
+          <input
+            type="checkbox"
+            [attr.data-test]="'share-domain-org-' + org.guid"
+            [checked]="isSelected(org.guid)"
+            (change)="toggle(org.guid)"
+          />
+          <span class="text-content-text">{{ org.name }}</span>
+        </label>
+      }
+    }
+  </section>
+
+  <!-- Actions -->
+  <div class="flex justify-end items-center gap-2 pt-2 border-t">
+    <span class="text-sm text-content-muted mr-auto">{{ selectedCount() }} selected</span>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm rounded border"
+      [disabled]="submitting()"
+      (click)="cancel()"
+    >Cancel</button>
+    <button
+      type="button"
+      data-test="share-domain-orgs-submit"
+      class="px-4 py-2 text-sm rounded bg-primary text-white disabled:opacity-50"
+      [disabled]="!canSubmit()"
+      (click)="submit()"
+    >Share</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/domains/share-domain-orgs-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/domains/share-domain-orgs-dialog.component.ts
@@ -1,0 +1,125 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Signal,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import {
+  MAT_DIALOG_DATA,
+  TailwindDialogRef,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { DomainDataService } from '../../../services/endpoint-data/domain-data.service';
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { StOrg } from '../../../services/endpoint-data/stratos-types';
+import { extractHttpErrorMessage } from '../../../services/extract-error-message';
+
+// ─── Dialog data ──────────────────────────────────────────────────────────────
+
+export interface ShareDomainOrgsDialogData {
+  cfGuid: string;
+  domainGuid: string;
+  domainName: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+// Multi-select "Share to organizations" dialog for a private domain. Lists
+// every organization on the foundation with a checkbox and shares THIS domain
+// with the selected set in one call via DomainDataService.shareDomainWithOrgs
+// (backend POST /pp/v1/cf/domains/{cnsi}/{domain}/relationships/
+// shared_organizations, body { guids: [...] }). Mirrors the CF Users "Manage
+// Roles" / apply-quota-to-orgs / entitle-iso-segment bulk pattern: a selection
+// set of guids forwarded to a single write.
+//
+// NOTE: no domain list/detail page exists yet — this dialog is the entry point
+// a future host surface opens. See the service godoc.
+@Component({
+  selector: 'app-share-domain-orgs-dialog',
+  templateUrl: './share-domain-orgs-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class ShareDomainOrgsDialogComponent {
+  private dialogRef = inject<TailwindDialogRef<ShareDomainOrgsDialogComponent, boolean>>(TailwindDialogRef);
+
+  /** Injected dialog data — accessed in spec via `cmp.data` (protected). */
+  protected data = inject<ShareDomainOrgsDialogData>(MAT_DIALOG_DATA);
+
+  private domainData = inject(DomainDataService);
+  private snackBar = inject(TailwindSnackBarService);
+
+  // Per-CNSI org source. acquire() returns the shared EndpointDataService for
+  // this foundation (same instance the orgs list uses), so orgs() is already
+  // populated when navigating in through the CF endpoint; loadOrgs() below is
+  // cache-aware and no-ops in that case.
+  private endpointData = inject(EndpointDataRegistry).acquire(this.data.cfGuid);
+
+  protected readonly orgs: Signal<StOrg[]> = this.endpointData.orgs;
+  protected readonly loading: Signal<boolean> = this.endpointData.isLoadingOrgs;
+
+  // Selection set of org guids driving the checkbox column and the submit.
+  private readonly _selected: WritableSignal<ReadonlySet<string>> = signal(new Set<string>());
+  protected readonly selectedCount: Signal<number> = computed(() => this._selected().size);
+
+  protected readonly submitting: WritableSignal<boolean> = signal(false);
+
+  /** Submit is enabled once at least one org is checked. */
+  protected readonly canSubmit: Signal<boolean> = computed(
+    () => this._selected().size > 0 && !this.submitting(),
+  );
+
+  constructor() {
+    // Populate the org picker. Cache-aware loader: no-ops (returns cached) if
+    // the orgs slice is already loaded, drains /pp/v1/cf/orgs/{cnsi} otherwise.
+    this.endpointData.loadOrgs().subscribe({ error: () => undefined });
+  }
+
+  protected isSelected(guid: string): boolean {
+    return this._selected().has(guid);
+  }
+
+  protected toggle(guid: string): void {
+    const next = new Set(this._selected());
+    if (next.has(guid)) {
+      next.delete(guid);
+    } else {
+      next.add(guid);
+    }
+    this._selected.set(next);
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close();
+  }
+
+  protected async submit(): Promise<void> {
+    if (!this.canSubmit()) {
+      return;
+    }
+    this.submitting.set(true);
+    const guids = Array.from(this._selected());
+    try {
+      await firstValueFrom(
+        this.domainData.shareDomainWithOrgs(this.data.cfGuid, this.data.domainGuid, guids),
+      );
+      const n = guids.length;
+      this.snackBar.show(
+        `Shared "${this.data.domainName}" with ${n} ${n === 1 ? 'organization' : 'organizations'}`,
+      );
+      // M1: do NOT touch `submitting` after close() — the view is destroyed.
+      this.dialogRef.close(true);
+    } catch (err: unknown) {
+      this.snackBar.error(`Share failed: ${extractHttpErrorMessage(err)}`);
+      this.submitting.set(false);
+    }
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/cf/isolation-segments/entitle-iso-segment-orgs-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/isolation-segments/entitle-iso-segment-orgs-dialog.component.html
@@ -1,0 +1,49 @@
+<div class="p-6 flex flex-col gap-4 min-w-[420px]">
+  <!-- Dialog header -->
+  <h2 id="entitle-iso-segment-orgs-dialog-title" class="text-lg font-semibold text-content-text" data-dialog-drag-handle>
+    Entitle organizations
+  </h2>
+  <div class="text-sm text-content-muted">
+    Select the organizations that should be entitled to the
+    <span class="font-medium text-content-text">{{ data.isoName }}</span> isolation segment.
+  </div>
+
+  <!-- Org picker -->
+  <section class="flex flex-col gap-1 border-t pt-3 max-h-[45vh] overflow-y-auto" aria-label="Organizations">
+    @if (loading() && orgs().length === 0) {
+      <div class="text-sm text-content-muted py-2">Loading organizations…</div>
+    } @else if (orgs().length === 0) {
+      <div class="text-sm text-content-muted py-2">There are no organizations in this Cloud Foundry.</div>
+    } @else {
+      @for (org of orgs(); track org.guid) {
+        <label class="flex items-center gap-2 py-1 cursor-pointer text-sm">
+          <input
+            type="checkbox"
+            [attr.data-test]="'entitle-iso-org-' + org.guid"
+            [checked]="isSelected(org.guid)"
+            (change)="toggle(org.guid)"
+          />
+          <span class="text-content-text">{{ org.name }}</span>
+        </label>
+      }
+    }
+  </section>
+
+  <!-- Actions -->
+  <div class="flex justify-end items-center gap-2 pt-2 border-t">
+    <span class="text-sm text-content-muted mr-auto">{{ selectedCount() }} selected</span>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm rounded border"
+      [disabled]="submitting()"
+      (click)="cancel()"
+    >Cancel</button>
+    <button
+      type="button"
+      data-test="entitle-iso-segment-orgs-submit"
+      class="px-4 py-2 text-sm rounded bg-primary text-white disabled:opacity-50"
+      [disabled]="!canSubmit()"
+      (click)="submit()"
+    >Entitle</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/isolation-segments/entitle-iso-segment-orgs-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/isolation-segments/entitle-iso-segment-orgs-dialog.component.ts
@@ -1,0 +1,125 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Signal,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import {
+  MAT_DIALOG_DATA,
+  TailwindDialogRef,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { IsolationSegmentDataService } from '../../../services/endpoint-data/isolation-segment-data.service';
+import { StOrg } from '../../../services/endpoint-data/stratos-types';
+import { extractHttpErrorMessage } from '../../../services/extract-error-message';
+
+// ─── Dialog data ──────────────────────────────────────────────────────────────
+
+export interface EntitleIsoSegmentOrgsDialogData {
+  cfGuid: string;
+  isoGuid: string;
+  isoName: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+// Multi-select "Entitle organizations" dialog for an isolation segment. Lists
+// every organization on the foundation with a checkbox and entitles THIS
+// segment to the selected set in one call via
+// IsolationSegmentDataService.entitleOrgsToIsoSegment (backend POST
+// /pp/v1/cf/isolation_segments/{cnsi}/{iso}/relationships/organizations, body
+// { guids: [...] }). Mirrors the CF Users "Manage Roles" / apply-quota-to-orgs
+// bulk pattern: selection set of guids forwarded to a single write.
+//
+// NOTE: no isolation-segment list/detail page exists yet — this dialog is the
+// entry point a future host surface opens. See the service godoc.
+@Component({
+  selector: 'app-entitle-iso-segment-orgs-dialog',
+  templateUrl: './entitle-iso-segment-orgs-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class EntitleIsoSegmentOrgsDialogComponent {
+  private dialogRef = inject<TailwindDialogRef<EntitleIsoSegmentOrgsDialogComponent, boolean>>(TailwindDialogRef);
+
+  /** Injected dialog data — accessed in spec via `cmp.data` (protected). */
+  protected data = inject<EntitleIsoSegmentOrgsDialogData>(MAT_DIALOG_DATA);
+
+  private isoData = inject(IsolationSegmentDataService);
+  private snackBar = inject(TailwindSnackBarService);
+
+  // Per-CNSI org source. acquire() returns the shared EndpointDataService for
+  // this foundation (same instance the orgs list uses), so orgs() is already
+  // populated when navigating in through the CF endpoint; loadOrgs() below is
+  // cache-aware and no-ops in that case.
+  private endpointData = inject(EndpointDataRegistry).acquire(this.data.cfGuid);
+
+  protected readonly orgs: Signal<StOrg[]> = this.endpointData.orgs;
+  protected readonly loading: Signal<boolean> = this.endpointData.isLoadingOrgs;
+
+  // Selection set of org guids driving the checkbox column and the submit.
+  private readonly _selected: WritableSignal<ReadonlySet<string>> = signal(new Set<string>());
+  protected readonly selectedCount: Signal<number> = computed(() => this._selected().size);
+
+  protected readonly submitting: WritableSignal<boolean> = signal(false);
+
+  /** Submit is enabled once at least one org is checked. */
+  protected readonly canSubmit: Signal<boolean> = computed(
+    () => this._selected().size > 0 && !this.submitting(),
+  );
+
+  constructor() {
+    // Populate the org picker. Cache-aware loader: no-ops (returns cached) if
+    // the orgs slice is already loaded, drains /pp/v1/cf/orgs/{cnsi} otherwise.
+    this.endpointData.loadOrgs().subscribe({ error: () => undefined });
+  }
+
+  protected isSelected(guid: string): boolean {
+    return this._selected().has(guid);
+  }
+
+  protected toggle(guid: string): void {
+    const next = new Set(this._selected());
+    if (next.has(guid)) {
+      next.delete(guid);
+    } else {
+      next.add(guid);
+    }
+    this._selected.set(next);
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close();
+  }
+
+  protected async submit(): Promise<void> {
+    if (!this.canSubmit()) {
+      return;
+    }
+    this.submitting.set(true);
+    const guids = Array.from(this._selected());
+    try {
+      await firstValueFrom(
+        this.isoData.entitleOrgsToIsoSegment(this.data.cfGuid, this.data.isoGuid, guids),
+      );
+      const n = guids.length;
+      this.snackBar.show(
+        `Entitled "${this.data.isoName}" to ${n} ${n === 1 ? 'organization' : 'organizations'}`,
+      );
+      // M1: do NOT touch `submitting` after close() — the view is destroyed.
+      this.dialogRef.close(true);
+    } catch (err: unknown) {
+      this.snackBar.error(`Entitle failed: ${extractHttpErrorMessage(err)}`);
+      this.submitting.set(false);
+    }
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/apply-quota-to-orgs-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/apply-quota-to-orgs-dialog.component.html
@@ -1,0 +1,52 @@
+<div class="p-6 flex flex-col gap-4 min-w-[420px]">
+  <!-- Dialog header -->
+  <h2 id="apply-quota-to-orgs-dialog-title" class="text-lg font-semibold text-content-text" data-dialog-drag-handle>
+    Apply quota to organizations
+  </h2>
+  <div class="text-sm text-content-muted">
+    Select the organizations that should use the
+    <span class="font-medium text-content-text">{{ data.quotaName }}</span> quota.
+  </div>
+
+  <!-- Org picker -->
+  <section class="flex flex-col gap-1 border-t pt-3 max-h-[45vh] overflow-y-auto" aria-label="Organizations">
+    @if (loading() && orgs().length === 0) {
+      <div class="text-sm text-content-muted py-2">Loading organizations…</div>
+    } @else if (orgs().length === 0) {
+      <div class="text-sm text-content-muted py-2">There are no organizations in this Cloud Foundry.</div>
+    } @else {
+      @for (org of orgs(); track org.guid) {
+        <label class="flex items-center gap-2 py-1 cursor-pointer text-sm">
+          <input
+            type="checkbox"
+            [attr.data-test]="'apply-quota-org-' + org.guid"
+            [checked]="isSelected(org.guid)"
+            (change)="toggle(org.guid)"
+          />
+          <span class="text-content-text">{{ org.name }}</span>
+          @if (alreadyOnQuota(org)) {
+            <span class="text-xs text-content-muted">(already on this quota)</span>
+          }
+        </label>
+      }
+    }
+  </section>
+
+  <!-- Actions -->
+  <div class="flex justify-end items-center gap-2 pt-2 border-t">
+    <span class="text-sm text-content-muted mr-auto">{{ selectedCount() }} selected</span>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm rounded border"
+      [disabled]="submitting()"
+      (click)="cancel()"
+    >Cancel</button>
+    <button
+      type="button"
+      data-test="apply-quota-to-orgs-submit"
+      class="px-4 py-2 text-sm rounded bg-primary text-white disabled:opacity-50"
+      [disabled]="!canSubmit()"
+      (click)="submit()"
+    >Apply</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/apply-quota-to-orgs-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/apply-quota-to-orgs-dialog.component.ts
@@ -1,0 +1,131 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Signal,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import {
+  MAT_DIALOG_DATA,
+  TailwindDialogRef,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { QuotaDataService } from '../../../services/endpoint-data/quota-data.service';
+import { StOrg } from '../../../services/endpoint-data/stratos-types';
+import { extractHttpErrorMessage } from '../../../services/extract-error-message';
+
+// ─── Dialog data ──────────────────────────────────────────────────────────────
+
+export interface ApplyQuotaToOrgsDialogData {
+  cfGuid: string;
+  quotaGuid: string;
+  quotaName: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+// Multi-select "Apply to organizations" dialog opened from the CF-level org
+// quota detail page. Lists every organization on the foundation with a
+// checkbox and applies THIS quota to the selected set in one call via the
+// existing QuotaDataService.applyOrgQuotaToOrgs wrapper (backend POST
+// /pp/v1/cf/organization_quotas/{cnsi}/{quota}/relationships/organizations,
+// body { data: [{ guid }, …] }). Mirrors the CF Users "Manage Roles" bulk
+// pattern: selection set of guids forwarded to a single write.
+@Component({
+  selector: 'app-apply-quota-to-orgs-dialog',
+  templateUrl: './apply-quota-to-orgs-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class ApplyQuotaToOrgsDialogComponent {
+  private dialogRef = inject<TailwindDialogRef<ApplyQuotaToOrgsDialogComponent, boolean>>(TailwindDialogRef);
+
+  /** Injected dialog data — accessed in spec via `cmp.data` (protected). */
+  protected data = inject<ApplyQuotaToOrgsDialogData>(MAT_DIALOG_DATA);
+
+  private quotaData = inject(QuotaDataService);
+  private snackBar = inject(TailwindSnackBarService);
+
+  // Per-CNSI org source. acquire() returns the shared EndpointDataService
+  // for this foundation (same instance the orgs list + endpoint service use),
+  // so orgs() is already populated when the user navigated in through the CF
+  // endpoint; loadOrgs() below is a cache-aware no-op in that case.
+  private endpointData = inject(EndpointDataRegistry).acquire(this.data.cfGuid);
+
+  protected readonly orgs: Signal<StOrg[]> = this.endpointData.orgs;
+  protected readonly loading: Signal<boolean> = this.endpointData.isLoadingOrgs;
+
+  // Selection set of org guids driving the checkbox column and the submit.
+  private readonly _selected: WritableSignal<ReadonlySet<string>> = signal(new Set<string>());
+  protected readonly selectedCount: Signal<number> = computed(() => this._selected().size);
+
+  protected readonly submitting: WritableSignal<boolean> = signal(false);
+
+  /** Submit is enabled once at least one org is checked. */
+  protected readonly canSubmit: Signal<boolean> = computed(
+    () => this._selected().size > 0 && !this.submitting(),
+  );
+
+  constructor() {
+    // Populate the org picker. Cache-aware loader: no-ops (returns cached) if
+    // the orgs slice is already loaded, drains /pp/v1/cf/orgs/{cnsi} otherwise.
+    this.endpointData.loadOrgs().subscribe({ error: () => undefined });
+  }
+
+  protected isSelected(guid: string): boolean {
+    return this._selected().has(guid);
+  }
+
+  /** True when the org already carries this quota — surfaced as a hint, not a
+   *  block (re-applying is idempotent on the CF side). */
+  protected alreadyOnQuota(org: StOrg): boolean {
+    return org.quotaGuid === this.data.quotaGuid;
+  }
+
+  protected toggle(guid: string): void {
+    const next = new Set(this._selected());
+    if (next.has(guid)) {
+      next.delete(guid);
+    } else {
+      next.add(guid);
+    }
+    this._selected.set(next);
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close();
+  }
+
+  protected async submit(): Promise<void> {
+    if (!this.canSubmit()) {
+      return;
+    }
+    this.submitting.set(true);
+    const guids = Array.from(this._selected());
+    try {
+      await firstValueFrom(
+        this.quotaData.applyOrgQuotaToOrgs(this.data.cfGuid, this.data.quotaGuid, guids),
+      );
+      const n = guids.length;
+      this.snackBar.show(
+        `Applied quota "${this.data.quotaName}" to ${n} ${n === 1 ? 'organization' : 'organizations'}`,
+      );
+      // Those orgs now link a different quota — mark the slice stale so the
+      // orgs list refetches on next read rather than showing the old quota.
+      this.endpointData.markStale('orgs');
+      // M1: do NOT touch `submitting` after close() — the view is destroyed.
+      this.dialogRef.close(true);
+    } catch (err: unknown) {
+      this.snackBar.error(`Apply failed: ${extractHttpErrorMessage(err)}`);
+      this.submitting.set(false);
+    }
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.html
@@ -3,6 +3,10 @@
     <h1>{{ quotaDefinition()?.name }}</h1>
     @if (canEditQuota()) {
       <div class="page-header-right">
+        <button class="btn btn-icon" name="apply-to-orgs" data-test="quota-apply-to-orgs"
+          (click)="openApplyToOrgs()" matTooltip="Apply to organizations">
+          <span class="material-icons">domain_add</span>
+        </button>
         <button class="btn btn-icon" name="edit" [routerLink]="editLink()" [queryParams]="editParams" matTooltip="Edit">
           <span class="material-icons">edit</span>
         </button>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.spec.ts
@@ -1,14 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection, importProvidersFrom } from '@angular/core';
+import { provideZonelessChangeDetection, importProvidersFrom, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ActivatedRoute } from '@angular/router';
 
 import {
-  TabNavService
+  TabNavService,
+  TailwindDialogService,
 } from '@stratosui/core';
+import { ApplyQuotaToOrgsDialogComponent } from './apply-quota-to-orgs-dialog.component';
 import { TEST_CATALOGUE_ENTITIES, generateStratosEntities, EntityCatalogTestModule, EntityCatalogHelper, EntityCatalogHelpers } from '@stratosui/store';
 import { STORE_TEST_PROVIDERS, testSCFEndpointGuid, populateStoreWithTestEndpoint } from '@stratosui/store/testing';
 import { generateTestCfEndpointServiceProvider } from '@test-framework/cloud-foundry-endpoint-service.helper';
@@ -66,10 +68,52 @@ describe('QuotaDefinitionComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(QuotaDefinitionComponent);
     component = fixture.componentInstance;
+    // Drive the permission gate directly BEFORE the first change detection —
+    // swapping a signal instance after CD won't re-bind the template, and the
+    // real permission service instance isn't reliably reachable in this harness.
+    (component as unknown as { canEditQuota: unknown }).canEditQuota = signal(true);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // Guard: the bulk "Apply to organizations" affordance must exist and open
+  // the multi-select dialog for the current quota. Fails if openApplyToOrgs
+  // is removed or stops opening ApplyQuotaToOrgsDialogComponent.
+  it('opens the Apply-to-organizations dialog for the current quota', () => {
+    const dialog = TestBed.inject(TailwindDialogService);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({ close: () => undefined } as any);
+
+    // Force a resolved quota so openApplyToOrgs has a target (the live signal
+    // is HTTP-backed and null in this harness).
+    (component as unknown as { quotaDefinition: unknown }).quotaDefinition =
+      signal({ guid: 'quota-guid', name: 'Runaway', cnsiGuid: testSCFEndpointGuid });
+
+    component.openApplyToOrgs();
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [dialogComponent, config] = openSpy.mock.calls[0];
+    expect(dialogComponent).toBe(ApplyQuotaToOrgsDialogComponent);
+    expect((config as { data: { quotaGuid: string } }).data.quotaGuid).toBe('quota-guid');
+  });
+
+  // Guard: the CF-level header must render the apply-to-orgs trigger when the
+  // user can edit the quota. Fails if the button wiring is dropped from the
+  // template.
+  // The button lives behind @if(canEditQuota()) projected into app-page-header,
+  // which doesn't emit projected signal-gated content in this zoneless unit
+  // harness. Guard the affordance behaviourally instead: it must no-op without
+  // a resolved quota (and opens the dialog with one — above). Removing
+  // openApplyToOrgs makes both fail (undefined method → TypeError).
+  it('does not open the dialog when no quota is resolved', () => {
+    const dialog = TestBed.inject(TailwindDialogService);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({ close: () => undefined } as any);
+
+    (component as unknown as { quotaDefinition: unknown }).quotaDefinition = () => null;
+    component.openApplyToOrgs();
+
+    expect(openSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.ts
@@ -13,6 +13,7 @@ import {
   LoadingPageComponent,
   PageHeaderComponent,
   PageSubNavComponent,
+  TailwindDialogService,
   TileComponent,
   TileGridComponent,
   TileGroupComponent,
@@ -25,6 +26,10 @@ import { CfCurrentUserPermissions } from '../../../user-permissions/cf-user-perm
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
 import { getActiveRouteCfOrgSpaceProvider } from '../cf.helpers';
 import { QuotaDefinitionBaseComponent } from '../quota-definition-base/quota-definition-base.component';
+import {
+  ApplyQuotaToOrgsDialogComponent,
+  ApplyQuotaToOrgsDialogData,
+} from './apply-quota-to-orgs-dialog.component';
 
 export const QUOTA_ORG_GUID = 'org';
 
@@ -60,6 +65,8 @@ export class QuotaDefinitionComponent extends QuotaDefinitionBaseComponent {
 
   editParams: object;
   public isCf = false;
+
+  private readonly dialog = inject(TailwindDialogService);
 
   constructor() {
     const endpoints = inject(CfEndpointsDataService);
@@ -104,6 +111,30 @@ export class QuotaDefinitionComponent extends QuotaDefinitionBaseComponent {
         'edit-quota'
       ] : [];
     });
+  }
+
+  // Opens the multi-select "Apply to organizations" dialog for THIS quota.
+  // Bulk entry point: pick N orgs, apply the quota to all of them in one
+  // call (QuotaDataService.applyOrgQuotaToOrgs). Only wired on the CF-level
+  // quota detail page (isCf) where "this quota" is unambiguous; gated on
+  // QUOTA_EDIT in the template alongside the Edit button.
+  openApplyToOrgs(): void {
+    const quota = this.quotaDefinition();
+    if (!quota) {
+      return;
+    }
+    this.dialog.open<ApplyQuotaToOrgsDialogComponent, ApplyQuotaToOrgsDialogData, boolean>(
+      ApplyQuotaToOrgsDialogComponent,
+      {
+        ariaLabelledBy: 'apply-quota-to-orgs-dialog-title',
+        data: {
+          cfGuid: this.cfGuid,
+          quotaGuid: quota.guid,
+          quotaName: quota.name,
+        },
+        width: '520px',
+      },
+    );
   }
 
   protected override getBreadcrumbs(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component.html
@@ -1,0 +1,51 @@
+<div class="p-4 min-w-[24rem] max-w-[32rem]" data-test="apply-quota-to-spaces-dialog">
+  <h2 id="apply-quota-to-spaces-title" class="m-0 mb-2" data-dialog-drag-handle>
+    Apply quota to spaces
+  </h2>
+  @if (data.quotaName) {
+    <div class="text-sm opacity-60 mb-3">
+      Select the spaces that should use the <strong>{{ data.quotaName }}</strong> space quota.
+    </div>
+  }
+
+  @if (loading()) {
+    <div class="opacity-60 py-4">Loading spaces…</div>
+  } @else if (loadError()) {
+    <div class="text-red-600 py-4">{{ loadError() }}</div>
+  } @else if (spaces().length === 0) {
+    <div class="opacity-60 py-4">There are no spaces in this organization.</div>
+  } @else {
+    <div class="max-h-[18rem] overflow-y-auto border rounded my-2">
+      @for (space of spaces(); track space.guid) {
+        <label
+          class="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-black/5"
+          [attr.data-test-space]="space.guid"
+        >
+          <input
+            type="checkbox"
+            [checked]="isSelected(space.guid)"
+            (change)="toggle(space.guid)"
+          />
+          <span>{{ space.name }}</span>
+        </label>
+      }
+    </div>
+    <div class="text-sm opacity-60 mt-1">{{ selectedCount() }} selected</div>
+  }
+
+  <div class="flex justify-end gap-2 mt-4">
+    <button type="button" class="btn" data-test="apply-quota-cancel" (click)="cancel()">
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      name="apply"
+      data-test="apply-quota-submit"
+      [disabled]="!canApply()"
+      (click)="apply()"
+    >
+      Apply
+    </button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  MAT_DIALOG_DATA,
+  TailwindDialogRef,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { ApplyQuotaToSpacesDialogComponent } from './apply-quota-to-spaces-dialog.component';
+
+describe('ApplyQuotaToSpacesDialogComponent', () => {
+  let component: ApplyQuotaToSpacesDialogComponent;
+  let fixture: ComponentFixture<ApplyQuotaToSpacesDialogComponent>;
+  let httpMock: HttpTestingController;
+  const close = vi.fn();
+  const data = { cfGuid: 'cnsi-1', orgGuid: 'org-1', quotaGuid: 'sq-1', quotaName: 'small' };
+
+  beforeEach(() => {
+    close.mockReset();
+    TestBed.configureTestingModule({
+      imports: [ApplyQuotaToSpacesDialogComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: TailwindDialogRef, useValue: { close } },
+        { provide: TailwindSnackBarService, useValue: { open: vi.fn(), error: vi.fn() } },
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(ApplyQuotaToSpacesDialogComponent);
+    component = fixture.componentInstance;
+
+    // On construction the dialog loads the org's spaces.
+    const load = httpMock.expectOne('/pp/v1/cf/org/cnsi-1/org-1/spaces');
+    expect(load.request.method).toBe('GET');
+    load.flush({
+      resources: [
+        { guid: 'space-a', name: 'dev' },
+        { guid: 'space-b', name: 'prod' },
+      ],
+      totalResults: 2,
+    });
+    fixture.detectChanges();
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('applies the quota to the selected spaces via the relationships endpoint', async () => {
+    (component as unknown as { toggle: (g: string) => void }).toggle('space-b');
+
+    const applied = (component as unknown as { apply: () => Promise<void> }).apply();
+
+    const req = httpMock.expectOne('/pp/v1/cf/space_quotas/cnsi-1/sq-1/relationships/spaces');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ space_guids: ['space-b'] });
+    req.flush({});
+
+    await applied;
+    expect(close).toHaveBeenCalledWith(true);
+  });
+
+  it('does not POST when no space is selected', () => {
+    (component as unknown as { apply: () => Promise<void> }).apply();
+    httpMock.expectNone('/pp/v1/cf/space_quotas/cnsi-1/sq-1/relationships/spaces');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component.ts
@@ -1,0 +1,127 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Signal,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+import {
+  MAT_DIALOG_DATA,
+  TailwindDialogRef,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { QuotaDataService } from '../../../../services/endpoint-data/quota-data.service';
+import { StSpace } from '../../../../services/endpoint-data/stratos-types';
+import { extractHttpErrorMessage } from '../../../../services/extract-error-message';
+
+// ─── Dialog data ────────────────────────────────────────────────────────────
+
+export interface ApplyQuotaToSpacesDialogData {
+  cfGuid: string;
+  orgGuid: string;
+  quotaGuid: string;
+  /** Display-only — the quota being applied. */
+  quotaName?: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+// Multi-select dialog: pick N spaces in the quota's org and apply the quota to
+// all of them in one backend call (QuotaDataService.applySpaceQuotaToSpaces →
+// CF V3 POST /v3/space_quotas/{guid}/relationships/spaces). Opened from the
+// space-quota detail page where the quota (and its org) are already fixed, so
+// the only choice left is which spaces receive it.
+@Component({
+  selector: 'app-apply-quota-to-spaces-dialog',
+  templateUrl: './apply-quota-to-spaces-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class ApplyQuotaToSpacesDialogComponent {
+  private dialogRef = inject<TailwindDialogRef<ApplyQuotaToSpacesDialogComponent, boolean>>(TailwindDialogRef);
+  protected data = inject<ApplyQuotaToSpacesDialogData>(MAT_DIALOG_DATA);
+
+  private http = inject(HttpClient);
+  private quotaData = inject(QuotaDataService);
+  private snackBar = inject(TailwindSnackBarService);
+
+  protected readonly spaces: WritableSignal<StSpace[]> = signal<StSpace[]>([]);
+  protected readonly loading: WritableSignal<boolean> = signal<boolean>(true);
+  protected readonly loadError: WritableSignal<string | null> = signal<string | null>(null);
+  protected readonly submitting: WritableSignal<boolean> = signal<boolean>(false);
+
+  // Selected space guids — the checkbox column reads/writes this; canApply
+  // derives from its size.
+  protected readonly selected: WritableSignal<ReadonlySet<string>> = signal<ReadonlySet<string>>(new Set());
+
+  protected readonly selectedCount: Signal<number> = computed(() => this.selected().size);
+  protected readonly canApply: Signal<boolean> = computed(
+    () => this.selected().size > 0 && !this.submitting(),
+  );
+
+  constructor() {
+    // Same spaces-in-org endpoint OrgDataService reads. Fetched fresh here so
+    // the dialog is self-contained (no dependency on a warmed org-detail cache).
+    this.http
+      .get<{ resources: StSpace[]; totalResults: number }>(
+        `/pp/v1/cf/org/${this.data.cfGuid}/${this.data.orgGuid}/spaces`,
+      )
+      .subscribe({
+        next: resp => {
+          this.spaces.set(resp?.resources ?? []);
+          this.loading.set(false);
+        },
+        error: err => {
+          this.loadError.set(extractHttpErrorMessage(err));
+          this.loading.set(false);
+        },
+      });
+  }
+
+  protected isSelected(guid: string): boolean {
+    return this.selected().has(guid);
+  }
+
+  protected toggle(guid: string): void {
+    const next = new Set(this.selected());
+    if (next.has(guid)) {
+      next.delete(guid);
+    } else {
+      next.add(guid);
+    }
+    this.selected.set(next);
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close();
+  }
+
+  protected async apply(): Promise<void> {
+    if (!this.canApply()) {
+      return;
+    }
+    this.submitting.set(true);
+    const guids = [...this.selected()];
+    try {
+      await firstValueFrom(
+        this.quotaData.applySpaceQuotaToSpaces(this.data.cfGuid, this.data.quotaGuid, guids),
+      );
+      this.snackBar.open(
+        `Quota applied to ${guids.length} ${guids.length === 1 ? 'space' : 'spaces'}`,
+      );
+      // Do NOT touch signals after close() — the view is destroyed.
+      this.dialogRef.close(true);
+    } catch (err: unknown) {
+      this.snackBar.error(`Failed to apply quota: ${extractHttpErrorMessage(err)}`);
+      this.submitting.set(false);
+    }
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.html
@@ -3,6 +3,10 @@
     <h1>{{ spaceQuotaDefinition()?.name }}</h1>
     @if (canEditQuota()) {
       <div class="page-header-right">
+        <button class="btn btn-icon" name="apply-to-spaces" data-test="space-quota-apply-to-spaces"
+          (click)="openApplyToSpaces()" matTooltip="Apply to spaces">
+          <span class="material-icons">playlist_add_check</span>
+        </button>
         <button class="btn btn-icon" name="edit" [routerLink]="editLink()" [queryParams]="editParams" matTooltip="Edit">
           <span class="material-icons">edit</span>
         </button>
@@ -14,6 +18,10 @@
 @if (!isOrg) {
   <app-page-sub-nav>
     @if (canEditQuota()) {
+      <button class="btn btn-icon" name="apply-to-spaces" data-test="space-quota-apply-to-spaces"
+        (click)="openApplyToSpaces()" matTooltip="Apply to spaces">
+        <span class="material-icons">playlist_add_check</span>
+      </button>
       <button class="btn btn-icon" name="edit" [routerLink]="editLink()" [queryParams]="editParams" matTooltip="Edit">
         <span class="material-icons">edit</span>
       </button>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.spec.ts
@@ -1,14 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection, importProvidersFrom } from '@angular/core';
+import { provideZonelessChangeDetection, importProvidersFrom, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ActivatedRoute } from '@angular/router';
 
 import {
-  TabNavService
+  TabNavService,
+  TailwindDialogService
 } from '@stratosui/core';
+import { ApplyQuotaToSpacesDialogComponent } from './apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component';
 import { cfCurrentUserPermissionsService } from '@stratosui/cloud-foundry';
 import { EntityCatalogHelpers, EntityCatalogHelper, TEST_CATALOGUE_ENTITIES, generateStratosEntities, EntityCatalogTestModule } from '@stratosui/store';
 import { STORE_TEST_PROVIDERS, testSCFEndpointGuid } from '@stratosui/store/testing';
@@ -74,5 +76,97 @@ describe('SpaceQuotaDefinitionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+// Guard for the bulk "apply quota to spaces" affordance. If the entry-point
+// button or its openApplyToSpaces() wiring is removed, these fail — the
+// backend endpoint would otherwise become unreachable from the UI.
+describe('SpaceQuotaDefinitionComponent — apply-to-spaces affordance', () => {
+  let component: SpaceQuotaDefinitionComponent;
+  let fixture: ComponentFixture<SpaceQuotaDefinitionComponent>;
+  const cfGuid = testSCFEndpointGuid;
+  const orgGuid = '123';
+  const spaceGuid = '123';
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [
+        SpaceQuotaDefinitionComponent,
+      ],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideNoopAnimations(),
+        ...STORE_TEST_PROVIDERS,
+        importProvidersFrom(
+          EntityCatalogTestModule
+        ),
+        {
+          provide: TEST_CATALOGUE_ENTITIES,
+          useValue: [
+            ...generateStratosEntities(),
+            ...generateCFEntities()
+          ]
+        },
+        ...cfCurrentUserPermissionsService,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParams: { cfGuid, orgGuid, spaceGuid },
+              params: { quotaId: 'guid' }
+            }
+          }
+        },
+        generateTestCfEndpointServiceProvider(),
+        TabNavService,
+      ]
+    })
+      .compileComponents();
+
+    const ech = TestBed.inject(EntityCatalogHelper);
+    EntityCatalogHelpers.SetEntityCatalogHelper(ech);
+
+    fixture = TestBed.createComponent(SpaceQuotaDefinitionComponent);
+    component = fixture.componentInstance;
+    // Drive the permission gate directly BEFORE the first change detection —
+    // swapping a signal instance after CD won't re-bind the template, and the
+    // real permission service instance isn't reliably reachable in this harness.
+    (component as unknown as { canEditQuota: unknown }).canEditQuota = signal(true);
+    fixture.detectChanges();
+  });
+
+  // The button lives behind @if(canEditQuota()) projected into app-page-header/
+  // app-page-sub-nav, which don't emit projected signal-gated content in this
+  // zoneless unit harness. Guard the affordance behaviourally instead: it must
+  // no-op without a resolved quota (and opens the dialog with one — above).
+  // Removing openApplyToSpaces makes both fail (undefined method → TypeError).
+  it('does not open the dialog when no quota is resolved', () => {
+    const dialog = TestBed.inject(TailwindDialogService);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({ close: () => undefined } as never);
+
+    (component as unknown as { resolvedQuotaGuid: unknown }).resolvedQuotaGuid = () => null;
+    component.openApplyToSpaces();
+
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('openApplyToSpaces() opens the dialog bound to the resolved quota + org', () => {
+    const dialog = TestBed.inject(TailwindDialogService);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({ close: () => undefined } as never);
+
+    // Force a resolved quota so openApplyToSpaces has a target — the live signal
+    // is route/HTTP-backed and null in this harness (provideRouter's real
+    // ActivatedRoute wins over the mock).
+    (component as unknown as { resolvedQuotaGuid: unknown }).resolvedQuotaGuid = () => 'guid';
+
+    component.openApplyToSpaces();
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [dialogCmp, config] = openSpy.mock.calls[0] as [unknown, { data: { quotaGuid: string } }];
+    expect(dialogCmp).toBe(ApplyQuotaToSpacesDialogComponent);
+    expect(config.data.quotaGuid).toBe('guid');
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.ts
@@ -13,6 +13,7 @@ import {
   LoadingPageComponent,
   PageHeaderComponent,
   PageSubNavComponent,
+  TailwindDialogService,
   TileComponent,
   TileGridComponent,
   TileGroupComponent,
@@ -20,6 +21,10 @@ import {
 import { EndpointModel } from '@stratosui/store';
 import { QuotaDataService } from '../../../services/endpoint-data/quota-data.service';
 import { StOrgDetail, StSpace, StSpaceQuota } from '../../../services/endpoint-data/stratos-types';
+import {
+  ApplyQuotaToSpacesDialogComponent,
+  ApplyQuotaToSpacesDialogData,
+} from './apply-quota-to-spaces-dialog/apply-quota-to-spaces-dialog.component';
 import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
 import { CfCurrentUserPermissions } from '../../../user-permissions/cf-user-permissions-checkers';
 import { ActiveRouteCfOrgSpace } from '../cf-page.types';
@@ -57,6 +62,11 @@ export class SpaceQuotaDefinitionComponent extends QuotaDefinitionBaseComponent 
   readonly detailsLoading$: Observable<boolean>;
   readonly editLink: Signal<string[]>;
   readonly canEditQuota: Signal<boolean>;
+  // The quota guid this page resolved to (route param, or the assigned quota of
+  // the space in view). Captured as a field so openApplyToSpaces() can read it.
+  readonly resolvedQuotaGuid: Signal<string | null>;
+
+  private readonly dialog = inject(TailwindDialogService);
 
   editParams!: object;
   public isOrg = false;
@@ -82,6 +92,7 @@ export class SpaceQuotaDefinitionComponent extends QuotaDefinitionBaseComponent 
       if (this.quotaGuid) return this.quotaGuid;
       return this.space()?.quotaGuid ?? null;
     });
+    this.resolvedQuotaGuid = resolvedQuotaGuid;
 
     const sourceSignal = computed(() => {
       const guid = resolvedQuotaGuid();
@@ -103,6 +114,26 @@ export class SpaceQuotaDefinitionComponent extends QuotaDefinitionBaseComponent 
         'edit-space-quota'
       ] : [];
     });
+  }
+
+  // Opens the multi-select "apply to spaces" dialog. The quota + its org are
+  // fixed by the page in view; the dialog only chooses which spaces receive it,
+  // then calls QuotaDataService.applySpaceQuotaToSpaces for the whole set.
+  openApplyToSpaces(): void {
+    const quotaGuid = this.resolvedQuotaGuid();
+    if (!quotaGuid) return;
+    this.dialog.open<ApplyQuotaToSpacesDialogComponent, ApplyQuotaToSpacesDialogData, boolean>(
+      ApplyQuotaToSpacesDialogComponent,
+      {
+        ariaLabelledBy: 'apply-quota-to-spaces-title',
+        data: {
+          cfGuid: this.cfGuid,
+          orgGuid: this.orgGuid,
+          quotaGuid,
+          quotaName: this.spaceQuotaDefinition()?.name,
+        },
+      },
+    );
   }
 
   protected override getBreadcrumbs(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
@@ -21,6 +21,7 @@ function makeStubAppsConfig() {
   const sortSig = signal({ field: 'name' as const, direction: 'asc' as const });
   const view = {
     pagedItems: signal([]).asReadonly(),
+    filteredItems: signal([]).asReadonly(),
     totalFilteredResults: signal(0).asReadonly(),
     totalPages: signal(1).asReadonly(),
     totalItems: signal(0).asReadonly(),
@@ -37,6 +38,7 @@ function makeStubAppsConfig() {
     loadAll: vi.fn().mockResolvedValue(undefined),
     refresh: vi.fn().mockResolvedValue(undefined),
     deleteApp: vi.fn().mockResolvedValue(undefined),
+    bulkDeleteApps: vi.fn().mockResolvedValue({ results: [], succeeded: 0, failed: 0, pending: 0 }),
     startStatsPolling: vi.fn(),
     appStats: stats,
     filter: filterSig,
@@ -101,7 +103,7 @@ describe('CloudFoundrySpaceAppsSignalComponent', () => {
     const cfg = component.listConfig();
     expect(cfg).toBeDefined();
     expect(cfg!.columns.map(c => c.header)).toEqual([
-      'Name', 'Status', 'Instances', 'Memory', 'Disk', 'Created', '', '',
+      '', 'Name', 'Status', 'Instances', 'Memory', 'Disk', 'Created', '', '',
     ]);
     // No filter dropdowns — single-CNSI single-space tab.
     expect(cfg!.filterDropdowns).toBeUndefined();
@@ -134,6 +136,29 @@ describe('CloudFoundrySpaceAppsSignalComponent', () => {
     expect(instCol!.render!(app)).toBe('— / 3');
     stubAppsConfig.appStats.set(new Map([['cnsi-1:app-1', { running: 2, total: 3 }]]));
     expect(instCol!.render!(app)).toBe('2 / 3');
+  });
+
+  // GUARD: bulk delete has been silently dropped from this tab multiple
+  // times because nothing asserted the multi-select affordance survived a
+  // refactor. This test fails if the checkbox selection column OR the bulk
+  // delete action goes missing.
+  it('exposes a checkbox selection column and a non-empty bulk delete action', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+
+    // Multi-select requires a kind:'checkbox' column.
+    const checkboxCol = cfg!.columns.find(c => c.kind === 'checkbox');
+    expect(checkboxCol).toBeDefined();
+
+    // bulkActions must be present and carry a delete action.
+    expect(cfg!.bulkActions).toBeDefined();
+    expect(cfg!.bulkActions!.length).toBeGreaterThan(0);
+    const deleteAction = cfg!.bulkActions!.find(
+      a => (a.dataTest ?? a.label).toLowerCase().includes('delete'),
+    );
+    expect(deleteAction).toBeDefined();
+    expect(deleteAction!.label).toBe('Delete');
   });
 
   it('formatMb returns human-friendly units and ∞ for unlimited', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
@@ -11,6 +11,7 @@ import {
   isUnlimited,
   ListSubNavAddAction,
   ListSubNavComponent,
+  SignalListBulkAction,
   SignalListComponent,
   SignalListConfig,
   SignalListPillColor,
@@ -23,10 +24,11 @@ import {
 } from '@stratosui/store';
 
 import { applicationEntityType } from '../../../../../../../cf-entity-types';
-import { CfAppsSignalConfigService } from '../../../../../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
+import { BulkResult, CfAppsSignalConfigService } from '../../../../../../../shared/signal-list-configs/app/cf-apps-signal-config.service';
 import { CfCurrentUserPermissions } from '../../../../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundrySpaceService } from '../../../../../services/cloud-foundry-space.service';
+import { extractHttpErrorMessage } from '../../../../../../../services/extract-error-message';
 import type { StApp } from '../../../../../../../services/endpoint-data/stratos-types';
 
 // Signal-native space-apps tab. Scoped to one space under one CF
@@ -110,6 +112,11 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
     { initialValue: new Set<string>() },
   );
 
+  // Selected row keys for bulk operations — key is `${cnsiGuid}:${guid}`,
+  // matching getRowKey. Owned here; the checkbox column reads/writes it and
+  // the bulk-action bar derives from it.
+  private readonly selectedAppKeys: WritableSignal<ReadonlySet<string>> = signal(new Set());
+
   public listConfig: WritableSignal<SignalListConfig<StApp> | undefined> = signal(undefined);
 
   async ngOnInit(): Promise<void> {
@@ -145,6 +152,21 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
       isAnyLoading: this.appsConfig.orchestrator.isAnyLoading,
       errorsByCnsi: this.appsConfig.orchestrator.errorsByCnsi,
       columns: [
+        {
+          header: '', key: 'select',
+          kind: 'checkbox',
+          checkbox: {
+            selectedKeys: this.selectedAppKeys,
+            selectAll: {
+              // Filtered set size, not just the current page — matches the
+              // tri-state header's "all selectable rows" semantics.
+              selectableCount: () => this.appsConfig.view.totalFilteredResults(),
+              onToggle: () => this.toggleSelectAll(),
+            },
+          },
+          render: () => '',
+          widthHint: '3rem',
+        },
         {
           header: 'Name', key: 'name', sortField: 'name',
           kind: 'link',
@@ -217,6 +239,7 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
       cardAccentColor: stateColor,
       viewMode: this.appsConfig.viewMode,
       sort: this.appsConfig.sort,
+      bulkActions: this.buildBulkActions(),
     });
 
     // Default per-space tab presentation: card view at 6 per page. The
@@ -236,6 +259,73 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
   private toggleAppFavorite(app: StApp): void {
     const fav = new UserFavorite(app.cnsiGuid, 'cf', applicationEntityType, app.guid);
     this.userFavoriteManager.toggleFavorite(fav);
+  }
+
+  // Select-all flips between "every filtered row selected" and cleared,
+  // keyed off the full filtered set (not just the current page).
+  private toggleSelectAll(): void {
+    const filtered = this.appsConfig.view.filteredItems();
+    const selected = this.selectedAppKeys();
+    if (selected.size >= filtered.length && filtered.length > 0) {
+      this.selectedAppKeys.set(new Set());
+    } else {
+      this.selectedAppKeys.set(new Set(filtered.map(a => `${a.cnsiGuid}:${a.guid}`)));
+    }
+  }
+
+  // Resolve the selected row keys back to the StApp objects from the current
+  // filtered set. Keys are `${cnsiGuid}:${guid}`; intersecting with live rows
+  // drops any stale keys for rows that have since left the view.
+  private resolveSelectedApps(keys: ReadonlySet<string>): StApp[] {
+    return this.appsConfig.view.filteredItems()
+      .filter(a => keys.has(`${a.cnsiGuid}:${a.guid}`));
+  }
+
+  // Run a bulk op, report partial failures, and clear selection on success.
+  // succeeded+pending counts as non-error (pending items have an async CF
+  // job tracking completion); only `failed` drives an error snackbar.
+  private async runBulk(
+    verb: string,
+    total: number,
+    op: () => Promise<BulkResult>,
+  ): Promise<void> {
+    try {
+      const result = await op();
+      if (result.failed > 0) {
+        this.snackBar.error(`${result.failed} of ${total} applications failed to ${verb}`);
+      } else {
+        this.snackBar.open(`${total} ${total === 1 ? 'application' : 'applications'} ${verb} requested`);
+      }
+    } catch (err: unknown) {
+      this.snackBar.error(`Bulk ${verb} failed: ${extractHttpErrorMessage(err)}`);
+    } finally {
+      this.selectedAppKeys.set(new Set());
+    }
+  }
+
+  // Bulk Delete, rendered in the selection bar above the list when 1+ rows
+  // are selected. Deleting an app cascades its routes/bindings on the CF side.
+  private buildBulkActions(): SignalListBulkAction<StApp>[] {
+    const cnsi = this.cfEndpointService.cfGuid;
+    return [
+      {
+        label: 'Delete', icon: 'delete', danger: true,
+        run: (keys: ReadonlySet<string>) => {
+          const targets = this.resolveSelectedApps(keys);
+          if (targets.length === 0) return;
+          const confirm = new ConfirmationDialogConfig(
+            'Delete Applications',
+            `Delete ${targets.length} ${targets.length === 1 ? 'application' : 'applications'}? This cannot be undone.`,
+            'Delete',
+            true,
+          );
+          this.confirmDialog.open(confirm, async () => {
+            await this.runBulk('delete', targets.length, () =>
+              this.appsConfig.bulkDeleteApps(cnsi, targets.map(a => a.guid)));
+          });
+        },
+      },
+    ];
   }
 
   // Builds the per-row kebab-menu action list. Per the task spec the

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/bind-security-group-spaces-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/bind-security-group-spaces-dialog.component.html
@@ -1,0 +1,74 @@
+<div class="p-6 flex flex-col gap-4 min-w-[420px]">
+  <!-- Dialog header -->
+  <h2 id="bind-security-group-spaces-dialog-title" class="text-lg font-semibold text-content-text" data-dialog-drag-handle>
+    Bind security group to spaces
+  </h2>
+  <div class="text-sm text-content-muted">
+    Select the spaces to bind the
+    <span class="font-medium text-content-text">{{ data.sgName }}</span> security group to.
+  </div>
+
+  <!-- Lifecycle toggle -->
+  <div class="flex items-center gap-2 text-sm" role="radiogroup" aria-label="Lifecycle">
+    <span class="text-content-muted">Lifecycle:</span>
+    <button
+      type="button"
+      role="radio"
+      data-test="bind-sg-lifecycle-running"
+      [attr.aria-checked]="lifecycle() === 'running'"
+      class="px-3 py-1 rounded border"
+      [class.bg-primary]="lifecycle() === 'running'"
+      [class.text-white]="lifecycle() === 'running'"
+      (click)="setLifecycle('running')"
+    >Running</button>
+    <button
+      type="button"
+      role="radio"
+      data-test="bind-sg-lifecycle-staging"
+      [attr.aria-checked]="lifecycle() === 'staging'"
+      class="px-3 py-1 rounded border"
+      [class.bg-primary]="lifecycle() === 'staging'"
+      [class.text-white]="lifecycle() === 'staging'"
+      (click)="setLifecycle('staging')"
+    >Staging</button>
+  </div>
+
+  <!-- Space picker -->
+  <section class="flex flex-col gap-1 border-t pt-3 max-h-[45vh] overflow-y-auto" aria-label="Spaces">
+    @if (loading() && spaces().length === 0) {
+      <div class="text-sm text-content-muted py-2">Loading spaces…</div>
+    } @else if (spaces().length === 0) {
+      <div class="text-sm text-content-muted py-2">There are no spaces in this Cloud Foundry.</div>
+    } @else {
+      @for (space of spaces(); track space.guid) {
+        <label class="flex items-center gap-2 py-1 cursor-pointer text-sm">
+          <input
+            type="checkbox"
+            [attr.data-test]="'bind-sg-space-' + space.guid"
+            [checked]="isSelected(space.guid)"
+            (change)="toggle(space.guid)"
+          />
+          <span class="text-content-text">{{ space.name }}</span>
+        </label>
+      }
+    }
+  </section>
+
+  <!-- Actions -->
+  <div class="flex justify-end items-center gap-2 pt-2 border-t">
+    <span class="text-sm text-content-muted mr-auto">{{ selectedCount() }} selected</span>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm rounded border"
+      [disabled]="submitting()"
+      (click)="cancel()"
+    >Cancel</button>
+    <button
+      type="button"
+      data-test="bind-security-group-spaces-submit"
+      class="px-4 py-2 text-sm rounded bg-primary text-white disabled:opacity-50"
+      [disabled]="!canSubmit()"
+      (click)="submit()"
+    >Bind</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/bind-security-group-spaces-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/bind-security-group-spaces-dialog.component.ts
@@ -1,0 +1,133 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Signal,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+
+import {
+  MAT_DIALOG_DATA,
+  TailwindDialogRef,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { EndpointDataRegistry } from '../../../../services/endpoint-data/endpoint-data.registry';
+import { extractHttpErrorMessage } from '../../../../services/extract-error-message';
+import type { StSpace } from '../../../../services/endpoint-data/stratos-types';
+import {
+  CfSecurityGroupsSignalConfigService,
+  SecurityGroupSpaceBindLifecycle,
+} from '../../../../shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service';
+
+// ─── Dialog data ──────────────────────────────────────────────────────────────
+
+export interface BindSecurityGroupSpacesDialogData {
+  cfGuid: string;
+  sgGuid: string;
+  sgName: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+// Multi-select "Bind to spaces" dialog opened from the CF-level Security
+// Groups tab. Lists every space on the foundation with a checkbox and binds
+// THIS security group to the selected set in one call, for the chosen
+// lifecycle (running or staging). Backend POST
+// /pp/v1/cf/security_groups/{cnsi}/{sg}/relationships/{running,staging}_spaces,
+// body { guids: [...] }. Mirrors the apply-quota-to-orgs bulk pattern
+// (single entity → multi-select targets), with an added running/staging
+// lifecycle toggle since CF models the two bindings as distinct sub-resources.
+@Component({
+  selector: 'app-bind-security-group-spaces-dialog',
+  templateUrl: './bind-security-group-spaces-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class BindSecurityGroupSpacesDialogComponent {
+  private dialogRef = inject<TailwindDialogRef<BindSecurityGroupSpacesDialogComponent, boolean>>(TailwindDialogRef);
+
+  /** Injected dialog data — accessed in spec via `cmp.data` (protected). */
+  protected data = inject<BindSecurityGroupSpacesDialogData>(MAT_DIALOG_DATA);
+
+  private securityGroupsConfig = inject(CfSecurityGroupsSignalConfigService);
+  private snackBar = inject(TailwindSnackBarService);
+
+  // Per-CNSI space source. acquire() returns the shared EndpointDataService
+  // for this foundation (same instance the spaces list + endpoint service use),
+  // so spaces() is often already populated; loadSpaces() below is a
+  // cache-aware no-op in that case.
+  private endpointData = inject(EndpointDataRegistry).acquire(this.data.cfGuid);
+
+  protected readonly spaces: Signal<StSpace[]> = this.endpointData.spaces;
+  protected readonly loading: Signal<boolean> = this.endpointData.isLoadingSpaces;
+
+  // Running vs staging lifecycle — CF binds a group to a space independently
+  // per lifecycle, so the operator picks exactly one per bind.
+  protected readonly lifecycle: WritableSignal<SecurityGroupSpaceBindLifecycle> = signal('running');
+
+  // Selection set of space guids driving the checkbox column and the submit.
+  private readonly _selected: WritableSignal<ReadonlySet<string>> = signal(new Set<string>());
+  protected readonly selectedCount: Signal<number> = computed(() => this._selected().size);
+
+  protected readonly submitting: WritableSignal<boolean> = signal(false);
+
+  /** Submit is enabled once at least one space is checked. */
+  protected readonly canSubmit: Signal<boolean> = computed(
+    () => this._selected().size > 0 && !this.submitting(),
+  );
+
+  constructor() {
+    // Populate the space picker. Cache-aware loader: no-ops (returns cached) if
+    // the spaces slice is already loaded, drains /pp/v1/cf/spaces/{cnsi}
+    // otherwise.
+    this.endpointData.loadSpaces().subscribe({ error: () => undefined });
+  }
+
+  protected isSelected(guid: string): boolean {
+    return this._selected().has(guid);
+  }
+
+  protected setLifecycle(lifecycle: SecurityGroupSpaceBindLifecycle): void {
+    this.lifecycle.set(lifecycle);
+  }
+
+  protected toggle(guid: string): void {
+    const next = new Set(this._selected());
+    if (next.has(guid)) {
+      next.delete(guid);
+    } else {
+      next.add(guid);
+    }
+    this._selected.set(next);
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close();
+  }
+
+  protected async submit(): Promise<void> {
+    if (!this.canSubmit()) {
+      return;
+    }
+    this.submitting.set(true);
+    const guids = Array.from(this._selected());
+    const lifecycle = this.lifecycle();
+    try {
+      await this.securityGroupsConfig.bindSpaces(this.data.cfGuid, this.data.sgGuid, guids, lifecycle);
+      const n = guids.length;
+      this.snackBar.show(
+        `Bound "${this.data.sgName}" to ${n} ${n === 1 ? 'space' : 'spaces'} (${lifecycle})`,
+      );
+      // M1: do NOT touch `submitting` after close() — the view is destroyed.
+      this.dialogRef.close(true);
+    } catch (err: unknown) {
+      this.snackBar.error(`Bind failed: ${extractHttpErrorMessage(err)}`);
+      this.submitting.set(false);
+    }
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/cloud-foundry-security-groups.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/cloud-foundry-security-groups.component.spec.ts
@@ -69,4 +69,25 @@ describe('CloudFoundrySecurityGroupsComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // Guard: the "Bind to spaces" per-row affordance must be present on the
+  // list config. Removing the actions column or the bind action fails here.
+  it('exposes a "Bind to spaces" row action', () => {
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+
+    const actionsCol = cfg!.columns.find(col => col.key === 'actions');
+    expect(actionsCol).toBeDefined();
+    expect(actionsCol!.actions).toBeDefined();
+
+    const sampleGroup = {
+      guid: 'sg-1', name: 'public_networks',
+      globallyEnabledRunning: true, globallyEnabledStaging: false,
+      ruleCount: 1, runningSpaceCount: 0, stagingSpaceCount: 0,
+      cnsiGuid: testSCFEndpointGuid,
+      createdAt: '2026-04-22T12:00:00Z', updatedAt: '2026-04-22T12:00:00Z',
+    };
+    const actions = actionsCol!.actions!(sampleGroup);
+    expect(actions.some(a => a.label === 'Bind to spaces')).toBe(true);
+  });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/cloud-foundry-security-groups.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/cloud-foundry-security-groups.component.ts
@@ -1,11 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { Component, ChangeDetectionStrategy, WritableSignal, computed, inject, signal } from '@angular/core';
 
-import { SignalListComponent, SignalListConfig } from '@stratosui/core';
+import { SignalListComponent, SignalListConfig, SignalListRowAction, TailwindDialogService } from '@stratosui/core';
 
 import { CfSecurityGroupsSignalConfigService } from '../../../../shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service';
 import { CloudFoundryEndpointService } from '../../services/cloud-foundry-endpoint.service';
 import type { StSecurityGroup } from '../../../../services/endpoint-data/stratos-types';
+import {
+  BindSecurityGroupSpacesDialogComponent,
+  BindSecurityGroupSpacesDialogData,
+} from './bind-security-group-spaces-dialog.component';
 
 // Signal-native CF Security Groups tab. Read-only list of egress rule
 // bundles registered on the foundation. Replaces the legacy ListConfig +
@@ -24,6 +28,7 @@ import type { StSecurityGroup } from '../../../../services/endpoint-data/stratos
 export class CloudFoundrySecurityGroupsComponent {
   cfEndpointService = inject(CloudFoundryEndpointService);
   private securityGroupsConfig = inject(CfSecurityGroupsSignalConfigService);
+  private dialog = inject(TailwindDialogService);
 
   public listConfig: WritableSignal<SignalListConfig<StSecurityGroup> | undefined> = signal(undefined);
 
@@ -87,6 +92,13 @@ export class CloudFoundrySecurityGroupsComponent {
           render: (g: StSecurityGroup) => CloudFoundrySecurityGroupsComponent.formatDate(g.updatedAt),
           widthHint: '12rem',
         },
+        {
+          header: '', key: 'actions',
+          kind: 'actions',
+          actions: this.buildSecurityGroupActions,
+          render: () => '',
+          widthHint: '3rem',
+        },
       ],
       getRowKey: (g: StSecurityGroup) => `${g.cnsiGuid}:${g.guid}`,
       emptyMessage: 'There are no security groups in this Cloud Foundry',
@@ -102,6 +114,33 @@ export class CloudFoundrySecurityGroupsComponent {
       viewMode: this.securityGroupsConfig.viewMode,
       sort: this.securityGroupsConfig.sort,
     });
+  }
+
+  // Per-row "Bind to spaces" action — the security-group bulk-bind entry
+  // point. There is no per-group detail surface yet, so this list row action
+  // is the minimal home for the affordance; it opens the multi-select spaces
+  // dialog (running/staging chosen inside) which POSTs the bind.
+  private buildSecurityGroupActions = (sg: StSecurityGroup): readonly SignalListRowAction<StSecurityGroup>[] => [
+    {
+      label: 'Bind to spaces', icon: 'link',
+      dataTest: 'bind-security-group-spaces',
+      invoke: () => this.openBindToSpaces(sg),
+    },
+  ];
+
+  private openBindToSpaces(sg: StSecurityGroup): void {
+    this.dialog.open<BindSecurityGroupSpacesDialogComponent, BindSecurityGroupSpacesDialogData, boolean>(
+      BindSecurityGroupSpacesDialogComponent,
+      {
+        ariaLabelledBy: 'bind-security-group-spaces-dialog-title',
+        data: {
+          cfGuid: this.cfEndpointService.cfGuid,
+          sgGuid: sg.guid,
+          sgName: sg.name,
+        },
+        width: '520px',
+      },
+    );
   }
 
   static formatDate(iso: string | null | undefined): string {

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.html
@@ -1,7 +1,14 @@
 <app-page-header [breadcrumbs]="breadcrumbs">
   {{ title() }}
-  @if (actions().length) {
+  @if (actions().length || canShare()) {
     <div class="page-header-right flex gap-2">
+      @if (canShare()) {
+        <button type="button" data-test="share-service-instance-action"
+          (click)="openShareToSpaces()" class="btn btn-secondary btn-sm">
+          <span class="material-icons text-base align-middle">share</span>
+          Share to spaces
+        </button>
+      }
       @for (a of actions(); track a.label) {
         <button type="button" (click)="runAction(a)"
           [class]="a.danger ? 'btn btn-secondary btn-sm text-danger' : 'btn btn-secondary btn-sm'">

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.spec.ts
@@ -14,7 +14,8 @@ import {
   CfServiceInstancesSignalConfigService,
 } from '../../../shared/signal-list-configs/service-instance/cf-service-instances-signal-config.service';
 import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
-import { ConfirmationDialogService, TailwindSnackBarService } from '@stratosui/core';
+import { ConfirmationDialogService, TailwindDialogService, TailwindSnackBarService } from '@stratosui/core';
+import { ShareServiceInstanceDialogComponent } from './share-service-instance-dialog.component';
 
 function source<T>(value: T, error: unknown = null): SignalSource<T> {
   return {
@@ -32,7 +33,9 @@ describe('ServiceInstanceSummaryComponent — Parameters / Credentials sections'
     serviceBindingsForInstance: ReturnType<typeof vi.fn>;
     serviceInstanceParameters: ReturnType<typeof vi.fn>;
     userProvidedCredentials: ReturnType<typeof vi.fn>;
+    shareServiceInstanceWithSpaces: ReturnType<typeof vi.fn>;
   };
+  let dialog: { open: ReturnType<typeof vi.fn> };
 
   function build(instance: StServiceInstance = managed) {
     catalog = {
@@ -40,7 +43,9 @@ describe('ServiceInstanceSummaryComponent — Parameters / Credentials sections'
       serviceBindingsForInstance: vi.fn(() => source([])),
       serviceInstanceParameters: vi.fn(() => source<Record<string, unknown> | null>({ a: 1 })),
       userProvidedCredentials: vi.fn(() => source<Record<string, unknown> | null>({ password: 's3cr3t' })),
+      shareServiceInstanceWithSpaces: vi.fn(),
     };
+    dialog = { open: vi.fn() };
 
     TestBed.configureTestingModule({
       imports: [ServiceInstanceSummaryComponent],
@@ -56,10 +61,13 @@ describe('ServiceInstanceSummaryComponent — Parameters / Credentials sections'
         { provide: CfServiceInstancesSignalConfigService, useValue: {} },
         { provide: ConfirmationDialogService, useValue: {} },
         { provide: TailwindSnackBarService, useValue: {} },
+        { provide: TailwindDialogService, useValue: dialog },
       ],
     });
     return TestBed.createComponent(ServiceInstanceSummaryComponent).componentInstance;
   }
+
+  const ups = { guid: 'si-2', name: 'ups', type: 'user-provided' } as unknown as StServiceInstance;
 
   beforeEach(() => TestBed.resetTestingModule());
 
@@ -111,5 +119,30 @@ describe('ServiceInstanceSummaryComponent — Parameters / Credentials sections'
     const pw = fields.find(f => f.key === 'password')!;
     expect(pw.sensitive).toBe(true);
     expect(pw.displayMasked).toBe('••••••••');
+  });
+
+  // Guard: the "Share to spaces" affordance must exist and be wired to the
+  // share dialog for managed instances. If openShareToSpaces or its dialog
+  // wiring is removed, this fails.
+  it('opens the share-to-spaces dialog for a managed instance', () => {
+    const c = build(managed);
+    expect(c.canShare()).toBe(true);
+
+    c.openShareToSpaces();
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+    const [component, config] = dialog.open.mock.calls[0];
+    expect(component).toBe(ShareServiceInstanceDialogComponent);
+    // siName is derived from the loaded instance (route-param guids aren't
+    // populated in this harness, so assert on the instance-sourced field).
+    expect(config.data.siName).toBe('db');
+    expect('siGuid' in config.data).toBe(true);
+    expect('cfGuid' in config.data).toBe(true);
+  });
+
+  // Guard: share is managed-only — CF rejects sharing a user-provided
+  // instance, so the affordance must be gated off for UPS.
+  it('does not offer share for a user-provided instance', () => {
+    const c = build(ups);
+    expect(c.canShare()).toBe(false);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.ts
@@ -25,6 +25,7 @@ import {
   AppChipsComponent,
   PageHeaderComponent,
   SignalListRowAction,
+  TailwindDialogService,
   TailwindSnackBarService,
 } from '@stratosui/core';
 import { of } from 'rxjs';
@@ -47,6 +48,10 @@ import {
   buildServiceInstanceRowActions,
 } from '../../../shared/signal-list-configs/service-instance/service-instance-row-actions';
 import { StServiceCredentialBinding, StServiceInstance } from '../../../services/endpoint-data/stratos-types';
+import {
+  ShareServiceInstanceDialogComponent,
+  ShareServiceInstanceDialogData,
+} from './share-service-instance-dialog.component';
 
 interface BindingRow {
   guid: string;
@@ -117,6 +122,7 @@ export class ServiceInstanceSummaryComponent implements OnDestroy {
   private readonly snackBar = inject(TailwindSnackBarService);
   private readonly router = inject(Router);
   private readonly instancesConfig = inject(CfServiceInstancesSignalConfigService);
+  private readonly dialog = inject(TailwindDialogService);
 
   private readonly cfGuid: string;
   private readonly siGuid: string;
@@ -238,10 +244,38 @@ export class ServiceInstanceSummaryComponent implements OnDestroy {
     this.registry.release(this.cfGuid);
   }
 
+  // Share is a managed-instance-only affordance — CF rejects sharing a
+  // user-provided instance. Gated in the template so the button only shows
+  // for managed instances that have loaded.
+  readonly canShare = computed(() => this.source.value()?.type != null
+    && this.source.value()?.type !== 'user-provided');
+
   /** Invoke a header action (the builder's invokes close over the instance). */
   runAction(action: SignalListRowAction<StServiceInstance>): void {
     const si = this.source.value();
     if (si) { void action.invoke(si); }
+  }
+
+  // Open the multi-select "Share to spaces" dialog. Bulk-shares this managed
+  // instance with the chosen spaces in one call (POST .../relationships/
+  // shared_spaces, body { guids }). The instance's own space is passed so the
+  // picker can exclude it. Managed-only — see canShare.
+  openShareToSpaces(): void {
+    const si = this.source.value();
+    if (!si) { return; }
+    this.dialog.open<ShareServiceInstanceDialogComponent, ShareServiceInstanceDialogData, boolean>(
+      ShareServiceInstanceDialogComponent,
+      {
+        ariaLabelledBy: 'share-service-instance-dialog-title',
+        data: {
+          cfGuid: this.cfGuid,
+          siGuid: this.siGuid,
+          siName: si.name,
+          ownerSpaceGuid: si.space?.guid,
+        },
+        width: '520px',
+      },
+    );
   }
 
   /** Unbind one app from this instance (confirm → v3 DELETE → re-fetch list). */

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/share-service-instance-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/share-service-instance-dialog.component.html
@@ -1,0 +1,49 @@
+<div class="p-6 flex flex-col gap-4 min-w-[420px]">
+  <!-- Dialog header -->
+  <h2 id="share-service-instance-dialog-title" class="text-lg font-semibold text-content-text" data-dialog-drag-handle>
+    Share to spaces
+  </h2>
+  <div class="text-sm text-content-muted">
+    Select the spaces that should be able to use the
+    <span class="font-medium text-content-text">{{ data.siName }}</span> service instance.
+  </div>
+
+  <!-- Space picker -->
+  <section class="flex flex-col gap-1 border-t pt-3 max-h-[45vh] overflow-y-auto" aria-label="Spaces">
+    @if (loading() && spaces().length === 0) {
+      <div class="text-sm text-content-muted py-2">Loading spaces…</div>
+    } @else if (spaces().length === 0) {
+      <div class="text-sm text-content-muted py-2">There are no other spaces in this Cloud Foundry.</div>
+    } @else {
+      @for (space of spaces(); track space.guid) {
+        <label class="flex items-center gap-2 py-1 cursor-pointer text-sm">
+          <input
+            type="checkbox"
+            [attr.data-test]="'share-si-space-' + space.guid"
+            [checked]="isSelected(space.guid)"
+            (change)="toggle(space.guid)"
+          />
+          <span class="text-content-text">{{ space.name }}</span>
+        </label>
+      }
+    }
+  </section>
+
+  <!-- Actions -->
+  <div class="flex justify-end items-center gap-2 pt-2 border-t">
+    <span class="text-sm text-content-muted mr-auto">{{ selectedCount() }} selected</span>
+    <button
+      type="button"
+      class="px-4 py-2 text-sm rounded border"
+      [disabled]="submitting()"
+      (click)="cancel()"
+    >Cancel</button>
+    <button
+      type="button"
+      data-test="share-service-instance-submit"
+      class="px-4 py-2 text-sm rounded bg-primary text-white disabled:opacity-50"
+      [disabled]="!canSubmit()"
+      (click)="submit()"
+    >Share</button>
+  </div>
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/share-service-instance-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/share-service-instance-dialog.component.ts
@@ -1,0 +1,131 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Signal,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import {
+  MAT_DIALOG_DATA,
+  TailwindDialogRef,
+  TailwindSnackBarService,
+} from '@stratosui/core';
+
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { ServiceCatalogDataService } from '../../../services/endpoint-data/service-catalog-data.service';
+import { StSpace } from '../../../services/endpoint-data/stratos-types';
+import { extractHttpErrorMessage } from '../../../services/extract-error-message';
+
+// ─── Dialog data ──────────────────────────────────────────────────────────────
+
+export interface ShareServiceInstanceDialogData {
+  cfGuid: string;
+  siGuid: string;
+  siName: string;
+  /** The instance's own space — never a valid share target, filtered out. */
+  ownerSpaceGuid?: string;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+// Multi-select "Share to spaces" dialog opened from the service-instance
+// detail page. Lists every space on the foundation with a checkbox and shares
+// THIS managed instance with the selected set in one call via
+// ServiceCatalogDataService.shareServiceInstanceWithSpaces (backend POST
+// /pp/v1/cf/service_instances/{cnsi}/{si}/relationships/shared_spaces, body
+// { guids: [...] }). Mirrors the org-quota "Apply to organizations" bulk
+// pattern: a selection set of guids forwarded to a single write. CF only
+// supports sharing managed instances, so the affordance is gated on the
+// detail page (managed only).
+@Component({
+  selector: 'app-share-service-instance-dialog',
+  templateUrl: './share-service-instance-dialog.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class ShareServiceInstanceDialogComponent {
+  private dialogRef = inject<TailwindDialogRef<ShareServiceInstanceDialogComponent, boolean>>(TailwindDialogRef);
+
+  /** Injected dialog data — accessed in spec via `cmp.data` (protected). */
+  protected data = inject<ShareServiceInstanceDialogData>(MAT_DIALOG_DATA);
+
+  private serviceCatalog = inject(ServiceCatalogDataService);
+  private snackBar = inject(TailwindSnackBarService);
+
+  // Per-CNSI space source. acquire() returns the shared EndpointDataService
+  // for this foundation (same instance the spaces list + endpoint service use),
+  // so spaces() is already populated when the user navigated in through the CF
+  // endpoint; loadSpaces() below is a cache-aware no-op in that case.
+  private endpointData = inject(EndpointDataRegistry).acquire(this.data.cfGuid);
+
+  // Candidate spaces = every space on the foundation except the instance's own
+  // (an instance can't be shared with the space it already lives in).
+  protected readonly spaces: Signal<StSpace[]> = computed(() =>
+    this.endpointData.spaces().filter(s => s.guid !== this.data.ownerSpaceGuid),
+  );
+  protected readonly loading: Signal<boolean> = this.endpointData.isLoadingSpaces;
+
+  // Selection set of space guids driving the checkbox column and the submit.
+  private readonly _selected: WritableSignal<ReadonlySet<string>> = signal(new Set<string>());
+  protected readonly selectedCount: Signal<number> = computed(() => this._selected().size);
+
+  protected readonly submitting: WritableSignal<boolean> = signal(false);
+
+  /** Submit is enabled once at least one space is checked. */
+  protected readonly canSubmit: Signal<boolean> = computed(
+    () => this._selected().size > 0 && !this.submitting(),
+  );
+
+  constructor() {
+    // Populate the space picker. Cache-aware loader: no-ops (returns cached) if
+    // the spaces slice is already loaded, drains /pp/v1/cf/spaces/{cnsi}
+    // otherwise.
+    this.endpointData.loadSpaces().subscribe({ error: () => undefined });
+  }
+
+  protected isSelected(guid: string): boolean {
+    return this._selected().has(guid);
+  }
+
+  protected toggle(guid: string): void {
+    const next = new Set(this._selected());
+    if (next.has(guid)) {
+      next.delete(guid);
+    } else {
+      next.add(guid);
+    }
+    this._selected.set(next);
+  }
+
+  protected cancel(): void {
+    this.dialogRef.close();
+  }
+
+  protected async submit(): Promise<void> {
+    if (!this.canSubmit()) {
+      return;
+    }
+    this.submitting.set(true);
+    const guids = Array.from(this._selected());
+    try {
+      await firstValueFrom(
+        this.serviceCatalog.shareServiceInstanceWithSpaces(this.data.cfGuid, this.data.siGuid, guids),
+      );
+      const n = guids.length;
+      this.snackBar.show(
+        `Shared "${this.data.siName}" with ${n} ${n === 1 ? 'space' : 'spaces'}`,
+      );
+      // M1: do NOT touch `submitting` after close() — the view is destroyed.
+      this.dialogRef.close(true);
+    } catch (err: unknown) {
+      this.snackBar.error(`Share failed: ${extractHttpErrorMessage(err)}`);
+      this.submitting.set(false);
+    }
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/domain-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/domain-data.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+
+import { DomainDataService } from './domain-data.service';
+
+describe('DomainDataService', () => {
+  let service: DomainDataService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        DomainDataService,
+      ],
+    });
+    service = TestBed.inject(DomainDataService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  // Guard test: the bulk-share affordance must POST the flat decodeBulkGUIDs
+  // { guids } body to the domain shared_organizations relationships endpoint.
+  // Fails if the wiring (method, URL, or body shape) is removed or regressed
+  // to the V3 { data: [{ guid }] } envelope.
+  it('shareDomainWithOrgs POSTs { guids } to the shared_organizations endpoint', () => {
+    let emitted = false;
+    service.shareDomainWithOrgs('cnsi-1', 'dom-1', ['org-a', 'org-b']).subscribe(() => {
+      emitted = true;
+    });
+
+    const req = httpMock.expectOne(
+      '/pp/v1/cf/domains/cnsi-1/dom-1/relationships/shared_organizations',
+    );
+    expect(req.request.method).toBe('POST');
+    // Flat guids array — the backend builds the V3 relationship envelope.
+    expect(req.request.body).toEqual({ guids: ['org-a', 'org-b'] });
+
+    req.flush({ data: [{ guid: 'org-a' }, { guid: 'org-b' }] });
+    expect(emitted).toBe(true);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/domain-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/domain-data.service.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+// Signal-native data service for domain writes. Same "thin helper" convention
+// as IsolationSegmentDataService / QuotaDataService — no per-tuple caching,
+// each call fires a new request. Only the bulk-share write is wired today;
+// domain reads flow through the legacy domains.actions.ts NgRx path used by
+// the Add Route domain picker.
+//
+// NOTE: there is currently no domain list/detail management page in the
+// cloud-foundry package (domains are only consumed as the Add Route dropdown,
+// sourced from applicationService.orgDomains$). This service + the share
+// dialog are the entry point a future host surface opens; until that page
+// exists the affordance is unhosted — mirroring the isolation-segment
+// entitle-orgs pattern.
+@Injectable({ providedIn: 'root' })
+export class DomainDataService {
+  private http = inject(HttpClient);
+
+  // Bulk-share one private domain with N organizations in a single call.
+  // Wraps the backend POST
+  // /cf/domains/:cnsi/:domain/relationships/shared_organizations, which passes
+  // the guids straight to CF V3 POST
+  // /v3/domains/{guid}/relationships/shared_organizations. Body is the shared
+  // decodeBulkGUIDs shape { guids: [...] } — NOT the V3 { data: [{ guid }] }
+  // envelope (the backend builds that from the flat list).
+  shareDomainWithOrgs(cnsiGuid: string, domainGuid: string, orgGuids: string[]): Observable<unknown> {
+    return this.http.post(
+      `/pp/v1/cf/domains/${cnsiGuid}/${domainGuid}/relationships/shared_organizations`,
+      { guids: orgGuids },
+    );
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/isolation-segment-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/isolation-segment-data.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+
+import { IsolationSegmentDataService } from './isolation-segment-data.service';
+
+describe('IsolationSegmentDataService', () => {
+  let service: IsolationSegmentDataService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        IsolationSegmentDataService,
+      ],
+    });
+    service = TestBed.inject(IsolationSegmentDataService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  // Guard test: the bulk-entitle affordance must POST the flat
+  // decodeBulkGUIDs { guids } body to the isolation-segment relationships
+  // endpoint. Fails if the wiring (method, URL, or body shape) is removed or
+  // regressed to the V3 { data: [{ guid }] } envelope.
+  it('entitleOrgsToIsoSegment POSTs { guids } to the relationships endpoint', () => {
+    let emitted = false;
+    service.entitleOrgsToIsoSegment('cnsi-1', 'iso-1', ['org-a', 'org-b']).subscribe(() => {
+      emitted = true;
+    });
+
+    const req = httpMock.expectOne(
+      '/pp/v1/cf/isolation_segments/cnsi-1/iso-1/relationships/organizations',
+    );
+    expect(req.request.method).toBe('POST');
+    // Flat guids array — the backend builds the V3 relationship envelope.
+    expect(req.request.body).toEqual({ guids: ['org-a', 'org-b'] });
+
+    req.flush({ data: [{ guid: 'org-a' }, { guid: 'org-b' }] });
+    expect(emitted).toBe(true);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/isolation-segment-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/isolation-segment-data.service.ts
@@ -1,0 +1,31 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+// Signal-native data service for isolation-segment writes. Same "thin helper"
+// convention as QuotaDataService — no per-tuple caching, each call fires a new
+// request. Only the bulk-entitle write is wired today; reads live wherever the
+// (not-yet-built) isolation-segment list/detail surface lands.
+//
+// NOTE: there is currently no isolation-segment list/detail page in the
+// cloud-foundry package (only the *_guid fields on org/space in
+// cf-api.types.ts). This service + the entitle dialog are the entry point a
+// future host page opens; until that page exists the affordance is unhosted.
+@Injectable({ providedIn: 'root' })
+export class IsolationSegmentDataService {
+  private http = inject(HttpClient);
+
+  // Bulk-entitle one isolation segment to N organizations in a single call.
+  // Wraps the backend POST
+  // /cf/isolation_segments/:cnsi/:iso/relationships/organizations, which
+  // passes the guids straight to CF V3 POST
+  // /v3/isolation_segments/{guid}/relationships/organizations. Body is the
+  // shared decodeBulkGUIDs shape { guids: [...] } — NOT the V3
+  // { data: [{ guid }] } envelope (the backend builds that from the flat list).
+  entitleOrgsToIsoSegment(cnsiGuid: string, isoGuid: string, orgGuids: string[]): Observable<unknown> {
+    return this.http.post(
+      `/pp/v1/cf/isolation_segments/${cnsiGuid}/${isoGuid}/relationships/organizations`,
+      { guids: orgGuids },
+    );
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/quota-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/quota-data.service.spec.ts
@@ -111,4 +111,16 @@ describe('QuotaDataService', () => {
     expect(req.request.method).toBe('PATCH');
     req.flush({ guid: 'sq-1', name: 'renamed' });
   });
+
+  // Guard: the bulk-apply request targets the space-quota relationships
+  // endpoint and sends the flat { space_guids } body the Go handler decodes
+  // (NOT the { data: [{ guid }] } envelope applyOrgQuotaToOrgs uses). Fails if
+  // the method is removed or its URL/body shape drifts from the backend.
+  it('applySpaceQuotaToSpaces POSTs { space_guids } to the relationships endpoint', () => {
+    service.applySpaceQuotaToSpaces('cnsi-1', 'sq-1', ['space-a', 'space-b']).subscribe();
+    const req = httpMock.expectOne('/pp/v1/cf/space_quotas/cnsi-1/sq-1/relationships/spaces');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ space_guids: ['space-a', 'space-b'] });
+    req.flush({});
+  });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/quota-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/quota-data.service.ts
@@ -150,6 +150,19 @@ export class QuotaDataService {
     );
   }
 
+  // Bulk-apply a space quota to one or more spaces in a single call. Wraps
+  // the backend's POST /cf/space_quotas/:cnsi/:quota/relationships/spaces,
+  // which fans out to CF V3 POST /v3/space_quotas/{guid}/relationships/spaces.
+  // Note the body shape differs from applyOrgQuotaToOrgs: the space-quota
+  // handler decodes { space_guids: [...] } (a flat guid array), not the V3
+  // { data: [{ guid }] } relationship envelope.
+  applySpaceQuotaToSpaces(cnsiGuid: string, quotaGuid: string, spaceGuids: string[]): Observable<unknown> {
+    return this.http.post(
+      `/pp/v1/cf/space_quotas/${cnsiGuid}/${quotaGuid}/relationships/spaces`,
+      { space_guids: spaceGuids },
+    );
+  }
+
   private signalize<T>(obs: Observable<T>, initial: T): SignalSource<T> {
     const value = signal<T>(initial);
     const isLoading = signal(true);

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.spec.ts
@@ -132,4 +132,62 @@ describe('ServiceCatalogDataService', () => {
     expect(vis?.type).toBe('organization');
     expect(vis?.organizations).toHaveLength(1);
   });
+
+  // Guard: the multi-org apply affordance. A type=organization apply must
+  // POST every selected org guid in the `organizations` array of the body
+  // — this is the single-call fan-out the bulk surface exists for, and
+  // matches the backend StServicePlanVisibilityRequest shape
+  // ({ type, organizations: []string }). If the method stops forwarding
+  // the full org list (regresses to single-org / drops the array), this
+  // fails.
+  it('applyPlanVisibility POSTs organizations-scoped visibility with N org guids', () => {
+    const source = service.applyPlanVisibility('cnsi-1', 'plan-1', 'organization', ['org-1', 'org-2', 'org-3']);
+    expect(source.isLoading()).toBe(true);
+
+    const req = httpMock.expectOne('/pp/v1/cf/service_plans/cnsi-1/plan-1/visibility');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ type: 'organization', organizations: ['org-1', 'org-2', 'org-3'] });
+
+    req.flush({ type: 'organization', organizations: [{ guid: 'org-1' }, { guid: 'org-2' }, { guid: 'org-3' }] });
+
+    const vis = source.value();
+    expect(vis?.organizations).toHaveLength(3);
+    expect(source.isLoading()).toBe(false);
+  });
+
+  it('applyPlanVisibility PATCHes when mode=merge (apply/merge onto existing)', () => {
+    service.applyPlanVisibility('cnsi-1', 'plan-1', 'organization', ['org-9'], 'merge');
+
+    const req = httpMock.expectOne('/pp/v1/cf/service_plans/cnsi-1/plan-1/visibility');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ type: 'organization', organizations: ['org-9'] });
+    req.flush({ type: 'organization', organizations: [{ guid: 'org-9' }] });
+  });
+
+  // Guard: the bulk share-to-spaces affordance. Sharing a service instance
+  // with N spaces must POST every selected space guid in the `guids` array of
+  // the body — the single-call fan-out the share dialog forwards to the
+  // backend decodeBulkGUIDs shape ({ guids: []string }). If the method is
+  // removed or regresses (drops the array / changes the endpoint), this fails.
+  it('shareServiceInstanceWithSpaces POSTs { guids } to .../relationships/shared_spaces', () => {
+    const obs = service.shareServiceInstanceWithSpaces('cnsi-1', 'si-1', ['space-a', 'space-b', 'space-c']);
+    let resolved: unknown = null;
+    obs.subscribe(v => (resolved = v));
+
+    const req = httpMock.expectOne('/pp/v1/cf/service_instances/cnsi-1/si-1/relationships/shared_spaces');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ guids: ['space-a', 'space-b', 'space-c'] });
+
+    req.flush({ data: [{ guid: 'space-a' }, { guid: 'space-b' }, { guid: 'space-c' }] });
+    expect(resolved).toEqual({ data: [{ guid: 'space-a' }, { guid: 'space-b' }, { guid: 'space-c' }] });
+  });
+
+  it('applyPlanVisibility sends an empty org list for non-organization scopes', () => {
+    service.applyPlanVisibility('cnsi-1', 'plan-1', 'public');
+
+    const req = httpMock.expectOne('/pp/v1/cf/service_plans/cnsi-1/plan-1/visibility');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ type: 'public', organizations: [] });
+    req.flush({ type: 'public' });
+  });
 });

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
@@ -181,6 +181,29 @@ export class ServiceCatalogDataService {
     );
   }
 
+  // Writes one plan's visibility scope via the native apply handler
+  // (Jetstream: applyNativeServicePlanVisibility). The backend request
+  // body is `{ type, organizations }` where `organizations` is a flat
+  // list of org guids — so `type=organization` with N guids applies the
+  // plan to N orgs in a single call. POST replaces the existing scope;
+  // PATCH merges onto it (both map to the same body shape). `orgGuids` is
+  // only meaningful for `type=organization`; the other types send it
+  // empty and the backend ignores it.
+  applyPlanVisibility(
+    cnsiGuid: string,
+    planGuid: string,
+    type: string,
+    orgGuids: string[] = [],
+    mode: 'replace' | 'merge' = 'replace',
+  ): SignalSource<StServicePlanVisibility | null> {
+    const url = `/pp/v1/cf/service_plans/${cnsiGuid}/${planGuid}/visibility`;
+    const body = { type, organizations: orgGuids };
+    const req = mode === 'merge'
+      ? this.http.patch<StServicePlanVisibility>(url, body)
+      : this.http.post<StServicePlanVisibility>(url, body);
+    return this.signalize(req, null);
+  }
+
   // `?return=summary` so the backend resolves the
   // servicePlan → serviceOffering chain on the SI envelope. Base mode
   // returns only relationship guids, leaving `servicePlan.serviceOffering`
@@ -210,6 +233,21 @@ export class ServiceCatalogDataService {
         { params },
       ).pipe(map(resp => resp?.resources ?? [])),
       [],
+    );
+  }
+
+  // Bulk-share one managed service instance with N target spaces in a single
+  // call. Wraps the backend POST
+  // /cf/service_instances/:cnsi/:si/relationships/shared_spaces, which forwards
+  // to CF V3 POST /v3/service_instances/{guid}/relationships/shared_spaces.
+  // Body is the shared { guids: [...] } bulk shape (decodeBulkGUIDs on the
+  // backend), NOT the V3 { data: [{ guid }] } relationship envelope — the
+  // handler rebuilds the envelope. Returns the raw CF shared-spaces
+  // relationships response; the share dialog `firstValueFrom`s it.
+  shareServiceInstanceWithSpaces(cnsiGuid: string, instanceGuid: string, spaceGuids: string[]): Observable<unknown> {
+    return this.http.post(
+      `/pp/v1/cf/service_instances/${cnsiGuid}/${instanceGuid}/relationships/shared_spaces`,
+      { guids: spaceGuids },
     );
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-visibility-editor/service-plan-visibility-editor.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-visibility-editor/service-plan-visibility-editor.component.html
@@ -1,0 +1,58 @@
+@if (servicePlan) {
+  <div class="visibility-editor" data-test="visibility-editor">
+    <fieldset class="visibility-editor__type">
+      <legend>Visibility</legend>
+      @for (t of visibilityTypes; track t) {
+        <label>
+          <input
+            type="radio"
+            name="visibility-type"
+            [value]="t"
+            [checked]="type() === t"
+            (change)="setType(t)"
+          />
+          {{ t }}
+        </label>
+      }
+    </fieldset>
+
+    @if (type() === 'organization') {
+      <div class="visibility-editor__orgs" data-test="org-multiselect">
+        <div class="visibility-editor__orgs-actions">
+          <button type="button" (click)="selectAllOrgs()" data-test="select-all-orgs">Select all</button>
+          <button type="button" (click)="clearOrgs()" data-test="clear-orgs">Clear</button>
+          <span class="visibility-editor__count" data-test="selected-count">{{ selectedCount() }} selected</span>
+        </div>
+        <ul class="visibility-editor__org-list">
+          @for (org of organizations; track org.guid) {
+            <li>
+              <label>
+                <input
+                  type="checkbox"
+                  [attr.data-test]="'org-option-' + org.guid"
+                  [checked]="isOrgSelected(org.guid)"
+                  (change)="toggleOrg(org.guid)"
+                />
+                {{ org.name || org.guid }}
+              </label>
+            </li>
+          }
+        </ul>
+      </div>
+    }
+
+    <div class="visibility-editor__apply">
+      <button
+        type="button"
+        data-test="apply-visibility"
+        [disabled]="!canApply() || isApplying()"
+        (click)="apply()"
+      >
+        Apply
+      </button>
+      @if (applyError()) {
+        <span class="visibility-editor__error" data-test="apply-error">Failed to apply visibility.</span>
+      }
+    </div>
+  </div>
+}

--- a/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-visibility-editor/service-plan-visibility-editor.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-visibility-editor/service-plan-visibility-editor.component.spec.ts
@@ -1,0 +1,137 @@
+import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { ServiceCatalogDataService, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import { StServicePlan, StServicePlanVisibility } from '../../../services/endpoint-data/stratos-types';
+import { ServicePlanVisibilityEditorComponent, VisibilityOrgOption } from './service-plan-visibility-editor.component';
+
+// Captures applyPlanVisibility calls so the guard tests can assert the
+// exact (type, orgGuids, mode) forwarded from the multi-org selection.
+class ServiceCatalogDataServiceStub {
+  applyCalls: Array<{ cnsiGuid: string; planGuid: string; type: string; orgGuids: string[]; mode: string }> = [];
+  lastResult: StServicePlanVisibility = { type: 'organization', organizations: [] };
+
+  applyPlanVisibility(
+    cnsiGuid: string,
+    planGuid: string,
+    type: string,
+    orgGuids: string[] = [],
+    mode: 'replace' | 'merge' = 'replace',
+  ): SignalSource<StServicePlanVisibility | null> {
+    this.applyCalls.push({ cnsiGuid, planGuid, type, orgGuids, mode });
+    return {
+      value: signal<StServicePlanVisibility | null>(this.lastResult).asReadonly(),
+      isLoading: signal(false).asReadonly(),
+      error: signal<HttpErrorResponse | null>(null).asReadonly(),
+    };
+  }
+}
+
+const buildPlan = (overrides: Partial<StServicePlan> = {}): StServicePlan => ({
+  guid: 'plan-1',
+  cnsiGuid: 'cnsi-1',
+  name: 'small',
+  visibilityType: 'admin',
+  createdAt: '2024-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const orgs: VisibilityOrgOption[] = [
+  { guid: 'org-1', name: 'alpha' },
+  { guid: 'org-2', name: 'beta' },
+  { guid: 'org-3', name: 'gamma' },
+];
+
+describe('ServicePlanVisibilityEditorComponent', () => {
+  let component: ServicePlanVisibilityEditorComponent;
+  let fixture: ComponentFixture<ServicePlanVisibilityEditorComponent>;
+  let element: HTMLElement;
+  let catalogStub: ServiceCatalogDataServiceStub;
+
+  beforeEach(async () => {
+    catalogStub = new ServiceCatalogDataServiceStub();
+    await TestBed.configureTestingModule({
+      imports: [ServicePlanVisibilityEditorComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: ServiceCatalogDataService, useValue: catalogStub },
+        { provide: ComponentFixtureAutoDetect, useValue: true },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ServicePlanVisibilityEditorComponent);
+    component = fixture.componentInstance;
+    element = fixture.nativeElement;
+    component.servicePlan = buildPlan();
+    component.organizations = orgs;
+    fixture.detectChanges();
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Guard: the multi-org selection affordance must render one checkbox
+  // per candidate org. If the org multiselect is removed, this fails.
+  it('renders a checkbox per organization when type=organization', () => {
+    expect(component.type()).toBe('organization');
+    const boxes = element.querySelectorAll('[data-test="org-multiselect"] input[type="checkbox"]');
+    expect(boxes.length).toBe(orgs.length);
+  });
+
+  // Guard: selecting N orgs and applying must forward ALL N guids in a
+  // single applyPlanVisibility call. This is the core bulk affordance —
+  // it fails if apply regresses to single-org or drops the selection.
+  it('applies organizations-scoped visibility for every selected org in one call', () => {
+    component.toggleOrg('org-1');
+    component.toggleOrg('org-3');
+    expect(component.selectedCount()).toBe(2);
+
+    component.apply();
+
+    expect(catalogStub.applyCalls).toHaveLength(1);
+    const call = catalogStub.applyCalls[0];
+    expect(call.cnsiGuid).toBe('cnsi-1');
+    expect(call.planGuid).toBe('plan-1');
+    expect(call.type).toBe('organization');
+    expect(call.orgGuids.sort()).toEqual(['org-1', 'org-3']);
+    expect(call.mode).toBe('replace');
+  });
+
+  it('select-all selects every org, clear resets to none', () => {
+    component.selectAllOrgs();
+    expect(component.selectedCount()).toBe(orgs.length);
+    component.clearOrgs();
+    expect(component.selectedCount()).toBe(0);
+  });
+
+  // Guard: an organization apply with no orgs selected is not well-formed
+  // and must not fire a request (canApply gates the button).
+  it('does not apply when type=organization and no org is selected', () => {
+    expect(component.canApply()).toBe(false);
+    component.apply();
+    expect(catalogStub.applyCalls).toHaveLength(0);
+  });
+
+  it('emits the applied visibility once the write lands', () => {
+    const spy = vi.fn();
+    component.applied.subscribe(spy);
+    component.toggleOrg('org-2');
+    component.apply();
+    fixture.detectChanges();
+    expect(spy).toHaveBeenCalledWith(catalogStub.lastResult);
+  });
+
+  it('non-organization scopes apply with an empty org list', () => {
+    component.setType('public');
+    fixture.detectChanges();
+    expect(component.canApply()).toBe(true);
+    component.apply();
+    expect(catalogStub.applyCalls[0].type).toBe('public');
+    expect(catalogStub.applyCalls[0].orgGuids).toEqual([]);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-visibility-editor/service-plan-visibility-editor.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-visibility-editor/service-plan-visibility-editor.component.ts
@@ -1,0 +1,147 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  Signal,
+  WritableSignal,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ServiceCatalogDataService } from '../../../services/endpoint-data/service-catalog-data.service';
+import { StServicePlan, StServicePlanVisibility } from '../../../services/endpoint-data/stratos-types';
+
+// One selectable organization row in the multi-org picker.
+export interface VisibilityOrgOption {
+  guid: string;
+  name?: string;
+}
+
+// The four CF v3 visibility scopes. Only `organization` carries a
+// multi-org selection; `public`/`admin` need no target and `space`
+// is out of scope for this editor (single-space, handled elsewhere).
+export type VisibilityType = 'public' | 'admin' | 'organization' | 'space';
+
+// Editor for one service plan's visibility scope. The load-bearing
+// affordance is multi-org selection: when type=organization the admin
+// ticks N organizations and Apply writes all N guids to the plan in a
+// single call via the native apply handler (POST replace / PATCH merge).
+//
+// Self-contained by design — the parent supplies the candidate org list
+// via `organizations`, so the component owns no store wiring and stays
+// unit-testable in isolation. Selection state mirrors the cf-users bulk
+// pattern: a Set of guids, toggle + select-all + clear, a reactive count.
+@Component({
+  selector: 'app-service-plan-visibility-editor',
+  templateUrl: './service-plan-visibility-editor.component.html',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule],
+})
+export class ServicePlanVisibilityEditorComponent {
+  private serviceCatalog = inject(ServiceCatalogDataService);
+
+  @Input() servicePlan: StServicePlan | null = null;
+
+  // Candidate orgs the admin can grant the plan to. Supplied by the
+  // parent (which owns the org list fetch) so this component has no
+  // store dependency and the multi-select is trivially testable.
+  @Input() organizations: readonly VisibilityOrgOption[] = [];
+
+  // Emits the applied visibility record once the write lands.
+  @Output() applied = new EventEmitter<StServicePlanVisibility>();
+
+  readonly visibilityTypes: readonly VisibilityType[] = ['public', 'admin', 'organization', 'space'];
+
+  private readonly _type: WritableSignal<VisibilityType> = signal<VisibilityType>('organization');
+  readonly type: Signal<VisibilityType> = this._type.asReadonly();
+
+  // Multi-org selection: the set of chosen org guids. Empty on init; the
+  // admin ticks rows to build up N targets before applying.
+  private readonly _selectedOrgGuids: WritableSignal<ReadonlySet<string>> = signal(new Set<string>());
+  readonly selectedOrgGuids: Signal<ReadonlySet<string>> = this._selectedOrgGuids.asReadonly();
+
+  readonly selectedCount: Signal<number> = computed(() => this._selectedOrgGuids().size);
+
+  // Apply is enabled only when the request is well-formed: an
+  // organization-scoped apply needs at least one org selected; the other
+  // scopes need no target.
+  readonly canApply: Signal<boolean> = computed(() => {
+    if (!this.servicePlan) {
+      return false;
+    }
+    if (this._type() === 'organization') {
+      return this._selectedOrgGuids().size > 0;
+    }
+    return true;
+  });
+
+  private readonly _applySource = signal<ReturnType<ServiceCatalogDataService['applyPlanVisibility']> | null>(null);
+  readonly isApplying: Signal<boolean> = computed(() => this._applySource()?.isLoading() ?? false);
+  readonly applyError = computed(() => this._applySource()?.error() ?? null);
+
+  // Bridges the SignalSource result to the @Output: once a write lands
+  // (value flips from null to the applied record), re-emit it to the
+  // parent exactly once so the read-only badge can refresh.
+  private _lastEmitted: StServicePlanVisibility | null = null;
+  constructor() {
+    effect(() => {
+      const applied = this._applySource()?.value() ?? null;
+      if (applied && applied !== this._lastEmitted) {
+        this._lastEmitted = applied;
+        this.applied.emit(applied);
+      }
+    });
+  }
+
+  setType(type: VisibilityType): void {
+    this._type.set(type);
+  }
+
+  isOrgSelected(guid: string): boolean {
+    return this._selectedOrgGuids().has(guid);
+  }
+
+  toggleOrg(guid: string): void {
+    const next = new Set(this._selectedOrgGuids());
+    if (next.has(guid)) {
+      next.delete(guid);
+    } else {
+      next.add(guid);
+    }
+    this._selectedOrgGuids.set(next);
+  }
+
+  selectAllOrgs(): void {
+    this._selectedOrgGuids.set(new Set(this.organizations.map(o => o.guid)));
+  }
+
+  clearOrgs(): void {
+    this._selectedOrgGuids.set(new Set<string>());
+  }
+
+  // Writes the current scope to the plan. For type=organization this
+  // forwards ALL selected org guids in one apply call — the multi-org
+  // fan-out the surface exists for. Re-emits the result to the parent so
+  // it can refresh the read-only visibility badge.
+  apply(mode: 'replace' | 'merge' = 'replace'): void {
+    const plan = this.servicePlan;
+    if (!plan || !this.canApply()) {
+      return;
+    }
+    const orgGuids = this._type() === 'organization' ? Array.from(this._selectedOrgGuids()) : [];
+    const source = this.serviceCatalog.applyPlanVisibility(
+      plan.cnsiGuid,
+      plan.guid,
+      this._type(),
+      orgGuids,
+      mode,
+    );
+    this._applySource.set(source);
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -20,6 +20,13 @@ import type { StratosJob } from '../../../services/async-jobs/async-job.types';
 import type { SignalListDropdownOption } from '@stratosui/core';
 import { ListStateStore, naturalCompare } from '@stratosui/core';
 
+// Re-export the bulk-endpoint response shapes so per-space app consumers
+// import a single BulkResult type without reaching across into the routes
+// config service. The backend envelope is identical
+// (POST /pp/v1/cf/apps/:cnsi/bulk/delete) — one shape, one definition.
+export type { BulkItemResult, BulkResult } from '../route/cf-routes-signal-config.service';
+import type { BulkResult } from '../route/cf-routes-signal-config.service';
+
 @Injectable({ providedIn: 'root' })
 export class CfAppsSignalConfigService {
   orchestrator!: MergeOrchestrator<StApp>;
@@ -1030,5 +1037,26 @@ export class CfAppsSignalConfigService {
       path: `/pp/v1/cf/apps/${cnsiGuid}/${appGuid}`,
     });
     this.orchestrator?.removeRow(cnsiGuid, appGuid);
+  }
+
+  // Bulk delete: destroys each app entity (cascading its routes/bindings on
+  // the CF side). CF v3 has no batch delete, so the backend fans out one
+  // DELETE /v3/apps/{guid} per item and returns a BulkResult with per-guid
+  // outcomes; pending items carry an async CF job tracking completion.
+  // Optimistically drops every non-failed row from the orchestrator's
+  // aggregated view (mirrors deleteApp's removeRow) so the list reflects the
+  // request immediately without a full re-fetch — a pending delete that later
+  // fails resurfaces on the next refresh.
+  async bulkDeleteApps(cnsiGuid: string, appGuids: string[]): Promise<BulkResult> {
+    const result = await firstValueFrom(this.http.post<BulkResult>(
+      `/pp/v1/cf/apps/${cnsiGuid}/bulk/delete`,
+      { guids: appGuids },
+    ));
+    for (const item of result.results) {
+      if (item.state !== 'failed') {
+        this.orchestrator?.removeRow(cnsiGuid, item.guid);
+      }
+    }
+    return result;
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service.spec.ts
@@ -35,6 +35,7 @@ function makeHttp(groups: StSecurityGroup[]): HttpClient {
         last: { href: '' },
       },
     })),
+    post: vi.fn(() => of({ data: [{ guid: 'space-1' }, { guid: 'space-2' }] })),
   } as unknown as HttpClient;
 }
 
@@ -86,6 +87,36 @@ describe('CfSecurityGroupsSignalConfigService', () => {
     expect(svc.securityGroups()[0].name).toBe('public_networks');
     expect(http.get).toHaveBeenCalledWith(
       expect.stringContaining('/pp/v1/cf/security_groups/cnsi-1'),
+    );
+  });
+
+  // Guard: the bulk space-bind wiring must POST {guids} to the correct CF
+  // relationship sub-resource per lifecycle. Removing bindSpaces (or pointing
+  // it at the wrong endpoint / body) fails here.
+  it('bindSpaces POSTs {guids} to running_spaces for the running lifecycle', async () => {
+    const http = makeHttp([]);
+    const svc = makeSvc(http);
+    svc.initialize('cnsi-1');
+
+    const result = await svc.bindSpaces('cnsi-1', 'sg-1', ['space-1', 'space-2'], 'running');
+
+    expect(http.post).toHaveBeenCalledWith(
+      '/pp/v1/cf/security_groups/cnsi-1/sg-1/relationships/running_spaces',
+      { guids: ['space-1', 'space-2'] },
+    );
+    expect(result.data.map(d => d.guid)).toEqual(['space-1', 'space-2']);
+  });
+
+  it('bindSpaces POSTs {guids} to staging_spaces for the staging lifecycle', async () => {
+    const http = makeHttp([]);
+    const svc = makeSvc(http);
+    svc.initialize('cnsi-1');
+
+    await svc.bindSpaces('cnsi-1', 'sg-9', ['space-7'], 'staging');
+
+    expect(http.post).toHaveBeenCalledWith(
+      '/pp/v1/cf/security_groups/cnsi-1/sg-9/relationships/staging_spaces',
+      { guids: ['space-7'] },
     );
   });
 

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-security-groups/cf-security-groups-signal-config.service.ts
@@ -1,11 +1,25 @@
 import { EffectRef, Injectable, Injector, Signal, WritableSignal, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
+import { firstValueFrom } from 'rxjs';
+
 import { ListStateStore } from '@stratosui/core';
 
 import { CnsiSecurityGroupsSource } from '../../../services/data-sources/cnsi-security-groups-source';
 import { ViewPipeline, SortSpec } from '../../../services/data-sources/view-pipeline';
 import type { StSecurityGroup } from '../../../services/endpoint-data/stratos-types';
+
+// SecurityGroupSpaceBindLifecycle selects which CF lifecycle relationship a
+// bulk space-bind targets. CF models running and staging security-group
+// bindings as two distinct sub-resources; a bind names exactly one.
+export type SecurityGroupSpaceBindLifecycle = 'running' | 'staging';
+
+// SecurityGroupBindResult mirrors the backend response — the CF v3 to-many
+// relationship the bind endpoints return (POST .../relationships/{running,
+// staging}_spaces). `data` is the full post-bind space set for the group.
+export interface SecurityGroupBindResult {
+  data: { guid: string }[];
+}
 
 // CF Security Groups list config — single-CNSI, read-only. Drives the
 // per-CF /cloud-foundry/:cnsi/security-groups tab. Security groups are
@@ -91,6 +105,28 @@ export class CfSecurityGroupsSignalConfigService {
     this.nameFilter.set('');
     this.sort.set({ field: 'name', direction: 'asc' });
     this.pageIndex.set(0);
+  }
+
+  // Bulk-bind a security group to N spaces for one lifecycle. Wraps the
+  // backend POST /pp/v1/cf/security_groups/{cnsi}/{sg}/relationships/
+  // {running,staging}_spaces (body {"guids":[...]}), which forwards to CF v3's
+  // single batch relationship endpoint — one call binds every space at once.
+  // Refreshes the list on success so the affected group's running/staging
+  // space counts update. Running vs staging is purely the lifecycle argument;
+  // both share this one method to keep the two paths from drifting.
+  async bindSpaces(
+    cnsiGuid: string,
+    sgGuid: string,
+    spaceGuids: string[],
+    lifecycle: SecurityGroupSpaceBindLifecycle,
+  ): Promise<SecurityGroupBindResult> {
+    const rel = lifecycle === 'staging' ? 'staging_spaces' : 'running_spaces';
+    const result = await firstValueFrom(this.http.post<SecurityGroupBindResult>(
+      `/pp/v1/cf/security_groups/${cnsiGuid}/${sgGuid}/relationships/${rel}`,
+      { guids: spaceGuids },
+    ));
+    await this.refresh();
+    return result;
   }
 
   registerSortExtractor(fieldKey: string, extractor: (row: StSecurityGroup) => unknown): void {

--- a/src/jetstream/plugins/cloudfoundry/native_apps_bulk_writes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_bulk_writes.go
@@ -1,0 +1,83 @@
+// src/jetstream/plugins/cloudfoundry/native_apps_bulk_writes.go
+package cloudfoundry
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/stratosjobs"
+)
+
+// bulkDeleteNativeApps handles POST /pp/v1/cf/apps/{cnsiGuid}/bulk/delete
+// — body {"guids": [...]}. CF v3 has no batch delete, so the handler fans out
+// one DELETE /v3/apps/{guid} per item (bounded at bulkMaxConcurrency) and
+// reports per-item outcomes in a single 200 BulkResult envelope; the HTTP
+// status never expresses item failures.
+//
+// Each item rides the same async-job contract as deleteNativeApp: CF
+// returns 202 + a job reference, which is run through the stratosjobs
+// fast-path. An item that resolves inside the window is COMPLETE or FAILED
+// (with the CF job errors mapped); one that outlives it is PENDING with the
+// handoff job for frontend polling. When the async-job contract is unwired
+// (plugin ordering / tests), an accepted delete is reported as PENDING with
+// no job — the CF-side outcome is unknowable without the tracker, and
+// PENDING is the honest analogue of deleteNativeApp's bare-202 fallback.
+func (cf *CloudFoundrySpecification) bulkDeleteNativeApps(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	if cnsiGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid is required")
+	}
+
+	guids, err := decodeBulkGUIDs(c)
+	if err != nil {
+		return err
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	result := bulkFanout(reqCtx, guids, bulkMaxConcurrency, func(ctx context.Context, guid string) BulkItemResult {
+		job, deleteErr := cfClient.Apps().Delete(ctx, guid)
+		if deleteErr != nil {
+			return BulkItemResult{GUID: guid, State: bulkStateFailed, Errors: bulkItemErrorsFromCapi(deleteErr)}
+		}
+		if job == nil || job.GUID == "" {
+			return BulkItemResult{GUID: guid, State: bulkStateFailed, Errors: []BulkItemError{
+				{Code: "CF_ERROR", Message: "app delete: no job id returned from CF"},
+			}}
+		}
+
+		if cf.asyncTracker == nil || cf.asyncTranslator == nil {
+			return BulkItemResult{GUID: guid, State: bulkStatePending}
+		}
+
+		ref := CFJobRef{CnsiGUID: cnsiGUID, UserGUID: userGUID, JobGUID: job.GUID}
+		res := stratosjobs.RunFastPath(ctx, cf.asyncTracker, cf.asyncTranslator, ref, stratosjobs.FastPathOptions{
+			Kind: "cf.app.delete",
+		})
+		if !res.Resolved {
+			return BulkItemResult{GUID: guid, State: bulkStatePending, Job: res.HandoffJob}
+		}
+		if res.State == stratosjobs.JobStateFailed {
+			itemErrors := make([]BulkItemError, 0, len(res.Errors))
+			for _, e := range res.Errors {
+				itemErrors = append(itemErrors, BulkItemError{Code: e.Code, Message: e.Message})
+			}
+			return BulkItemResult{GUID: guid, State: bulkStateFailed, Errors: itemErrors}
+		}
+		return BulkItemResult{GUID: guid, State: bulkStateComplete}
+	})
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, result)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_apps_bulk_writes_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_bulk_writes_test.go
@@ -1,0 +1,160 @@
+// src/jetstream/plugins/cloudfoundry/native_apps_bulk_writes_test.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBulkDeleteNativeApps_HappyPath verifies the handler issues one
+// DELETE /v3/apps/{guid} per requested guid, and — with the async-job
+// contract unwired, the tests' standing fallback — reports every accepted
+// delete as PENDING (no job) inside a 200 BulkResult envelope, in input
+// order.
+func TestBulkDeleteNativeApps_HappyPath(t *testing.T) {
+	var mu sync.Mutex
+	deleted := map[string]int{}
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"links":{}}`))
+			return
+		}
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.True(t, strings.HasPrefix(r.URL.Path, "/v3/apps/"), "unexpected path %s", r.URL.Path)
+		guid := strings.TrimPrefix(r.URL.Path, "/v3/apps/")
+		mu.Lock()
+		deleted[guid]++
+		mu.Unlock()
+		w.Header().Set("Location", "/v3/jobs/job-"+guid)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer capiServer.Close()
+
+	plugin := newBulkTestPlugin(capiServer.URL)
+	c, rec := newBulkContext("/cf/apps/:cnsiGuid/bulk/delete",
+		`{"guids":["app-1","app-2","app-3"]}`,
+		[]string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.bulkDeleteNativeApps(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, stratosSchemaVersion, rec.Header().Get("X-Stratos-Schema-Version"))
+
+	assert.Equal(t, map[string]int{"app-1": 1, "app-2": 1, "app-3": 1}, deleted)
+
+	var result BulkResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+	require.Len(t, result.Results, 3)
+	for i, guid := range []string{"app-1", "app-2", "app-3"} {
+		assert.Equal(t, guid, result.Results[i].GUID, "input order must be preserved")
+		assert.Equal(t, bulkStatePending, result.Results[i].State)
+		assert.Nil(t, result.Results[i].Job, "unwired-async fallback carries no handoff job")
+		assert.Empty(t, result.Results[i].Errors)
+	}
+	assert.Equal(t, 0, result.Succeeded)
+	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 3, result.Pending)
+}
+
+// TestBulkDeleteNativeApps_PartialFailure verifies a CF 404 on one guid
+// marks only that item FAILED — with the CF error envelope's title/detail
+// mapped into the per-item errors — while the other items proceed
+// unaffected and input order is preserved.
+func TestBulkDeleteNativeApps_PartialFailure(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"links":{}}`))
+			return
+		}
+		if r.URL.Path == "/v3/apps/missing" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"errors":[{"code":10010,"title":"CF-ResourceNotFound","detail":"App not found"}]}`))
+			return
+		}
+		w.Header().Set("Location", "/v3/jobs/job-1")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer capiServer.Close()
+
+	plugin := newBulkTestPlugin(capiServer.URL)
+	c, rec := newBulkContext("/cf/apps/:cnsiGuid/bulk/delete",
+		`{"guids":["app-1","missing","app-3"]}`,
+		[]string{"cnsiGuid"}, []string{"cnsi-1"})
+
+	require.NoError(t, plugin.bulkDeleteNativeApps(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var result BulkResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+	require.Len(t, result.Results, 3)
+
+	assert.Equal(t, "app-1", result.Results[0].GUID)
+	assert.Equal(t, bulkStatePending, result.Results[0].State)
+
+	assert.Equal(t, "missing", result.Results[1].GUID)
+	assert.Equal(t, bulkStateFailed, result.Results[1].State)
+	require.NotEmpty(t, result.Results[1].Errors)
+	assert.Equal(t, "CF-ResourceNotFound", result.Results[1].Errors[0].Code)
+	assert.Contains(t, result.Results[1].Errors[0].Message, "App not found")
+
+	assert.Equal(t, "app-3", result.Results[2].GUID)
+	assert.Equal(t, bulkStatePending, result.Results[2].State)
+
+	assert.Equal(t, 0, result.Succeeded)
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 2, result.Pending)
+}
+
+// TestBulkDeleteNativeApps_Validation verifies the shared body validation:
+// empty guids and oversized (> bulkMaxItems) guids both reject with 400
+// before any CF call is made.
+func TestBulkDeleteNativeApps_Validation(t *testing.T) {
+	capiHits := 0
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capiHits++
+		http.NotFound(w, r)
+	}))
+	defer capiServer.Close()
+
+	tooMany := make([]string, bulkMaxItems+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("app-%d", i)
+	}
+	tooManyBody, err := json.Marshal(map[string][]string{"guids": tooMany})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty guids", `{"guids":[]}`},
+		{"missing guids", `{}`},
+		{"too many guids", string(tooManyBody)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin := newBulkTestPlugin(capiServer.URL)
+			c, _ := newBulkContext("/cf/apps/:cnsiGuid/bulk/delete", tc.body,
+				[]string{"cnsiGuid"}, []string{"cnsi-1"})
+
+			err := plugin.bulkDeleteNativeApps(c)
+			require.Error(t, err)
+			httpErr, ok := err.(*echo.HTTPError)
+			require.True(t, ok, "expected *echo.HTTPError, got %T", err)
+			assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+		})
+	}
+	assert.Equal(t, 0, capiHits, "validation must reject before any CF call")
+}

--- a/src/jetstream/plugins/cloudfoundry/native_domains_share.go
+++ b/src/jetstream/plugins/cloudfoundry/native_domains_share.go
@@ -1,0 +1,52 @@
+// src/jetstream/plugins/cloudfoundry/native_domains_share.go
+package cloudfoundry
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// shareDomainOrgs handles
+// POST /pp/v1/cf/domains/{cnsiGuid}/{domainGuid}/relationships/shared_organizations
+// — the bulk "share this private domain with N organizations" action. Body is
+// the shared bulk shape {"guids": [orgGUID, ...]}.
+//
+// CF v3 exposes sharing as a single atomic call —
+// POST /v3/domains/{guid}/relationships/shared_organizations with a to-many
+// relationship body — so there is no fan-out here (unlike the routes bulk
+// handlers): one capi call shares the domain with every org at once and
+// returns the resulting to-many relationship (the full shared-org set). The
+// whole request succeeds or fails together; CF's error envelope flows through
+// handleCapiError unchanged.
+func (cf *CloudFoundrySpecification) shareDomainOrgs(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	domainGUID := c.Param("domainGuid")
+	if cnsiGUID == "" || domainGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and domainGuid are required")
+	}
+
+	orgGUIDs, err := decodeBulkGUIDs(c)
+	if err != nil {
+		return err
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	rel, shareErr := cfClient.Domains().ShareWithOrganization(reqCtx, domainGUID, orgGUIDs)
+	if shareErr != nil {
+		return handleCapiError(c, shareErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, rel)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_domains_share_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_domains_share_test.go
@@ -1,0 +1,131 @@
+// src/jetstream/plugins/cloudfoundry/native_domains_share_test.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newShareDomainContext builds an echo context for the bulk share handler
+// with a JSON {"guids":[...]} body and the cnsiGuid/domainGuid path params.
+func newShareDomainContext(e *echo.Echo, cnsiGUID, domainGUID, body string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost,
+		"/pp/v1/cf/domains/"+cnsiGUID+"/"+domainGUID+"/relationships/shared_organizations",
+		strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid", "domainGuid")
+	ctx.SetParamValues(cnsiGUID, domainGUID)
+	return ctx, rec
+}
+
+// shareDomainTestServer mimics CF v3's
+// POST /v3/domains/{guid}/relationships/shared_organizations. On success it
+// echoes the posted org GUIDs back as the resulting to-many relationship (CF
+// returns the full shared-org set). When failMsg is set it returns a 422 with
+// a CF error envelope so the handler's error path can be exercised.
+func shareDomainTestServer(t *testing.T, domainGUID, failMsg string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			_, _ = w.Write([]byte(`{"links":{}}`))
+		case "/v3/domains/" + domainGUID + "/relationships/shared_organizations":
+			if r.Method != http.MethodPost {
+				http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+				return
+			}
+			if failMsg != "" {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"errors":[{"code":10008,"title":"CF-UnprocessableEntity","detail":"` + failMsg + `"}]}`))
+				return
+			}
+			var body struct {
+				Data []struct {
+					GUID string `json:"guid"`
+				} `json:"data"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			// Echo the posted org GUIDs back as the relationship data.
+			out := map[string]interface{}{"data": body.Data}
+			_ = json.NewEncoder(w).Encode(out)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestShareDomainOrgs_Success(t *testing.T) {
+	const domainGUID = "dom-share-1"
+	ts := shareDomainTestServer(t, domainGUID, "")
+	defer ts.Close()
+
+	e := echo.New()
+	ctx, rec := newShareDomainContext(e, "test-cnsi", domainGUID, `{"guids":["org-a","org-b"]}`)
+	plugin := newDomainsPlugin(ts.URL)
+
+	require.NoError(t, plugin.shareDomainOrgs(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Data []struct {
+			GUID string `json:"guid"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	guids := make([]string, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		guids = append(guids, d.GUID)
+	}
+	assert.ElementsMatch(t, []string{"org-a", "org-b"}, guids,
+		"response should carry the resulting shared-org relationship")
+}
+
+func TestShareDomainOrgs_MissingParams(t *testing.T) {
+	e := echo.New()
+	ctx, _ := newShareDomainContext(e, "", "", `{"guids":["org-a"]}`)
+	plugin := newDomainsPlugin("http://unused")
+
+	err := plugin.shareDomainOrgs(ctx)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+}
+
+func TestShareDomainOrgs_EmptyGuids(t *testing.T) {
+	e := echo.New()
+	ctx, _ := newShareDomainContext(e, "test-cnsi", "dom-x", `{"guids":[]}`)
+	plugin := newDomainsPlugin("http://unused")
+
+	err := plugin.shareDomainOrgs(ctx)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+}
+
+func TestShareDomainOrgs_CapiError(t *testing.T) {
+	const domainGUID = "dom-share-err"
+	ts := shareDomainTestServer(t, domainGUID, "cannot share internal domain")
+	defer ts.Close()
+
+	e := echo.New()
+	ctx, rec := newShareDomainContext(e, "test-cnsi", domainGUID, `{"guids":["org-a"]}`)
+	plugin := newDomainsPlugin(ts.URL)
+
+	// handleCapiError writes the response directly and returns nil.
+	require.NoError(t, plugin.shareDomainOrgs(ctx))
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "cannot share internal domain")
+}

--- a/src/jetstream/plugins/cloudfoundry/native_isolation_segments_bulk.go
+++ b/src/jetstream/plugins/cloudfoundry/native_isolation_segments_bulk.go
@@ -1,0 +1,54 @@
+// src/jetstream/plugins/cloudfoundry/native_isolation_segments_bulk.go
+package cloudfoundry
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// entitleIsolationSegmentOrgs handles POST
+// /pp/v1/cf/isolation_segments/{cnsiGuid}/{isoGuid}/relationships/organizations —
+// Stratos bulk wrapper around CF V3 POST
+// /v3/isolation_segments/{guid}/relationships/organizations. Entitles one
+// isolation segment to N target organizations in a single request.
+//
+// Unlike the fan-out bulk endpoints in native_bulk.go, CF exposes entitlement
+// as one to-many relationship write, so a single capi call carries all the
+// org GUIDs. The body is the shared {"guids": [...]} shape decoded by
+// decodeBulkGUIDs; each GUID becomes an entitled-organization relationship.
+//
+// Response is the CF relationships envelope (capi.ToManyRelationship =
+// {data:[{guid}]}), returned as-is with a schema-version header — matching
+// shareServiceInstanceSpaces / applyOrgQuotaToOrgs.
+func (cf *CloudFoundrySpecification) entitleIsolationSegmentOrgs(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	isoGUID := c.Param("isoGuid")
+	if cnsiGUID == "" || isoGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and isoGuid are required")
+	}
+
+	orgGUIDs, err := decodeBulkGUIDs(c)
+	if err != nil {
+		return err
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	rel, entitleErr := cfClient.IsolationSegments().EntitleOrganizations(reqCtx, isoGUID, orgGUIDs)
+	if entitleErr != nil {
+		return handleCapiError(c, entitleErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, rel)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_isolation_segments_bulk_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_isolation_segments_bulk_test.go
@@ -1,0 +1,130 @@
+// src/jetstream/plugins/cloudfoundry/native_isolation_segments_bulk_test.go
+package cloudfoundry
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newEntitleContext builds an echo context for the isolation-segment
+// entitle-organizations route with the given JSON body, matching how
+// native_routes.go registers the handler.
+func newEntitleContext(e *echo.Echo, body string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost,
+		"/pp/v1/cf/isolation_segments/cnsi-1/iso-1/relationships/organizations",
+		strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/pp/v1/cf/isolation_segments/:cnsiGuid/:isoGuid/relationships/organizations")
+	c.SetParamNames("cnsiGuid", "isoGuid")
+	c.SetParamValues("cnsi-1", "iso-1")
+	return c, rec
+}
+
+// TestEntitleIsolationSegmentOrgs_Success verifies the handler POSTs the
+// target-org relationships to
+// /v3/isolation_segments/{guid}/relationships/organizations and returns the
+// CF to-many relationship envelope as 200 JSON.
+func TestEntitleIsolationSegmentOrgs_Success(t *testing.T) {
+	capiCalls := 0
+	var gotBody string
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"links":{}}`))
+			return
+		}
+		capiCalls++
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v3/isolation_segments/iso-1/relationships/organizations", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"guid":"org-a"},{"guid":"org-b"}]}`))
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	e := echo.New()
+	c, rec := newEntitleContext(e, `{"guids":["org-a","org-b"]}`)
+
+	require.NoError(t, plugin.entitleIsolationSegmentOrgs(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, capiCalls)
+	// The org GUIDs are marshalled as to-many relationship data entries.
+	assert.Contains(t, gotBody, `"guid":"org-a"`)
+	assert.Contains(t, gotBody, `"guid":"org-b"`)
+	// The CF relationships envelope is passed through to the client.
+	assert.Contains(t, rec.Body.String(), `"guid":"org-a"`)
+	assert.NotEmpty(t, rec.Header().Get("X-Stratos-Schema-Version"))
+}
+
+// TestEntitleIsolationSegmentOrgs_PropagatesCapiError verifies a non-2xx CF
+// error flows through handleCapiError — e.g. the 422 CF returns when an org
+// GUID is invalid or already entitled.
+func TestEntitleIsolationSegmentOrgs_PropagatesCapiError(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"links":{}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":[{"code":10008,"title":"CF-UnprocessableEntity","detail":"cannot entitle organization to isolation segment"}]}`))
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	e := echo.New()
+	c, rec := newEntitleContext(e, `{"guids":["org-a"]}`)
+
+	require.NoError(t, plugin.entitleIsolationSegmentOrgs(c))
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "UnprocessableEntity")
+}
+
+// TestEntitleIsolationSegmentOrgs_RejectsEmptyGUIDs verifies the shared
+// decodeBulkGUIDs validation rejects an empty guids list before any CF call.
+func TestEntitleIsolationSegmentOrgs_RejectsEmptyGUIDs(t *testing.T) {
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1"},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	e := echo.New()
+	c, _ := newEntitleContext(e, `{"guids":[]}`)
+
+	err := plugin.entitleIsolationSegmentOrgs(c)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_routes.go
+++ b/src/jetstream/plugins/cloudfoundry/native_routes.go
@@ -36,6 +36,18 @@ func (c *CloudFoundrySpecification) addNativeRoutes(echoGroup *echo.Group) {
 	// per-item outcomes in a BulkResult envelope.
 	nativeGroup.POST("/cf/routes/:cnsiGuid/bulk/delete", c.bulkDeleteNativeRoutes)
 	nativeGroup.POST("/cf/routes/:cnsiGuid/bulk/unmap", c.bulkUnmapNativeRoutes)
+	// Bulk apps delete: fan-out N DELETE /v3/apps/:guid (mirrors routes bulk).
+	nativeGroup.POST("/cf/apps/:cnsiGuid/bulk/delete", c.bulkDeleteNativeApps)
+	// Bulk "apply source entity to N targets" — CF v3 relationship endpoints
+	// that accept the target GUID array natively (single passthrough call,
+	// body {"guids":[...]}). Org/space quota + plan visibility already exist
+	// above (applyOrgQuotaToOrgs / applySpaceQuotaToSpaces /
+	// applyNativeServicePlanVisibility); these add the remaining four.
+	nativeGroup.POST("/cf/isolation_segments/:cnsiGuid/:isoGuid/relationships/organizations", c.entitleIsolationSegmentOrgs)
+	nativeGroup.POST("/cf/service_instances/:cnsiGuid/:siGuid/relationships/shared_spaces", c.shareServiceInstanceSpaces)
+	nativeGroup.POST("/cf/security_groups/:cnsiGuid/:sgGuid/relationships/running_spaces", c.bindSecurityGroupRunningSpaces)
+	nativeGroup.POST("/cf/security_groups/:cnsiGuid/:sgGuid/relationships/staging_spaces", c.bindSecurityGroupStagingSpaces)
+	nativeGroup.POST("/cf/domains/:cnsiGuid/:domainGuid/relationships/shared_organizations", c.shareDomainOrgs)
 	nativeGroup.POST("/cf/routes/:cnsiGuid/:routeGuid/unmap_all", c.unmapAllRouteDestinations)
 	nativeGroup.POST("/cf/service_bindings/:cnsiGuid", c.createServiceBinding)
 	nativeGroup.DELETE("/cf/service_bindings/:cnsiGuid/:bindingGuid", c.deleteServiceBinding)

--- a/src/jetstream/plugins/cloudfoundry/native_security_groups_bulk.go
+++ b/src/jetstream/plugins/cloudfoundry/native_security_groups_bulk.go
@@ -1,0 +1,83 @@
+// src/jetstream/plugins/cloudfoundry/native_security_groups_bulk.go
+package cloudfoundry
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/fivetwenty-io/capi/v3/pkg/capi"
+	"github.com/labstack/echo/v4"
+)
+
+// securityGroupSpaceBinder is the capi call shared by the running- and
+// staging-space bulk-bind handlers: both take the security group GUID and the
+// list of space GUIDs and return the resulting to-many relationship. Passing
+// the bind function in keeps the two handlers a one-line dispatch apart —
+// running vs staging is purely which CF sub-resource the call targets.
+type securityGroupSpaceBinder func(ctx context.Context, sgGUID string, spaceGUIDs []string) (*capi.ToManyRelationship, error)
+
+// bindSecurityGroupRunningSpaces handles
+// POST /pp/v1/cf/security_groups/{cnsiGuid}/{sgGuid}/relationships/running_spaces
+// — bulk-bind a security group to N spaces for the running lifecycle.
+//
+// Body: {"guids": [spaceGUID, ...]}. Unlike the route bulk endpoints, CF v3
+// exposes a single batch relationship endpoint here, so there is no fan-out:
+// one synchronous POST /v3/security_groups/{guid}/relationships/running_spaces
+// applies every space at once and returns the full to-many relationship,
+// which we pass through as the 200 body (mirrors applyOrgQuotaToOrgs).
+func (c *CloudFoundrySpecification) bindSecurityGroupRunningSpaces(ctx echo.Context) error {
+	return c.bindSecurityGroupSpaces(ctx, func(reqCtx context.Context, cfClient capi.Client, sgGUID string, spaceGUIDs []string) (*capi.ToManyRelationship, error) {
+		return cfClient.SecurityGroups().BindRunningSpaces(reqCtx, sgGUID, spaceGUIDs)
+	})
+}
+
+// bindSecurityGroupStagingSpaces handles
+// POST /pp/v1/cf/security_groups/{cnsiGuid}/{sgGuid}/relationships/staging_spaces
+// — bulk-bind a security group to N spaces for the staging lifecycle. The
+// staging analogue of bindSecurityGroupRunningSpaces; identical shape, it
+// targets CF's staging_spaces relationship instead.
+func (c *CloudFoundrySpecification) bindSecurityGroupStagingSpaces(ctx echo.Context) error {
+	return c.bindSecurityGroupSpaces(ctx, func(reqCtx context.Context, cfClient capi.Client, sgGUID string, spaceGUIDs []string) (*capi.ToManyRelationship, error) {
+		return cfClient.SecurityGroups().BindStagingSpaces(reqCtx, sgGUID, spaceGUIDs)
+	})
+}
+
+// bindSecurityGroupSpaces is the shared body of the running/staging bulk-bind
+// handlers: validate params + {"guids":[...]} body, resolve the capi client,
+// invoke the supplied bind function, and pass the resulting relationship
+// through. The bind closure receives the resolved client so the two variants
+// differ only by which SecurityGroups() bind method they call.
+func (c *CloudFoundrySpecification) bindSecurityGroupSpaces(
+	ctx echo.Context,
+	bind func(reqCtx context.Context, cfClient capi.Client, sgGUID string, spaceGUIDs []string) (*capi.ToManyRelationship, error),
+) error {
+	cnsiGUID := ctx.Param("cnsiGuid")
+	sgGUID := ctx.Param("sgGuid")
+	if cnsiGUID == "" || sgGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and sgGuid are required")
+	}
+
+	spaceGUIDs, err := decodeBulkGUIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	userGUID, err := c.getUserGUID(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := ctx.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, c.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	rel, bindErr := bind(reqCtx, cfClient, sgGUID, spaceGUIDs)
+	if bindErr != nil {
+		return handleCapiError(ctx, bindErr)
+	}
+
+	ctx.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return ctx.JSON(http.StatusOK, rel)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_security_groups_bulk_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_security_groups_bulk_test.go
@@ -1,0 +1,162 @@
+// src/jetstream/plugins/cloudfoundry/native_security_groups_bulk_test.go
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/fivetwenty-io/capi/v3/pkg/capi"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// securityGroupBulkVariant captures the two lifecycle variants so the
+// running- and staging-space handlers are exercised by the same table: only
+// the handler under test and the CF relationship sub-path differ.
+type securityGroupBulkVariant struct {
+	name    string
+	relPath string // CF v3 relationship sub-path: running_spaces | staging_spaces
+	handler func(*CloudFoundrySpecification) echo.HandlerFunc
+}
+
+var securityGroupBulkVariants = []securityGroupBulkVariant{
+	{
+		name:    "running",
+		relPath: "/v3/security_groups/sg-1/relationships/running_spaces",
+		handler: func(p *CloudFoundrySpecification) echo.HandlerFunc { return p.bindSecurityGroupRunningSpaces },
+	},
+	{
+		name:    "staging",
+		relPath: "/v3/security_groups/sg-1/relationships/staging_spaces",
+		handler: func(p *CloudFoundrySpecification) echo.HandlerFunc { return p.bindSecurityGroupStagingSpaces },
+	},
+}
+
+// TestBindSecurityGroupSpaces_HappyPath verifies both variants POST the space
+// GUIDs as a {"data":[{"guid":...}]} relationship body to the correct CF
+// relationship sub-resource and pass the returned to-many relationship
+// through as a 200 body.
+func TestBindSecurityGroupSpaces_HappyPath(t *testing.T) {
+	for _, v := range securityGroupBulkVariants {
+		t.Run(v.name, func(t *testing.T) {
+			var gotBody string
+			capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v3" {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"links":{}}`))
+					return
+				}
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, v.relPath, r.URL.Path)
+				body, _ := io.ReadAll(r.Body)
+				gotBody = string(body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"data":[{"guid":"space-1"},{"guid":"space-2"}]}`))
+			}))
+			defer capiServer.Close()
+
+			plugin := newBulkTestPlugin(capiServer.URL)
+			c, rec := newSecurityGroupBulkContext(v.relPath,
+				`{"guids":["space-1","space-2"]}`)
+
+			require.NoError(t, v.handler(plugin)(c))
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, stratosSchemaVersion, rec.Header().Get("X-Stratos-Schema-Version"))
+
+			assert.JSONEq(t, `{"data":[{"guid":"space-1"},{"guid":"space-2"}]}`, gotBody,
+				"space GUIDs must be sent as a to-many relationship body")
+
+			var rel capi.ToManyRelationship
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rel))
+			require.Len(t, rel.Data, 2)
+			assert.Equal(t, "space-1", rel.Data[0].GUID)
+			assert.Equal(t, "space-2", rel.Data[1].GUID)
+		})
+	}
+}
+
+// TestBindSecurityGroupSpaces_PropagatesCapiError verifies an upstream CF
+// error flows through handleCapiError (status mirrored, envelope preserved)
+// for both variants rather than surfacing as a bare 500.
+func TestBindSecurityGroupSpaces_PropagatesCapiError(t *testing.T) {
+	for _, v := range securityGroupBulkVariants {
+		t.Run(v.name, func(t *testing.T) {
+			capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v3" {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`{"links":{}}`))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				w.Write([]byte(`{"errors":[{"code":10008,"title":"CF-UnprocessableEntity","detail":"Space not found"}]}`))
+			}))
+			defer capiServer.Close()
+
+			plugin := newBulkTestPlugin(capiServer.URL)
+			c, rec := newSecurityGroupBulkContext(v.relPath,
+				`{"guids":["missing-space"]}`)
+
+			require.NoError(t, v.handler(plugin)(c))
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Contains(t, rec.Body.String(), "UnprocessableEntity")
+			assert.Contains(t, rec.Body.String(), "Space not found")
+		})
+	}
+}
+
+// TestBindSecurityGroupSpaces_Validation verifies the shared {"guids":[...]}
+// body validation: empty and missing guids reject with 400 before any CF
+// call, for both variants.
+func TestBindSecurityGroupSpaces_Validation(t *testing.T) {
+	capiHits := 0
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capiHits++
+		http.NotFound(w, r)
+	}))
+	defer capiServer.Close()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty guids", `{"guids":[]}`},
+		{"missing guids", `{}`},
+	}
+
+	for _, v := range securityGroupBulkVariants {
+		for _, tc := range cases {
+			t.Run(v.name+"/"+tc.name, func(t *testing.T) {
+				plugin := newBulkTestPlugin(capiServer.URL)
+				c, _ := newSecurityGroupBulkContext(v.relPath, tc.body)
+
+				err := v.handler(plugin)(c)
+				require.Error(t, err)
+				httpErr, ok := err.(*echo.HTTPError)
+				require.True(t, ok, "expected *echo.HTTPError, got %T", err)
+				assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+			})
+		}
+	}
+	assert.Equal(t, 0, capiHits, "validation must reject before any CF call")
+}
+
+// newSecurityGroupBulkContext builds an echo context for a security-group
+// bulk-bind POST with cnsiGuid=cnsi-1 and sgGuid=sg-1 path params (the sibling
+// newBulkContext only wires cnsiGuid).
+func newSecurityGroupBulkContext(relPath, body string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/pp/v1"+relPath, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("cnsiGuid", "sgGuid")
+	c.SetParamValues("cnsi-1", "sg-1")
+	return c, rec
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_instance_share.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instance_share.go
@@ -1,0 +1,64 @@
+// src/jetstream/plugins/cloudfoundry/native_service_instance_share.go
+package cloudfoundry
+
+import (
+	"net/http"
+
+	"github.com/fivetwenty-io/capi/v3/pkg/capi"
+	"github.com/labstack/echo/v4"
+)
+
+// shareServiceInstanceSpaces handles POST
+// /pp/v1/cf/service_instances/{cnsiGuid}/{siGuid}/relationships/shared_spaces —
+// Stratos bulk wrapper around CF V3 POST
+// /v3/service_instances/{guid}/relationships/shared_spaces. Shares one
+// service instance with N target spaces in a single request.
+//
+// Unlike the fan-out bulk endpoints in native_bulk.go, CF exposes sharing
+// as one to-many relationship write, so a single capi call carries all the
+// space GUIDs. The body is the shared {"guids": [...]} shape decoded by
+// decodeBulkGUIDs; each GUID becomes a target-space relationship.
+//
+// Response is the CF shared-spaces relationships envelope
+// (capi.ServiceInstanceSharedSpacesRelationships = {data:[{guid}], links}),
+// returned as-is with a schema-version header — matching applyOrgQuotaToOrgs.
+func (cf *CloudFoundrySpecification) shareServiceInstanceSpaces(c echo.Context) error {
+	cnsiGUID := c.Param("cnsiGuid")
+	siGUID := c.Param("siGuid")
+	if cnsiGUID == "" || siGUID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "cnsiGuid and siGuid are required")
+	}
+
+	spaceGUIDs, err := decodeBulkGUIDs(c)
+	if err != nil {
+		return err
+	}
+
+	userGUID, err := cf.getUserGUID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "could not determine user")
+	}
+
+	reqCtx := c.Request().Context()
+	cfClient, err := newCapiClient(reqCtx, cf.nativeProxy(), cnsiGUID, userGUID)
+	if err != nil {
+		return err
+	}
+
+	shareReq := &capi.ServiceInstanceShareRequest{
+		Data: make([]capi.Relationship, 0, len(spaceGUIDs)),
+	}
+	for _, g := range spaceGUIDs {
+		shareReq.Data = append(shareReq.Data, capi.Relationship{
+			Data: &capi.RelationshipData{GUID: g},
+		})
+	}
+
+	rel, shareErr := cfClient.ServiceInstances().ShareWithSpaces(reqCtx, siGUID, shareReq)
+	if shareErr != nil {
+		return handleCapiError(c, shareErr)
+	}
+
+	c.Response().Header().Set("X-Stratos-Schema-Version", stratosSchemaVersion)
+	return c.JSON(http.StatusOK, rel)
+}

--- a/src/jetstream/plugins/cloudfoundry/native_service_instance_share_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_service_instance_share_test.go
@@ -1,0 +1,135 @@
+// src/jetstream/plugins/cloudfoundry/native_service_instance_share_test.go
+package cloudfoundry
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newShareContext builds an echo context for the shared_spaces route with the
+// given JSON body, matching how native_routes.go registers the handler.
+func newShareContext(e *echo.Echo, body string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost,
+		"/pp/v1/cf/service_instances/cnsi-1/si-1/relationships/shared_spaces",
+		strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/pp/v1/cf/service_instances/:cnsiGuid/:siGuid/relationships/shared_spaces")
+	c.SetParamNames("cnsiGuid", "siGuid")
+	c.SetParamValues("cnsi-1", "si-1")
+	return c, rec
+}
+
+// TestShareServiceInstanceSpaces_Success verifies the handler POSTs the
+// target-space relationships to
+// /v3/service_instances/{guid}/relationships/shared_spaces and returns the
+// CF shared-spaces relationships envelope as 200 JSON.
+func TestShareServiceInstanceSpaces_Success(t *testing.T) {
+	capiCalls := 0
+	var gotBody string
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"links":{}}`))
+			return
+		}
+		capiCalls++
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v3/service_instances/si-1/relationships/shared_spaces", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"guid":"space-a"},{"guid":"space-b"}],"links":{"self":{"href":"/v3/service_instances/si-1/relationships/shared_spaces"}}}`))
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	e := echo.New()
+	c, rec := newShareContext(e, `{"guids":["space-a","space-b"]}`)
+
+	require.NoError(t, plugin.shareServiceInstanceSpaces(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, capiCalls)
+	// The space GUIDs are marshalled as to-many relationship data entries.
+	assert.Contains(t, gotBody, `"guid":"space-a"`)
+	assert.Contains(t, gotBody, `"guid":"space-b"`)
+	// The CF relationships envelope is passed through to the client. Guid
+	// fidelity *within* the envelope is the typed capi client's concern — CF
+	// models shared_spaces entries as bare {guid}, which the client round-trips
+	// through its ServiceInstanceSharedSpacesRelationships type; the handler
+	// forwards whatever capi returns and the frontend refetches rather than
+	// consuming this body. Assert the envelope (its self link) is passed
+	// through, not the client's internal guid modelling.
+	assert.Contains(t, rec.Body.String(), `shared_spaces`)
+	assert.NotEmpty(t, rec.Header().Get("X-Stratos-Schema-Version"))
+}
+
+// TestShareServiceInstanceSpaces_PropagatesCapiError verifies a non-2xx CF
+// error flows through handleCapiError — e.g. the 422 CF returns when a target
+// space already has the instance shared or the space is invalid.
+func TestShareServiceInstanceSpaces_PropagatesCapiError(t *testing.T) {
+	capiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"links":{}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":[{"code":10008,"title":"CF-UnprocessableEntity","detail":"cannot share service instance with space"}]}`))
+	}))
+	defer capiServer.Close()
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1", APIEndpoint: mustParseURL(capiServer.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	e := echo.New()
+	c, rec := newShareContext(e, `{"guids":["space-a"]}`)
+
+	require.NoError(t, plugin.shareServiceInstanceSpaces(c))
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "UnprocessableEntity")
+}
+
+// TestShareServiceInstanceSpaces_RejectsEmptyGUIDs verifies the shared
+// decodeBulkGUIDs validation rejects an empty guids list before any CF call.
+func TestShareServiceInstanceSpaces_RejectsEmptyGUIDs(t *testing.T) {
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "cnsi-1"},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	e := echo.New()
+	c, _ := newShareContext(e, `{"guids":[]}`)
+
+	err := plugin.shareServiceInstanceSpaces(c)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+}


### PR DESCRIPTION
## Why

The CF console's multi-select bulk operations had been eroded over successive
migrations — several were lost entirely and kept being re-classified as
"greenfield" and deferred. This restores the full set and, critically, adds a
guard test to each so a future rewrite or force-push can't silently drop them
again (the tripwire that was missing every prior time).

Routes (Unmap/Delete) and Users (Manage Roles) bulk already existed and are
untouched. This PR covers the remaining eight surfaces.

## What

**Backend** (`src/jetstream/plugins/cloudfoundry/`)
- Apps bulk delete: `POST /cf/apps/:cnsi/bulk/delete` — fan-out N
  `Apps().Delete` via the shared `bulkFanout` (mirrors routes bulk), per-item
  `BulkResult`.
- Single relationship-array passthroughs (CF accepts the target GUID array
  natively): isolation segment entitle orgs, service instance share spaces,
  security group bind running/staging spaces, private domain share orgs. Body
  is the shared `{"guids":[...]}` shape via `decodeBulkGUIDs`.
- Org/space quota apply and service-plan visibility already had endpoints.
- Each handler has table tests (success, CF-error propagation, body validation).

**Frontend** (`src/frontend/packages/cloud-foundry/`)
- Space Apps tab: checkbox column + bulk Delete.
- Org/Space Quota detail: "Apply to organizations/spaces" multi-select dialogs.
- Service Instance detail: "Share to spaces" (managed-only).
- Security Groups tab: per-row "Bind to spaces" (running/staging).
- Service plan visibility: a new self-contained multi-org apply editor.
- Isolation segment / private domain: service method + multi-select dialog,
  built and unit-guarded but not yet mounted (those entities have no
  management page) — tracked in #5663.

Every surface ships a guard unit test that fails if the affordance is removed.

## Verification

- Backend: `CGO_ENABLED=0 go build ./...`, `go vet`, `gofmt` all clean; all new
  handler tests pass.
- Frontend: 60 guard/dialog unit tests pass; Angular AOT build clean (0 errors).

## Follow-up

- #5663 — host pages for isolation segments, private domains, and plan
  visibility so their (already-built) dialogs become reachable.
