### PR TITLE
fix(cf): stop refetching catalogs the endpoint already loaded

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.spec.ts
@@ -83,3 +83,57 @@ describe('CnsiAppsSource', () => {
     expect(http.put).toHaveBeenCalledWith('/pp/v1/cf/apps/cnsi-1/a/routes/r-1', {});
   });
 });
+
+// Apps are drained per endpoint by EndpointDataService. The source used to
+// run its own drain unless handed a finished cache, so mounting the wall
+// while the endpoint drain was in flight ran both.
+describe('CnsiAppsSource — joins the endpoint apps load', () => {
+  const app = { guid: 'a', name: 'from-eds' } as unknown as StApp;
+
+  function makeEds(apps: StApp[]) {
+    return {
+      loadApps: vi.fn(() => of(undefined)),
+      refreshApps: vi.fn(() => of(undefined)),
+      apps: () => apps,
+    };
+  }
+
+  it('load() joins the shared drain instead of fetching', async () => {
+    const http = makeHttp({ resources: [], pagination: { totalResults: 0, totalPages: 1, next: null } });
+    const eds = makeEds([app]);
+    const src = new CnsiAppsSource('cnsi-1', http, eds as never);
+
+    await src.load();
+
+    expect(eds.loadApps).toHaveBeenCalledTimes(1);
+    expect(http.get).not.toHaveBeenCalled();
+    expect(src.items()).toEqual([app]);
+    expect(src.loading()).toBe(false);
+  });
+
+  it('refresh() bypasses the shared cache rather than joining it', async () => {
+    const http = makeHttp({ resources: [], pagination: { totalResults: 0, totalPages: 1, next: null } });
+    const eds = makeEds([app]);
+    const src = new CnsiAppsSource('cnsi-1', http, eds as never);
+
+    await src.refresh();
+
+    // User asked for current data — a cache-serving loadApps() would defeat it.
+    expect(eds.refreshApps).toHaveBeenCalledTimes(1);
+    expect(eds.loadApps).not.toHaveBeenCalled();
+    expect(http.get).not.toHaveBeenCalled();
+  });
+
+  it('still drains itself when no endpoint service was threaded in', async () => {
+    const http = makeHttp({
+      resources: [{ guid: 'b', name: 'own-drain' } as unknown as StApp],
+      pagination: { totalResults: 1, totalPages: 1, next: null },
+    });
+    const src = new CnsiAppsSource('cnsi-1', http);
+
+    await src.load();
+
+    expect(http.get).toHaveBeenCalled();
+    expect(src.items()).toHaveLength(1);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-apps-source.ts
@@ -20,6 +20,42 @@ export class CnsiAppsSource extends CnsiEntitySource<StApp> {
     super(cnsiGuid, http, pageSize);
   }
 
+  // Apps are drained per endpoint by EndpointDataService (home cards, detail
+  // views, the pre-warm queue). Draining them again here duplicates that
+  // work: the caller used to hand us a finished cache via preSeed(), which
+  // covered a *completed* drain but not one still in flight — mount the wall
+  // mid-drain and both ran. loadApps() closes that window: warm cache, live
+  // in-flight observable, or a fresh drain, whichever applies. Both URL
+  // shapes return the same enriched rows (verified field-by-field against a
+  // live foundation: identical keys, routes included), so there's nothing
+  // the per-source `?return=summary` drain was adding.
+  //
+  // Falls back to the base drain when no EDS was threaded in — the cold
+  // bookmark / HMR paths the constructor comment describes.
+  override async load(): Promise<void> {
+    if (!this.eds) return super.load();
+    this.setLoading(true);
+    try {
+      await firstValueFrom(this.eds.loadApps());
+      this.preSeed(this.eds.apps());
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  // refresh() is user-driven ("give me current data"), so it must bypass the
+  // shared cache rather than join it — refreshApps() re-drains unconditionally.
+  override async refresh(): Promise<void> {
+    if (!this.eds) return super.refresh();
+    this.setLoading(true);
+    try {
+      await firstValueFrom(this.eds.refreshApps());
+      this.preSeed(this.eds.apps());
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
   // NOTE: app delete routes through EntityDeleteController (see
   // CfAppsSignalConfigService.deleteApp); create/update/action stay here.
 

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-entity-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-entity-source.ts
@@ -93,6 +93,16 @@ export abstract class CnsiEntitySource<T> {
     this._preseeded = true;
   }
 
+  /**
+   * Report loading while a subclass satisfies load() from somewhere other
+   * than _doLoad() — joining an endpoint-level drain, say. Without this the
+   * source stays loading() === false for the whole join and consumers show
+   * an empty list instead of a spinner.
+   */
+  protected setLoading(loading: boolean): void {
+    this._loading.set(loading);
+  }
+
   private async _doLoad(): Promise<void> {
     // Short-circuit when preSeed() handed us a ready bundle. The seed
     // satisfies this load(); refresh() (or any subsequent load() after

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -68,7 +68,7 @@ describe('CfAppsSignalConfigService', () => {
     eds.addApp(a);
     (eds as unknown as { _appsLastFetched: { set: (d: Date) => void } })._appsLastFetched.set(new Date());
 
-    const registry = { acquire: vi.fn(() => eds) } as unknown as EndpointDataRegistry;
+    const registry = { acquire: vi.fn(() => eds), peek: vi.fn(() => eds) } as unknown as EndpointDataRegistry;
     TestBed.configureTestingModule({
       providers: [
         { provide: HttpClient, useValue: http },
@@ -91,7 +91,7 @@ describe('CfAppsSignalConfigService', () => {
     const eds = new EndpointDataService(http, { write: () => {}, read: () => undefined } as never, 'cf-1');
     // No addApp / no appsLastFetched mutation — appsLastFetched stays null.
 
-    const registry = { acquire: vi.fn(() => eds) } as unknown as EndpointDataRegistry;
+    const registry = { acquire: vi.fn(() => eds), peek: vi.fn(() => eds) } as unknown as EndpointDataRegistry;
     TestBed.configureTestingModule({
       providers: [
         { provide: HttpClient, useValue: http },
@@ -175,7 +175,7 @@ describe('CfAppsSignalConfigService', () => {
       const eds = new EndpointDataService(http, { write: () => {}, read: () => undefined } as never, 'cf-1');
       for (const a of apps) eds.addApp(a);
       (eds as unknown as { _appsLastFetched: { set: (d: Date) => void } })._appsLastFetched.set(new Date());
-      const registry = { acquire: vi.fn(() => eds) } as unknown as EndpointDataRegistry;
+      const registry = { acquire: vi.fn(() => eds), peek: vi.fn(() => eds) } as unknown as EndpointDataRegistry;
       TestBed.configureTestingModule({
         providers: [
           { provide: HttpClient, useValue: http },

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -45,6 +45,18 @@ beforeEach(() => TestBed.resetTestingModule());
 // destroys).
 afterEach(() => TestBed.resetTestingModule());
 
+// Drain microtasks until `done()` holds, rather than a fixed tick count.
+// The number of awaits between initialize() and the first spaces request is
+// an implementation detail — it changed when loadNames() started joining the
+// endpoint's shared space load — and encoding it makes the drain tests fail
+// for reasons unrelated to what they assert.
+async function drainUntil(done: () => boolean, maxTicks = 40): Promise<void> {
+  for (let i = 0; i < maxTicks && !done(); i++) {
+    await Promise.resolve();
+    TestBed.tick();
+  }
+}
+
 describe('CfAppsSignalConfigService', () => {
   it('constructs one CnsiAppsSource per connected CF in scope', () => {
     const http = makeHttp();
@@ -1023,7 +1035,7 @@ describe('CfAppsSignalConfigService', () => {
     svc.initialize(['cnsi-1']);
     void svc.ensureNamesLoaded(['cnsi-1']);
     // Drain microtasks until the priority chunk request is open.
-    for (let i = 0; i < 6; i++) { await Promise.resolve(); TestBed.tick(); }
+    await drainUntil(() => subjects.length > 0);
     expect(subjects.length).toBe(1); // only priority is in flight before resolution
 
     // Resolve the priority request → background workers spin up (cap 3).
@@ -1064,14 +1076,14 @@ describe('CfAppsSignalConfigService', () => {
     const svc = makeSvc(httpMock, cf);
     svc.initialize(['cnsi-1']);
     void svc.ensureNamesLoaded(['cnsi-1']);
-    for (let i = 0; i < 4; i++) { await Promise.resolve(); TestBed.tick(); }
+    await drainUntil(() => subjects.length > 0);
     expect(subjects.length).toBe(1);
 
     // Second initialize() bumps the generation; the still-pending gen-1
     // chunk must NOT merge into _spacesByCnsi when it eventually resolves.
     svc.initialize(['cnsi-1']);
     void svc.ensureNamesLoaded(['cnsi-1']);
-    for (let i = 0; i < 4; i++) { await Promise.resolve(); TestBed.tick(); }
+    await drainUntil(() => subjects.length > 1);
 
     // Resolve the stale request with a space that would otherwise leak in.
     subjects[0].next({
@@ -1134,5 +1146,61 @@ describe('CfAppsSignalConfigService — org catalog shares the endpoint load', (
 
     const orgCalls = (http.get as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(c => orgsUrl(c[0]));
     expect(orgCalls.length).toBe(1);
+  });
+});
+
+// The endpoint's full space list is drained by summary pages via
+// EndpointDataService.loadSpaces(); the per-org fanout here re-fetched the
+// same spaces. loadNames() now joins the shared slice when there is one.
+describe('CfAppsSignalConfigService — space catalog shares the endpoint load', () => {
+  const spacesFanout = (url: unknown) => typeof url === 'string' && url.includes('organization_guids=');
+
+  function makeSvcWith(http: HttpClient, peeked: unknown): CfAppsSignalConfigService {
+    const registry = {
+      acquire: vi.fn(() => peeked),
+      peek: vi.fn(() => peeked),
+    } as unknown as EndpointDataRegistry;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpClient, useValue: http },
+        { provide: CloudFoundryService, useValue: makeStubCfService() },
+        { provide: EndpointDataRegistry, useValue: registry },
+        CfAppsSignalConfigService,
+      ],
+    });
+    return TestBed.inject(CfAppsSignalConfigService);
+  }
+
+  const edsWith = (spaces: Array<{ guid: string; name: string }>) => ({
+    loadOrgs: vi.fn(() => of(undefined)),
+    orgs: () => [{ guid: 'org-1', name: 'org one' }],
+    loadSpaces: vi.fn(() => of(undefined)),
+    spaces: () => spaces,
+  });
+
+  it('seeds space names from the shared load instead of the per-org fanout', async () => {
+    const http = makeHttp();
+    const eds = edsWith([{ guid: 'space-1', name: 'space one' }]);
+    const svc = makeSvcWith(http, eds);
+
+    await svc.ensureNamesLoaded(['cf-1']);
+
+    expect(eds.loadSpaces).toHaveBeenCalledTimes(1);
+    expect(svc.spaceNames().get('space-1')).toBe('space one');
+    const fanout = (http.get as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(c => spacesFanout(c[0]));
+    expect(fanout).toEqual([]);
+  });
+
+  it('falls back to the fanout when the shared slice drained nothing', async () => {
+    const http = makeHttp();
+    // A CF whose spaces drain failed reports an empty slice — the names
+    // still have to come from somewhere, so the fanout must still run.
+    const eds = edsWith([]);
+    const svc = makeSvcWith(http, eds);
+
+    await svc.ensureNamesLoaded(['cf-1']);
+
+    const fanout = (http.get as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(c => spacesFanout(c[0]));
+    expect(fanout.length).toBeGreaterThan(0);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -1086,3 +1086,53 @@ describe('CfAppsSignalConfigService', () => {
     expect(svc.spaceNames().get('space-stale')).toBeUndefined();
   });
 });
+
+// A summary page and this tab both need the endpoint's full org list. Each
+// used to fetch it independently, so arriving here while the other's drain
+// was still running issued two concurrent
+// /pp/v1/cf/orgs/{cnsi}?per_page=500&page=1 requests. loadNames() now joins
+// the endpoint's shared load (EndpointDataService.loadOrgs) instead.
+describe('CfAppsSignalConfigService — org catalog shares the endpoint load', () => {
+  const orgsUrl = (url: unknown) => typeof url === 'string' && url.includes('/pp/v1/cf/orgs/');
+
+  function makeSvcWithPeek(http: HttpClient, peeked: unknown): CfAppsSignalConfigService {
+    const registry = {
+      acquire: vi.fn(() => peeked),
+      peek: vi.fn(() => peeked),
+    } as unknown as EndpointDataRegistry;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpClient, useValue: http },
+        { provide: CloudFoundryService, useValue: makeStubCfService() },
+        { provide: EndpointDataRegistry, useValue: registry },
+        CfAppsSignalConfigService,
+      ],
+    });
+    return TestBed.inject(CfAppsSignalConfigService);
+  }
+
+  it('joins the endpoint org load rather than issuing its own orgs request', async () => {
+    const http = makeHttp();
+    const loadOrgs = vi.fn(() => of(undefined));
+    const eds = { loadOrgs, orgs: () => [{ guid: 'org-1', name: 'org one' }] };
+    const svc = makeSvcWithPeek(http, eds);
+
+    await svc.ensureNamesLoaded(['cf-1']);
+
+    expect(loadOrgs).toHaveBeenCalledTimes(1);
+    // The spaces drain still uses http; the orgs catalog must not.
+    const orgCalls = (http.get as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(c => orgsUrl(c[0]));
+    expect(orgCalls).toEqual([]);
+    expect(svc.orgNames().get('org-1')).toBe('org one');
+  });
+
+  it('falls back to a direct fetch for a guid the registry never acquired', async () => {
+    const http = makeHttp();
+    const svc = makeSvcWithPeek(http, undefined);
+
+    await svc.ensureNamesLoaded(['cf-1']);
+
+    const orgCalls = (http.get as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(c => orgsUrl(c[0]));
+    expect(orgCalls.length).toBe(1);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -399,13 +399,12 @@ export class CfAppsSignalConfigService {
     const sources = cnsiGuids.map(guid => {
       const eds = this.endpointRegistry.acquire(guid);
       const source = new CnsiAppsSource(guid, this.http, eds);
-      // If a prior page (home card / detail view / earlier tab mount) has
-      // already drained this CF's apps into the shared EndpointDataService,
-      // seed the new source from that cache so the user lands on populated
-      // rows instead of staring at a spinner while we re-fetch the same
-      // data. The base class's preSeed flag short-circuits the next load()
-      // exactly once; an explicit refresh() falls through to the normal
-      // HTTP drain.
+      // Warm cache seeds SYNCHRONOUSLY, at mount, so the user lands on
+      // populated rows. CnsiAppsSource.load() now joins the endpoint's
+      // shared drain as well, which covers the cold and still-in-flight
+      // cases this block never could — but that join is necessarily async,
+      // and awaiting it here would trade an instant first paint for a
+      // spinner on every warm mount.
       if (eds.appsLastFetched() !== null) {
         source.preSeed(eds.apps());
       }

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -517,12 +517,40 @@ export class CfAppsSignalConfigService {
     // #500 → "—" in the CF/Org/Space cell), so spaces are fetched per-org-
     // batch below once orgs are known.
     const namePerPage = 500;
-    const fetchOrgs = (guid: string) =>
-      firstValueFrom(this.http.get<StOrgsResponse>(
+    // Join the endpoint's shared org load instead of issuing a second
+    // identical request. A summary page and this tab both want the full org
+    // list, and each used to fetch it independently — arriving here while
+    // the other's drain was still in flight produced two concurrent
+    // `/pp/v1/cf/orgs/{cnsi}?per_page=500&page=1` calls (measured: 13s and
+    // 22s, overlapping). EndpointDataService.loadOrgs() is the single owner
+    // of that state per endpoint: it serves a warm cache outright, returns
+    // the in-flight observable when a drain is already running, and its
+    // shareReplay hands a completed drain's result to a late subscriber —
+    // so joining can't hang waiting on a completion signal that already
+    // fired. Whichever page arrives first starts the load; the other joins.
+    //
+    // peek() rather than acquire(): acquire() on an unseen guid enqueues the
+    // home-card load/details/pre-warm cascade, which this tab must not
+    // trigger. initialize() has already acquired every scoped guid by the
+    // time we run, so the lookup hits; the direct fetch stays as the
+    // fallback for a guid that was never acquired (e.g. ensureNamesLoaded()
+    // deriving guids from connectedEndpoints() beyond the mounted scope).
+    const fetchOrgs = async (guid: string): Promise<{ guid: string; orgs: StOrg[] }> => {
+      const eds = this.endpointRegistry.peek?.(guid);
+      if (eds) {
+        try {
+          await firstValueFrom(eds.loadOrgs());
+          return { guid, orgs: eds.orgs() };
+        } catch {
+          return { guid, orgs: [] as StOrg[] };
+        }
+      }
+      return firstValueFrom(this.http.get<StOrgsResponse>(
         `/pp/v1/cf/orgs/${guid}?per_page=${namePerPage}&page=1`,
       ))
         .then(r => ({ guid, orgs: r.resources as StOrg[] }))
         .catch(() => ({ guid, orgs: [] as StOrg[] }));
+    };
 
     this._isLoadingOrgs.set(true);
     this._isLoadingSpaces.set(true);

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -573,7 +573,15 @@ export class CfAppsSignalConfigService {
     // chunk's RTT is bounded (≤20 orgs of spaces) so awaiting it yields
     // a brief, predictable initial-mount delay in exchange for visible
     // names on first paint.
-    const drainPromises = cnsiGuids.map(cnsi => {
+    // Same story as the org catalog above: an endpoint's full space list may
+    // already be cached or draining on the shared EndpointDataService (a
+    // summary page fetches `/cf/spaces/{cnsi}?per_page=500&page=N` for every
+    // page), and the per-org fanout below re-fetches exactly those spaces —
+    // measured together on one mount as 14 requests / 37.5s. When the shared
+    // slice is available, join it and seed from its result; the fanout is
+    // only worth its request count when nothing else is loading the data.
+    const drainPromises = cnsiGuids.map(async cnsi => {
+      if (await this.seedSpacesFromEndpoint(cnsi, gen)) return;
       const orgs = orgMap.get(cnsi) ?? [];
       const orderedOrgGuids = this.orderOrgsForCnsi(cnsi, orgs);
       return this.drainSpacesByOrgChunks(cnsi, orderedOrgGuids, gen);
@@ -583,6 +591,32 @@ export class CfAppsSignalConfigService {
     // hence allSettled.
     await Promise.allSettled(drainPromises);
     this._isLoadingSpaces.set(false);
+  }
+
+  // Seeds _spacesByCnsi for one endpoint from its shared EndpointDataService
+  // space slice, joining an in-flight drain rather than starting a second
+  // one. Returns false when there's nothing to join (no cached instance, or
+  // the drain produced nothing) so the caller falls back to the per-org
+  // fanout — a slow CF whose drain failed must still get its names.
+  private async seedSpacesFromEndpoint(cnsi: string, gen: number): Promise<boolean> {
+    const eds = this.endpointRegistry.peek(cnsi);
+    if (!eds) return false;
+    try {
+      await firstValueFrom(eds.loadSpaces());
+    } catch {
+      return false;
+    }
+    // A newer initialize() started while we waited — drop the result rather
+    // than merging it into the new mount's map.
+    if (gen !== this._initGen) return true;
+    const spaces = eds.spaces();
+    if (!spaces.length) return false;
+    this._spacesByCnsi.update(curr => {
+      const next = new Map(curr);
+      next.set(cnsi, spaces.slice());
+      return next;
+    });
+    return true;
   }
 
   // Returns the cnsi's orgs ordered with "priority" orgs first (those

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -536,7 +536,7 @@ export class CfAppsSignalConfigService {
     // fallback for a guid that was never acquired (e.g. ensureNamesLoaded()
     // deriving guids from connectedEndpoints() beyond the mounted scope).
     const fetchOrgs = async (guid: string): Promise<{ guid: string; orgs: StOrg[] }> => {
-      const eds = this.endpointRegistry.peek?.(guid);
+      const eds = this.endpointRegistry.peek(guid);
       if (eds) {
         try {
           await firstValueFrom(eds.loadOrgs());

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HttpClient } from '@angular/common/http';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { EndpointDataRegistry } from '../../../services/endpoint-data/endpoint-data.registry';
+import { EntityDeleteController } from '../../../services/deletes/entity-delete.controller';
+import { CfRoutesSignalConfigService } from './cf-routes-signal-config.service';
+
+// The full route list has no slice on EndpointDataService to join (it keeps
+// only _routeCount), so this service is its own single owner — the cache and
+// in-flight guard live here. Before that, every mount re-drained the list.
+describe('CfRoutesSignalConfigService — route list fetch guard', () => {
+  const routesUrl = (url: unknown) => typeof url === 'string' && /\/pp\/v1\/cf\/routes\/[^/?]+$/.test(url);
+
+  let routesStale = false;
+
+  function makeHttp(): HttpClient {
+    return {
+      get: vi.fn((url: string) => {
+        if (routesUrl(url)) {
+          return of({ resources: [{ guid: 'r1', url: 'a.example.com', spaceGuid: 'sp-1' }] });
+        }
+        return of({ resources: [], pagination: { totalResults: 0, totalPages: 1, next: null } });
+      }),
+    } as unknown as HttpClient;
+  }
+
+  function makeSvc(http: HttpClient): CfRoutesSignalConfigService {
+    const eds = {
+      loadDetails: () => of(undefined),
+      routesStale: () => routesStale,
+      apps: () => [],
+      orgs: () => [],
+      spaces: () => [],
+      isLoadingOrgs: () => false,
+      isLoadingSpaces: () => false,
+      refreshApps: () => of(undefined),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: HttpClient, useValue: http },
+        { provide: EndpointDataRegistry, useValue: { acquire: vi.fn(() => eds), peek: vi.fn(() => eds), release: vi.fn() } },
+        { provide: EntityDeleteController, useValue: {} },
+        CfRoutesSignalConfigService,
+      ],
+    });
+    return TestBed.inject(CfRoutesSignalConfigService);
+  }
+
+  const routeFetches = (http: HttpClient) =>
+    (http.get as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(c => routesUrl(c[0]));
+
+  beforeEach(() => { routesStale = false; TestBed.resetTestingModule(); });
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('re-mounting the same endpoint serves the cached list', async () => {
+    const http = makeHttp();
+    const svc = makeSvc(http);
+
+    svc.initialize('cnsi-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    svc.initialize('cnsi-1');
+    await Promise.resolve();
+
+    expect(routeFetches(http).length).toBe(1);
+  });
+
+  it('refetches when the cascade marked routes stale', async () => {
+    const http = makeHttp();
+    const svc = makeSvc(http);
+
+    svc.initialize('cnsi-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    // A write touching routes flips this — the cached list is now wrong.
+    routesStale = true;
+    svc.initialize('cnsi-1');
+    await Promise.resolve();
+
+    expect(routeFetches(http).length).toBe(2);
+  });
+
+  it('refetches when the endpoint changes', async () => {
+    const http = makeHttp();
+    const svc = makeSvc(http);
+
+    svc.initialize('cnsi-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    svc.initialize('cnsi-2');
+    await Promise.resolve();
+
+    expect(routeFetches(http).length).toBe(2);
+  });
+
+  it('refresh() bypasses the cache', async () => {
+    const http = makeHttp();
+    const svc = makeSvc(http);
+
+    svc.initialize('cnsi-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    await svc.refresh();
+
+    expect(routeFetches(http).length).toBe(2);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/route/cf-routes-signal-config.service.ts
@@ -262,18 +262,50 @@ export class CfRoutesSignalConfigService {
     return opts;
   });
 
-  private async fetchRoutes(): Promise<void> {
+  // Every mount used to re-drain the whole route list, with no cache and no
+  // in-flight guard — measured live, tabbing Routes → Summary → Routes issued
+  // two full fetches, and two mounts close together would overlap outright.
+  // EndpointDataService owns no full route slice to join (it keeps only
+  // _routeCount, deliberately), so this service is the single owner and the
+  // guard belongs here.
+  //
+  // Cached result is reused when it belongs to the current endpoint and the
+  // cascade hasn't marked routes stale — a write that touches routes flips
+  // routesStale, so post-mutation reads never serve a stale list. force=true
+  // is for the user-driven and post-write paths that must see fresh data.
+  private _routesInFlight: Promise<void> | null = null;
+  private _routesFetchedFor: string | null = null;
+
+  private fetchRoutes(force = false): Promise<void> {
+    const stale = this.endpointDataService?.routesStale() ?? false;
+    if (!force && !stale && this._routesFetchedFor === this.cnsiGuid && this._allRoutes().length > 0) {
+      return Promise.resolve();
+    }
+    // A forced fetch always goes to the network; joining an in-flight read
+    // could hand back a response that predates the write that forced it.
+    if (!force && this._routesInFlight) return this._routesInFlight;
+    const run = this.runFetchRoutes();
+    this._routesInFlight = run;
+    return run;
+  }
+
+  private async runFetchRoutes(): Promise<void> {
+    const cnsiGuid = this.cnsiGuid;
     try {
       const resp = await firstValueFrom(
-        this.http.get<StRoutesResponse>(`/pp/v1/cf/routes/${this.cnsiGuid}`),
+        this.http.get<StRoutesResponse>(`/pp/v1/cf/routes/${cnsiGuid}`),
       );
       this._allRoutes.set(resp?.resources ?? []);
-      this._hasLoadedOnce.set(true);
+      // Stamp on success only — a failed fetch must leave the cache cold so
+      // the next mount retries instead of serving the failure.
+      this._routesFetchedFor = cnsiGuid;
     } catch {
       // Swallow — errors surface via the list's generic error UI if wired;
       // we still flip hasLoadedOnce so the empty state renders instead of
       // a forever-loading spinner.
+    } finally {
       this._hasLoadedOnce.set(true);
+      this._routesInFlight = null;
     }
   }
 
@@ -286,7 +318,7 @@ export class CfRoutesSignalConfigService {
   }
 
   async refresh(): Promise<void> {
-    await this.fetchRoutes();
+    await this.fetchRoutes(true);
     // Also refresh apps so recently-mapped routes pick up new names.
     // refreshApps() bypasses the cache guard — user-driven refresh always
     // re-fetches.
@@ -318,7 +350,7 @@ export class CfRoutesSignalConfigService {
     // not on the EDS cache — re-fetch so the just-deleted row leaves the view.
     // The controller has already marked the routes/space/app slices stale for
     // the cross-tab UX.
-    await this.fetchRoutes();
+    await this.fetchRoutes(true);
   }
 
   // Per-row Unmap on a route entry. Hits the single unmap_all endpoint,
@@ -340,7 +372,7 @@ export class CfRoutesSignalConfigService {
       `/pp/v1/cf/routes/${cnsiGuid}/${routeGuid}/unmap_all`,
       {},
     ));
-    await this.fetchRoutes();
+    await this.fetchRoutes(true);
   }
 
   // Bulk delete: destroys each route entity (which also unmaps any bound
@@ -352,7 +384,7 @@ export class CfRoutesSignalConfigService {
       `/pp/v1/cf/routes/${cnsiGuid}/bulk/delete`,
       { guids: routeGuids },
     ));
-    await this.fetchRoutes();
+    await this.fetchRoutes(true);
     return result;
   }
 
@@ -364,7 +396,7 @@ export class CfRoutesSignalConfigService {
       `/pp/v1/cf/routes/${cnsiGuid}/bulk/unmap`,
       { guids: routeGuids },
     ));
-    await this.fetchRoutes();
+    await this.fetchRoutes(true);
     return result;
   }
 }


### PR DESCRIPTION
Several list pages re-fetch data an endpoint has already loaded — or is
loading right now — because each one owns a private in-flight guard that no
other page can see. Following an org summary's "N applications" tile into the
Applications tab issued two concurrent, identical
`/pp/v1/cf/orgs/{cnsi}?per_page=500&page=1` requests: 13s and 22s, overlapping,
against a real foundation.

`EndpointDataService` already models this correctly. Each of its `loadX()`
methods serves a warm cache outright, hands back the in-flight observable when
a drain is running, and replays a finished drain to a late subscriber — so
whichever page arrives first owns the load and the rest join it without
stalling on a completion signal they missed. The fix is to route the
duplicating callers through it rather than to add more private guards.

## Measured, live, against a real foundation

Endpoint with 56 apps, 2511 spaces, 63 orgs.

| Scenario | Metric | Before | After |
|---|---|---|---|
| Org summary tile → Applications tab | `orgs?per_page=500&page=1` | 2, overlapping (13s + 22s) | 1 |
| | Organization dropdown | "All" for ~9.3s | resolves immediately |
| Same, spaces catalog | spaces requests | 14 (6 full-page + 7 per-org fanout + 1 guid batch) | 7 (6 full-page + 1 guid batch) |
| | in flight | 37.5s | 25.9s |
| Cold load, CF-scoped Applications tab | apps full drains | 2, overlapping (13.2s + 14.1s) | 1 |
| | in flight | 27.3s | 7.6s |
| Routes → Summary → Routes, one document | route list fetches | 2 | 1 |

Rendered output is unchanged throughout: same rows, same paginator totals
(`1 – 6 of 56`, `1 – 1 of 1`), `Org/Space` cells resolved with no em-dash
placeholders left behind.

## What changed

**Orgs.** `CfAppsSignalConfigService.loadNames()` joins `loadOrgs()` instead of
issuing its own request. It uses `peek()` rather than `acquire()` — `acquire()`
on an unseen guid enqueues the home-card load/details/pre-warm cascade, which
this tab must not trigger; `initialize()` has already acquired every scoped
guid by then. The dropdown showing "All" was the same defect: the tab couldn't
name the carried-in org because it was waiting on its own redundant fetch.

**Spaces.** Same shape one layer down. A summary page drains the endpoint's
full space list; the tab then re-fetched those same spaces through a per-org
`?organization_guids=` fanout. It now seeds from the shared slice, keeping the
fanout as the fallback for an endpoint with no cached instance or whose drain
yielded nothing — a CF whose full drain failed must still resolve its names.

**Apps.** `CnsiAppsSource` drained apps itself unless handed a finished cache,
so a cold mount ran the source's `?return=summary&per_page=100` alongside the
endpoint's `?per_page=500&page=1`. It now joins the shared drain, covering the
warm, in-flight and cold cases alike. Both URL shapes return the same enriched
rows — verified field-by-field, identical keys with routes included.
`refresh()` stays user-driven and goes through `refreshApps()`, which
re-drains rather than serving the cache the user just asked to bypass.

The synchronous warm-cache `preSeed` stays in place. Joining is necessarily
async, and routing the warm path through it would trade an instant first paint
for a spinner on every warm mount — four space-scoped tests caught exactly that
when the consolidation first went in.

**Routes.** The odd one out: `EndpointDataService` deliberately keeps only
`_routeCount`, no full route slice, because draining every route on home-page
load would balloon the count card's cost. So there is nothing to join, and
`CfRoutesSignalConfigService` — a root singleton both Routes tabs inject — is
its own single owner. The cache and in-flight guard live there. Cached results
are reused for the same endpoint until the cascade marks routes stale;
`refresh()` and every post-write path force a fetch so a delete can never serve
the list it just invalidated.

## Tests

`make check gate` passes: 642 files, 3239 tests, no failures.

New coverage for each join, and `CfRoutesSignalConfigService` gets the spec
file it never had (cache reuse, stale-flag refetch, endpoint change,
`refresh()` bypass). Every new assertion was negative-controlled — disabling
the code under test fails the corresponding test, so none of them are hollow.

Two drain tests move from a fixed microtask count to draining until their
condition holds. Awaiting a shared slice before falling back shifts the first
fallback request a few awaits later, which those fixed counts had encoded; the
invariants they assert are unchanged.

Registry stubs in the apps spec gained the `peek()` they were missing — a stub
that omits a method the production code depends on pushes defensiveness into
the source.
