### PR TITLE
feat(security)(jetstream): optional opt-in Content-Security-Policy header (CONSOLE_CSP)

### DIFF
--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -440,6 +440,7 @@ type PortalConfig struct {
 	CFClient                           string   `configName:"CF_CLIENT"`
 	CFClientSecret                     string   `configName:"CF_CLIENT_SECRET"`
 	AllowedOrigins                     []string `configName:"ALLOWED_ORIGINS"`
+	CSPPolicy                          string   `configName:"CONSOLE_CSP"`
 	SessionStoreSecret                 string   `configName:"SESSION_STORE_SECRET"`
 	EncryptionKeyVolume                string   `configName:"ENCRYPTION_KEY_VOLUME"`
 	EncryptionKeyFilename              string   `configName:"ENCRYPTION_KEY_FILENAME"`

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -80,6 +80,30 @@ const (
 	defaultSessionSecret = "wheeee!"
 )
 
+// defaultCSPPolicy is the Content-Security-Policy applied when CONSOLE_CSP is
+// set to "default" (or "on"). CSP is opt-in: with CONSOLE_CSP unset, no header
+// is emitted (preserving prior behavior). It is scoped to what the Stratos SPA
+// needs:
+//   - default/script/connect from same origin ('self'); WebSockets for the
+//     backend log/stream endpoints (ws:/wss:)
+//   - 'unsafe-inline' styles: Angular + the index.html loading splash inject
+//     inline <style>; Google Fonts stylesheet is allowed
+//   - data: images/fonts (inlined icons) and Google Fonts font files
+//   - worker-src blob: — the Monaco editor spins up its language web-workers
+//     from blob URLs
+//   - frame-ancestors 'self' mirrors the existing X-Frame-Options: SAMEORIGIN
+// Operators can instead set CONSOLE_CSP to a full policy string to use verbatim.
+const defaultCSPPolicy = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+	"font-src 'self' data: https://fonts.gstatic.com; " +
+	"img-src 'self' data:; " +
+	"connect-src 'self' ws: wss:; " +
+	"worker-src 'self' blob:; " +
+	"frame-ancestors 'self'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'"
+
 var appVersion string
 var buildDate string
 var gitCommit string
@@ -615,6 +639,26 @@ func loadPortalConfig(pc api.PortalConfig, env *env.VarSet) (api.PortalConfig, e
 	}
 
 	log.Debugf("Portal config auth endpoint type initialised to: %v", pc.AuthEndpointType)
+
+	// Content Security Policy (opt-in). To preserve existing behavior, no CSP
+	// header is emitted unless CONSOLE_CSP opts in. Recognized values:
+	//   - "default" / "on" -> apply the built-in defaultCSPPolicy (scoped to
+	//     what the Stratos SPA + Monaco editor need)
+	//   - "" / "off" / "none" / "false" / "disabled" -> no header (default)
+	//   - anything else -> treated as a full policy string, used verbatim
+	// The explicit off-values are normalized to "" so a well-meaning
+	// CONSOLE_CSP=off never leaks as a literal Content-Security-Policy value.
+	switch {
+	case strings.EqualFold(pc.CSPPolicy, "default"), strings.EqualFold(pc.CSPPolicy, "on"):
+		pc.CSPPolicy = defaultCSPPolicy
+	case pc.CSPPolicy == "",
+		strings.EqualFold(pc.CSPPolicy, "off"),
+		strings.EqualFold(pc.CSPPolicy, "none"),
+		strings.EqualFold(pc.CSPPolicy, "false"),
+		strings.EqualFold(pc.CSPPolicy, "disabled"):
+		pc.CSPPolicy = ""
+	}
+
 	return pc, nil
 }
 
@@ -811,6 +855,12 @@ func start(config api.PortalConfig, p *portalProxy, needSetupMiddleware bool, is
 	}))
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
 		XFrameOptions: "SAMEORIGIN",
+		// Content Security Policy (opt-in via CONSOLE_CSP). Empty by default,
+		// so no CSP header is emitted unless an operator opts in — Echo's
+		// Secure middleware skips the header when this is "". CONSOLE_CSP may
+		// be "default"/"on" (built-in defaultCSPPolicy) or a full policy
+		// string; see loadPortalConfig.
+		ContentSecurityPolicy: config.CSPPolicy,
 	}))
 
 	if !isUpgrade {

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -84,8 +84,8 @@ const (
 // set to "default" (or "on"). CSP is opt-in: with CONSOLE_CSP unset, no header
 // is emitted (preserving prior behavior). It is scoped to what the Stratos SPA
 // needs:
-//   - default/script/connect from same origin ('self'); WebSockets for the
-//     backend log/stream endpoints (ws:/wss:)
+//   - default/script/connect from same origin ('self'); same-origin 'self'
+//     also permits the backend log/stream WebSockets (wss:// on the HTTPS page)
 //   - 'unsafe-inline' styles: Angular + the index.html loading splash inject
 //     inline <style>; Google Fonts stylesheet is allowed
 //   - data: images/fonts (inlined icons) and Google Fonts font files
@@ -98,7 +98,10 @@ const defaultCSPPolicy = "default-src 'self'; " +
 	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
 	"font-src 'self' data: https://fonts.gstatic.com; " +
 	"img-src 'self' data:; " +
-	"connect-src 'self' ws: wss:; " +
+	// 'self' also covers same-origin WebSocket (wss:// on an HTTPS page), so
+	// the backend log/stream sockets connect without a bare ws:/wss: wildcard
+	// (which scanners flag as overly permissive — it would allow any host).
+	"connect-src 'self'; " +
 	"worker-src 'self' blob:; " +
 	"frame-ancestors 'self'; " +
 	"base-uri 'self'; " +

--- a/src/jetstream/main_test.go
+++ b/src/jetstream/main_test.go
@@ -118,6 +118,62 @@ func TestLoadPortalConfig(t *testing.T) {
 	if result.SessionStoreSecret != "cookiesecret" {
 		t.Error("Unable to get SessionStoreSecret from config")
 	}
+
+	// CSP is opt-in: CONSOLE_CSP not supplied above, so no header should be
+	// configured (preserves prior no-CSP behavior).
+	if result.CSPPolicy != "" {
+		t.Errorf("Expected no CSP policy when CONSOLE_CSP unset, got: %q", result.CSPPolicy)
+	}
+}
+
+func TestLoadPortalConfigDefaultCSP(t *testing.T) {
+	var pc api.PortalConfig
+
+	// "default" and "on" both opt into the built-in default policy.
+	for _, val := range []string{"default", "Default", "on", "ON"} {
+		result, err := loadPortalConfig(pc, env.NewVarSet(env.WithMapLookup(map[string]string{
+			"CONSOLE_CSP": val,
+		})))
+		if err != nil {
+			t.Fatalf("Unable to load portal config for CONSOLE_CSP=%q: %v", val, err)
+		}
+		if result.CSPPolicy != defaultCSPPolicy {
+			t.Errorf("Expected default CSP policy for CONSOLE_CSP=%q, got %q", val, result.CSPPolicy)
+		}
+	}
+}
+
+func TestLoadPortalConfigCustomCSP(t *testing.T) {
+	var pc api.PortalConfig
+	const custom = "default-src 'self'"
+
+	result, err := loadPortalConfig(pc, env.NewVarSet(env.WithMapLookup(map[string]string{
+		"CONSOLE_CSP": custom,
+	})))
+	if err != nil {
+		t.Fatalf("Unable to load portal config: %v", err)
+	}
+	if result.CSPPolicy != custom {
+		t.Errorf("Expected custom CSP policy %q, got %q", custom, result.CSPPolicy)
+	}
+}
+
+func TestLoadPortalConfigOptOutCSP(t *testing.T) {
+	var pc api.PortalConfig
+
+	// Explicit off-values normalize to "" so a well-meaning CONSOLE_CSP=off
+	// never leaks as a literal Content-Security-Policy header value.
+	for _, val := range []string{"off", "OFF", "none", "None", "false", "disabled"} {
+		result, err := loadPortalConfig(pc, env.NewVarSet(env.WithMapLookup(map[string]string{
+			"CONSOLE_CSP": val,
+		})))
+		if err != nil {
+			t.Fatalf("Unable to load portal config for CONSOLE_CSP=%q: %v", val, err)
+		}
+		if result.CSPPolicy != "" {
+			t.Errorf("Expected CONSOLE_CSP=%q to disable CSP (empty), got %q", val, result.CSPPolicy)
+		}
+	}
 }
 
 func TestLoadDatabaseConfig(t *testing.T) {


### PR DESCRIPTION
## Problem

Jetstream serves no `Content-Security-Policy` header. OWASP ZAP (and other scanners) flag this as a medium-severity finding (CWE-693) — CSP is a defense-in-depth layer against XSS and data-injection. The backend already sets `X-Frame-Options: SAMEORIGIN` via Echo's `Secure` middleware, so CSP is a natural addition right beside it.

## Change

Add a CSP through the existing `middleware.SecureWithConfig`, gated on a new `CONSOLE_CSP` env var. **It is opt-in** — with `CONSOLE_CSP` unset, no header is emitted, so an upgrade never changes a deployment's response headers (or risks breaking asset loading) without an explicit opt-in.

`CONSOLE_CSP` values:
- **unset / `off` / `none` / `false` / `disabled`** → no header (default; preserves current behavior)
- **`default` / `on`** → the built-in `defaultCSPPolicy`
- **any other value** → used verbatim as the policy string

Built-in default policy:

```
default-src 'self';
script-src 'self';
style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
font-src 'self' data: https://fonts.gstatic.com;
img-src 'self' data:;
connect-src 'self';
worker-src 'self' blob:;
frame-ancestors 'self';
base-uri 'self';
form-action 'self'
```

Rationale per allowance:
- `'unsafe-inline'` styles — Angular and the `index.html` loading splash inject inline `<style>`; Google Fonts stylesheet allowed.
- `data:` / `fonts.gstatic.com` fonts, `data:` images — inlined icons + Google Fonts.
- `connect-src 'self'` — same-origin also covers the backend log/stream `wss://` sockets on the HTTPS page (no bare `ws:`/`wss:` wildcard, which scanners flag as overly permissive).
- `worker-src blob:` — the Monaco editor spins up its language web-workers from blob URLs.
- `frame-ancestors 'self'` mirrors the existing `X-Frame-Options: SAMEORIGIN`.

No `unsafe-eval` — AOT production builds don't need it.

## Files
- `main.go` — `defaultCSPPolicy` const; wire `ContentSecurityPolicy` into the Secure middleware; opt-in resolution in `loadPortalConfig`.
- `api/structs.go` — new `CSPPolicy` field (`CONSOLE_CSP`).
- `main_test.go` — tests for unset (no header), `default`/`on`, custom-verbatim, and explicit-off cases.

## Verification

```
$ go build ./...        # rc=0
$ go vet .              # rc=0
$ go test -run TestLoadPortalConfig -count=1 .
ok  github.com/cloudfoundry/stratos/src/jetstream
```

Validated live against a cloud.gov dev deployment with `CONSOLE_CSP=default`:

```
$ curl -sSI https://<dev-host>/ | grep -i content-security-policy
content-security-policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'
```

OWASP ZAP full active scans across iterations confirmed:
- the original **"CSP Header Not Set"** (Medium) is resolved, and
- the initial **"CSP: Wildcard Directive"** finding (from a first-cut `connect-src ... ws: wss:`) is resolved by tightening `connect-src` to `'self'`.

### Known limitation
ZAP still reports **`CSP: style-src unsafe-inline`**. Removing `'unsafe-inline'` from `style-src` requires nonce/hash support wired through Angular's inline-style injection (and the `index.html` loading splash) — a larger change than this PR. Documented here as a known, framework-imposed limitation; operators who need a stricter policy can supply their own via `CONSOLE_CSP`.

---

*Implemented with AI assistance (OpenCode); reviewed by a human contributor. Commits are DCO signed-off.*
