### PR TITLE
fix(deploy): support private, self-hosted, and nested-subgroup GitLab in the deploy wizard

### DIFF
--- a/changelog.d/0030-fix-gitlab-deploy-token.md
+++ b/changelog.d/0030-fix-gitlab-deploy-token.md
@@ -1,0 +1,2 @@
+[BugFixes]
+- Deploying an application from a private or self-hosted GitLab now works: the access token entered in the deploy wizard is applied to every GitLab API call (previously only GitHub tokens were sent, so private/self-hosted GitLab lookups were unauthenticated and returned "Repository not found"), and the GitLab base URL is normalized to its `/api/v4` REST root so users can enter just the host (e.g. `https://gitlab.example.com`) instead of the full API URL.

--- a/changelog.d/0030-fix-gitlab-deploy-token.md
+++ b/changelog.d/0030-fix-gitlab-deploy-token.md
@@ -1,2 +1,4 @@
 [BugFixes]
 - Deploying an application from a private or self-hosted GitLab now works: the access token entered in the deploy wizard is applied to every GitLab API call (previously only GitHub tokens were sent, so private/self-hosted GitLab lookups were unauthenticated and returned "Repository not found"), and the GitLab base URL is normalized to its `/api/v4` REST root so users can enter just the host (e.g. `https://gitlab.example.com`) instead of the full API URL.
+- GitLab projects in nested subgroups (e.g. `group/subgroup/project`) can now be deployed: the repository lookup accepts paths with more than two segments and URL-encodes the full path, the repository-suggestions search queries the group namespace (including subgroups) instead of the `/users` endpoint (which returned "404 User Not Found" for a group path), and the project-name validator no longer rejects nested paths.
+

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.html
@@ -80,7 +80,7 @@
                           </label>
                           <input id="projectName" type="text" class="input" [disabled]="isRedeploy" [(ngModel)]="repository"
                             placeholder="owner/repo" name="projectName"
-                            [appGithubProjectExists]="sourceType.id + ',' + projectExistsEndpointGuid + ',' + (accessToken || '')" required
+                            [appGithubProjectExists]="sourceType.id + ',' + projectExistsEndpointGuid + ',' + (scmBaseApiUrl || '') + ',' + (accessToken || '')" required
                             list="repo-suggestions">
                           <!-- Repository suggestions datalist -->
                           <datalist id="repo-suggestions">

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.spec.ts
@@ -129,9 +129,34 @@ describe('DeployApplicationStep2Component', () => {
       expect(scmSpy.setPublicApi).not.toHaveBeenCalled();
     });
 
-    it('skips token handling when the active SCM is not GitHub (e.g. GitLab)', () => {
+    it('applies the access token for GitLab too, and normalizes the base URL to /api/v4', () => {
       scmSpy.getType.mockReturnValue('gitlab');
-      invoke('https://gitlab.example.com/api/v4', 'pat-should-be-ignored');
+      // User types the plain host; we append the GitLab API root before it
+      // reaches the SCM.
+      invoke('https://workshop.cloud.gov', 'pat-gitlab');
+
+      expect(scmSpy.setPublicApi).toHaveBeenCalledWith('https://workshop.cloud.gov/api/v4');
+      expect(scmSpy.setAccessToken).toHaveBeenCalledWith('pat-gitlab');
+      expect(scmSpy.clearAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('does not double-append /api/v4 when the GitLab base URL already includes it', () => {
+      scmSpy.getType.mockReturnValue('gitlab');
+      invoke('https://workshop.cloud.gov/api/v4', 'pat-gitlab');
+
+      expect(scmSpy.setPublicApi).toHaveBeenCalledWith('https://workshop.cloud.gov/api/v4');
+    });
+
+    it('does not append /api/v4 for a GitHub Enterprise base URL', () => {
+      scmSpy.getType.mockReturnValue('github');
+      invoke('https://github.example.com/api/v3', 'pat-abc123');
+
+      expect(scmSpy.setPublicApi).toHaveBeenCalledWith('https://github.example.com/api/v3');
+    });
+
+    it('skips token handling when the active SCM is neither GitHub nor GitLab', () => {
+      scmSpy.getType.mockReturnValue('bitbucket');
+      invoke('https://bitbucket.example.com', 'pat-should-be-ignored');
 
       expect(scmSpy.setAccessToken).not.toHaveBeenCalled();
       expect(scmSpy.clearAccessToken).not.toHaveBeenCalled();
@@ -186,6 +211,26 @@ describe('DeployApplicationStep2Component', () => {
       expect(component.gitMode).toBe('enterprise');
       expect(component.githubEnterpriseUrl).toBe('https://github.corp.com');
       expect(component.accessToken).toBe('tok');
+    });
+  });
+
+  describe('normalizeGitlabApiUrl', () => {
+    const normalize = (u: string) => DeployApplicationStep2Component.normalizeGitlabApiUrl(u);
+
+    it('appends /api/v4 to a plain host', () => {
+      expect(normalize('https://workshop.cloud.gov')).toBe('https://workshop.cloud.gov/api/v4');
+    });
+
+    it('trims a trailing slash before appending', () => {
+      expect(normalize('https://workshop.cloud.gov/')).toBe('https://workshop.cloud.gov/api/v4');
+    });
+
+    it('is idempotent when /api/v4 is already present', () => {
+      expect(normalize('https://workshop.cloud.gov/api/v4')).toBe('https://workshop.cloud.gov/api/v4');
+    });
+
+    it('is idempotent when /api/v4 is present with a trailing slash', () => {
+      expect(normalize('https://workshop.cloud.gov/api/v4/')).toBe('https://workshop.cloud.gov/api/v4');
     });
   });
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2/deploy-application-step2.component.ts
@@ -9,7 +9,6 @@ import {
   GitBranch,
   GitCommit,
   GitDataService,
-  GitHubSCM,
   GitRepo,
   GitSCM,
   GitSCMService,
@@ -152,6 +151,21 @@ export class DeployApplicationStep2Component
   // in Public mode.
   get projectExistsEndpointGuid(): string {
     return this.gitMode === 'public' ? (this.sourceType?.endpointGuid ?? '') : '';
+  }
+
+  // Base API URL to pass to the project-exists validator so its own SCM
+  // instance targets the same host the suggestions/lookup SCM does. Empty in
+  // Public mode (the validator uses the registered endpoint / default public
+  // API). In Private/Enterprise mode it's the user-supplied base URL,
+  // normalized to /api/v4 for GitLab so the validator hits the REST API rather
+  // than the web UI (which 302-redirects and yields a false "not found").
+  get scmBaseApiUrl(): string {
+    if (this.gitMode === 'public' || !this.githubEnterpriseUrl) {
+      return '';
+    }
+    return this.sourceType?.id === DEPLOY_TYPES_IDS.GITLAB
+      ? DeployApplicationStep2Component.normalizeGitlabApiUrl(this.githubEnterpriseUrl)
+      : this.githubEnterpriseUrl;
   }
 
   // Git URL
@@ -422,9 +436,9 @@ export class DeployApplicationStep2Component
   }
 
   // Forwards the two optional inputs (GHE base URL, GitHub PAT) into the
-  // active GitHubSCM instance so that subsequent repo/branch/commit API calls
-  // target the right host with the right Authorization header. Silent no-op
-  // when the active SCM is not GitHub (e.g. GitLab selected).
+  // active SCM instance so that subsequent repo/branch/commit API calls
+  // target the right host with the right Authorization header. Applies to
+  // both GitHub (Enterprise) and self-hosted GitLab.
   private applyGithubEnterpriseAndToken(enterpriseUrl: string | undefined, token: string | undefined) {
     if (!this.scm) {
       return;
@@ -440,14 +454,30 @@ export class DeployApplicationStep2Component
     this.isInvalidGithubEnterpriseUrl = !!enterpriseUrl && !isValidUrl(enterpriseUrl);
 
     if (enterpriseUrl && !this.isInvalidGithubEnterpriseUrl) {
-      (this.scm as unknown as BaseSCM).setPublicApi(enterpriseUrl);
+      // GitLab's REST API lives under /api/v4. Users type the plain host
+      // (e.g. https://workshop.cloud.gov) in the Self-hosted GitLab field, so
+      // normalize to the API root before it reaches the SCM — otherwise every
+      // call hits the GitLab web UI (which 302-redirects to /users/sign_in for
+      // an unauthenticated browser request, producing the CORS/redirect errors
+      // and a spurious "Repository not found"). GitHub Enterprise users type
+      // the full /api/v3 URL themselves, so only GitLab needs this.
+      const apiUrl = this.scm.getType() === 'gitlab'
+        ? DeployApplicationStep2Component.normalizeGitlabApiUrl(enterpriseUrl)
+        : enterpriseUrl;
+      (this.scm as unknown as BaseSCM).setPublicApi(apiUrl);
     }
 
-    if (this.scm.getType() === 'github') {
+    // Apply/clear the PAT for both GitHub and GitLab (both expose
+    // setAccessToken/clearAccessToken). Previously this was gated to GitHub
+    // only, so a GitLab token typed in Private/Enterprise mode was never sent
+    // and private / self-hosted GitLab projects 404'd.
+    const scmType = this.scm.getType();
+    if (scmType === 'github' || scmType === 'gitlab') {
+      const tokenScm = this.scm as unknown as { setAccessToken(t: string): void; clearAccessToken(): void };
       if (token) {
-        (this.scm as GitHubSCM).setAccessToken(token);
+        tokenScm.setAccessToken(token);
       } else {
-        (this.scm as GitHubSCM).clearAccessToken();
+        tokenScm.clearAccessToken();
       }
     }
   }
@@ -487,6 +517,21 @@ export class DeployApplicationStep2Component
       return 'private';
     }
     return 'public';
+  }
+
+  // Normalize a self-hosted GitLab base URL to its REST API root. The user
+  // types the plain host (e.g. https://workshop.cloud.gov); the GitLab API is
+  // served from `<host>/api/v4`. Idempotent: a URL that already ends in
+  // /api/v4 (with or without a trailing slash) is returned unchanged, and any
+  // trailing slash on the host is trimmed first so we never emit a double
+  // slash. Falls back to the raw input if it isn't a parseable URL (the caller
+  // has already flagged invalid URLs via isInvalidGithubEnterpriseUrl).
+  static normalizeGitlabApiUrl(baseUrl: string): string {
+    const trimmed = baseUrl.replace(/\/+$/, '');
+    if (/\/api\/v4$/.test(trimmed)) {
+      return trimmed;
+    }
+    return `${trimmed}/api/v4`;
   }
 
   // Tab handler: switch the active access mode and clear the now-irrelevant

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.spec.ts
@@ -41,22 +41,23 @@ describe('GithubProjectExistsDirective', () => {
 
     // First change only records the baseline — it must NOT re-run validation
     // or clear cached state (see redeploy-seed guard below).
-    directive.appGithubProjectExists = 'github,,';
+    // Value shape: `<scm type>,<endpoint guid>,<base api url>,<access token>`.
+    directive.appGithubProjectExists = 'github,,,';
     directive.ngOnChanges({
-      appGithubProjectExists: { currentValue: 'github,,', previousValue: undefined, firstChange: true, isFirstChange: () => true },
+      appGithubProjectExists: { currentValue: 'github,,,', previousValue: undefined, firstChange: true, isFirstChange: () => true },
     } as any);
     expect(reRuns).toBe(0);
 
     // Token added — auth context changed, so validation must re-run.
-    directive.appGithubProjectExists = 'github,,ghp_secrettoken';
+    directive.appGithubProjectExists = 'github,,,ghp_secrettoken';
     directive.ngOnChanges({
-      appGithubProjectExists: { currentValue: 'github,,ghp_secrettoken', previousValue: 'github,,', firstChange: false, isFirstChange: () => false },
+      appGithubProjectExists: { currentValue: 'github,,,ghp_secrettoken', previousValue: 'github,,,', firstChange: false, isFirstChange: () => false },
     } as any);
     expect(reRuns).toBe(1);
 
     // Same value again — no auth change, so no extra re-run.
     directive.ngOnChanges({
-      appGithubProjectExists: { currentValue: 'github,,ghp_secrettoken', previousValue: 'github,,ghp_secrettoken', firstChange: false, isFirstChange: () => false },
+      appGithubProjectExists: { currentValue: 'github,,,ghp_secrettoken', previousValue: 'github,,,ghp_secrettoken', firstChange: false, isFirstChange: () => false },
     } as any);
     expect(reRuns).toBe(1);
   });
@@ -75,9 +76,9 @@ describe('GithubProjectExistsDirective', () => {
     };
     const clearSpy = vi.spyOn(deployData, 'projectDoesntExist');
 
-    directive.appGithubProjectExists = 'github,747ed39a-guid,';
+    directive.appGithubProjectExists = 'github,747ed39a-guid,,';
     directive.ngOnChanges({
-      appGithubProjectExists: { currentValue: 'github,747ed39a-guid,', previousValue: undefined, firstChange: true, isFirstChange: () => true },
+      appGithubProjectExists: { currentValue: 'github,747ed39a-guid,,', previousValue: undefined, firstChange: true, isFirstChange: () => true },
     } as any);
 
     expect(clearSpy).not.toHaveBeenCalled();
@@ -85,8 +86,15 @@ describe('GithubProjectExistsDirective', () => {
 
   it('preserves commas in the access token when splitting the auth context', () => {
     const directive = TestBed.runInInjectionContext(() => new GithubProjectExistsDirective());
-    directive.appGithubProjectExists = 'github,,tok,en,with,commas';
+    directive.appGithubProjectExists = 'github,,,tok,en,with,commas';
     const parsed = (directive as any).getTypeAndEndpointWithAuth();
-    expect(parsed).toEqual(['github', '', 'tok,en,with,commas']);
+    expect(parsed).toEqual(['github', '', '', 'tok,en,with,commas']);
+  });
+
+  it('parses the base api url (GitLab self-hosted) between the guid and the token', () => {
+    const directive = TestBed.runInInjectionContext(() => new GithubProjectExistsDirective());
+    directive.appGithubProjectExists = 'gitlab,,https://workshop.cloud.gov/api/v4,glpat-xyz';
+    const parsed = (directive as any).getTypeAndEndpointWithAuth();
+    expect(parsed).toEqual(['gitlab', '', 'https://workshop.cloud.gov/api/v4', 'glpat-xyz']);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
@@ -81,10 +81,12 @@ export class GithubProjectExistsDirective implements Validator, OnChanges {
   }
 
   // Reduce API calls trying to validate until we have a valid name
-  // Must be of the form USER/NAME - where NAME must be at least 2 charts in length
+  // Must be of the form OWNER/NAME (GitHub) or NAMESPACE/.../NAME (GitLab
+  // nested subgroups), i.e. at least two segments, and the final segment
+  // (the project name) must be more than 2 characters.
   private isValidProjectName(name: string) {
     const parts = name.split('/');
-    return parts.length === 2 && parts[1].length > 2;
+    return parts.length >= 2 && parts[parts.length - 1].length > 2;
   }
 
   private haveAlreadyChecked(name: string) {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/github-project-exists.directive.ts
@@ -23,12 +23,12 @@ const GITHUB_PROJECT_EXISTS = {
 })
 export class GithubProjectExistsDirective implements Validator, OnChanges {
 
-  // Value shape: `<scm type>,<endpoint guid>,<access token>`. Changing the
-  // token (or endpoint) must re-trigger validation — an NgControl async
-  // validator only re-runs when its OWN control (the project name) changes,
-  // so without OnChanges a token added AFTER the project name was entered
-  // would never be re-checked, leaving a stale "does not exist" from the
-  // earlier unauthenticated lookup.
+  // Value shape: `<scm type>,<endpoint guid>,<base api url>,<access token>`.
+  // Changing the token, endpoint, or base URL must re-trigger validation — an
+  // NgControl async validator only re-runs when its OWN control (the project
+  // name) changes, so without OnChanges a token/URL added AFTER the project
+  // name was entered would never be re-checked, leaving a stale "does not
+  // exist" from the earlier unauthenticated / wrong-host lookup.
   @Input() appGithubProjectExists!: string;
 
   private lastValue = '';
@@ -91,14 +91,15 @@ export class GithubProjectExistsDirective implements Validator, OnChanges {
     return this.lastValue.length && this.lastValue.indexOf(name) === 0;
   }
 
-  private getTypeAndEndpointWithAuth(): [GitSCMType, string, string] | null {
+  private getTypeAndEndpointWithAuth(): [GitSCMType, string, string, string] | null {
     const res = this.appGithubProjectExists.split(',');
-    if (res.length >= 3) {
+    if (res.length >= 4) {
       // A PAT can legitimately contain commas — rejoin everything after the
-      // scm type + endpoint guid so the token is passed intact.
-      return [res[0] as GitSCMType, res[1], res.slice(2).join(',')];
+      // scm type + endpoint guid + base URL so the token is passed intact.
+      // The base URL never contains a comma.
+      return [res[0] as GitSCMType, res[1], res[2], res.slice(3).join(',')];
     }
-    console.warn('appGithubProjectExists value should be `<scm type>,<endpoint guid>,<access token>`');
+    console.warn('appGithubProjectExists value should be `<scm type>,<endpoint guid>,<base api url>,<access token>`');
     return null;
   }
 
@@ -117,10 +118,19 @@ export class GithubProjectExistsDirective implements Validator, OnChanges {
         tap(createAppState => {
           const typeAndEndpoint = this.getTypeAndEndpointWithAuth();
           if (typeAndEndpoint && createAppState?.projectExists && createAppState.projectExists.name !== c.value) {
-            this.deployData.checkProjectExists(
-              this.scmService.getSCM(...typeAndEndpoint),
-              c.value,
-            );
+            const [type, endpointGuid, baseApiUrl, token] = typeAndEndpoint;
+            const scm = this.scmService.getSCM(type, endpointGuid, token || undefined);
+            // Private/Enterprise mode: the user typed a base URL (GitLab
+            // self-hosted, or GitHub Enterprise), so point the validator's SCM
+            // at that host. Without this the validator would hit the default
+            // public API (gitlab.com / api.github.com) and 404, showing a
+            // spurious "Repository not found" for a repo that lives on the
+            // self-hosted host. The suggestions path already does this via the
+            // component's own SCM; the validator uses its own instance.
+            if (baseApiUrl) {
+              (scm as unknown as { setPublicApi(url: string): void }).setPublicApi(baseApiUrl);
+            }
+            this.deployData.checkProjectExists(scm, c.value);
           }
         }),
         filter(createAppState =>

--- a/src/frontend/packages/git/src/shared/scm/gitlab-scm.spec.ts
+++ b/src/frontend/packages/git/src/shared/scm/gitlab-scm.spec.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { of } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { GitLabSCM } from './gitlab-scm';
 
@@ -31,5 +33,66 @@ describe('GitLabSCM access token', () => {
     scm.clearAccessToken();
     options = (scm as unknown as { options?: { headers?: Record<string, string> } }).options;
     expect(options?.headers).toEqual({});
+  });
+});
+
+describe('GitLabSCM nested subgroups', () => {
+  // Point the SCM at the public API root so getAPI() (no registered endpoint)
+  // returns { url: <root> } and we can assert the exact request URL.
+  const makeScm = () => {
+    const scm = new GitLabSCM('');
+    (scm as unknown as { publicApiUrl: string }).publicApiUrl = 'https://workshop.cloud.gov/api/v4';
+    return scm;
+  };
+
+  it('getRepository URL-encodes a nested group/subgroup/project path whole', () => {
+    const scm = makeScm();
+    const get = vi.fn().mockReturnValue(of({ path_with_namespace: 'cloud-gov/platform/rag-demo', namespace: { name: 'platform' } }));
+    const httpClient = { get } as any;
+
+    scm.getRepository(httpClient, 'cloud-gov/platform/rag-demo').pipe(take(1)).subscribe();
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0]).toBe(
+      'https://workshop.cloud.gov/api/v4/projects/cloud-gov%2Fplatform%2Frag-demo'
+    );
+  });
+
+  it('getRepository still resolves a simple two-segment path', () => {
+    const scm = makeScm();
+    const get = vi.fn().mockReturnValue(of({ path_with_namespace: 'group/repo', namespace: { name: 'group' } }));
+    const httpClient = { get } as any;
+
+    scm.getRepository(httpClient, 'group/repo').pipe(take(1)).subscribe();
+
+    expect(get.mock.calls[0][0]).toBe('https://workshop.cloud.gov/api/v4/projects/group%2Frepo');
+  });
+
+  it('getMatchingRepositories searches the group namespace (with subgroups), not /users, for a nested path', () => {
+    const scm = makeScm();
+    const get = vi.fn().mockReturnValue(of([]));
+    const httpClient = { get } as any;
+
+    scm.getMatchingRepositories(httpClient, 'cloud-gov/platform/rag').pipe(take(1)).subscribe();
+
+    const urls = get.mock.calls.map((c: unknown[]) => c[0] as string);
+    // Nested namespace is not a user, so the /users lookup must be skipped.
+    expect(urls.some(u => u.includes('/users/'))).toBe(false);
+    // The namespace (cloud-gov/platform) is URL-encoded and subgroups included.
+    expect(urls).toContain(
+      'https://workshop.cloud.gov/api/v4/groups/cloud-gov%2Fplatform/projects?search=rag&include_subgroups=true'
+    );
+  });
+
+  it('getMatchingRepositories still tries the /users lookup for a single-segment namespace', () => {
+    const scm = makeScm();
+    const get = vi.fn().mockReturnValue(of([]));
+    const httpClient = { get } as any;
+
+    scm.getMatchingRepositories(httpClient, 'someuser/rag').pipe(take(1)).subscribe();
+
+    const urls = get.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(urls).toContain('https://workshop.cloud.gov/api/v4/users/someuser/projects/?search=rag');
+    expect(urls).toContain('https://workshop.cloud.gov/api/v4/groups/someuser/projects?search=rag&include_subgroups=true');
   });
 });

--- a/src/frontend/packages/git/src/shared/scm/gitlab-scm.spec.ts
+++ b/src/frontend/packages/git/src/shared/scm/gitlab-scm.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import { GitLabSCM } from './gitlab-scm';
+
+describe('GitLabSCM access token', () => {
+  it('sets an Authorization: Bearer header when a token is passed to the constructor', () => {
+    const scm = new GitLabSCM('', 'pat-abc123');
+    const options = (scm as unknown as { options?: { headers?: Record<string, string> } }).options;
+    expect(options).toBeDefined();
+    expect(options?.headers?.['Authorization']).toBe('Bearer pat-abc123');
+  });
+
+  it('does not set options when no token is supplied', () => {
+    const scm = new GitLabSCM('');
+    const options = (scm as unknown as { options?: unknown }).options;
+    expect(options).toBeUndefined();
+  });
+
+  it('ignores a whitespace-only token', () => {
+    const scm = new GitLabSCM('', '   ');
+    const options = (scm as unknown as { options?: unknown }).options;
+    expect(options).toBeUndefined();
+  });
+
+  it('setAccessToken then clearAccessToken empties the auth headers', () => {
+    const scm = new GitLabSCM('');
+    scm.setAccessToken('pat-xyz');
+    let options = (scm as unknown as { options?: { headers?: Record<string, string> } }).options;
+    expect(options?.headers?.['Authorization']).toBe('Bearer pat-xyz');
+
+    scm.clearAccessToken();
+    options = (scm as unknown as { options?: { headers?: Record<string, string> } }).options;
+    expect(options?.headers).toEqual({});
+  });
+});

--- a/src/frontend/packages/git/src/shared/scm/gitlab-scm.ts
+++ b/src/frontend/packages/git/src/shared/scm/gitlab-scm.ts
@@ -5,6 +5,7 @@ import { combineLatest, Observable, of as observableOf, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { Md5 } from 'ts-md5';
 
+import { HttpOptions } from '../../../../core/src/core/core.types';
 import { GitBranch, GitCommit, GitRepo, GitSuggestedRepo } from '../../store/git.public-types';
 import { GitSCM, SCMIcon } from './scm';
 import { BaseSCM, GitApiRequest } from './scm-base';
@@ -16,8 +17,15 @@ const GITLAB_PER_PAGE_PARAM_VALUE = 100;
 
 export class GitLabSCM extends BaseSCM implements GitSCM {
 
+  // Optional per-request options carrying an Authorization header when a PAT
+  // has been supplied (Private/Enterprise mode). Mirrors GitHubSCM so the
+  // token reaches every GitLab API call — without this GitLab lookups were
+  // always unauthenticated and private/self-hosted projects 404'd.
+  private options?: HttpOptions;
+
   constructor(
     endpointGuid: string,
+    accessToken?: string,
     endpointsData?: EndpointsDataService,
     injector?: Injector,
   ) {
@@ -25,6 +33,22 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
     this.endpointGuid = endpointGuid;
     this.endpointsData = endpointsData;
     this.injector = injector;
+    if (accessToken && accessToken.trim() !== '') {
+      this.setAccessToken(accessToken);
+    }
+  }
+
+  // GitLab's REST API accepts a PAT via the Authorization: Bearer header
+  // (equivalent to the PRIVATE-TOKEN header). Match GitHubSCM's shape.
+  setAccessToken(token: string) {
+    this.options = new HttpOptions();
+    this.options.headers = { Authorization: `Bearer ${token}` };
+  }
+
+  clearAccessToken() {
+    if (this.options) {
+      this.options.headers = {};
+    }
   }
 
   getType(): GitSCMType {
@@ -47,7 +71,7 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
 
     const obs$: Observable<unknown> = parts.length !== 2 ?
       observableOf(null) :
-      this.getAPI().pipe(switchMap(api => httpClient.get(`${api.url}/projects/${parts.join('%2F')}`, api.requestArgs)));
+      this.getAPI(this.options).pipe(switchMap(api => httpClient.get(`${api.url}/projects/${parts.join('%2F')}`, api.requestArgs)));
 
     return obs$.pipe(
       map((data: unknown) => {
@@ -63,7 +87,7 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
 
   getBranch(httpClient: HttpClient, projectName: string, branchName: string): Observable<GitBranch> {
     const prjNameEncoded = encodeURIComponent(projectName);
-    return this.getAPI().pipe(
+    return this.getAPI(this.options).pipe(
       switchMap(api => httpClient.get(`${api.url}/projects/${prjNameEncoded}/repository/branches/${branchName}`, api.requestArgs)),
       map((data: unknown) => {
         const branch = data as { commit: { id: string; sha?: string } };
@@ -76,7 +100,7 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
 
   getBranches(httpClient: HttpClient, projectName: string): Observable<GitBranch[]> {
     const prjNameEncoded = encodeURIComponent(projectName);
-    return this.getAPI().pipe(
+    return this.getAPI(this.options).pipe(
       switchMap(api => httpClient.get(
         `${api.url}/projects/${prjNameEncoded}/repository/branches`, {
         ...api.requestArgs,
@@ -106,7 +130,7 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
   }
 
   getCommitApi(projectName: string, commitSha: string): Observable<GitApiRequest> {
-    return this.getAPI().pipe(
+    return this.getAPI(this.options).pipe(
       map(api => {
         const prjNameEncoded = encodeURIComponent(projectName);
         return {
@@ -119,7 +143,7 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
 
   getCommits(httpClient: HttpClient, projectName: string, commitSha: string): Observable<GitCommit[]> {
     const prjNameEncoded = encodeURIComponent(projectName);
-    return this.getAPI().pipe(
+    return this.getAPI(this.options).pipe(
       switchMap(api => httpClient.get(
         `${api.url}/projects/${prjNameEncoded}/repository/commits?ref_name=${commitSha}`, {
         ...api.requestArgs,
@@ -153,7 +177,7 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
   }
 
   private getMatchingUserGroupRepositories(httpClient: HttpClient, prjParts: string[]): Observable<GitRepo[]> {
-    return this.getAPI().pipe(
+    return this.getAPI(this.options).pipe(
       switchMap(api => combineLatest([
         httpClient.get<[]>(`${api.url}/users/${prjParts[0]}/projects/?search=${prjParts[1]}`, api.requestArgs).pipe(
           catchError(() => of([]))
@@ -167,7 +191,7 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
   }
 
   private getMatchingProjects(httpClient: HttpClient, exactProjectName: string): Observable<GitRepo[]> {
-    return this.getAPI().pipe(
+    return this.getAPI(this.options).pipe(
       switchMap(api => httpClient.get(`${api.url}/projects?search=${exactProjectName}`, {
         ...api.requestArgs,
         params: {

--- a/src/frontend/packages/git/src/shared/scm/gitlab-scm.ts
+++ b/src/frontend/packages/git/src/shared/scm/gitlab-scm.ts
@@ -69,9 +69,15 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
   getRepository(httpClient: HttpClient, projectName: string): Observable<GitRepo> {
     const parts = projectName.split('/');
 
-    const obs$: Observable<unknown> = parts.length !== 2 ?
+    // GitLab projects can live in nested subgroups
+    // (group/subgroup/.../project), so any path with at least a namespace and
+    // a project (>= 2 segments) is valid. The full path is URL-encoded whole
+    // (cloud-gov/platform/rag-demo -> cloud-gov%2Fplatform%2Frag-demo) as
+    // GitLab's "project ID or URL-encoded path" API expects.
+    const obs$: Observable<unknown> = parts.length < 2 ?
       observableOf(null) :
-      this.getAPI(this.options).pipe(switchMap(api => httpClient.get(`${api.url}/projects/${parts.join('%2F')}`, api.requestArgs)));
+      this.getAPI(this.options).pipe(
+        switchMap(api => httpClient.get(`${api.url}/projects/${encodeURIComponent(projectName)}`, api.requestArgs)));
 
     return obs$.pipe(
       map((data: unknown) => {
@@ -177,12 +183,26 @@ export class GitLabSCM extends BaseSCM implements GitSCM {
   }
 
   private getMatchingUserGroupRepositories(httpClient: HttpClient, prjParts: string[]): Observable<GitRepo[]> {
+    // The last segment is the (partial) project name being searched; every
+    // segment before it forms the namespace, which for nested subgroups is
+    // itself a slash-joined path (e.g. cloud-gov/platform). URL-encode the
+    // whole namespace so the subgroup separator survives as %2F. A user
+    // namespace is always a single segment, so only attempt the /users lookup
+    // when there's exactly one namespace segment — otherwise it 404s with
+    // "User Not Found" (a group path is not a user).
+    const search = prjParts[prjParts.length - 1];
+    const namespaceParts = prjParts.slice(0, -1);
+    const namespace = encodeURIComponent(namespaceParts.join('/'));
+    const isUserNamespace = namespaceParts.length === 1;
+
     return this.getAPI(this.options).pipe(
       switchMap(api => combineLatest([
-        httpClient.get<[]>(`${api.url}/users/${prjParts[0]}/projects/?search=${prjParts[1]}`, api.requestArgs).pipe(
-          catchError(() => of([]))
-        ),
-        httpClient.get<[]>(`${api.url}/groups/${prjParts[0]}/projects?search=${prjParts[1]}`, api.requestArgs).pipe(
+        isUserNamespace ?
+          httpClient.get<[]>(`${api.url}/users/${namespace}/projects/?search=${search}`, api.requestArgs).pipe(
+            catchError(() => of([]))
+          ) :
+          of([] as []),
+        httpClient.get<[]>(`${api.url}/groups/${namespace}/projects?search=${search}&include_subgroups=true`, api.requestArgs).pipe(
           catchError(() => of([]))
         ),
       ])),

--- a/src/frontend/packages/git/src/shared/scm/scm.service.ts
+++ b/src/frontend/packages/git/src/shared/scm/scm.service.ts
@@ -29,7 +29,7 @@ export class GitSCMService {
       case 'github':
         return new GitHubSCM(this.gitHubURL, endpointGuid, accessToken, this.endpointsData, this.injector);
       case 'gitlab':
-        return new GitLabSCM(endpointGuid, this.endpointsData, this.injector);
+        return new GitLabSCM(endpointGuid, accessToken, this.endpointsData, this.injector);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes deploying an application from a **private or self-hosted GitLab** (and GitLab projects in **nested subgroups**) via the Deploy Application wizard. Previously these failed with "Repository not found", and the browser console showed the GitLab API calls either 302-redirecting to `/users/sign_in` (unauthenticated) or 404ing with `404 User Not Found`.

## Problems & fixes

**1. Access token was never sent to GitLab.**
The wizard applied the entered PAT only when the active SCM was GitHub, so every GitLab lookup was unauthenticated (302 → `/users/sign_in`). `GitLabSCM` now accepts a token (constructor + `setAccessToken`/`clearAccessToken`, mirroring `GitHubSCM`) and threads it through every API call, and the wizard applies the token for GitLab too.

**2. Self-hosted GitLab base URL hit the web UI, not the API.**
The base URL (e.g. `https://gitlab.example.com`) was passed to the SCM verbatim, so calls hit the web UI instead of the REST API. The wizard now normalizes a GitLab base URL to its `/api/v4` root (idempotently), and the project-exists validator's own SCM instance is pointed at the same host so it no longer falls back to `gitlab.com`. The validator auth context is extended to `<scm type>,<endpoint guid>,<base api url>,<access token>` so a late-entered base URL or token re-triggers validation.

**3. Nested subgroups (`group/subgroup/project`) were rejected.**
`getRepository` only accepted exactly two path segments and joined them with a literal `%2F`, so a three-segment subgroup path was rejected locally before any API call. It now accepts `>= 2` segments and URL-encodes the whole path (`group/subgroup/project` → `group%2Fsubgroup%2Fproject`), matching GitLab's URL-encoded-path project lookup. The suggestions lookup always queried `/users/<owner>/projects`, but a nested namespace is a group, not a user (→ `404 User Not Found`); it now splits into namespace + search term, only queries `/users` for a single-segment namespace, and queries `/groups/<url-encoded-namespace>/projects?...&include_subgroups=true`. The validator's `isValidProjectName` also accepts `>= 2` segments.

## Testing

- `vitest --project=git` (incl. new `gitlab-scm.spec.ts` cases: token header, base-URL normalization, encoded nested lookup, group-vs-user selection, `include_subgroups`)
- `vitest --project=cloud-foundry` deploy-application suite (incl. new step2 base-URL-normalization and validator-context cases)
- `eslint` clean on all touched files
- **Manually validated** against a self-hosted GitLab: deployed a project in a nested subgroup (`group/subgroup/project`) using a personal access token — repository resolves, branch list populates, deploy proceeds.

## Notes

- A changelog fragment is included (`changelog.d/0030-fix-gitlab-deploy-token.md`).
- Builds on the deploy-application Source Config / token-revalidate work from #5707.
