### PR TITLE
chore: neutral simplification markers and #5707 review follow-ups

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.ts
@@ -16,7 +16,7 @@ export function extractCreateParameters(plan: StServicePlan | null | undefined):
  * schema-form's filterSchema) and treats an otherwise-empty object as "no
  * configurable parameters".
  *
- * ponytail: strips only top-level `$schema` and gates on key-count. If live
+ * simplification: strips only top-level `$schema` and gates on key-count. If live
  * verify shows nested noise (`additionalProperties: false`, bare `type:object`
  * with no `properties`), extend the strip/gate here rather than per-caller.
  */

--- a/src/frontend/packages/core/src/shared/components/schema-widget-renderer/schema-resolve.util.ts
+++ b/src/frontend/packages/core/src/shared/components/schema-widget-renderer/schema-resolve.util.ts
@@ -96,7 +96,7 @@ export function classifyNode(node: JsonSchema, root: JsonSchema): ResolvedNode {
  */
 export function schemaToSkeleton(schema: JsonSchema, root: JsonSchema = schema, seen: Set<JsonSchema> = new Set()): unknown {
   const node = classifyNode(schema, root);
-  // ponytail: guard self-referential $ref schemas (recursive defs) — emit null rather than recurse forever.
+  // NOTE: guard self-referential $ref schemas (recursive defs) — emit null rather than recurse forever.
   if (seen.has(node.schema)) {
     return null;
   }
@@ -165,7 +165,7 @@ export function mergeSkeleton(skeleton: unknown, data: unknown): unknown {
  * objects that become empty after cleaning — while KEEPING meaningful falsy values
  * (`false`, `0`). Used so the params actually submitted contain only what the user
  * set: an untouched JSON skeleton collapses to `undefined` (→ no params).
- * ponytail: empty strings are treated as unset and dropped; a broker needing a
+ * simplification: empty strings are treated as unset and dropped; a broker needing a
  * literal "" param isn't supported here — out of scope for the schema editor.
  */
 export function stripEmpty(value: unknown): unknown {

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
@@ -409,7 +409,7 @@ export class TailwindDialogService {
    * the drag — track the pointer 1:1, and stops a resize-drag that ends on the
    * backdrop from re-centering.
    *
-   * ponytail: hand-rolled mouse-drag rather than @angular/cdk's cdkDrag — the
+   * simplification: hand-rolled mouse-drag rather than @angular/cdk's cdkDrag — the
    * panel is created imperatively (document.createElement), so an Angular
    * directive can't decorate it. Mouse events (not pointer) keep it testable
    * in jsdom, which lacks setPointerCapture.

--- a/src/frontend/packages/core/src/shared/services/tailwind-snackbar.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-snackbar.service.ts
@@ -204,7 +204,7 @@ export class TailwindSnackBarService {
     // to a wider container with proper wrapping lets multi-line messages
     // render in full while keeping short ones on a single line.
     //
-    // ponytail: bg-gray-800/text-white is a deliberate INVERSE overlay, not a
+    // NOTE: bg-gray-800/text-white is a deliberate INVERSE overlay, not a
     // theme surface — a toast stays dark in both light and dark mode. Kept raw
     // (no content-* token) so the #5494 sweep doesn't flip it to a light-on-light
     // surface and break the white action/close text + the !bg-danger error variant.

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -129,7 +129,7 @@ async function main() {
     // `<id>.background`, e.g. the login scene's .login-bg overlay). Background
     // edits on the parent are painted over by it, which reads as a broken
     // editor — surface the backdrop with a jump link instead.
-    // ponytail: naming-convention detection; geometry-based full-bleed
+    // simplification: naming-convention detection; geometry-based full-bleed
     // detection if a scene ever ships a backdrop under another name.
     const backdrop = nodeFor(`${snapshotId}.background`);
     openLeverEditor({


### PR DESCRIPTION
Two unrelated tidy-ups, both comment- and type-level only, no behaviour change.

## 1. Neutral markers for deliberate simplifications

Six comments flagged deliberate shortcuts or do-not-refactor notes behind an ad-hoc prefix instead of the marker already used elsewhere in the tree. This renames the prefix; the notes themselves are unchanged in substance and worth keeping — one of them is load-bearing.

| File | New marker | Why |
|---|---|---|
| `plan-parameters-preview.util.ts:19` | `simplification:` | strips only top-level `$schema`, names the upgrade path |
| `schema-resolve.util.ts:168` | `simplification:` | empty strings treated as unset, deliberately scoped out |
| `tailwind-dialog.service.ts:412` | `simplification:` | hand-rolled drag instead of `cdkDrag`, with the reason |
| `tools/stb/src/main.ts:132` | `simplification:` | naming-convention detection, names the upgrade path |
| `schema-resolve.util.ts:99` | `NOTE:` | recursion guard, not a shortcut |
| `tailwind-snackbar.service.ts:207` | `NOTE:` | inverse-overlay warning, not a shortcut |

`simplification:` is not a new convention — `scripts/lint-e2e-data-test.mjs:68` already uses it. The two that became `NOTE:` were never simplifications: one is a correctness guard against infinite recursion on self-referential `$ref` schemas, the other warns that the snackbar's `bg-gray-800`/`text-white` are a deliberate inverse overlay kept raw so a theming sweep doesn't convert them to `content-*` tokens and produce light-on-light text.

## 2. Follow-ups from the #5707 review

Three loose ends raised in review on #5707 that merged before they were picked up.

`onNext` coalesced the endpoint guid at the `saveAppDetails` call with `?? ''`. `SourceType.endpointGuid` is optional, so that operator was carrying the type rather than ever changing a value — the public branch is already guarded non-empty above it and the other branch is a literal `''`. Narrowed at the declaration instead and dropped from the object literal.

The two `setGitMode` specs asserted with `toHaveBeenCalledWith`, which matches any call, while their comment described the last one. Switched to `toHaveBeenLastCalledWith` so the assertion states what the comment claims — a strictly stronger check, still green.

The deferral comment in `setActive` said a synchronous `pOnEnter` would run "before the entering step is marked active". The step is marked active a few lines above it. The real constraint is that change detection has not yet re-rendered the content outlet for the new `currentIndex`, so the callback would run against a view still showing the outgoing step. Reworded to say that.

Related: #5710 covers the missing test coverage that let the earlier version of that comment go unchallenged.

---

`make check gate` green.
