### PR TITLE
Fix login redirect loop and app-delete route/binding orphans

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/app-routes-picker.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/app-routes-picker.component.ts
@@ -44,6 +44,14 @@ import type { StRoute } from '../../../services/endpoint-data/stratos-types';
                 [checked]="isSelected(route.guid)"
                 (change)="toggle(route.guid)" />
               <span class="flex-1 text-content-text truncate" [attr.title]="route.url">{{ route.url }}</span>
+              @if ((route.appGuids?.length ?? 0) > 1) {
+                <span
+                  data-test="route-shared-badge"
+                  class="text-warning-shade-500 text-xs whitespace-nowrap"
+                  title="This route is also mapped to other applications - deleting it will remove it for them too.">
+                  Shared ({{ route.appGuids!.length }} apps)
+                </span>
+              }
             </li>
           }
         </ul>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -357,7 +357,9 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
 
   // Bulk Delete, rendered in the selection bar when 1+ rows are selected.
   // Selection can span orgs/spaces within this CNSI; the backend
-  // (/pp/v1/cf/apps/:cnsi/bulk/delete) fans out the per-app deletes.
+  // (/pp/v1/cf/apps/:cnsi/bulk/delete) fans out the per-app deletes. CF does
+  // not cascade-delete routes/bindings when an app goes away - the checkbox
+  // opts into cleaning those up first (#5692).
   private buildBulkActions(): SignalListBulkAction<StApp>[] {
     const cnsi = this.cfEndpointService.cfGuid;
     return [
@@ -371,10 +373,14 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
             `Delete ${targets.length} ${targets.length === 1 ? 'application' : 'applications'}? This cannot be undone.`,
             'Delete',
             true,
+            { label: 'Also delete these applications\' routes and service bindings' },
           );
-          this.confirmDialog.open(confirm, async () => {
+          this.confirmDialog.open(confirm, async (result?: { checkboxChecked?: boolean }) => {
+            const guids = targets.map(a => a.guid);
             await this.runBulk('delete', targets.length, () =>
-              this.appsConfig.bulkDeleteApps(cnsi, targets.map(a => a.guid)));
+              result?.checkboxChecked
+                ? this.appsConfig.bulkDeleteAppsWithCleanup(cnsi, guids)
+                : this.appsConfig.bulkDeleteApps(cnsi, guids));
           });
         },
       },
@@ -399,9 +405,13 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
             `Delete the app "${app.name}"? This cannot be undone.`,
             'Delete',
             true,
+            { label: 'Also delete this application\'s routes and service bindings' },
           );
-          this.confirmDialog.open(confirm, async () => {
-            await runAction('Delete', () => this.appsConfig.deleteApp(app.cnsiGuid, app.guid));
+          this.confirmDialog.open(confirm, async (result?: { checkboxChecked?: boolean }) => {
+            await runAction('Delete', () =>
+              result?.checkboxChecked
+                ? this.appsConfig.bulkDeleteAppsWithCleanup(app.cnsiGuid, [app.guid]).then(() => {})
+                : this.appsConfig.deleteApp(app.cnsiGuid, app.guid));
           });
         },
       },

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
@@ -308,7 +308,8 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
   }
 
   // Bulk Delete, rendered in the selection bar above the list when 1+ rows
-  // are selected. Deleting an app cascades its routes/bindings on the CF side.
+  // are selected. CF does not cascade-delete routes/bindings when an app
+  // goes away - the checkbox opts into cleaning those up first (#5692).
   private buildBulkActions(): SignalListBulkAction<StApp>[] {
     const cnsi = this.cfEndpointService.cfGuid;
     return [
@@ -322,10 +323,14 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
             `Delete ${targets.length} ${targets.length === 1 ? 'application' : 'applications'}? This cannot be undone.`,
             'Delete',
             true,
+            { label: 'Also delete these applications\' routes and service bindings' },
           );
-          this.confirmDialog.open(confirm, async () => {
+          this.confirmDialog.open(confirm, async (result?: { checkboxChecked?: boolean }) => {
+            const guids = targets.map(a => a.guid);
             await this.runBulk('delete', targets.length, () =>
-              this.appsConfig.bulkDeleteApps(cnsi, targets.map(a => a.guid)));
+              result?.checkboxChecked
+                ? this.appsConfig.bulkDeleteAppsWithCleanup(cnsi, guids)
+                : this.appsConfig.bulkDeleteApps(cnsi, guids));
           });
         },
       },
@@ -354,9 +359,13 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
             `Delete the app "${app.name}"? This cannot be undone.`,
             'Delete',
             true,
+            { label: 'Also delete this application\'s routes and service bindings' },
           );
-          this.confirmDialog.open(confirm, async () => {
-            await runAction('Delete', () => this.appsConfig.deleteApp(app.cnsiGuid, app.guid));
+          this.confirmDialog.open(confirm, async (result?: { checkboxChecked?: boolean }) => {
+            await runAction('Delete', () =>
+              result?.checkboxChecked
+                ? this.appsConfig.bulkDeleteAppsWithCleanup(app.cnsiGuid, [app.guid]).then(() => {})
+                : this.appsConfig.deleteApp(app.cnsiGuid, app.guid));
           });
         },
       },

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -653,6 +653,68 @@ describe('CfAppsSignalConfigService', () => {
     expect(remaining).toEqual(['app-bad']); // failed row stays; completed row removed
   });
 
+  it('bulkDeleteAppsWithCleanup deletes only routes/bindings fully owned by the batch, then bulk-deletes the apps', async () => {
+    const deleteCalls: string[] = [];
+    const httpMock = {
+      get: vi.fn((url: string) => {
+        if (url === '/pp/v1/cf/apps/cnsi-1/app-A/routes') {
+          return of({
+            resources: [
+              // Shared with app-B, also in this batch -> safe to delete.
+              { guid: 'r-shared-ab', url: 'ab.example.com', host: 'ab', path: '', domainGuid: 'd', spaceGuid: 's', createdAt: '', updatedAt: '', appGuids: ['app-A', 'app-B'] },
+              // Shared with app-C, NOT in this batch -> must survive.
+              { guid: 'r-shared-ac', url: 'ac.example.com', host: 'ac', path: '', domainGuid: 'd', spaceGuid: 's', createdAt: '', updatedAt: '', appGuids: ['app-A', 'app-C'] },
+            ],
+            totalResults: 2,
+          });
+        }
+        if (url === '/pp/v1/cf/apps/cnsi-1/app-B/routes') {
+          return of({
+            resources: [
+              { guid: 'r-shared-ab', url: 'ab.example.com', host: 'ab', path: '', domainGuid: 'd', spaceGuid: 's', createdAt: '', updatedAt: '', appGuids: ['app-A', 'app-B'] },
+            ],
+            totalResults: 1,
+          });
+        }
+        if (url === '/pp/v1/cf/apps/cnsi-1/app-A/service_bindings?return=summary') {
+          return of({
+            resources: [
+              {
+                guid: 'b-1', cnsiGuid: 'cnsi-1', name: 'x', type: 'app',
+                serviceInstance: { guid: 'si-1', name: 'db', type: 'managed' },
+                app: { guid: 'app-A' }, createdAt: '', updatedAt: '',
+              },
+            ],
+            pagination: { totalResults: 1, totalPages: 1, first: null, last: null, next: null, previous: null },
+          });
+        }
+        if (url === '/pp/v1/cf/apps/cnsi-1/app-B/service_bindings?return=summary') {
+          return of({ resources: [], pagination: { totalResults: 0, totalPages: 1, first: null, last: null, next: null, previous: null } });
+        }
+        return of({ resources: [], pagination: {} });
+      }),
+      delete: vi.fn((url: string) => {
+        deleteCalls.push(url);
+        return of(new HttpResponse<unknown>({ status: 200, body: { result: {}, state: 'COMPLETE' } }));
+      }),
+      post: vi.fn(() => of({
+        results: [
+          { guid: 'app-A', state: 'COMPLETE' },
+          { guid: 'app-B', state: 'COMPLETE' },
+        ],
+        succeeded: 2, failed: 0, pending: 0,
+      })),
+    } as unknown as HttpClient;
+    const svc = makeSvc(httpMock);
+
+    await svc.bulkDeleteAppsWithCleanup('cnsi-1', ['app-A', 'app-B']);
+
+    expect(deleteCalls.filter(u => u === '/pp/v1/cf/routes/cnsi-1/r-shared-ab')).toHaveLength(1); // deduped, not once per app
+    expect(deleteCalls).not.toContain('/pp/v1/cf/routes/cnsi-1/r-shared-ac');
+    expect(deleteCalls).toContain('/pp/v1/cf/service_bindings/cnsi-1/b-1');
+    expect(httpMock.post).toHaveBeenCalledWith('/pp/v1/cf/apps/cnsi-1/bulk/delete', { guids: ['app-A', 'app-B'] });
+  });
+
   it('resolver fetches space names for visible-row guids that are NOT in the catalog', async () => {
     // Catalog (per_page=500&page=1) returns NO spaces — simulating the
     // overflow case where the visible row's space lives beyond page 1.

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -1054,14 +1054,17 @@ export class CfAppsSignalConfigService {
     this.orchestrator?.removeRow(cnsiGuid, appGuid);
   }
 
-  // Bulk delete: destroys each app entity (cascading its routes/bindings on
-  // the CF side). CF v3 has no batch delete, so the backend fans out one
-  // DELETE /v3/apps/{guid} per item and returns a BulkResult with per-guid
-  // outcomes; pending items carry an async CF job tracking completion.
-  // Optimistically drops every non-failed row from the orchestrator's
-  // aggregated view (mirrors deleteApp's removeRow) so the list reflects the
-  // request immediately without a full re-fetch — a pending delete that later
-  // fails resurfaces on the next refresh.
+  // Bulk delete: destroys each app entity. CF v3 does not cascade-delete a
+  // route or service binding when the app goes away (only the destination/
+  // binding to that app is implicitly gone with it) - see
+  // bulkDeleteAppsWithCleanup for the opt-in cleanup path. CF v3 also has no
+  // batch delete, so the backend fans out one DELETE /v3/apps/{guid} per item
+  // and returns a BulkResult with per-guid outcomes; pending items carry an
+  // async CF job tracking completion. Optimistically drops every non-failed
+  // row from the orchestrator's aggregated view (mirrors deleteApp's
+  // removeRow) so the list reflects the request immediately without a full
+  // re-fetch — a pending delete that later fails resurfaces on the next
+  // refresh.
   async bulkDeleteApps(cnsiGuid: string, appGuids: string[]): Promise<BulkResult> {
     const result = await firstValueFrom(this.http.post<BulkResult>(
       `/pp/v1/cf/apps/${cnsiGuid}/bulk/delete`,
@@ -1073,5 +1076,46 @@ export class CfAppsSignalConfigService {
       }
     }
     return result;
+  }
+
+  // Opt-in cleanup variant of bulkDeleteApps: resolves each app's routes and
+  // service bindings first, deletes them, then runs the bulk app delete -
+  // otherwise a bulk delete leaves every selected app's routes behind (44 of
+  // 48 routes orphaned in one observed test space, #5692).
+  //
+  // A route is only deleted if every one of its destinations belongs to an
+  // app in this same batch - a route shared with an app NOT being deleted
+  // here must survive, matching the single-app delete wizard's per-route
+  // picker semantics.
+  //
+  // Best-effort: a route/binding delete failure is swallowed (mirrors
+  // deleteWithCleanup's per-item fan-out) so one bad relationship doesn't
+  // block the rest of the cleanup or the app deletes that follow.
+  async bulkDeleteAppsWithCleanup(cnsiGuid: string, appGuids: string[]): Promise<BulkResult> {
+    const targets = new Set(appGuids);
+    const perApp = await Promise.all(appGuids.map(async guid => ({
+      routes: await this.fetchAppRoutes(cnsiGuid, guid),
+      bindings: await this.fetchAppServiceBindings(cnsiGuid, guid),
+    })));
+
+    const routesToDelete = new Map<string, StRoute>();
+    for (const { routes } of perApp) {
+      for (const route of routes) {
+        // appGuids always carries at least the app this route was fetched
+        // for (see toStRoute); an empty/missing value would mean "unknown
+        // destinations" - treat that conservatively as "don't delete".
+        if (route.appGuids?.length && route.appGuids.every(appGuid => targets.has(appGuid))) {
+          routesToDelete.set(route.guid, route);
+        }
+      }
+    }
+    const bindingsToDelete = perApp.flatMap(({ bindings }) => bindings);
+
+    await Promise.all([
+      ...Array.from(routesToDelete.values()).map(route => this.deleteRoute(cnsiGuid, route.guid).catch(() => {})),
+      ...bindingsToDelete.map(binding => this.deleteServiceBinding(cnsiGuid, binding.guid).catch(() => {})),
+    ]);
+
+    return this.bulkDeleteApps(cnsiGuid, appGuids);
   }
 }

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
@@ -148,8 +148,6 @@ describe('LoginPageComponent', () => {
         .mockReturnValue(of(null));
 
       // Simulate returning from the IdP with an error message in the URL.
-      const original = (component as any).shouldAutoRedirectNosplash?.bind(component);
-      void original;
       history.replaceState({}, '', '/login?SSO_Message=Invalid+auth');
 
       fixture.detectChanges();
@@ -192,6 +190,28 @@ describe('LoginPageComponent', () => {
       await fixture.whenStable();
 
       expect(ssoSpy).not.toHaveBeenCalled();
+    });
+
+    it('clears a stale redirect counter once a valid session is observed', async () => {
+      vi.spyOn((component as any).router, 'navigate').mockResolvedValue(true);
+
+      // Simulate a stale count left over from an earlier failed round-trip.
+      sessionStorage.setItem('stratos_login_redirect_attempts', '2');
+
+      fixture.detectChanges();
+      authData.auth.set({
+        loggedIn: true,
+        loggingIn: false,
+        user: null,
+        error: false,
+        errorResponse: '',
+        verifying: false,
+        sessionData: { valid: true } as any,
+      });
+
+      await fixture.whenStable();
+
+      expect(sessionStorage.getItem('stratos_login_redirect_attempts')).toBeNull();
     });
   });
 

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
@@ -204,6 +204,12 @@ export class LoginPageComponent implements OnInit {
     this.redirectAttemptsSubject$.next(0);
   }
 
+  // Single cap check shared by every auto-redirect guard so there is one
+  // budget, not a per-path copy of the comparison.
+  private get underRedirectCap(): boolean {
+    return this.redirectAttempts <= this.MAX_REDIRECT_ATTEMPTS;
+  }
+
   ngOnInit() {
     // Initialize the BehaviorSubject with current value
     this.redirectAttemptsSubject$.next(this.redirectAttempts);
@@ -245,17 +251,21 @@ export class LoginPageComponent implements OnInit {
           return;
         }
 
-        // Handle SSO no-splash redirect
-        if (auth.sessionData?.ssoOptions &&
-            auth.sessionData.ssoOptions.indexOf('nosplash') >= 0 &&
-            !queryParamMap().SSO_Message) {
+        // Handle SSO no-splash redirect, under the same cap as the
+        // unauthenticated nosplash path below (see shouldAutoRedirectNosplash) -
+        // otherwise a valid session that keeps landing back on /login can
+        // bounce to the IdP indefinitely.
+        if (this.shouldAutoRedirectLoggedInNosplash(auth)) {
+          this.redirectAttempts++;
           this.doSSOLoginReactive().subscribe();
           return;
         }
 
-        // A valid session was established, so a genuine login round-trip
-        // completed: clear the nosplash redirect counter so a later visit
-        // does not inherit a stale count from an earlier failed attempt.
+        // Either nosplash isn't in play, or the cap above stopped a bounce
+        // loop: this attempt cycle is over, so clear the counter now rather
+        // than only on a successful nav below - otherwise a cap hit here
+        // leaves a stale count that blocks an unrelated, later unauthenticated
+        // visit from auto-redirecting.
         this.clearRedirectAttempts();
 
         // Normal redirect
@@ -346,14 +356,22 @@ export class LoginPageComponent implements OnInit {
     const nosplash       = !!auth.sessionData?.ssoOptions?.includes('nosplash');
     return idle && noValidSession && nosplash
       && !queryParamMap().SSO_Message
-      && this.redirectAttempts <= this.MAX_REDIRECT_ATTEMPTS;
+      && this.underRedirectCap;
+  }
+
+  // Logged-in counterpart to shouldAutoRedirectNosplash: a valid session
+  // still configured for nosplash SSO gets bounced to the IdP too, under the
+  // same shared cap.
+  private shouldAutoRedirectLoggedInNosplash(auth: AuthState): boolean {
+    const nosplash = !!auth.sessionData?.ssoOptions?.includes('nosplash');
+    return nosplash && !queryParamMap().SSO_Message && this.underRedirectCap;
   }
 
   private async handleSuccessfulLogin(auth: AuthState): Promise<null> {
     this.redirectAttempts++;
 
     // Prevent infinite redirect loop
-    if (this.redirectAttempts > this.MAX_REDIRECT_ATTEMPTS) {
+    if (!this.underRedirectCap) {
       return null;
     }
 

--- a/src/frontend/packages/core/src/shared/components/confirmation-dialog.config.ts
+++ b/src/frontend/packages/core/src/shared/components/confirmation-dialog.config.ts
@@ -3,11 +3,21 @@
 export interface TypeToConfirm {
   textToMatch: string;
 }
+
+export interface ConfirmationCheckbox {
+  label: string;
+  default?: boolean;
+}
+
 export class ConfirmationDialogConfig {
   constructor(
     public title: string,
     public message: string | TypeToConfirm,
     public confirm = 'Ok',
-    public critical = false
+    public critical = false,
+    // Optional opt-in checkbox (e.g. "also delete related routes"). When
+    // set, the dialog resolves with { checkboxChecked: boolean } instead
+    // of plain `true` so the caller can read the user's choice.
+    public checkbox?: ConfirmationCheckbox,
   ) { }
 }

--- a/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html
+++ b/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html
@@ -17,12 +17,18 @@
       </div>
     </div>
   }
+  @if (data.checkbox) {
+    <div class="confirm-dialog__checkbox mb-4 flex items-center gap-2">
+      <input type="checkbox" id="confirmCheckbox" [(ngModel)]="checkboxChecked" />
+      <label for="confirmCheckbox" class="text-content-text">{{ data.checkbox.label }}</label>
+    </div>
+  }
   <div class="confirm-dialog__actions flex gap-2 justify-end mt-6">
     <button class="btn btn-secondary" (click)="onNoClick()" cdkFocusInitial>Cancel</button>
     @if (data.confirm) {
       <button class="confirm-dialog__confirm"
         [class]="data.critical || textToMatch ? 'btn btn-danger' : 'btn btn-primary'"
-        (click)="dialogRef.close(true)"
+        (click)="onConfirmClick()"
         [disabled]="textToMatch && textToMatch !== matchValue">{{
       data.confirm }}</button>
     }

--- a/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.ts
+++ b/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.ts
@@ -28,6 +28,9 @@ export class DialogConfirmComponent {
   // Bound via ngModel to the type-to-confirm input
   public matchValue?: string;
 
+  // Bound via ngModel to the optional checkbox (data.checkbox)
+  public checkboxChecked = false;
+
   constructor() {
     const data = this.data;
 
@@ -35,10 +38,17 @@ export class DialogConfirmComponent {
     if (typeToConfirm && typeToConfirm.textToMatch) {
       this.textToMatch = typeToConfirm.textToMatch;
     }
+    this.checkboxChecked = !!data.checkbox?.default;
   }
 
   onNoClick(): void {
     this.dialogRef.close();
+  }
+
+  onConfirmClick(): void {
+    // Plain `true` when there's no checkbox (existing callers just check
+    // truthiness); an object when there is, so the caller can read the choice.
+    this.dialogRef.close(this.data.checkbox ? { checkboxChecked: this.checkboxChecked } : true);
   }
 
   handlePaste($event: ClipboardEvent) {


### PR DESCRIPTION
## Summary
- Unifies the login page's nosplash auto-redirect loop guard across all three redirect call sites (previously the logged-in path had no cap at all, and a capped-out counter could stay stale across a manual login/logout). Closes #5687.
- Adds an opt-in "also delete routes and service bindings" checkbox to every application delete confirmation that lacked cleanup - both bulk-delete actions and both per-row quick-delete actions (which bypass the delete wizard entirely). CF v3 does not cascade-delete routes/bindings when an app is deleted, so bulk delete was leaving orphaned routes behind (one observed test space had 44 orphaned out of 48). A route is only cleaned up when every one of its destinations belongs to an app in the same delete batch, matching the existing single-app delete wizard's semantics. Closes #5692.
- Confirmation dialogs gain a reusable optional checkbox primitive (`ConfirmationDialogConfig.checkbox`) as the building block for the above; existing callers are unaffected.
- The single-app delete wizard's route picker now flags routes shared with other applications.

## Test plan
- [x] `bun run test:core` - login-page + dialog-confirm specs pass (new counter-reset test added, dead spec line removed)
- [x] `bun run test:cloud-foundry` - cf-apps-signal-config (new `bulkDeleteAppsWithCleanup` multi-destination-skip test added), both apps-signal components, app-routes-picker specs pass
- [x] Full frontend suite (`bun run test`): 3221 passed, 0 failures
- [x] `bunx eslint` clean on all touched files
- [x] Live Playwright verification against a real CF foundation - done against fw-lab-norm (see comment below); login redirect-loop guard and app-delete route/binding cleanup (both per-row and bulk) confirmed working via `cf` CLI ground truth.
