### PR TITLE
Derive dependency release notes from the commit log

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,12 @@
 
 version: 2
 
+# The commit-message prefix is pinned on every ecosystem below, not left to
+# Dependabot's default: build/release-notes.sh reads the bumps for a release
+# window straight out of the commit log with `--grep '^chore(deps'`, since
+# Dependabot opens PRs but never runs the fragment tooling itself. Change a
+# prefix here and those bumps stop reaching the release notes.
+
 # Disable Dependabot during Angular
 updates:
   # bun ecosystem, not npm: the lockfile is bun.lock (no package-lock.json),
@@ -11,12 +17,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     open-pull-requests-limit: 0 # version updates off; security updates still open PRs
 
   - package-ecosystem: "bun"
     directory: "/website"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     open-pull-requests-limit: 2
     groups: # one grouped PR so the site's dep tree doesn't dominate the list
       website:
@@ -27,5 +39,8 @@ updates:
     directory: "src/jetstream/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     open-pull-requests-limit: 0 # GoLang CVE updates being done as part of refactor
     

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -409,6 +409,35 @@ jobs:
           path: dist/bin/jetstream
           retention-days: 1
 
+  # Advisory only, and deliberately NOT in pr-success's needs: a hard failure
+  # here would fire on pipeline fixes, docs-only changes, reverts and bumps,
+  # and a gate with that false-positive rate gets routed around rather than
+  # obeyed. A ::warning:: renders inline on the Files tab; a plain log line
+  # would be invisible once the check goes green.
+  #
+  # Dependabot is exempt because it cannot act on the advice — it never runs
+  # release-notes.sh. Its bumps are picked up instead by
+  # `release-notes.sh check` at `make stamp tag` time, off the commit log.
+  changelog-fragment:
+    name: Changelog Fragment (advisory)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for a release-notes fragment
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only --diff-filter=A "$BASE...HEAD" \
+             | grep -qE '^changelog\.d/[0-9]+-.*\.md$'; then
+            echo "✅ Release-notes fragment present."
+            exit 0
+          fi
+          echo "::warning title=No release-notes fragment::This PR adds no changelog.d fragment, so it will not appear in the release notes. Run ./build/release-notes.sh new — or ignore this if the change needs no note."
+
   pr-success:
     name: PR Quality Gate
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@
 #   make unpublish TAG=vX       Delete a GitHub release (assets included)
 #   make stamp untag TAG=vX     Delete a tag (local + remote)
 #   make sweep                  Remove published changelog.d fragments
+#   make changelog              Report dependency bumps since the last tag
+#                               (./build/release-notes.sh deps drafts them)
 #   make install                Install dependencies
 #   make stage                  Stage for local testing
 #   make clean                  Remove all build output
@@ -966,7 +968,7 @@ $(call register, stamp, untag)
 # changelog.d fragments (build/release-notes.sh).
 # --prerelease derives from the tag itself: alpha/beta/rc only — dev.N tags
 # CAN be full releases (keep in sync with release.yml validate-version).
-.PHONY: publish unpublish sweep
+.PHONY: publish unpublish sweep changelog
 publish:
 	@test -f $($(_HIDE)RELEASE_DIR)/SHA256SUMS || { echo "ERROR: no release artifacts in $($(_HIDE)RELEASE_DIR)/ — run 'make release' first" >&2; exit 1; }
 	@TAG="$(TAG)"; \
@@ -985,6 +987,14 @@ unpublish:
 sweep:
 	@chmod +x build/release-notes.sh
 	$($(_HIDE)DRY)./build/release-notes.sh sweep
+
+# changelog reports how many dependency bumps have landed since the last
+# release tag — the "is a build due yet?" question, answerable between
+# releases. Read-only, so no DRYRUN guard. `stamp tag` runs the same check
+# before it freezes the notes into the tag body.
+changelog:
+	@chmod +x build/release-notes.sh
+	@./build/release-notes.sh check
 
 # ── Deploy (documentation website) ───────────────────────────
 # Grammar: make deploy website <destination> — the component says what is

--- a/build/create-git-tag.sh
+++ b/build/create-git-tag.sh
@@ -61,6 +61,9 @@ main() {
   # it via --notes-from-tag.
   local commit=$(git rev-parse --short HEAD)
   local notes
+  # Reported here, before the notes are frozen into the tag body, so the
+  # author can still act on it. Warns, never blocks.
+  "${ROOT_DIR}/build/release-notes.sh" check || true
   notes=$("${ROOT_DIR}/build/release-notes.sh" assemble)
   if [ -z "${notes}" ]; then
     warn "No changelog.d fragments — tag body falls back to a pointer line"

--- a/build/release-notes.sh
+++ b/build/release-notes.sh
@@ -3,6 +3,12 @@
 #
 #   release-notes.sh new [slug]   Create changelog.d/NNNN-<slug>.md
 #                                 (slug defaults to the current branch)
+#   release-notes.sh deps [since] Draft the dependency-updates fragment from
+#                                 the dependabot commits in the release
+#                                 window (since defaults to the last v* tag)
+#   release-notes.sh check [since] Warn if the window has dependency bumps
+#                                 with no dependency-updates fragment.
+#                                 Always exits 0 — this reports, never gates
 #   release-notes.sh assemble     Print fragments merged into the release
 #                                 layout on stdout (empty if no fragments)
 #   release-notes.sh sweep        git rm all fragments (post-publish; the
@@ -14,7 +20,7 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 FRAG_DIR="${FRAG_DIR:-${ROOT_DIR}/changelog.d}"
 
 # Section order is the release-notes layout: Breaking Changes lead when
@@ -25,9 +31,10 @@ fragments() {
   find "${FRAG_DIR}" -maxdepth 1 -name '[0-9]*.md' 2>/dev/null | LC_ALL=C sort
 }
 
-cmd_new() {
-  local slug="${1:-$(git -C "${ROOT_DIR}" branch --show-current)}"
-  slug=$(printf '%s' "${slug}" | tr '[:upper:]' '[:lower:]' \
+# Next free NNNN-<slug>.md path. Errors if the slug is empty or taken.
+next_file() {
+  local slug
+  slug=$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' \
     | tr -cs 'a-z0-9' '-' | sed 's/^-*//; s/-*$//')
   if [ -z "${slug}" ]; then
     echo "ERROR: empty slug (detached HEAD?) — pass one: release-notes.sh new <slug>" >&2
@@ -45,8 +52,86 @@ cmd_new() {
     echo "ERROR: ${file} already exists" >&2
     exit 1
   fi
+  echo "${file}"
+}
+
+cmd_new() {
+  local file
+  file=$(next_file "${1:-$(git -C "${ROOT_DIR}" branch --show-current)}")
   printf '[Features]\n- \n' > "${file}"
   echo "${file}"
+}
+
+# The release window: <last v* tag>..HEAD, or all history before the first
+# tag. Dependabot is the reason this is derived rather than authored — it
+# opens PRs but never runs this script, so its bumps reach a release only if
+# something reads them out of the log.
+dep_range() {
+  local since="${1:-}"
+  if [ -z "${since}" ]; then
+    since=$(git -C "${ROOT_DIR}" describe --tags --match 'v[0-9]*' --abbrev=0 2>/dev/null || true)
+  fi
+  echo "${since:+${since}..}HEAD"
+}
+
+# Bump subjects in the window, prefix stripped, deduped, oldest first.
+# Keyed on the commit-message prefix pinned in .github/dependabot.yaml,
+# which also catches dependency work done by hand under the same prefix —
+# for a changelog bullet that is wanted, not a miss.
+dep_subjects() {
+  git -C "${ROOT_DIR}" log --reverse --no-merges --format='%s' \
+      --grep='^chore(deps' "$(dep_range "${1:-}")" -- 2>/dev/null \
+    | sed -E 's/^chore\(deps[^)]*\): *(bump )?//I' \
+    | awk 'NF && !seen[$0]++'
+}
+
+DEPS_SLUG='dependency-updates'
+
+cmd_deps() {
+  local subjects
+  subjects=$(dep_subjects "${1:-}")
+  if [ -z "${subjects}" ]; then
+    echo "changelog.d: no dependency bumps in $(dep_range "${1:-}") — nothing to draft"
+    return 0
+  fi
+  local file
+  file=$(next_file "${DEPS_SLUG}")
+  {
+    echo '[Chores]'
+    printf -- '- Dependency updates: %s.\n' \
+      "$(echo "${subjects}" | paste -sd ';' - | sed 's/;/; /g')"
+  } > "${file}"
+  echo "${file}"
+  echo "Drafted from $(echo "${subjects}" | wc -l | tr -d ' ') bump(s) in $(dep_range "${1:-}") — edit into prose before release." >&2
+}
+
+# Does any fragment cover dependency work? Deliberately a loose text match and
+# not an exact one against the bump subjects: `deps` writes a DRAFT that the
+# author is meant to rewrite into prose, and prose that no longer quotes the
+# raw subjects would make an exact match warn on every well-curated release.
+#
+# Known limit: a dependency fragment left behind from an already-published
+# window silences the report for the current one. `make sweep` after each
+# release is what keeps that from happening; the directory is meant to be
+# empty right after a release (see changelog.d/README.md).
+has_deps_fragment() {
+  local files
+  files=$(fragments)
+  [ -n "${files}" ] || return 1   # empty input would leave grep reading stdin
+  echo "${files}" | xargs grep -qiE 'depend|bump' 2>/dev/null
+}
+
+# The count goes to stdout unconditionally, so this doubles as an any-time
+# status command: "how much dependency work has piled up since the last
+# release" is the question that decides whether a patch build is due, and it
+# needs answering between releases, not only at tag time.
+cmd_check() {
+  local n
+  n=$(dep_subjects "${1:-}" | wc -l | tr -d ' ')
+  echo "changelog.d: ${n} dependency bump(s) in $(dep_range "${1:-}")"
+  { [ "${n}" -gt 0 ] && ! has_deps_fragment; } || return 0
+  echo "WARNING: none of them are mentioned in any fragment, so they will not" >&2
+  echo "         appear in the release notes. Draft them: ./build/release-notes.sh deps" >&2
 }
 
 cmd_assemble() {
@@ -112,10 +197,12 @@ cmd_sweep() {
 
 case "${1:-}" in
   new)      shift; cmd_new "$@" ;;
+  deps)     shift; cmd_deps "$@" ;;
+  check)    shift; cmd_check "$@" ;;
   assemble) cmd_assemble ;;
   sweep)    cmd_sweep ;;
   *)
-    echo "Usage: release-notes.sh new [slug] | assemble | sweep" >&2
+    echo "Usage: release-notes.sh new [slug] | deps [since] | check [since] | assemble | sweep" >&2
     exit 1
     ;;
 esac

--- a/build/test-release-notes.sh
+++ b/build/test-release-notes.sh
@@ -66,7 +66,53 @@ rm "${FRAG_DIR}/0004-bad.md"
 
 printf 'stray line before any header\n' > "${FRAG_DIR}/0005-stray.md"
 check_fails "content before a section header fails" bash "${RN}" assemble
-rm "${FRAG_DIR}/0005-stray.md"
+rm "${FRAG_DIR}"/*.md
+
+# deps/check read git history, so they need a repo of their own rather than
+# the checkout this harness runs in.
+echo "deps:"
+export ROOT_DIR="${TMPDIR}/repo"
+mkdir -p "${ROOT_DIR}"
+git -C "${ROOT_DIR}" init -q
+git -C "${ROOT_DIR}" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'feat: base'
+git -C "${ROOT_DIR}" tag v1.0.0
+for msg in 'chore(deps): bump left from 1 to 2' \
+           'feat: unrelated work' \
+           'chore(deps-dev): bump right from 3 to 4' \
+           'chore(deps): bump left from 1 to 2'; do
+  git -C "${ROOT_DIR}" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "${msg}"
+done
+
+check "no fragment yet → check warns" "1" \
+  "$(bash "${RN}" check 2>&1 >/dev/null | grep -c '^WARNING')"
+
+frag=$(bash "${RN}" deps 2>/dev/null)
+check "deps fragment is named for the slug" "${FRAG_DIR}/0001-dependency-updates.md" "${frag}"
+check "bumps deduped, prefix stripped, non-deps commits ignored" \
+  "[Chores]
+- Dependency updates: left from 1 to 2; right from 3 to 4." "$(cat "${frag}")"
+check "drafted fragment silences check" "" "$(bash "${RN}" check 2>&1 >/dev/null)"
+# The draft is meant to be rewritten; prose that drops the raw subjects must
+# still count as covered, or every well-curated release warns.
+check "hand-written prose still counts as covered" "" \
+  "$(printf '[Chores]\n- Routine dependency updates (#1, #2).\n' > "${frag}"
+     bash "${RN}" check 2>&1 >/dev/null)"
+check "unrelated fragment does not count as covered" "1" \
+  "$(printf '[Features]\n- a feature\n' > "${frag}"
+     bash "${RN}" check 2>&1 >/dev/null | grep -c '^WARNING')"
+rm "${frag}"
+check "check exits 0 even when warning" "0" \
+  "$(bash "${RN}" check >/dev/null 2>&1; echo $?)"
+# Runnable between releases to answer "has enough piled up to cut a build?"
+check "count reported on stdout regardless of coverage" \
+  "changelog.d: 2 dependency bump(s) in v1.0.0..HEAD" "$(bash "${RN}" check 2>/dev/null)"
+
+git -C "${ROOT_DIR}" tag v1.1.0
+check "window starts at the newest tag" \
+  "changelog.d: no dependency bumps in v1.1.0..HEAD — nothing to draft" \
+  "$(bash "${RN}" deps 2>/dev/null)"
+check "explicit since overrides the tag" "${FRAG_DIR}/0001-dependency-updates.md" \
+  "$(bash "${RN}" deps v1.0.0 2>/dev/null)"
 
 echo ""
 echo "${PASS} passed, ${FAIL} failed"

--- a/changelog.d/0030-website-deps-bump.md
+++ b/changelog.d/0030-website-deps-bump.md
@@ -1,0 +1,2 @@
+[Chores]
+- Bumped the website dependency group: `@radix-ui/react-avatar` 1.2.6 (restoring React Server Components compatibility), `@radix-ui/react-slot` 1.3.3, `lucide-react` 1.27.0, `baseline-browser-mapping` 2.11.6 and `postcss` 8.5.24 (#5716).

--- a/changelog.d/0031-changelog-dependency-gate.md
+++ b/changelog.d/0031-changelog-dependency-gate.md
@@ -1,0 +1,2 @@
+[Chores]
+- Dependency bumps now reach the release notes on their own: `release-notes.sh check` reports how many have landed since the last tag and `release-notes.sh deps` drafts the fragment from them, both reading the `chore(deps)` commit prefix now pinned in the Dependabot config. `make stamp tag` runs the check before freezing the tag body, and pull requests that add no fragment get a non-blocking warning on the Files tab.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -46,3 +46,31 @@ Preview the assembled notes any time:
 ```bash
 ./build/release-notes.sh assemble
 ```
+
+## Dependency updates
+
+Dependabot opens PRs but never runs this tooling, so its bumps are read out
+of the commit log instead of being authored per PR — they are identified by
+the `chore(deps)` commit prefix pinned in `.github/dependabot.yaml`.
+
+```bash
+./build/release-notes.sh check   # how many bumps since the last release tag
+./build/release-notes.sh deps    # draft NNNN-dependency-updates.md from them
+```
+
+`check` is safe to run at any time and answers "has enough piled up to be
+worth a build yet?". It also runs automatically during `make stamp tag`,
+before the notes are frozen into the tag body, and warns there if bumps
+landed that no fragment mentions. It only ever warns — it never blocks.
+
+`deps` writes a draft, one bump per clause. Edit it into prose before the
+release; the prose is what ships. Both commands take an optional starting
+ref (`./build/release-notes.sh deps v5.0.0-dev.147`) when the window should
+not be the last tag.
+
+Because both read the commit log, they only see bumps that have **landed on
+this branch** — a bump still sitting in an open PR is not counted.
+
+A pull request that adds no fragment at all gets a non-blocking warning on
+the Files tab. Dependabot's own PRs are exempt from it, since they are
+covered by the two commands above.


### PR DESCRIPTION
Dependabot opens PRs but never runs the release-notes fragment tooling, so
its bumps reach a release only if someone writes them up by hand. Nothing
reported the omission until the notes came out thin — #5716 merged green,
with no fragment and no warning.

Two commands read the bumps out of the commit log instead:

```
$ make changelog
changelog.d: 1 dependency bump(s) in v5.0.0-dev.147..HEAD

$ ./build/release-notes.sh deps
changelog.d/0031-dependency-updates.md
```

`check` prints the count whether or not anything is missing, so it also
answers "has enough piled up to be worth a build yet?" between releases.
`deps` writes a draft to rewrite into prose — the prose is what ships.

`create-git-tag.sh` runs the check before the notes are frozen into the tag
body, so the report arrives while the author can still act on it.

Both key on the `chore(deps)` commit prefix, which this PR pins in
`.github/dependabot.yaml` rather than leaving to Dependabot's default —
if it drifts, the bumps silently stop being found, so the config carries a
comment saying so.

Pull requests that add no fragment now get a non-blocking `::warning::` on
the Files tab. It is deliberately **not** in `pr-success`'s `needs`: a hard
failure would fire on pipeline fixes, docs-only changes, reverts and bumps,
and a gate with that false-positive rate gets routed around rather than
obeyed. Dependabot is exempt from it, since it cannot act on the advice.

### Known limits

- Both commands see only what has landed on the branch; a bump in an open PR
  is not counted.
- "Covered" is a loose text match rather than an exact one against the commit
  subjects, because the draft is meant to be rewritten into prose. The cost is
  that a dependency fragment left over from an already-published window
  silences the report for the current one — `make sweep` after each release is
  what prevents that. Commented in the code and the README.
- The grep also catches dependency work done by hand under the same prefix.
  For a changelog bullet that is wanted.

### Testing

`build/test-release-notes.sh` goes from 7 checks to 17, covering the window
resolution, dedup and prefix stripping, the `SINCE` override, prose still
counting as covered, and that the check exits 0 even while warning.

Two of those tests were written after they caught real bugs in this branch:
`xargs` with empty input left `grep` reading stdin, so the check went silent
on a freshly swept directory; and matching fragments against raw commit
subjects false-positived on any hand-written entry.

The second commit adds the fragment #5716 landed without.