### PR TITLE
Document the documentation link configuration fields

### DIFF
--- a/src/frontend/packages/theme/README.md
+++ b/src/frontend/packages/theme/README.md
@@ -55,7 +55,10 @@ from these locations in order:
     "name": "Acme Corp",
     "displayName": "Acme Cloud",
     "website": "https://acme.example.com",
-    "supportEmail": "support@acme.example.com"
+    "supportEmail": "support@acme.example.com",
+    "documentationUrl": "https://cloudfoundry.github.io/stratos/",
+    "documentationTarget": "tab",
+    "documentationLabel": "documentation"
   },
   "logos": {
     "main": "/assets/acme-logo.png",
@@ -120,8 +123,11 @@ from these locations in order:
 |---------|-------|----------|-------------|
 | `company.name` | string | Yes | Company name used in branding and page title |
 | `company.displayName` | string | No | Display name (falls back to `name`) |
-| `company.website` | string | No | Company website URL |
-| `company.supportEmail` | string | No | Support contact email |
+| `company.website` | string | No | Company website URL. Shown as a link in the side navigation. Honoured only over `https` |
+| `company.supportEmail` | string | No | Support contact email. Shown as a `mailto:` link in the side navigation |
+| `company.documentationUrl` | string | No | Documentation to open from the page header. Honoured only over `https`; without it no documentation control appears |
+| `company.documentationTarget` | `tab` \| `popup` | No | How the documentation opens by default (`tab`). Users can override this for themselves from the header control |
+| `company.documentationLabel` | string | No | What the documentation is called in the control's tooltip (`documentation`) |
 | `logos.main` | string | Yes | Main logo for login page and headers |
 | `logos.navigation` | string | Yes | Logo for expanded navigation bar |
 | `logos.navigationIcon` | string | Yes | Icon-only logo for collapsed nav |
@@ -196,6 +202,33 @@ from these locations in order:
 | `getLoginSubtitle()` | Login page subtitle |
 | `getBrandingInfo()` | Full branding object |
 | `getLoginConfig()` | Full login config object |
+| `getCompanyWebsite()` | Company website URL, or `undefined` unless `https` |
+| `getSupportEmail()` | Support contact email |
+| `getDocumentationUrl()` | Documentation URL, or `undefined` unless `https` |
+| `getDocumentationTarget()` | `tab` or `popup` — user choice, else config, else `tab` |
+| `getDocumentationLabel()` | Documentation name for the tooltip |
+| `setDocumentationTarget(t)` | Records the user's `tab`/`popup` choice |
+
+### Documentation Link Behaviour
+
+Setting `company.documentationUrl` puts a documentation control in the
+page header. It opens in a tab or a separate window, and reuses the
+same one on repeat clicks rather than accumulating new ones.
+
+That reuse has a consequence operators should know about. Keeping one
+window addressable means the console stays its opener, and a page can
+navigate whatever opened it. So the configured documentation site is
+able to navigate the console's tab away. The two properties cannot be
+separated — every way of severing the opener (`noopener`,
+`Cross-Origin-Opener-Policy`, discarding the handle) also ends the
+reuse. Point `documentationUrl` at a host you trust as much as the
+console itself.
+
+URLs are honoured only over `https`. Anything else, including a
+malformed value, renders no control rather than a broken or dangerous
+link. There is no reachability check: a well-formed URL to a dead host
+still produces a link, because the browser cannot inspect a
+cross-origin response to know the difference.
 
 ### Config Defaults (Layer 4)
 


### PR DESCRIPTION
Follow-up to #5708, which shipped the documentation link but not a description
of the fields that drive it.

`docs/branding-architecture.md` points operators at the theme package README for
"the complete `company-config.json` schema with all fields documented", so that
is where the three new `company` fields belong. They are added to both the schema
example and the field reference table.

It also corrects two neighbouring rows that #5708 made stale. `company.website`
and `company.supportEmail` were documented as config-only values; they now render
as links in the side navigation, and `website` is honoured only over https.

## The behaviour section

The one part that is not a field description. Pointing `documentationUrl` at a
host grants that host the ability to navigate the console's tab, because keeping
a single window addressable for reuse means remaining its opener — and a page can
navigate whatever opened it. The two cannot be separated: every way of severing
the opener also ends the reuse, checked across Chromium, Firefox and WebKit.

That is a judgement an operator makes when they choose the URL, so it is
documented where they choose it rather than living only in the history of #5708.
The section also records that there is no reachability check, since the browser
cannot inspect a cross-origin response to tell a live documentation host from a
dead one.

## Testing

`node scripts/lint-docs.mjs` — 58 files checked, 0 problems. Documentation only;
no code changes.
