### PR TITLE
fix(deploy): make GitHub/GitLab app deploy work (Source Config, private repos, token re-validate)

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -80,7 +80,7 @@
                           </label>
                           <input id="projectName" type="text" class="input" [disabled]="isRedeploy" [(ngModel)]="repository"
                             placeholder="owner/repo" name="projectName"
-                            [appGithubProjectExists]="sourceType.id + ',' + sourceType.endpointGuid + ',' + (accessToken || '')" required
+                            [appGithubProjectExists]="sourceType.id + ',' + projectExistsEndpointGuid + ',' + (accessToken || '')" required
                             list="repo-suggestions">
                           <!-- Repository suggestions datalist -->
                           <datalist id="repo-suggestions">

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -95,7 +95,9 @@
                         @if (sourceSelectionForm.controls.projectName?.errors?.githubProjectDoesNotExist && !sourceSelectionForm.controls.projectName?.errors?.githubProjectError) {
                           <div class="text-danger text-sm mt-1"
                             >
-                            Project does not exist
+                            Repository not found. Check the owner/name is exact (it is
+                            case-sensitive), and for a private repository make sure your
+                            access token is authorized for it.
                           </div>
                         }
                         @if (sourceSelectionForm.controls.projectName?.errors?.githubProjectError) {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
@@ -189,6 +189,56 @@ describe('DeployApplicationStep2Component', () => {
     });
   });
 
+  // Regression guard: a separately-registered github.com endpoint tags the
+  // GitHub source type with its guid. In Private/Enterprise mode the user
+  // supplies a token directly in the form, so project-exists validation and
+  // repo/branch lookups must talk to the SCM API with THAT token, not proxy
+  // through the registered endpoint's stored creds (which 404s on a private
+  // repo the typed token can actually see). Only Public mode should carry the
+  // endpoint guid.
+  describe('projectExistsEndpointGuid (private/enterprise must not proxy via registered endpoint)', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(DeployApplicationStep2Component);
+      component = fixture.componentInstance;
+      // Simulate the GitHub source type carrying a registered endpoint guid.
+      component.sourceType = {
+        id: 'github',
+        group: 'gitscm',
+        name: 'GitHub',
+        endpointGuid: '747ed39a-endpoint-guid',
+      } as any;
+    });
+
+    it('uses the registered endpoint guid in Public mode', () => {
+      component.gitMode = 'public';
+      expect(component.projectExistsEndpointGuid).toBe('747ed39a-endpoint-guid');
+    });
+
+    it('drops the endpoint guid in Private mode (use the typed token directly)', () => {
+      component.gitMode = 'private';
+      expect(component.projectExistsEndpointGuid).toBe('');
+    });
+
+    it('drops the endpoint guid in Enterprise mode (use the typed token directly)', () => {
+      component.gitMode = 'enterprise';
+      expect(component.projectExistsEndpointGuid).toBe('');
+    });
+
+    it('rebuilds the SCM with no endpoint guid when switching to Private', () => {
+      const getSCM = vi.spyOn(TestBed.inject(GitSCMService), 'getSCM');
+      component.setGitMode('private');
+      // Last getSCM call should target the github type with an empty guid so
+      // the SCM talks to the API directly with the form token.
+      expect(getSCM).toHaveBeenCalledWith('github', '');
+    });
+
+    it('rebuilds the SCM with the endpoint guid when switching to Public', () => {
+      const getSCM = vi.spyOn(TestBed.inject(GitSCMService), 'getSCM');
+      component.setGitMode('public');
+      expect(getSCM).toHaveBeenCalledWith('github', '747ed39a-endpoint-guid');
+    });
+  });
+
   describe('applyGithubEnterpriseAndToken — form wiring', () => {
     let scmSpy: {
       setPublicApi: ReturnType<typeof vi.fn>;

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -143,6 +143,17 @@ export class DeployApplicationStep2Component
   gitMode: GitAccessMode = 'public';
   // --------------
 
+  // Endpoint guid to use for the project-exists validator (and repo/branch
+  // lookups). When the user is in Private/Enterprise mode they've supplied a
+  // token directly in the form, so we must talk to the SCM API with that token
+  // rather than proxying through a registered endpoint (whose stored creds —
+  // or lack thereof — would otherwise be used, causing a 404 on a private repo
+  // the typed token can actually see). Only use the registered endpoint's guid
+  // in Public mode.
+  get projectExistsEndpointGuid(): string {
+    return this.gitMode === 'public' ? (this.sourceType?.endpointGuid ?? '') : '';
+  }
+
   // Git URL
   gitUrl!: string;
   gitUrlBranchName!: string;
@@ -171,19 +182,23 @@ export class DeployApplicationStep2Component
     // Set the details based on which source type is selected
     if (this.sourceType.group === 'gitscm') {
       const branch = this.repositoryBranch;
-      const endpointGuid = this.sourceType.endpointGuid;
+      // Public mode deploys via the registered endpoint (its stored creds);
+      // Private/Enterprise mode deploys with the token typed in the form and
+      // no endpoint. So only require an endpoint guid in Public mode.
+      const endpointGuid = this.gitMode === 'public' ? this.sourceType.endpointGuid : '';
       this.gitData.getRepository(this.scm, this.repository)
         .waitForValue$.pipe(take(1), defaultIfEmpty(null)).subscribe(repo => {
-        // A gitscm save needs a resolved repo, branch and endpoint; all three
-        // are populated by setupForGit before the step can validate.
-        if (!repo || !branch || !endpointGuid) { return; }
+        // A gitscm save needs a resolved repo and branch. An endpoint guid is
+        // only required for Public mode; Private/Enterprise carry the token.
+        if (!repo || !branch) { return; }
+        if (this.gitMode === 'public' && !endpointGuid) { return; }
         this.deployData.saveAppDetails({
           projectName: this.repository,
           branch,
           url: repo.clone_url,
           accessToken: this.accessToken,
           commit: this.isRedeploy ? this.commitInfo?.sha : undefined,
-          endpointGuid,
+          endpointGuid: endpointGuid ?? '',
         }, null);
       });
     } else if (this.sourceType.id === DEPLOY_TYPES_IDS.GIT_URL) {
@@ -354,7 +369,14 @@ export class DeployApplicationStep2Component
         if (!matched) { return; }
         this.sourceType = matched;
 
-        const newScm = this.scmService.getSCM(matched.id as GitSCMType, matched.endpointGuid ?? '');
+        const newScm = this.scmService.getSCM(
+          matched.id as GitSCMType,
+          // In Private/Enterprise mode the user supplies a token directly, so
+          // don't bind the SCM to a registered endpoint (which would proxy via
+          // the endpoint's own creds and 404 on private repos the typed token
+          // can see). Public mode still uses the registered endpoint guid.
+          this.gitMode === 'public' ? (matched.endpointGuid ?? '') : '',
+        );
         if (newScm) {
           // User selected one of the SCM options
           if (this.scm && newScm.getType() !== this.scm.getType()) {
@@ -478,6 +500,20 @@ export class DeployApplicationStep2Component
       this.accessToken = '';
     } else if (mode === 'private') {
       this.githubEnterpriseUrl = '';
+    }
+    // Rebuild the SCM for the new mode: Public binds to the registered
+    // endpoint guid (proxy via stored creds); Private/Enterprise talk to the
+    // SCM API directly with the token typed in the form. Without this rebuild,
+    // a Public-mode SCM (bound to the endpoint) would keep proxying and 404 on
+    // private repos the typed token can actually see.
+    if (this.sourceType) {
+      const rebuilt = this.scmService.getSCM(
+        this.sourceType.id as GitSCMType,
+        mode === 'public' ? (this.sourceType.endpointGuid ?? '') : '',
+      );
+      if (rebuilt) {
+        this.scm = rebuilt;
+      }
     }
     this.applyGithubEnterpriseAndToken(this.githubEnterpriseUrl, this.accessToken);
   }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
@@ -116,4 +116,26 @@ describe('DeployApplicationComponent', () => {
     expect(mockStep2_2.onEnter).toHaveBeenCalledWith(fakeFileInfo);
     expect((component as any).pendingFsFileInfo).toBeUndefined();
   });
+
+  // Regression guard for the "Source Config shows no options / Next disabled"
+  // bug. step2_1 (the git commit picker) is rendered via [hidden], so its
+  // @ViewChild fires at parent view-init — before step 2 has saved any
+  // git source. Building the commit list there (the old `v.onEnter()` in the
+  // setter) ran against an empty applicationSource and never resolved a
+  // project/branch. The build must instead happen on step activation via
+  // step2_1Handle.onEnter, which the stepper fires after step 2's submit.
+  it('builds the commit list on step2_1 activation (handle.onEnter), not at ViewChild init', () => {
+    const mockStep2_1 = { onEnter: vi.fn(), onLeave: vi.fn(), validate: of(false) };
+
+    // ViewChild fires at parent view-init. The setter must NOT call
+    // onEnter here — applicationSource has no git details yet, so the
+    // commit list would build empty (the reported bug).
+    (component as any).step2_1Ref = mockStep2_1;
+    expect(mockStep2_1.onEnter).not.toHaveBeenCalled();
+
+    // Stepper navigates into Source Config → fires handle.onEnter →
+    // the child builds the commit list against the now-populated source.
+    component.step2_1Handle.onEnter!();
+    expect(mockStep2_1.onEnter).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.ts
@@ -179,9 +179,15 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
     this.step2_1Sub?.unsubscribe();
     this.step2_1Sub = undefined;
     if (v) {
-      // Replicate the legacy [onEnter]="step2_1.onEnter" binding so the
-      // child re-validates against the SCM commit selection on entry.
-      v.onEnter();
+      // Subscription wiring only. The activation-time `onEnter` call (which
+      // builds the commit list from the git source populated by step 2's
+      // submit) lives on `step2_1Handle.onEnter` — see the `step2_2Ref`
+      // comment for why the ViewChild-time call is the wrong hook: step 2_1
+      // is rendered via `[hidden]` and so is instantiated up-front, before
+      // step 2 has saved any gitDetails. Calling `v.onEnter()` here ran the
+      // commit-list wrapper with an empty applicationSource, so it never
+      // resolved a project/branch — leaving "Source Config" with no options
+      // and the Next button disabled.
       this.step2_1Sub = v.validate.subscribe(valid => {
         this.step2_1Valid.set(!!valid);
         this.cdr.markForCheck();
@@ -297,6 +303,12 @@ export class DeployApplicationComponent implements OnInit, OnDestroy {
 
   step2_1Handle: SignalStepHandle = {
     valid: this.step2_1Valid.asReadonly(),
+    // Activation-time build of the commit list. Runs on each entry (not at
+    // ViewChild init) so it reads the git source that step 2's submit just
+    // saved — the commit-list wrapper resolves project/branch from
+    // applicationSource, which is empty until then. Re-entries after a
+    // Previous click also rebuild against the latest selection.
+    onEnter: () => this._step2_1?.onEnter(),
     onLeave: () => this._step2_1?.onLeave(),
     submit: async () => {
       const result = await firstValueFrom(this._step2_1!.onNext(0, null as any));

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.spec.ts
@@ -28,4 +28,42 @@ describe('GithubProjectExistsDirective', () => {
     const directive = TestBed.runInInjectionContext(() => new GithubProjectExistsDirective());
     expect(directive).toBeTruthy();
   });
+
+  // Regression guard: an async validator only re-runs when its own control
+  // (the project name) changes. When a PAT is added AFTER the project name is
+  // already entered, the token/auth context changes but the project name does
+  // not — so without OnChanges re-triggering validation, a stale
+  // "does not exist" from the earlier unauthenticated lookup would persist.
+  it('re-triggers validation when the auth context (token) changes', () => {
+    const directive = TestBed.runInInjectionContext(() => new GithubProjectExistsDirective());
+    let reRuns = 0;
+    directive.registerOnValidatorChange(() => reRuns++);
+
+    // Initial value (no token) — first assignment establishes the baseline.
+    directive.appGithubProjectExists = 'github,,';
+    directive.ngOnChanges({
+      appGithubProjectExists: { currentValue: 'github,,', previousValue: undefined, firstChange: true, isFirstChange: () => true },
+    } as any);
+    expect(reRuns).toBe(1);
+
+    // Token added — auth context changed, so validation must re-run.
+    directive.appGithubProjectExists = 'github,,ghp_secrettoken';
+    directive.ngOnChanges({
+      appGithubProjectExists: { currentValue: 'github,,ghp_secrettoken', previousValue: 'github,,', firstChange: false, isFirstChange: () => false },
+    } as any);
+    expect(reRuns).toBe(2);
+
+    // Same value again — no auth change, so no extra re-run.
+    directive.ngOnChanges({
+      appGithubProjectExists: { currentValue: 'github,,ghp_secrettoken', previousValue: 'github,,ghp_secrettoken', firstChange: false, isFirstChange: () => false },
+    } as any);
+    expect(reRuns).toBe(2);
+  });
+
+  it('preserves commas in the access token when splitting the auth context', () => {
+    const directive = TestBed.runInInjectionContext(() => new GithubProjectExistsDirective());
+    directive.appGithubProjectExists = 'github,,tok,en,with,commas';
+    const parsed = (directive as any).getTypeAndEndpointWithAuth();
+    expect(parsed).toEqual(['github', '', 'tok,en,with,commas']);
+  });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
@@ -39,25 +39,48 @@ describe('GithubProjectExistsDirective', () => {
     let reRuns = 0;
     directive.registerOnValidatorChange(() => reRuns++);
 
-    // Initial value (no token) — first assignment establishes the baseline.
+    // First change only records the baseline — it must NOT re-run validation
+    // or clear cached state (see redeploy-seed guard below).
     directive.appGithubProjectExists = 'github,,';
     directive.ngOnChanges({
       appGithubProjectExists: { currentValue: 'github,,', previousValue: undefined, firstChange: true, isFirstChange: () => true },
     } as any);
-    expect(reRuns).toBe(1);
+    expect(reRuns).toBe(0);
 
     // Token added — auth context changed, so validation must re-run.
     directive.appGithubProjectExists = 'github,,ghp_secrettoken';
     directive.ngOnChanges({
       appGithubProjectExists: { currentValue: 'github,,ghp_secrettoken', previousValue: 'github,,', firstChange: false, isFirstChange: () => false },
     } as any);
-    expect(reRuns).toBe(2);
+    expect(reRuns).toBe(1);
 
     // Same value again — no auth change, so no extra re-run.
     directive.ngOnChanges({
       appGithubProjectExists: { currentValue: 'github,,ghp_secrettoken', previousValue: 'github,,ghp_secrettoken', firstChange: false, isFirstChange: () => false },
     } as any);
-    expect(reRuns).toBe(2);
+    expect(reRuns).toBe(1);
+  });
+
+  // Regression guard (PR #5707 review): the redeploy path pre-seeds
+  // checkProjectExists() before the wizard renders, and this directive is
+  // constructed on first render even in a non-active step. The first
+  // ngOnChanges must NOT clear that seeded projectExists state, or the
+  // repository info card disappears on redeploy (the disabled project input
+  // never re-runs its async validator to rebuild it).
+  it('does not clear seeded projectExists state on the first change', () => {
+    const directive = TestBed.runInInjectionContext(() => new GithubProjectExistsDirective());
+    const deployData = (directive as any).deployData as {
+      projectDoesntExist: (n: string) => void;
+      state: () => { projectExists?: { name: string } };
+    };
+    const clearSpy = vi.spyOn(deployData, 'projectDoesntExist');
+
+    directive.appGithubProjectExists = 'github,747ed39a-guid,';
+    directive.ngOnChanges({
+      appGithubProjectExists: { currentValue: 'github,747ed39a-guid,', previousValue: undefined, firstChange: true, isFirstChange: () => true },
+    } as any);
+
+    expect(clearSpy).not.toHaveBeenCalled();
   });
 
   it('preserves commas in the access token when splitting the auth context', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, forwardRef, Input, inject } from '@angular/core';
+import { Directive, forwardRef, Input, inject, OnChanges, SimpleChanges } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { AbstractControl, NG_ASYNC_VALIDATORS, Validator } from '@angular/forms';
 import { GitSCMService, GitSCMType } from '@stratosui/git';
@@ -21,15 +21,47 @@ const GITHUB_PROJECT_EXISTS = {
   providers: [GITHUB_PROJECT_EXISTS],
   standalone: true
 })
-export class GithubProjectExistsDirective implements Validator {
+export class GithubProjectExistsDirective implements Validator, OnChanges {
 
+  // Value shape: `<scm type>,<endpoint guid>,<access token>`. Changing the
+  // token (or endpoint) must re-trigger validation — an NgControl async
+  // validator only re-runs when its OWN control (the project name) changes,
+  // so without OnChanges a token added AFTER the project name was entered
+  // would never be re-checked, leaving a stale "does not exist" from the
+  // earlier unauthenticated lookup.
   @Input() appGithubProjectExists!: string;
 
   private lastValue = '';
+  // The auth context (scm,guid,token) used for the last check. When it
+  // changes we must force a re-check even for the same project name.
+  private lastAuthContext = '';
+
+  private onChange?: () => void;
 
   private scmService = inject(GitSCMService);
   private deployData = inject(CfDeployAppDataService);
   private deployState$ = toObservable(this.deployData.state);
+
+  // Angular calls registerOnValidatorChange with a callback that re-runs this
+  // validator. We invoke it when the token/endpoint context changes so a
+  // late-entered PAT immediately re-validates the already-typed project.
+  registerOnValidatorChange(fn: () => void): void {
+    this.onChange = fn;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.appGithubProjectExists) {
+      const auth = this.appGithubProjectExists ?? '';
+      if (auth !== this.lastAuthContext) {
+        this.lastAuthContext = auth;
+        // Drop any cached project-exists result so the guard in validate()
+        // (name !== c.value) doesn't short-circuit the re-check under the new
+        // auth context, then ask Angular to re-run validation.
+        this.deployData.projectDoesntExist('');
+        this.onChange?.();
+      }
+    }
+  }
 
   // Reduce API calls trying to validate until we have a valid name
   // Must be of the form USER/NAME - where NAME must be at least 2 charts in length
@@ -44,8 +76,10 @@ export class GithubProjectExistsDirective implements Validator {
 
   private getTypeAndEndpointWithAuth(): [GitSCMType, string, string] | null {
     const res = this.appGithubProjectExists.split(',');
-    if (res.length === 3) {
-      return [res[0] as GitSCMType, res[1], res[2]];
+    if (res.length >= 3) {
+      // A PAT can legitimately contain commas — rejoin everything after the
+      // scm type + endpoint guid so the token is passed intact.
+      return [res[0] as GitSCMType, res[1], res.slice(2).join(',')];
     }
     console.warn('appGithubProjectExists value should be `<scm type>,<endpoint guid>,<access token>`');
     return null;

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
@@ -32,9 +32,10 @@ export class GithubProjectExistsDirective implements Validator, OnChanges {
   @Input() appGithubProjectExists!: string;
 
   private lastValue = '';
-  // The auth context (scm,guid,token) used for the last check. When it
-  // changes we must force a re-check even for the same project name.
-  private lastAuthContext = '';
+  // The auth context (scm,guid,token) used for the last check. `undefined`
+  // until the first ngOnChanges records the initial value — distinct from ''
+  // so we can tell "first render" apart from "token later cleared to empty".
+  private lastAuthContext: string | undefined = undefined;
 
   private onChange?: () => void;
 
@@ -50,16 +51,32 @@ export class GithubProjectExistsDirective implements Validator, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.appGithubProjectExists) {
-      const auth = this.appGithubProjectExists ?? '';
-      if (auth !== this.lastAuthContext) {
-        this.lastAuthContext = auth;
-        // Drop any cached project-exists result so the guard in validate()
-        // (name !== c.value) doesn't short-circuit the re-check under the new
-        // auth context, then ask Angular to re-run validation.
-        this.deployData.projectDoesntExist('');
-        this.onChange?.();
-      }
+    const change = changes.appGithubProjectExists;
+    if (!change) {
+      return;
+    }
+    const auth = this.appGithubProjectExists ?? '';
+
+    // First render just records the baseline. Do NOT clear projectExists here:
+    // the redeploy path pre-seeds checkProjectExists() before navigating to
+    // the wizard (CfDeployAppDataService is providedIn:'root'), and this
+    // directive is constructed on first render even when its step isn't active
+    // (Ivy doesn't defer <ng-content> in <ng-template>). Clearing on the first
+    // change would discard that seeded repo info, and on redeploy the project
+    // input is [disabled] so its async validator never re-runs to rebuild it.
+    if (this.lastAuthContext === undefined) {
+      this.lastAuthContext = auth;
+      return;
+    }
+
+    if (auth !== this.lastAuthContext) {
+      this.lastAuthContext = auth;
+      // Auth context genuinely changed (e.g. a PAT typed after the project
+      // name). Drop the cached project-exists result so validate()'s
+      // name-match guard doesn't short-circuit the re-check, then ask Angular
+      // to re-run validation under the new auth.
+      this.deployData.projectDoesntExist('');
+      this.onChange?.();
     }
   }
 

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -335,13 +335,18 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
     // Route through pOnEnter so signal-handle consumers (FWT-959 Shape 3
     // wizards) receive the enter callback — see comment above for rationale.
     //
-    // Delivery is deferred to after the NEXT render: the entering step's
-    // content is only instantiated by the ngTemplateOutlet on currentIndex
-    // during that render, so a synchronous pOnEnter here runs before any
-    // @ViewChild the handle's onEnter body dereferences exists — the enter
-    // callback was silently dropped for every step after the first (#5600:
-    // specify-details-step never received onEnter, so its formMode was
-    // never set and the step rendered empty).
+    // Delivery is deferred to after the NEXT render. Note: projected step
+    // content is NOT lazily instantiated — Ivy constructs <ng-content> inside
+    // an <ng-template> on first render regardless of the active step, so a
+    // step's directives/@Inputs (and their ngOnChanges) run up-front. The
+    // deferral is instead about ordering relative to THIS transition: a
+    // synchronous pOnEnter here would run before the entering step is marked
+    // active and before change detection settles for the newly-current index,
+    // so onEnter side effects (e.g. building a list keyed off the now-active
+    // step) could see stale state. afterNextRender guarantees the enter
+    // callback fires once the step is active and rendered (#5600:
+    // specify-details-step never received onEnter, so its formMode was never
+    // set and the step rendered empty).
     const enteringStep = this.steps[index];
     const enterData = this.enterData;
     this.enterData = undefined;


### PR DESCRIPTION
## Problem

Several issues in the **Deploy Application** wizard's git (GitHub/GitLab) path made it unusable end-to-end:

1. **Source Config step showed no options and the Next button stayed disabled**, so a git deploy could not proceed.
2. When it was forced through, the resulting `git clone` failed with **exit 128** (wrong branch).
3. **Private repositories failed** ("Project does not exist") when a `github.com`/`gitlab.com` endpoint was *also* registered.
4. A **token added after the project name** never re-validated.

Root-caused and fixed each below. All changes have unit tests; `eslint` is clean.

## Changes

### 1. Build the commit list on step activation, not `@ViewChild` init
The Source Config step (`step2_1`, the commit picker) is rendered via `[hidden]`, so Angular instantiates it up-front. The `step2_1Ref` `@ViewChild` setter called `onEnter()` at that instant — before step 2's submit had saved a git source — so the commit-list wrapper resolved an empty `applicationSource`, never fetched commits, and the step stayed invalid (no options, Next disabled). Moved the activation work to `step2_1Handle.onEnter`, which the stepper fires on real navigation into the step, after step 2 submits. This is the same `@ViewChild`-fires-once trap already fixed for `step2_2`/`step3` (#5600).

This also resolves the **exit 128** clone: the wizard had been carrying a wrong branch (e.g. `main` on a `master`-default repo → `Remote branch main not found`) because the branch was never resolved from the repo's real default.

### 2. Use the typed token, not a registered endpoint, for private repos
A separately-registered `github.com`/`gitlab.com` endpoint tags the source type with its guid. In **Private/Enterprise** access mode the user supplies a Personal Access Token directly in the form, but project-exists validation + repo/branch/commit lookups were still built against the registered endpoint guid — so requests proxied through the endpoint's stored creds (`/api/v1/proxy/<guid>/...`) and ignored the typed token. A private repo the token could see returned 404 ("Project does not exist"). Now only **Public** mode uses the registered endpoint; **Private/Enterprise** talk to the SCM API directly with the typed token.

### 3. Re-validate when the access token changes
An async validator only re-runs when its own control (the project name) changes. Adding a PAT *after* the name was entered didn't re-check (and the cache was keyed on name only), leaving a stale unauthenticated "does not exist". The directive now implements `OnChanges` + `registerOnValidatorChange`: an auth-context (scm/guid/token) change clears the cached result and re-triggers validation. Token parsing is also comma-safe.

### 4. Clearer repository-not-found message
`GET /repos/<owner>/<repo>` 404s both for "does not exist" and for a private repo the token isn't authorized for (GitHub 404s rather than 403s to avoid leaking existence). Reworded the flat "Project does not exist" to point at exact (case-sensitive) owner/name and, for private repos, token authorization.

## Verification

- Unit tests added/updated across `deploy-application.component`, `deploy-application-step2.component`, and `github-project-exists.directive`; all pass under `vitest --project=cloud-foundry`. `eslint` clean.
- **Validated on a live dev deployment:**
  - Public GitHub repo deploy: works.
  - Private GitHub repo with a classic PAT (repo scope, SSO-authorized): validates and deploys end-to-end.
  - Confirmed the Source Config regression reproduces on current `develop` and is resolved by this branch.

> Note: fine-grained PATs must have the target repo in their selected-repositories grant (and org approval) or GitHub returns 404 — this is expected GitHub behavior, not a Stratos issue; the improved message (change 4) now hints at it.

---

*Implemented with AI assistance (OpenCode); reviewed by a human contributor. Commits are DCO signed-off.*
