### PR TITLE
Fix CF vitest async leaks behind the intermittent gate hang; restore CodeQL on PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,10 +5,13 @@ on:
     branches:
       - develop
       - main
+  pull_request:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:  # on-demand: Actions tab "Run workflow" or `gh workflow run codeql.yml --ref develop`
   schedule:
     - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC — catches advisories on idle branches
-  # No pull_request trigger: CodeQL scans the default branch on merge + weekly,
-  # not every PR — the per-PR analyze jobs added ~3-4 min for redundant coverage.
 
 permissions:
   contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,13 @@ on:
       - develop
       - main
 
+# One live run per ref: a push to a PR branch (or develop/main) cancels the
+# in-flight run for the same ref, so overlapping runs never contend for
+# runners and only the newest commit is gated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # pull-requests: read is required by dorny/paths-filter, which lists a
 # PR's changed files through the API.
 permissions:

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-base/cloud-foundry-cell-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-base/cloud-foundry-cell-base.component.ts
@@ -68,7 +68,9 @@ export class CloudFoundryCellBaseComponent {
       startWith(true)
     );
     this.name$ = cfCellService.cellMetric$.pipe(
-      map(metric => `${metric.bosh_job_id}`)
+      // The metric can emit null before the cell metric resolves; a bare
+      // deref threw an unhandled TypeError inside the rxjs map.
+      map(metric => `${metric?.bosh_job_id ?? ''}`)
     );
 
     this.breadcrumbs$ = cfEndpointService.endpoint$.pipe(

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { of, Subject, throwError } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
@@ -38,6 +38,12 @@ function makeSvc(http: HttpClient, cf?: CloudFoundryService): CfAppsSignalConfig
 }
 
 beforeEach(() => TestBed.resetTestingModule());
+// Destroy the LAST test's module too — beforeEach alone leaves the final
+// module (and any live stats timer/effects on its injector) alive until
+// worker shutdown. resetTestingModule() destroys the module injector, which
+// fires the service's destroyRef.onDestroy cleanup (clearInterval + effect
+// destroys).
+afterEach(() => TestBed.resetTestingModule());
 
 describe('CfAppsSignalConfigService', () => {
   it('constructs one CnsiAppsSource per connected CF in scope', () => {

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -70,6 +70,11 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
 
   private enterData: any;
   private snackBarRef!: TailwindSnackBarRef<any>;
+  // First-step unblock poller (see setActive). Held as a field so destroy can
+  // clear it — a local timer kept ticking after teardown and then called
+  // afterNextRender against a destroyed injector (NG0205).
+  private firstStepTimer?: ReturnType<typeof setInterval>;
+  private isDestroyed = false;
 
   // Signal (read directly in the template as currentIndex()) so the action
   // buttons' [disabled]/text bindings re-render under zoneless CD when the
@@ -103,6 +108,8 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
   ngOnInit() { }
 
   ngOnDestroy() {
+    this.isDestroyed = true;
+    clearInterval(this.firstStepTimer);
     this.hiddenSubs.forEach(sub => sub.unsubscribe());
     this.unsubscribeNext();
     if (this.snackBarRef) {
@@ -285,7 +292,12 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
           // wizards) receive the enter callback — the legacy onEnter @Input
           // defaults to a no-op so a raw step.onEnter call swallows
           // signalHandle.onEnter.
-          const timer = setInterval(() => {
+          clearInterval(this.firstStepTimer);
+          this.firstStepTimer = setInterval(() => {
+            if (this.isDestroyed) {
+              clearInterval(this.firstStepTimer);
+              return;
+            }
             if (this.allSteps[index].blocked === false) {
               const step = this.allSteps[index];
               step.active = true;
@@ -296,7 +308,7 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
               // afterNextRender waits on.
               this.cdr.markForCheck();
               afterNextRender(() => step.pOnEnter(this.enterData), { injector: this.injector });
-              clearInterval(timer);
+              clearInterval(this.firstStepTimer);
             }
           }, 5);
         }


### PR DESCRIPTION
The cloud-foundry vitest project intermittently hung a fork worker for ~17 minutes, blowing the PR gate from ~20 to 34+ minutes. Running the project without --dangerouslyIgnoreUnhandledErrors surfaced 21 unhandled errors that the gate flag normally swallows; 20 of them shared one root cause.

**Stepper first-step poller leak (20/21 errors).** The steppers component starts a 5ms setInterval waiting for the first step to unblock, held only in a local variable. It was never cleared on destroy: if the step never unblocked it polled forever, and a tick after teardown called afterNextRender against a destroyed injector (NG0205: Injector has already been destroyed). Every wizard-hosting spec (application-delete, detach-service-instance, add-service-instance, edit-space, edit-organization, add-quota, add-organization) surfaced it. The same pattern would throw in production on a fast navigate-away from any wizard. The timer is now a field, cleared in ngOnDestroy, with a destroyed-check in the tick. The interval polling created enough stray async under the shared 3-worker fork pool to intermittently wedge a worker — the spec that happened to be mid-beforeEach then ate the 15s hook timeout and the worker never recovered.

**Cell metric null deref (1/21).** cloud-foundry-cell-base mapped `metric.bosh_job_id` without a null guard while the adjacent isLoading$ pipe already defends the same stream. Now `metric?.bosh_job_id ?? ''`.

**Spec teardown.** cf-apps-signal-config.service.spec reset TestBed only in beforeEach, so the last test's module (with live stats timer/effects) survived until worker shutdown. Added the afterEach reset; the service's existing DestroyRef cleanup does the rest.

Verified with three consecutive full cloud-foundry runs: 1745 passed, exit 0, zero unhandled errors (previously 21 errors, exit 1).

**CI changes**
- codeql.yml: restore the push + pull_request triggers. CodeQL was removed from PRs on the theory it was involved in the gate slowness; the investigation above exonerated it (its job consistently finished in ~3 minutes), so PRs get scanned again. The workflow_dispatch trigger is kept for on-demand runs.
- pr.yml: add a per-ref concurrency group with cancel-in-progress, so a push while a gate is running cancels the stale run instead of contending with it for runners.