### PR TITLE
fix(core): rework the shared-URL banner sentence for accuracy

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/components/duplicate-url-banner/duplicate-url-banner.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/duplicate-url-banner/duplicate-url-banner.component.spec.ts
@@ -37,16 +37,19 @@ describe('DuplicateUrlBannerComponent', () => {
     const text = fixture.nativeElement.textContent;
     // Endpoint-type label resolves via the entity catalog (empty in this
     // TestBed, so the cnsi_type falls through) - phrasing is what matters
-    expect(text).toMatch(/2 \S+ endpoints share a URL\./);
+    expect(text).toMatch(/A \S+ URL is shared by 2 endpoints\./);
     expect(text).toContain('Applications and organizations from each are shown together');
     expect(text).toContain('narrow to a single endpoint');
   });
 
-  it('pluralizes the verb when endpoints share more than one URL', () => {
+  it('names the group sizes when endpoints share more than one URL', () => {
     connected$.next([ep('shared-a'), ep('shared-a'), ep('shared-b'), ep('shared-b')]);
     const fixture = TestBed.createComponent(DuplicateUrlBannerComponent);
     fixture.detectChanges();
-    expect(fixture.nativeElement.textContent).toMatch(/4 \S+ endpoints share URLs\./);
+    // 2 disjoint pairs (shared-a, shared-b), not one group of 4 - "4 X
+    // endpoints" alone would misleadingly imply they all relate to each
+    // other, so the sentence must name the actual group sizes.
+    expect(fixture.nativeElement.textContent).toMatch(/2 \S+ URLs are shared by 4 endpoints \(2 and 2 per URL\)\./);
   });
 
   it('replaces the trailing sentence when a custom message is set', () => {
@@ -55,7 +58,7 @@ describe('DuplicateUrlBannerComponent', () => {
     fixture.componentInstance.message = 'Several of the endpoints below are views of the same foundation.';
     fixture.detectChanges();
     const text = fixture.nativeElement.textContent;
-    expect(text).toMatch(/2 \S+ endpoints share a URL\./);
+    expect(text).toMatch(/A \S+ URL is shared by 2 endpoints\./);
     expect(text).toContain('Several of the endpoints below are views of the same foundation.');
     expect(text).not.toContain('shown together');
   });

--- a/src/frontend/packages/core/src/features/home/home/home-url-banner/home-url-banner.component.spec.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-url-banner/home-url-banner.component.spec.ts
@@ -35,11 +35,11 @@ describe('HomeUrlBannerComponent', () => {
     connected$.next([ep('shared'), ep('shared'), ep('unique')]);
     const fixture = TestBed.createComponent(HomeUrlBannerComponent);
     fixture.detectChanges();
-    expect(fixture.componentInstance.message()).toContain('2 ');
-    expect(fixture.nativeElement.textContent).toContain('share a URL');
+    expect(fixture.componentInstance.message()).toContain('2 endpoints');
+    expect(fixture.nativeElement.textContent).toContain('is shared by 2 endpoints');
   });
 
-  it('reports mixed fleets per type in a single combined sentence', () => {
+  it('reports mixed fleets per type as independent clauses, never a lump sum', () => {
     connected$.next([
       ep('cf-shared'), ep('cf-shared'),
       ep('kube-shared', 'k8s'), ep('kube-shared', 'k8s'), ep('kube-shared', 'k8s'),
@@ -47,14 +47,15 @@ describe('HomeUrlBannerComponent', () => {
     const fixture = TestBed.createComponent(HomeUrlBannerComponent);
     fixture.detectChanges();
     const msg = fixture.componentInstance.message();
-    // Per-type counts joined into one sentence - never a lump sum ("5").
-    // Every part carries its own "endpoints" noun and the verb agrees:
-    // "2 X endpoints and 3 Y endpoints share URLs."
-    expect(msg).toMatch(/2 \S+ endpoints and 3 \S+ endpoints share URLs\./);
+    // Each type gets its own clause with its own verb - "X endpoints AND Y
+    // endpoints share URLs" would read as if the two types shared a URL
+    // with each other, which they never do (duplicate detection is
+    // strictly within a type). Never a lump sum ("5") either.
+    expect(msg).toMatch(/^A \S+ URL is shared by 2 endpoints; A \S+ URL is shared by 3 endpoints\.$/);
     expect(msg).not.toContain('5');
   });
 
-  it('joins three or more types with commas and a final "and"', () => {
+  it('gives each of three or more types its own clause', () => {
     connected$.next([
       ep('cf-shared'), ep('cf-shared'),
       ep('kube-shared', 'k8s'), ep('kube-shared', 'k8s'),
@@ -63,7 +64,7 @@ describe('HomeUrlBannerComponent', () => {
     const fixture = TestBed.createComponent(HomeUrlBannerComponent);
     fixture.detectChanges();
     expect(fixture.componentInstance.message())
-      .toMatch(/^2 \S+ endpoints, 2 \S+ endpoints, and 2 \S+ endpoints share URLs\.$/);
+      .toMatch(/^A \S+ URL is shared by 2 endpoints; A \S+ URL is shared by 2 endpoints; A \S+ URL is shared by 2 endpoints\.$/);
   });
 
   it('does not treat same-URL endpoints of different types as duplicates', () => {

--- a/src/frontend/packages/store/src/endpoint-utils.spec.ts
+++ b/src/frontend/packages/store/src/endpoint-utils.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { countDuplicateUrlEndpoints } from './endpoint-utils';
+import { countDuplicateUrlEndpoints, formatDuplicateUrlEndpointsMessage } from './endpoint-utils';
 import { EndpointModel } from './types/endpoint.types';
 
-function ep(host: string): EndpointModel {
-  return { api_endpoint: { Scheme: 'https', Host: host, Path: '' } } as unknown as EndpointModel;
+function ep(host: string, type: string = 'cf'): EndpointModel {
+  return { cnsi_type: type, api_endpoint: { Scheme: 'https', Host: host, Path: '' } } as unknown as EndpointModel;
 }
 
 describe('countDuplicateUrlEndpoints', () => {
@@ -28,5 +28,80 @@ describe('countDuplicateUrlEndpoints', () => {
     expect(
       countDuplicateUrlEndpoints([ep('x'), ep('x'), ep('y'), ep('y'), ep('z')]),
     ).toBe(4);
+  });
+});
+
+describe('formatDuplicateUrlEndpointsMessage', () => {
+  it('names one shared URL when a type has a single duplicate group', () => {
+    const msg = formatDuplicateUrlEndpointsMessage([ep('shared'), ep('shared'), ep('shared'), ep('shared')]);
+    expect(msg).toMatch(/^A \S+ URL is shared by 4 endpoints\.$/);
+  });
+
+  // Real-world case (fw-lab-norm, 07-26): 4 endpoints on one CF api URL plus
+  // 4 different endpoints on a second, unrelated CF api URL — 8 endpoints
+  // total but two disjoint pairs, not one group of 8 that all relate to each
+  // other. Lumping them into "8 X endpoints share URLs" is misleading: it
+  // reads as if all 8 are interconnected. The message must surface that
+  // there are 2 separate URLs involved.
+  it('names the group sizes when one type has multiple disjoint duplicate groups', () => {
+    const msg = formatDuplicateUrlEndpointsMessage([
+      ep('url-a'), ep('url-a'), ep('url-a'), ep('url-a'),
+      ep('url-b'), ep('url-b'), ep('url-b'), ep('url-b'),
+    ]);
+    expect(msg).toMatch(/^2 \S+ URLs are shared by 8 endpoints \(4 and 4 per URL\)\.$/);
+  });
+
+  // "11 across 3 URLs" alone invites a false assumption that the 3 groups
+  // are roughly equal-sized. Only listing the actual sizes rules that out.
+  // Leading with the URL count (3) makes the shape unambiguous up front.
+  it('lists uneven group sizes rather than just a group count', () => {
+    const msg = formatDuplicateUrlEndpointsMessage([
+      ep('url-a'), ep('url-a'),
+      ep('url-b'), ep('url-b'), ep('url-b'), ep('url-b'),
+      ep('url-c'), ep('url-c'), ep('url-c'), ep('url-c'), ep('url-c'),
+    ]);
+    expect(msg).toMatch(/^3 \S+ URLs are shared by 11 endpoints \(2, 4, and 5 per URL\)\.$/);
+  });
+
+  // Repeated sizes (two groups that happen to both have 3 endpoints) must
+  // stay listed plainly, not deduped or collapsed - "3 and 5" would hide
+  // that there are actually 2 separate groups of 3 plus 1 group of 5.
+  it('lists repeated group sizes without deduping them', () => {
+    const msg = formatDuplicateUrlEndpointsMessage([
+      ep('url-a'), ep('url-a'), ep('url-a'),
+      ep('url-b'), ep('url-b'), ep('url-b'),
+      ep('url-c'), ep('url-c'), ep('url-c'), ep('url-c'), ep('url-c'),
+    ]);
+    expect(msg).toMatch(/^3 \S+ URLs are shared by 11 endpoints \(3, 3, and 5 per URL\)\.$/);
+  });
+
+  // "X endpoints AND Y endpoints share URLs" reads as one joint action
+  // between the two groups - as if a CF endpoint and a k8s endpoint were
+  // sharing a URL with each other. They never are (duplicate detection is
+  // strictly within a type). Each type must be its own independent clause,
+  // with its own subject and verb, so nothing implies a cross-type relation.
+  it('gives each type its own independent clause instead of one shared verb', () => {
+    const msg = formatDuplicateUrlEndpointsMessage([
+      ep('cf-shared'), ep('cf-shared'),
+      ep('kube-shared', 'k8s'), ep('kube-shared', 'k8s'), ep('kube-shared', 'k8s'),
+    ]);
+    expect(msg).toMatch(/^A \S+ URL is shared by 2 endpoints; A \S+ URL is shared by 3 endpoints\.$/);
+  });
+
+  // Real-world case (fw-lab-norm, 07-26): 8 CF endpoints across 2 disjoint
+  // URL groups, plus 4 unrelated Kubernetes endpoints on a third URL. The
+  // old phrasing ("8 Cloud Foundry endpoints and 4 Kubernetes endpoints
+  // share URLs.") reads as if all 12 endpoints share one URL together.
+  it('stays accurate for multiple types where one also has multiple groups', () => {
+    const msg = formatDuplicateUrlEndpointsMessage([
+      ep('cf-url-a'), ep('cf-url-a'), ep('cf-url-a'), ep('cf-url-a'),
+      ep('cf-url-b'), ep('cf-url-b'), ep('cf-url-b'), ep('cf-url-b'),
+      ep('kube-url', 'k8s'), ep('kube-url', 'k8s'), ep('kube-url', 'k8s'), ep('kube-url', 'k8s'),
+    ]);
+    expect(msg).toMatch(/^2 \S+ URLs are shared by 8 endpoints \(4 and 4 per URL\); A \S+ URL is shared by 4 endpoints\.$/);
+  });
+
+  it('returns null when no URLs are shared', () => {
+    expect(formatDuplicateUrlEndpointsMessage([ep('a'), ep('b')])).toBeNull();
   });
 });

--- a/src/frontend/packages/store/src/endpoint-utils.ts
+++ b/src/frontend/packages/store/src/endpoint-utils.ts
@@ -23,11 +23,14 @@ export function countDuplicateUrlEndpoints(endpoints: EndpointModel[]): number |
 /**
  * Shared-URL detection with enough detail for grammatical banners: `count`
  * is the number of endpoints sitting in a shared-URL group (what
- * {@link countDuplicateUrlEndpoints} returns), `groups` is how many distinct
- * URLs are shared. 4 endpoints in one group "share a URL"; 2+2 across two
- * groups "share URLs". Null when all URLs are distinct.
+ * {@link countDuplicateUrlEndpoints} returns), `sizes` is each distinct
+ * group's own endpoint count (e.g. `[2, 4, 5]` for three separate shared
+ * URLs with 2, 4, and 5 endpoints respectively) - the total and group count
+ * alone ("11 across 3 URLs") invite a false assumption that the groups are
+ * roughly equal-sized; only the actual sizes rule that out. Null when all
+ * URLs are distinct.
  */
-export function duplicateUrlStats(endpoints: EndpointModel[]): { count: number; groups: number } | null {
+export function duplicateUrlStats(endpoints: EndpointModel[]): { count: number; sizes: number[] } | null {
   if (!endpoints || endpoints.length < 2) {
     return null;
   }
@@ -36,15 +39,9 @@ export function duplicateUrlStats(endpoints: EndpointModel[]): { count: number; 
     const url = getFullEndpointApiUrl(ep);
     urlCounts.set(url, (urlCounts.get(url) ?? 0) + 1);
   }
-  let dupCount = 0;
-  let groups = 0;
-  for (const count of urlCounts.values()) {
-    if (count > 1) {
-      dupCount += count;
-      groups++;
-    }
-  }
-  return dupCount > 0 ? { count: dupCount, groups } : null;
+  const sizes = [...urlCounts.values()].filter(count => count > 1).sort((a, b) => a - b);
+  const dupCount = sizes.reduce((sum, size) => sum + size, 0);
+  return dupCount > 0 ? { count: dupCount, sizes } : null;
 }
 
 /**
@@ -57,23 +54,40 @@ export function duplicateUrlStats(endpoints: EndpointModel[]): { count: number; 
 /**
  * The shared-URL banner sentence, built the same way everywhere it appears
  * (home page and the CF Application Wall / Marketplace / Services banner):
- * per-type counts joined into one sentence with the verb agreeing with how
- * many distinct URLs are shared, e.g. "4 Cloud Foundry endpoints share a
- * URL." or "4 Cloud Foundry endpoints and 4 Kubernetes endpoints share
- * URLs." Null when all URLs are distinct.
+ * one independent clause per type, e.g. "A Cloud Foundry URL is shared by
+ * 4 endpoints." or, with more than one group, "3 Cloud Foundry URLs are
+ * shared by 11 endpoints (2, 4, and 5 per URL)." Both forms lead with the
+ * URL(s) as the subject, so the single- and multi-group phrasing stay
+ * parallel. Two design choices this encodes:
+ *
+ * - Each type is its own clause with its own verb rather than one shared
+ *   verb across an "and"-joined list - a CF endpoint and a k8s endpoint
+ *   never share a URL with each other (duplicate detection is strictly
+ *   within a type), so joining them with "and...share URLs" would read as
+ *   if they did.
+ * - A multi-group type names every group's actual size, not just the
+ *   group count - "11 across 3 URLs" invites a false assumption that the
+ *   groups are roughly equal-sized (they might be 2, 4, and 5).
+ *
+ * Null when all URLs are distinct.
  */
 export function formatDuplicateUrlEndpointsMessage(endpoints: EndpointModel[]): string | null {
   const dups = countDuplicateUrlEndpointsByType(endpoints);
   if (!dups.length) {
     return null;
   }
-  const parts = dups.map(dup =>
-    `${dup.count} ${entityCatalog.getEndpoint(dup.type)?.definition?.label ?? dup.type} endpoints`);
-  const totalGroups = dups.reduce((sum, dup) => sum + dup.groups, 0);
-  return `${listFormat.format(parts)} ${totalGroups > 1 ? 'share URLs' : 'share a URL'}.`;
+  const clauses = dups.map(dup => {
+    const label = entityCatalog.getEndpoint(dup.type)?.definition?.label ?? dup.type;
+    if (dup.sizes.length === 1) {
+      return `A ${label} URL is shared by ${dup.count} endpoints`;
+    }
+    const sizesList = listFormat.format(dup.sizes.map(String));
+    return `${dup.sizes.length} ${label} URLs are shared by ${dup.count} endpoints (${sizesList} per URL)`;
+  });
+  return `${clauses.join('; ')}.`;
 }
 
-export function countDuplicateUrlEndpointsByType(endpoints: EndpointModel[]): { type: string; count: number; groups: number }[] {
+export function countDuplicateUrlEndpointsByType(endpoints: EndpointModel[]): { type: string; count: number; sizes: number[] }[] {
   if (!endpoints || endpoints.length < 2) {
     return [];
   }
@@ -87,7 +101,7 @@ export function countDuplicateUrlEndpointsByType(endpoints: EndpointModel[]): { 
       byType.set(type, [ep]);
     }
   }
-  const counts: { type: string; count: number; groups: number }[] = [];
+  const counts: { type: string; count: number; sizes: number[] }[] = [];
   for (const [type, group] of byType) {
     const stats = duplicateUrlStats(group);
     if (stats) {


### PR DESCRIPTION
## Summary
- The shared-URL banner (home page, plus the CF Application Wall/Marketplace/Services banner) joined multiple endpoint types into one shared-verb sentence — "8 Cloud Foundry endpoints and 4 Kubernetes endpoints share URLs." reads as if the two types share a URL with each other, which they never do (duplicate detection is strictly within a type). Each type now gets its own independent clause, semicolon-joined.
- A single type can have more than one disjoint duplicate-URL group (e.g. 4 endpoints on one URL, 4 different endpoints on a second, unrelated URL). Summing them ("8 endpoints across 2 URLs") still invites a false assumption the groups are roughly equal-sized, and falls apart entirely once sizes are uneven (2, 4, 5). The message now leads with the URL count and lists every group's actual size instead.
- The single- and multi-group phrasing were structurally inconsistent (endpoints-as-subject vs. URLs-as-subject). Both now lead with the URL(s): `"A Cloud Foundry URL is shared by 4 endpoints."` vs `"3 Cloud Foundry URLs are shared by 11 endpoints (2, 4, and 5 per URL)."`

Combined real-world example (fw-lab-norm's actual duplicate registrations — cf1-4 on one CF url, fw-lab-norm-1..4 on a different CF url, 4 kind-korifi variants on one k8s url):

> `2 Cloud Foundry URLs are shared by 8 endpoints (4 and 4 per URL); A Kubernetes URL is shared by 4 endpoints.`

`duplicateUrlStats` now returns each group's size directly (`sizes: number[]`) instead of just a group count, so `formatDuplicateUrlEndpointsMessage` can list them via `Intl.ListFormat`.

## Test plan
- [x] Updated all existing tests that encoded the old joined-sentence / group-count-only phrasing (`endpoint-utils.spec.ts`, `home-url-banner.component.spec.ts`, `duplicate-url-banner.component.spec.ts`)
- [x] Added coverage for uneven group sizes (2, 4, 5) and repeated group sizes (3, 3, 5)
- [x] `eslint` clean on all touched files
- [x] Full frontend test suite / production build — not run in this environment, only the 3 directly affected spec files (20 tests, all passing)