### PR TITLE
chore: neutral simplification markers and #5707 review follow-ups

### DIFF
--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
@@ -229,13 +229,13 @@ describe('DeployApplicationStep2Component', () => {
       component.setGitMode('private');
       // Last getSCM call should target the github type with an empty guid so
       // the SCM talks to the API directly with the form token.
-      expect(getSCM).toHaveBeenCalledWith('github', '');
+      expect(getSCM).toHaveBeenLastCalledWith('github', '');
     });
 
     it('rebuilds the SCM with the endpoint guid when switching to Public', () => {
       const getSCM = vi.spyOn(TestBed.inject(GitSCMService), 'getSCM');
       component.setGitMode('public');
-      expect(getSCM).toHaveBeenCalledWith('github', '747ed39a-endpoint-guid');
+      expect(getSCM).toHaveBeenLastCalledWith('github', '747ed39a-endpoint-guid');
     });
   });
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -185,7 +185,7 @@ export class DeployApplicationStep2Component
       // Public mode deploys via the registered endpoint (its stored creds);
       // Private/Enterprise mode deploys with the token typed in the form and
       // no endpoint. So only require an endpoint guid in Public mode.
-      const endpointGuid = this.gitMode === 'public' ? this.sourceType.endpointGuid : '';
+      const endpointGuid: string = this.gitMode === 'public' ? (this.sourceType.endpointGuid ?? '') : '';
       this.gitData.getRepository(this.scm, this.repository)
         .waitForValue$.pipe(take(1), defaultIfEmpty(null)).subscribe(repo => {
         // A gitscm save needs a resolved repo and branch. An endpoint guid is
@@ -198,7 +198,7 @@ export class DeployApplicationStep2Component
           url: repo.clone_url,
           accessToken: this.accessToken,
           commit: this.isRedeploy ? this.commitInfo?.sha : undefined,
-          endpointGuid: endpointGuid ?? '',
+          endpointGuid,
         }, null);
       });
     } else if (this.sourceType.id === DEPLOY_TYPES_IDS.GIT_URL) {

--- a/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/plan-parameters-preview-dialog/plan-parameters-preview.util.ts
@@ -16,7 +16,7 @@ export function extractCreateParameters(plan: StServicePlan | null | undefined):
  * schema-form's filterSchema) and treats an otherwise-empty object as "no
  * configurable parameters".
  *
- * ponytail: strips only top-level `$schema` and gates on key-count. If live
+ * simplification: strips only top-level `$schema` and gates on key-count. If live
  * verify shows nested noise (`additionalProperties: false`, bare `type:object`
  * with no `properties`), extend the strip/gate here rather than per-caller.
  */

--- a/src/frontend/packages/core/src/shared/components/schema-widget-renderer/schema-resolve.util.ts
+++ b/src/frontend/packages/core/src/shared/components/schema-widget-renderer/schema-resolve.util.ts
@@ -96,7 +96,7 @@ export function classifyNode(node: JsonSchema, root: JsonSchema): ResolvedNode {
  */
 export function schemaToSkeleton(schema: JsonSchema, root: JsonSchema = schema, seen: Set<JsonSchema> = new Set()): unknown {
   const node = classifyNode(schema, root);
-  // ponytail: guard self-referential $ref schemas (recursive defs) — emit null rather than recurse forever.
+  // NOTE: guard self-referential $ref schemas (recursive defs) — emit null rather than recurse forever.
   if (seen.has(node.schema)) {
     return null;
   }
@@ -165,7 +165,7 @@ export function mergeSkeleton(skeleton: unknown, data: unknown): unknown {
  * objects that become empty after cleaning — while KEEPING meaningful falsy values
  * (`false`, `0`). Used so the params actually submitted contain only what the user
  * set: an untouched JSON skeleton collapses to `undefined` (→ no params).
- * ponytail: empty strings are treated as unset and dropped; a broker needing a
+ * simplification: empty strings are treated as unset and dropped; a broker needing a
  * literal "" param isn't supported here — out of scope for the schema editor.
  */
 export function stripEmpty(value: unknown): unknown {

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.spec.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, Component, Directive, Input, OnChanges, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
@@ -11,7 +12,7 @@ import { createBasicStoreModule } from "@test-framework/core-test.helper";
 import { CoreTestingModule } from "@test-framework/core-test.modules";
 import { CoreModule } from '../../../../core/core.module';
 import { MDAppModule } from '../../../../core/md.module';
-import { StepComponent } from '../step/step.component';
+import { SignalStepHandle, StepComponent } from '../step/step.component';
 import { SteppersComponent } from './steppers.component';
 
 describe('SteppersComponent', () => {
@@ -103,5 +104,109 @@ describe('SteppersComponent', () => {
 
     await fixture.whenStable();
     expect(entered).toEqual([{ plan: 'p1' }]);
+  });
+});
+
+// The suite above builds StepComponent instances by hand and assigns
+// allSteps directly. That covers setActive's bookkeeping but never renders a
+// stepper, so nothing there can observe how projected step content is
+// actually instantiated — which is how an incorrect claim about lazy
+// instantiation sat in setActive's comment unchallenged. These mount a real
+// <app-steppers> with projected content instead.
+const projectionLog: string[] = [];
+
+@Directive({ selector: '[probeInput]', standalone: true })
+class ProbeInputDirective implements OnChanges {
+  @Input() probeInput = '';
+  ngOnChanges(): void {
+    projectionLog.push(`ngOnChanges:${this.probeInput}`);
+  }
+}
+
+@Component({ selector: 'probe-first', template: 'first', standalone: true })
+class ProbeFirstComponent {
+  constructor() { projectionLog.push('ctor:first'); }
+}
+
+@Component({
+  selector: 'probe-second',
+  standalone: true,
+  imports: [ProbeInputDirective],
+  // Nested @if mirrors deploy-application-step2, where the directive whose
+  // first-render ngOnChanges caused the trouble sits behind two of them.
+  template: `@if (outer) { @if (inner) { <span [probeInput]="token"></span> } }`,
+})
+class ProbeSecondComponent {
+  outer = true;
+  inner = true;
+  token = 'ctx';
+  constructor() { projectionLog.push('ctor:second'); }
+}
+
+@Component({
+  standalone: true,
+  imports: [SteppersComponent, StepComponent, ProbeFirstComponent, ProbeSecondComponent],
+  template: `
+    <app-steppers>
+      <app-step [title]="'One'" [signalHandle]="firstHandle"><probe-first></probe-first></app-step>
+      <app-step [title]="'Two'" [signalHandle]="secondHandle"><probe-second></probe-second></app-step>
+    </app-steppers>
+  `,
+})
+class ProjectionHostComponent {
+  entered: string[] = [];
+  firstHandle: SignalStepHandle = { valid: signal(true) };
+  secondHandle: SignalStepHandle = {
+    valid: signal(true),
+    onEnter: () => { this.entered.push('two'); },
+  };
+}
+
+describe('SteppersComponent — projected step content', () => {
+  let hostFixture: ComponentFixture<ProjectionHostComponent>;
+
+  beforeEach(async () => {
+    projectionLog.length = 0;
+    TestBed.configureTestingModule({
+      imports: [ProjectionHostComponent, RouterTestingModule],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    await TestBed.compileComponents();
+    hostFixture = TestBed.createComponent(ProjectionHostComponent);
+    hostFixture.detectChanges();
+    await hostFixture.whenStable();
+  });
+
+  // Ivy does not defer <ng-content> inside an <ng-template>: every step's
+  // projected content is constructed with the declaring view, whichever step
+  // is active. Anything reasoning about when a step's directives run — an
+  // @Input's ngOnChanges firing, a service touched on first render — must
+  // assume it happens up-front, not on activation. #5710.
+  it('constructs and change-detects a NON-active step on first render', () => {
+    expect(projectionLog).toContain('ctor:first');
+    // Step Two is never activated in this test.
+    expect(projectionLog).toContain('ctor:second');
+    // Its template ran too: the nested @if resolved and bound the directive.
+    expect(projectionLog).toContain('ngOnChanges:ctx');
+  });
+
+  // The companion to the hand-built delivery test above, but through a real
+  // stepper: onEnter must not arrive until after the activating render.
+  it('delivers onEnter to a projected step only after the activating render', async () => {
+    const steppers = hostFixture.debugElement
+      .query(By.directive(SteppersComponent))
+      .componentInstance as SteppersComponent;
+
+    expect(hostFixture.componentInstance.entered).toEqual([]);
+
+    steppers.setActive(1);
+    expect(hostFixture.componentInstance.entered).toEqual([]);
+
+    await hostFixture.whenStable();
+    expect(hostFixture.componentInstance.entered).toEqual(['two']);
   });
 });

--- a/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
+++ b/src/frontend/packages/core/src/shared/components/stepper/steppers/steppers.component.ts
@@ -339,12 +339,13 @@ export class SteppersComponent implements OnInit, AfterContentInit, OnDestroy {
     // content is NOT lazily instantiated — Ivy constructs <ng-content> inside
     // an <ng-template> on first render regardless of the active step, so a
     // step's directives/@Inputs (and their ngOnChanges) run up-front. The
-    // deferral is instead about ordering relative to THIS transition: a
-    // synchronous pOnEnter here would run before the entering step is marked
-    // active and before change detection settles for the newly-current index,
-    // so onEnter side effects (e.g. building a list keyed off the now-active
-    // step) could see stale state. afterNextRender guarantees the enter
-    // callback fires once the step is active and rendered (#5600:
+    // deferral is instead about ordering relative to THIS transition: the
+    // entering step is already marked active just above, but change detection
+    // has not yet re-rendered the content outlet for the new currentIndex, so
+    // a synchronous pOnEnter would run against a view that is still showing
+    // the outgoing step and onEnter side effects (e.g. building a list keyed
+    // off the now-active step) could see stale state. afterNextRender
+    // guarantees the enter callback fires once the step is rendered (#5600:
     // specify-details-step never received onEnter, so its formMode was never
     // set and the step rendered empty).
     const enteringStep = this.steps[index];

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
@@ -409,7 +409,7 @@ export class TailwindDialogService {
    * the drag — track the pointer 1:1, and stops a resize-drag that ends on the
    * backdrop from re-centering.
    *
-   * ponytail: hand-rolled mouse-drag rather than @angular/cdk's cdkDrag — the
+   * simplification: hand-rolled mouse-drag rather than @angular/cdk's cdkDrag — the
    * panel is created imperatively (document.createElement), so an Angular
    * directive can't decorate it. Mouse events (not pointer) keep it testable
    * in jsdom, which lacks setPointerCapture.

--- a/src/frontend/packages/core/src/shared/services/tailwind-snackbar.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-snackbar.service.ts
@@ -204,7 +204,7 @@ export class TailwindSnackBarService {
     // to a wider container with proper wrapping lets multi-line messages
     // render in full while keeping short ones on a single line.
     //
-    // ponytail: bg-gray-800/text-white is a deliberate INVERSE overlay, not a
+    // NOTE: bg-gray-800/text-white is a deliberate INVERSE overlay, not a
     // theme surface — a toast stays dark in both light and dark mode. Kept raw
     // (no content-* token) so the #5494 sweep doesn't flip it to a light-on-light
     // surface and break the white action/close text + the !bg-danger error variant.

--- a/tools/stb/src/main.ts
+++ b/tools/stb/src/main.ts
@@ -129,7 +129,7 @@ async function main() {
     // `<id>.background`, e.g. the login scene's .login-bg overlay). Background
     // edits on the parent are painted over by it, which reads as a broken
     // editor — surface the backdrop with a jump link instead.
-    // ponytail: naming-convention detection; geometry-based full-bleed
+    // simplification: naming-convention detection; geometry-based full-bleed
     // detection if a scene ever ships a backdrop under another name.
     const backdrop = nodeFor(`${snapshotId}.background`);
     openLeverEditor({


### PR DESCRIPTION
Three tidy-ups off the back of the #5707 review. No behaviour change; the only production-code edit is a type narrowing that removes a redundant operator.

## 1. Neutral markers for deliberate simplifications

Six comments flagged deliberate shortcuts or do-not-refactor notes behind an ad-hoc prefix instead of the marker already used elsewhere in the tree. This renames the prefix; the notes themselves are unchanged in substance and worth keeping — one of them is load-bearing.

| File | New marker | Why |
|---|---|---|
| `plan-parameters-preview.util.ts:19` | `simplification:` | strips only top-level `$schema`, names the upgrade path |
| `schema-resolve.util.ts:168` | `simplification:` | empty strings treated as unset, deliberately scoped out |
| `tailwind-dialog.service.ts:412` | `simplification:` | hand-rolled drag instead of `cdkDrag`, with the reason |
| `tools/stb/src/main.ts:132` | `simplification:` | naming-convention detection, names the upgrade path |
| `schema-resolve.util.ts:99` | `NOTE:` | recursion guard, not a shortcut |
| `tailwind-snackbar.service.ts:207` | `NOTE:` | inverse-overlay warning, not a shortcut |

`simplification:` is not a new convention — `scripts/lint-e2e-data-test.mjs:68` already uses it. The two that became `NOTE:` were never simplifications: one is a correctness guard against infinite recursion on self-referential `$ref` schemas, the other warns that the snackbar's `bg-gray-800`/`text-white` are a deliberate inverse overlay kept raw so a theming sweep doesn't convert them to `content-*` tokens and produce light-on-light text.

## 2. Follow-ups from the #5707 review

Three loose ends raised in review on #5707 that merged before they were picked up.

`onNext` coalesced the endpoint guid at the `saveAppDetails` call with `?? ''`. `SourceType.endpointGuid` is optional, so that operator was carrying the type rather than ever changing a value — the public branch is already guarded non-empty above it and the other branch is a literal `''`. Narrowed at the declaration instead and dropped from the object literal.

The two `setGitMode` specs asserted with `toHaveBeenCalledWith`, which matches any call, while their comment described the last one. Switched to `toHaveBeenLastCalledWith` so the assertion states what the comment claims — a strictly stronger check, still green.

The deferral comment in `setActive` said a synchronous `pOnEnter` would run "before the entering step is marked active". The step is marked active a few lines above it. The real constraint is that change detection has not yet re-rendered the content outlet for the new `currentIndex`, so the callback would run against a view still showing the outgoing step. Reworded to say that.

## 3. Real coverage for projected step content

Closes #5710.

The existing stepper suite builds `StepComponent` instances by hand and assigns `allSteps` directly. That covers `setActive`'s bookkeeping but never renders a stepper, so nothing in it can observe how projected step content is actually instantiated — which is how the incorrect claim in section 2 went unchallenged in the first place.

Adds a host that mounts a real `<app-steppers>` with projected content and pins two behaviours:

- A step that is never activated still has its content constructed **and** change-detected on first render. Ivy does not defer `<ng-content>` inside an `<ng-template>`, so a step's directives and their `ngOnChanges` run up-front. The probe places its directive behind nested `@if` blocks to mirror `deploy-application-step2`, where precisely this caused the regression fixed in #5707.
- `onEnter` still arrives only after the activating render, asserted through a rendered stepper rather than hand-built objects.

Both were checked against mutations rather than assumed meaningful: disabling the probe's outer `@if` fails the first (while construction is still logged, so it distinguishes template execution from construction), and calling `pOnEnter` synchronously fails the second — identically to the pre-existing hand-built test.

The older hand-built spec is left as-is; it remains a reasonable unit-level check of `setActive`. The point is that it is no longer the only coverage.

---

`make check gate` green.
