### PR TITLE
Add operator-configurable documentation link to the page header

### DIFF
--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
@@ -86,6 +86,27 @@
       }
     </ul>
 
+    <!-- Company links. Reference-grade, so plain rel="noopener noreferrer"
+         external links — unlike the header docs link these are one-shot. -->
+    @if (companyWebsite() || supportEmail()) {
+      <div class="nav-company-links border-t border-nav-border p-3 space-y-1" [class.hidden]="iconMode">
+        @if (companyWebsite(); as website) {
+          <a class="nav-company-website flex items-center p-2 text-nav-text-muted hover:text-nav-text hover:bg-nav-hover rounded-lg transition-all duration-200"
+            [href]="website" target="_blank" rel="noopener noreferrer">
+            <span class="material-icons text-xl shrink-0">language</span>
+            <span class="ml-3 text-sm font-medium">Website</span>
+          </a>
+        }
+        @if (supportEmail(); as email) {
+          <a class="nav-company-support flex items-center p-2 text-nav-text-muted hover:text-nav-text hover:bg-nav-hover rounded-lg transition-all duration-200"
+            [href]="'mailto:' + email">
+            <span class="material-icons text-xl shrink-0">mail_outline</span>
+            <span class="ml-3 text-sm font-medium">Support</span>
+          </a>
+        }
+      </div>
+    }
+
     <!-- Logout Button -->
     <div class="nav-logout border-t border-nav-border p-3">
       <button

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.ts
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.ts
@@ -63,6 +63,10 @@ export class SideNavComponent implements OnInit {
 
   public copyright = computed(() => this.branding.getCopyrightText());
 
+  // Operator-configured company links. website is https-validated by the service.
+  public companyWebsite = computed(() => this.branding.getCompanyWebsite());
+  public supportEmail = computed(() => this.branding.getSupportEmail());
+
   public environment = environment;
   public showAllMenuItems = false;
 

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.html
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.html
@@ -46,6 +46,36 @@
                 [favorite]="pFavorite">
               </app-entity-favorite-star>
             }
+
+            <!-- Documentation split control. The anchor opens the docs; the
+                 caret chooses tab vs popup. Named target so repeat clicks reuse
+                 one window rather than piling up; deliberately no rel="noopener"
+                 — severing the opener also severs the reuse. Popup mode is
+                 intercepted in the handler. See #5690. -->
+            @if (documentationUrl(); as docsUrl) {
+              <div class="page-header-documentation flex items-center text-header-text">
+                <a class="page-header-documentation-link pl-1.5 pr-0 py-1.5 hover:bg-white/10 rounded-l-md transition-colors"
+                  [href]="docsUrl"
+                  target="stratos-docs"
+                  (click)="openDocumentation($event, docsUrl)"
+                  [matTooltip]="documentationTooltip()"
+                  [attr.aria-label]="documentationTooltip()">
+                  <span class="material-icons text-base leading-5 block">menu_book</span>
+                </a>
+                <button type="button"
+                  class="page-header-documentation-toggle pl-1 pr-1.5 py-1.5 hover:bg-white/10 rounded-r-md transition-colors"
+                  (click)="toggleDocumentationTarget()"
+                  [matTooltip]="documentationTargetTooltip()"
+                  [attr.aria-label]="documentationTargetTooltip()">
+                  <span class="flex items-center gap-0.5 opacity-80">
+                    <span class="text-xs leading-5">{{ documentationTargetLabel() }}</span>
+                    <!-- Static rotate glyph: signals the word toggles, without a
+                         caret's implication that a menu will open. -->
+                    <span class="material-icons text-[13px] leading-5">autorenew</span>
+                  </span>
+                </button>
+              </div>
+            }
           </div>
 
           <!-- Right content -->

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.spec.ts
@@ -142,6 +142,8 @@ describe('PageHeaderComponent', () => {
     });
 
     afterEach(() => {
+      // Absorb any pending company-config request from StratosBrandingService before verify
+      httpMock.match('/assets/company-config.json');
       httpMock.verify();
       vi.restoreAllMocks();
     });

--- a/src/frontend/packages/core/src/shared/components/page-header/page-header.component.ts
+++ b/src/frontend/packages/core/src/shared/components/page-header/page-header.component.ts
@@ -1,7 +1,7 @@
 import { Portal, TemplatePortal } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, ChangeDetectorRef, AfterViewInit, Component, Input, OnDestroy, TemplateRef, ViewChild, ViewContainerRef, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, AfterViewInit, Component, Input, OnDestroy, TemplateRef, ViewChild, ViewContainerRef, computed, inject } from '@angular/core';
 import { RouterModule, ActivatedRoute, Router } from '@angular/router';
 import { toObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
@@ -13,6 +13,7 @@ import {
   UserProfileInfo,
   AuthTokenEnvelope,
 } from '@stratosui/store';
+import { StratosBrandingService } from '../../../../../theme/stratos-branding.service';
 import { DashboardSignalService } from '../../../core/signals/dashboard-signal.service';
 import { DashboardDataService } from '../../../core/dashboard-data.service';
 import { getTime } from 'date-fns';
@@ -37,6 +38,10 @@ import { RecentEntitiesComponent } from '../recent-entities/recent-entities.comp
 import { UserAvatarComponent } from '../user-avatar/user-avatar.component';
 import { PageHeaderEventsComponent } from './page-header-events/page-header-events.component';
 import { ThemeToggleComponent } from '../theme-toggle/theme-toggle.component';
+
+// Shared between the anchor's target and the popup window.open call, so both
+// modes address the same window and reuse it on repeat clicks.
+const DOCUMENTATION_WINDOW_NAME = 'stratos-docs';
 
 @Component({
   selector: 'app-page-header',
@@ -71,6 +76,44 @@ export class PageHeaderComponent implements OnDestroy, AfterViewInit {
   private dashboardSignals = inject(DashboardSignalService);
   private dashboardData = inject(DashboardDataService);
   private viewContainerRef = inject(ViewContainerRef);
+  private branding = inject(StratosBrandingService);
+
+  // Operator-configured docs link, https-validated by the branding service.
+  public documentationUrl = computed(() => this.branding.getDocumentationUrl());
+  public documentationTarget = computed(() => this.branding.getDocumentationTarget());
+  // Operators can rename "documentation" to whatever they call their docs.
+  public documentationLabel = computed(() => this.branding.getDocumentationLabel());
+  public documentationTooltip = computed(() =>
+    `Open ${this.documentationLabel()} in a reusable tab or window`
+  );
+
+  // Word toggle, behaving like the home page's sort button: the label shows the
+  // current state and the tooltip says what clicking will do.
+  public documentationTargetLabel = computed(() =>
+    this.documentationTarget() === 'popup' ? 'Window' : 'Tab'
+  );
+  public documentationTargetTooltip = computed(() =>
+    this.documentationTarget() === 'popup'
+      ? `Opens in a separate window — click to use a tab instead`
+      : `Opens in a tab — click to use a separate window instead`
+  );
+
+  /**
+   * In 'tab' mode the anchor does the work unaided, so middle-click and
+   * cmd-click keep behaving normally. Only 'popup' needs intercepting, because
+   * a window features string has no markup equivalent.
+   *
+   * The named target is what makes repeat clicks reuse one window instead of
+   * piling up; it only works while this window remains the opener, which is why
+   * there is deliberately no rel="noopener" here. See #5690.
+   */
+  openDocumentation(event: MouseEvent, url: string): void {
+    if (this.documentationTarget() !== 'popup') {
+      return;
+    }
+    event.preventDefault();
+    window.open(url, DOCUMENTATION_WINDOW_NAME, 'width=1024,height=900');
+  }
 
   public canAPIKeys$: Observable<boolean>;
   public breadcrumbDefinitions: IHeaderBreadcrumbLink[] | null = null;
@@ -353,6 +396,10 @@ export class PageHeaderComponent implements OnDestroy, AfterViewInit {
       this.isUserMenuOpen = false;
       this.refreshTokenObservables();
     }
+  }
+
+  toggleDocumentationTarget() {
+    this.branding.setDocumentationTarget(this.documentationTarget() === 'popup' ? 'tab' : 'popup');
   }
 
   closeUserMenu() {

--- a/src/frontend/packages/core/src/shared/services/stratos-branding.service.spec.ts
+++ b/src/frontend/packages/core/src/shared/services/stratos-branding.service.spec.ts
@@ -87,6 +87,89 @@ describe('StratosBrandingService', () => {
   });
 
   // ===========================================================================
+  // Operator-supplied URL validation (#5690)
+  // ===========================================================================
+
+  describe('operator-supplied company URLs', () => {
+    it('should return undefined when no documentation URL is configured', () => {
+      expect(service.getDocumentationUrl()).toBeUndefined();
+    });
+
+    it('should honour an https documentation URL', () => {
+      service.updateCompanyInfo({ documentationUrl: 'https://docs.cloud.gov/' });
+      expect(service.getDocumentationUrl()).toBe('https://docs.cloud.gov/');
+    });
+
+    it('should reject a plain http documentation URL', () => {
+      service.updateCompanyInfo({ documentationUrl: 'http://docs.cloud.gov/' });
+      expect(service.getDocumentationUrl()).toBeUndefined();
+    });
+
+    it('should reject a javascript: documentation URL', () => {
+      service.updateCompanyInfo({ documentationUrl: 'javascript:alert(1)' });
+      expect(service.getDocumentationUrl()).toBeUndefined();
+    });
+
+    it('should reject a data: documentation URL', () => {
+      service.updateCompanyInfo({ documentationUrl: 'data:text/html,<script>alert(1)</script>' });
+      expect(service.getDocumentationUrl()).toBeUndefined();
+    });
+
+    it('should reject an unparseable documentation URL', () => {
+      service.updateCompanyInfo({ documentationUrl: 'not a url' });
+      expect(service.getDocumentationUrl()).toBeUndefined();
+    });
+
+    it('should default the documentation target to tab', () => {
+      expect(service.getDocumentationTarget()).toBe('tab');
+    });
+
+    it('should honour an explicit popup documentation target', () => {
+      service.updateCompanyInfo({ documentationTarget: 'popup' });
+      expect(service.getDocumentationTarget()).toBe('popup');
+    });
+
+    it('should fall back to tab for an unrecognised documentation target', () => {
+      service.updateCompanyInfo({ documentationTarget: 'sidebar' as never });
+      expect(service.getDocumentationTarget()).toBe('tab');
+    });
+
+    it('should default the documentation label to "documentation"', () => {
+      expect(service.getDocumentationLabel()).toBe('documentation');
+    });
+
+    it('should let branding rename the documentation label', () => {
+      service.updateCompanyInfo({ documentationLabel: 'the Cloud.gov handbook' });
+      expect(service.getDocumentationLabel()).toBe('the Cloud.gov handbook');
+    });
+
+    it('should ignore a blank documentation label', () => {
+      service.updateCompanyInfo({ documentationLabel: '   ' });
+      expect(service.getDocumentationLabel()).toBe('documentation');
+    });
+
+    it('should let the user choice override the operator default', () => {
+      service.updateCompanyInfo({ documentationTarget: 'tab' });
+      service.setDocumentationTarget('popup');
+      expect(service.getDocumentationTarget()).toBe('popup');
+    });
+
+    it('should persist the user choice for the next session', () => {
+      service.setDocumentationTarget('popup');
+      expect(localStorage.getItem('stratos-docs-target')).toBe('popup');
+      service.setDocumentationTarget('tab');
+      expect(localStorage.getItem('stratos-docs-target')).toBe('tab');
+    });
+
+    it('should apply the same validation to the company website', () => {
+      service.updateCompanyInfo({ website: 'javascript:alert(1)' });
+      expect(service.getCompanyWebsite()).toBeUndefined();
+      service.updateCompanyInfo({ website: 'https://cloud.gov/' });
+      expect(service.getCompanyWebsite()).toBe('https://cloud.gov/');
+    });
+  });
+
+  // ===========================================================================
   // Layer 3: activateUserPreferences()
   // ===========================================================================
 

--- a/src/frontend/packages/theme/company-config.interface.ts
+++ b/src/frontend/packages/theme/company-config.interface.ts
@@ -5,6 +5,9 @@ export interface CompanyConfig {
     displayName?: string;  // Shown in nav/title — falls back to name
     website?: string;
     supportEmail?: string;
+    documentationUrl?: string;  // Operator docs, opened from the page header
+    documentationTarget?: 'tab' | 'popup';  // How to open it; defaults to 'tab'
+    documentationLabel?: string;  // Name used in the link's tooltip; defaults to 'documentation'
   };
 
   // Logo customization

--- a/src/frontend/packages/theme/stratos-branding.service.ts
+++ b/src/frontend/packages/theme/stratos-branding.service.ts
@@ -95,6 +95,11 @@ export class StratosBrandingService {
   private readonly THEME_MODE_KEY = 'stratos-theme-mode';
   private readonly BRANDING_STORAGE_KEY = 'stratos-branding';
   private readonly CONFIG_STORAGE_KEY = 'stratos-company-config';
+  private readonly DOCS_TARGET_KEY = 'stratos-docs-target';
+
+  // User's choice of how the documentation link opens. null = follow the
+  // operator's configured default. Hydrated from storage on construction.
+  private _docsTargetOverride = signal<'tab' | 'popup' | null>(null);
 
   // --- Media query ---
   private mediaQueryList!: MediaQueryList;
@@ -129,6 +134,7 @@ export class StratosBrandingService {
 
     // Start async company config load (Layer 1 update)
     this.loadCompanyConfig();
+    this.hydrateDocumentationTarget();
 
     // Remove initializing class after a small delay to enable transitions
     setTimeout(() => {
@@ -644,6 +650,73 @@ export class StratosBrandingService {
 
   getCopyrightText(): string | undefined {
     return this._config().footer.copyright;
+  }
+
+  /**
+   * company-config.json is operator-supplied, so a URL from it is only honoured
+   * over https. Anything else — javascript:, data:, a typo — yields undefined
+   * and the link is simply not rendered.
+   */
+  private httpsUrlOrUndefined(value?: string): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+    try {
+      return new URL(value).protocol === 'https:' ? value : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  getDocumentationUrl(): string | undefined {
+    return this.httpsUrlOrUndefined(this._config().company.documentationUrl);
+  }
+
+  /** What the docs are called in the UI, so operators can brand it. */
+  getDocumentationLabel(): string {
+    return this._config().company.documentationLabel?.trim() || 'documentation';
+  }
+
+  /**
+   * User choice wins over the operator default, mirroring how theme mode works.
+   * Anything unrecognised from either source falls back to 'tab'.
+   */
+  getDocumentationTarget(): 'tab' | 'popup' {
+    const override = this._docsTargetOverride();
+    if (override) {
+      return override;
+    }
+    return this._config().company.documentationTarget === 'popup' ? 'popup' : 'tab';
+  }
+
+  setDocumentationTarget(target: 'tab' | 'popup') {
+    this._docsTargetOverride.set(target);
+    try {
+      localStorage.setItem(this.DOCS_TARGET_KEY, target);
+    } catch (_error) {
+      // Storage unavailable (private mode / quota) — the choice still applies
+      // for this session, it just will not survive a reload.
+    }
+  }
+
+  private hydrateDocumentationTarget() {
+    try {
+      const stored = localStorage.getItem(this.DOCS_TARGET_KEY);
+      if (stored === 'tab' || stored === 'popup') {
+        this._docsTargetOverride.set(stored);
+      }
+    } catch (_error) {
+      // Storage unavailable — fall back to the operator default.
+    }
+  }
+
+  getCompanyWebsite(): string | undefined {
+    return this.httpsUrlOrUndefined(this._config().company.website);
+  }
+
+  // NOTE: not URL-validated — the value is only ever used behind a mailto: scheme.
+  getSupportEmail(): string | undefined {
+    return this._config().company.supportEmail;
   }
 
   // =========================================================================


### PR DESCRIPTION
Adds an operator-configurable documentation link to the page header, and gives
the company website and support address a place to appear. Both of those already
existed in the branding config but were never rendered anywhere.

Refs #5690.

## What it looks like

The documentation control sits beside the page title: a link, and a word toggle
reading `Tab` or `Window`. The toggle switches how the docs open, following the
convention already used by the home page's sort button — the label carries the
current state and the tooltip says what clicking will do. A static rotate glyph
marks it as clickable without a caret's implication that a menu will open.

The website and support links sit above Sign Out in the side navigation.

Nothing appears unless configured. With no `documentationUrl` set there is no
control in the header at all.

## Configuration

All three fields go under `company` in `company-config.json`:

| Field | Purpose |
|---|---|
| `documentationUrl` | The docs to open. Required for the control to appear. |
| `documentationTarget` | `tab` (default) or `popup` — the deployment's default. |
| `documentationLabel` | What to call the docs in the tooltip. Defaults to "documentation". |

A user's own choice of tab vs window overrides the deployment default and
persists, mirroring how theme mode already works.

## Two decisions worth reviewing

**The documentation link deliberately carries no `rel="noopener"`.**

It uses a named target so repeated clicks reuse one tab or window rather than
piling up new ones. Reuse and opener-severance turn out to be the same browser
permission: navigating a window you opened requires still being its opener. I
checked this across Chromium, Firefox and WebKit — `noopener`, `rel="noopener"`,
`Cross-Origin-Opener-Policy: same-origin` and nulling the handle each sever the
opener, and each costs the reuse. There is no combination that keeps both.

So this accepts a residual reverse-tabnabbing exposure: the documentation page
can navigate the console's tab. That is a real capability, confirmed in all three
engines, not a theoretical one. It is accepted here because the URL is set by the
operator and points at their own documentation host, not at anything a user
supplies. The website link is different — it is one-shot reference rather than
repeated navigation, so it keeps `rel="noopener noreferrer"` in line with the
other external links in the console.

Worth knowing for anyone revisiting this: Firefox alone permits navigating a
window after nulling its opener, which looks like it gives you reuse *and*
severance. Chromium and WebKit both refuse with a SecurityError, and the failure
is silent — the click simply does nothing. Building against Firefox's behaviour
would ship a button that quietly stops working in Chrome and Safari.

**URLs from the branding config are only honoured over https.**

`company-config.json` is operator-supplied, so a `javascript:` or `data:` value
would otherwise become a live link. Anything that is not https — including a
mistyped or unparseable value — yields no link rather than a broken or dangerous
one. The support address is not URL-validated, because it is only ever used
behind a `mailto:` scheme.

## Scope

This covers the "open the documentation without losing the console" half of
\#5690. Embedding the documentation in an iframe is not included: the hosts
involved send `X-Frame-Options: SAMEORIGIN`, so that needs a `frame-ancestors`
header on the documentation side and remains an operator-side option rather than
console code.

## Testing

Full gate green — 642 test files, 3254 tests. 15 new tests cover the https
validation, the target resolution and its persistence, and the label default.

Verified in a running console in both light and dark themes. Popup mode was
confirmed to produce an actual window rather than a tab (`outerWidth` matching
the requested size, opener retained), and reuse was confirmed by navigating the
open window elsewhere and checking that a further click brought it back — a tab
count alone would not distinguish reuse from a silently failed click.
