### PR TITLE
fix(log-viewer): increase maxLogLines buffer limit and make it a configurable Input

### DIFF
--- a/src/frontend/packages/core/src/shared/components/log-viewer/log-viewer.component.ts
+++ b/src/frontend/packages/core/src/shared/components/log-viewer/log-viewer.component.ts
@@ -86,7 +86,7 @@ export class LogViewerComponent implements OnInit, OnDestroy {
   private maxReconnectAttempts = 5;
   private lastConnectionError: ConnectionErrorInfo | null = null;
 
-  public maxLogLines = 1000;
+  @Input() maxLogLines = 10000;
   public isHighThroughput$!: Observable<boolean>;
   public isLocked$!: Observable<boolean>;
   public statusMessage$ = new BehaviorSubject<LogStreamMessage>({ message: '' });


### PR DESCRIPTION
Fixes #5537. The Log Viewer component previously capped stored log lines at a hardcoded limit of 1000 lines. This PR adds the @Input() decorator to maxLogLines and increases the default buffer limit to 10000 lines.