### PR TITLE
fix(changelog): judge dependency-fragment coverage by time, not presence

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -431,12 +431,15 @@ jobs:
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
         run: |
-          if git diff --name-only --diff-filter=A "$BASE...HEAD" \
+          # AM, not A: appending to an existing fragment is how a change joins
+          # a note that is already there — a dependency bump landing after the
+          # fragment that covers its group, for instance.
+          if git diff --name-only --diff-filter=AM "$BASE...HEAD" \
              | grep -qE '^changelog\.d/[0-9]+-.*\.md$'; then
             echo "✅ Release-notes fragment present."
             exit 0
           fi
-          echo "::warning title=No release-notes fragment::This PR adds no changelog.d fragment, so it will not appear in the release notes. Run ./build/release-notes.sh new — or ignore this if the change needs no note."
+          echo "::warning title=No release-notes fragment::This PR neither adds nor updates a changelog.d fragment, so it will not appear in the release notes. Run ./build/release-notes.sh new — or ignore this if the change needs no note."
 
   pr-success:
     name: PR Quality Gate

--- a/build/release-notes.sh
+++ b/build/release-notes.sh
@@ -105,20 +105,33 @@ cmd_deps() {
   echo "Drafted from $(echo "${subjects}" | wc -l | tr -d ' ') bump(s) in $(dep_range "${1:-}") — edit into prose before release." >&2
 }
 
-# Does any fragment cover dependency work? Deliberately a loose text match and
-# not an exact one against the bump subjects: `deps` writes a DRAFT that the
-# author is meant to rewrite into prose, and prose that no longer quotes the
-# raw subjects would make an exact match warn on every well-curated release.
+# When was dependency work last written up? Answering with a timestamp rather
+# than a yes/no is what makes the check survive an incremental window: a
+# fragment can only describe bumps that landed before it, so "does any
+# fragment mention dependencies" goes quiet the moment one does — even for
+# bumps that merge afterwards.
 #
-# Known limit: a dependency fragment left behind from an already-published
-# window silences the report for the current one. `make sweep` after each
-# release is what keeps that from happening; the directory is meant to be
-# empty right after a release (see changelog.d/README.md).
-has_deps_fragment() {
-  local files
-  files=$(fragments)
-  [ -n "${files}" ] || return 1   # empty input would leave grep reading stdin
-  echo "${files}" | xargs grep -qiE 'depend|bump' 2>/dev/null
+# The fragment side stays a loose text match: `deps` writes a DRAFT the author
+# is meant to rewrite, and prose that no longer quotes the raw subjects must
+# not warn on a well-curated release.
+#
+# A fragment git has no record of is being written right now, so it covers
+# everything; this also keeps the check quiet when FRAG_DIR sits outside the
+# repo. Prints nothing when no fragment mentions dependencies at all.
+newest_deps_fragment_time() {
+  local file t newest=0
+  for file in $(fragments); do
+    grep -qiE 'depend|bump' "${file}" 2>/dev/null || continue
+    t=$(git -C "${ROOT_DIR}" log -1 --format=%ct -- "${file}" 2>/dev/null) || t=''
+    [ -n "${t}" ] || { echo uncommitted; return 0; }
+    [ "${t}" -gt "${newest}" ] && newest=${t}
+  done
+  [ "${newest}" -gt 0 ] && echo "${newest}"
+}
+
+newest_dep_bump_time() {
+  git -C "${ROOT_DIR}" log -1 --format=%ct --no-merges \
+      --grep='^chore(deps' "$(dep_range "${1:-}")" -- 2>/dev/null
 }
 
 # The count goes to stdout unconditionally, so this doubles as an any-time
@@ -126,11 +139,19 @@ has_deps_fragment() {
 # release" is the question that decides whether a patch build is due, and it
 # needs answering between releases, not only at tag time.
 cmd_check() {
-  local n
+  local n frag bump why
   n=$(dep_subjects "${1:-}" | wc -l | tr -d ' ')
   echo "changelog.d: ${n} dependency bump(s) in $(dep_range "${1:-}")"
-  { [ "${n}" -gt 0 ] && ! has_deps_fragment; } || return 0
-  echo "WARNING: none of them are mentioned in any fragment, so they will not" >&2
+  [ "${n}" -gt 0 ] || return 0
+
+  frag=$(newest_deps_fragment_time || true)
+  [ "${frag}" = uncommitted ] && return 0
+  bump=$(newest_dep_bump_time "${1:-}" || true)
+  { [ -n "${frag}" ] && [ -n "${bump}" ] && [ "${frag}" -ge "${bump}" ]; } && return 0
+
+  why='none of them are mentioned in any fragment'
+  [ -n "${frag}" ] && why='some landed after the newest fragment that mentions them'
+  echo "WARNING: ${why}, so they will not" >&2
   echo "         appear in the release notes. Draft them: ./build/release-notes.sh deps" >&2
 }
 

--- a/build/test-release-notes.sh
+++ b/build/test-release-notes.sh
@@ -69,18 +69,36 @@ check_fails "content before a section header fails" bash "${RN}" assemble
 rm "${FRAG_DIR}"/*.md
 
 # deps/check read git history, so they need a repo of their own rather than
-# the checkout this harness runs in.
+# the checkout this harness runs in — and the fragments must live INSIDE it,
+# because coverage is now judged by when a fragment was committed relative to
+# the bumps. Commit dates are pinned so that ordering is deterministic rather
+# than dependent on how fast the harness runs.
 echo "deps:"
 export ROOT_DIR="${TMPDIR}/repo"
-mkdir -p "${ROOT_DIR}"
+export FRAG_DIR="${ROOT_DIR}/changelog.d"
+mkdir -p "${FRAG_DIR}"
 git -C "${ROOT_DIR}" init -q
-git -C "${ROOT_DIR}" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'feat: base'
-git -C "${ROOT_DIR}" tag v1.0.0
+
+repo_git() { git -C "${ROOT_DIR}" -c user.email=t@t -c user.name=t "$@"; }
+at() {  # at <date> <git args...>
+  local when=$1
+  shift
+  GIT_AUTHOR_DATE="${when}" GIT_COMMITTER_DATE="${when}" repo_git "$@"
+}
+commit_frag() {  # commit_frag <date> <message>
+  repo_git add -A changelog.d
+  at "$1" commit -q -m "$2"
+}
+
+at 2026-01-01T00:00:00 commit -q --allow-empty -m 'feat: base'
+repo_git tag v1.0.0
+day=1
 for msg in 'chore(deps): bump left from 1 to 2' \
            'feat: unrelated work' \
            'chore(deps-dev): bump right from 3 to 4' \
            'chore(deps): bump left from 1 to 2'; do
-  git -C "${ROOT_DIR}" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "${msg}"
+  day=$((day + 1))
+  at "2026-01-0${day}T00:00:00" commit -q --allow-empty -m "${msg}"
 done
 
 check "no fragment yet → check warns" "1" \
@@ -91,23 +109,53 @@ check "deps fragment is named for the slug" "${FRAG_DIR}/0001-dependency-updates
 check "bumps deduped, prefix stripped, non-deps commits ignored" \
   "[Chores]
 - Dependency updates: left from 1 to 2; right from 3 to 4." "$(cat "${frag}")"
+# A fragment git has no record of is being written right now.
+check "uncommitted fragment counts as covered" "" "$(bash "${RN}" check 2>&1 >/dev/null)"
+commit_frag 2026-01-10T00:00:00 'changelog: cover the bumps'
 check "drafted fragment silences check" "" "$(bash "${RN}" check 2>&1 >/dev/null)"
 # The draft is meant to be rewritten; prose that drops the raw subjects must
 # still count as covered, or every well-curated release warns.
 check "hand-written prose still counts as covered" "" \
   "$(printf '[Chores]\n- Routine dependency updates (#1, #2).\n' > "${frag}"
+     commit_frag 2026-01-11T00:00:00 'changelog: rewrite into prose'
      bash "${RN}" check 2>&1 >/dev/null)"
 check "unrelated fragment does not count as covered" "1" \
   "$(printf '[Features]\n- a feature\n' > "${frag}"
+     commit_frag 2026-01-12T00:00:00 'changelog: unrelated'
      bash "${RN}" check 2>&1 >/dev/null | grep -c '^WARNING')"
-rm "${frag}"
 check "check exits 0 even when warning" "0" \
   "$(bash "${RN}" check >/dev/null 2>&1; echo $?)"
 # Runnable between releases to answer "has enough piled up to cut a build?"
 check "count reported on stdout regardless of coverage" \
   "changelog.d: 2 dependency bump(s) in v1.0.0..HEAD" "$(bash "${RN}" check 2>/dev/null)"
 
-git -C "${ROOT_DIR}" tag v1.1.0
+# Coverage is time-ordered, not present/absent. An accurate fragment cannot
+# describe a bump that merges after it — the #5718 case, where the fragment
+# covering an earlier website bump silenced the report for a later one.
+echo "check ordering:"
+printf '[Chores]\n- Routine dependency updates (#1, #2).\n' > "${frag}"
+commit_frag 2026-01-13T00:00:00 'changelog: cover the bumps again'
+check "fragment newer than every bump is covered" "" \
+  "$(bash "${RN}" check 2>&1 >/dev/null)"
+at 2026-01-14T00:00:00 commit -q --allow-empty -m 'chore(deps): bump late from 5 to 6'
+check "bump landing after the fragment warns" "1" \
+  "$(bash "${RN}" check 2>&1 >/dev/null | grep -c '^WARNING')"
+check "the warning says the fragment is behind, not missing" "1" \
+  "$(bash "${RN}" check 2>&1 >/dev/null | grep -c 'landed after')"
+printf '[Chores]\n- Routine dependency updates (#1, #2, #3).\n' > "${frag}"
+commit_frag 2026-01-15T00:00:00 'changelog: cover the late bump'
+check "re-touching the fragment re-covers it" "" \
+  "$(bash "${RN}" check 2>&1 >/dev/null)"
+# A fragment left over from an already-published window is older than every
+# bump in the current one, so it no longer silences the report.
+at 2026-01-16T00:00:00 commit -q --allow-empty -m 'chore(deps): bump newer from 7 to 8'
+check "stale fragment from a past window does not cover" "1" \
+  "$(bash "${RN}" check 2>&1 >/dev/null | grep -c '^WARNING')"
+rm "${frag}"
+commit_frag 2026-01-17T00:00:00 'changelog: sweep'
+
+echo "window:"
+repo_git tag v1.1.0
 check "window starts at the newest tag" \
   "changelog.d: no dependency bumps in v1.1.0..HEAD — nothing to draft" \
   "$(bash "${RN}" deps 2>/dev/null)"

--- a/changelog.d/0030-website-deps-bump.md
+++ b/changelog.d/0030-website-deps-bump.md
@@ -1,2 +1,2 @@
 [Chores]
-- Bumped the website dependency group: `@radix-ui/react-avatar` 1.2.6 (restoring React Server Components compatibility), `@radix-ui/react-slot` 1.3.3, `lucide-react` 1.27.0, `baseline-browser-mapping` 2.11.6 and `postcss` 8.5.24 (#5716).
+- Bumped the website dependency group: `@radix-ui/react-avatar` 1.2.6 (restoring React Server Components compatibility), `@radix-ui/react-slot` 1.3.3, `lucide-react` 1.27.0, `baseline-browser-mapping` 2.11.6 and `postcss` 8.5.24 (#5716), then `@easyops-cn/docusaurus-search-local` 0.55.3 (#5718).


### PR DESCRIPTION
`release-notes.sh check` asked whether *any* fragment mentions dependencies. That
goes quiet the moment one does — including for bumps that merge afterwards.

#5718 hit it: fragment `0030` accurately covered #5716's website group, and its
existence alone silenced the report for the later `@easyops-cn/docusaurus-search-local`
bump, which reached `develop` with no note and no warning. The dependency gate
added in #5717 was working as written; the question it asked was the wrong one.

### What changed

Coverage is now judged by time: the newest dependency-mentioning fragment's commit
timestamp against the newest bump's. A fragment can only describe what landed before
it, so a bump arriving later is uncovered until someone touches the fragment again.

This also subsumes the stale-fragment limit the old comment documented — a leftover
from an already-published window is older than every bump in the current one, so it
no longer silences anything.

Deliberately unchanged: the fragment side stays a loose `depend|bump` text match.
`deps` writes a draft the author is meant to rewrite, and prose that no longer quotes
the raw subjects must not warn on a well-curated release. A fragment git has no record
of is being written right now and counts as covering everything.

Verified against the real commits: `0030` on `develop` predates the #5718 bump, so the
check now warns there; after the append in this PR it does not.

### Commits

- **`changelog: cover the docusaurus-search-local bump`** — appends #5718 to `0030`,
  keeping the website group's story in one bullet rather than splitting it across two
  fragments.
- **`changelog: judge fragment coverage by time, not presence`** — the check itself,
  plus tests 17 → 23. The test fragments move *inside* the throwaway repo and are
  committed at pinned dates; sitting outside it, every coverage assertion was passing
  through the uncommitted fallback and proving nothing.
- **`ci: count an updated fragment as a release note`** — the advisory PR check used
  `--diff-filter=A`, so a PR that appends to an existing fragment was reported as
  having none. Same present/absent blind spot one layer up, and it would have fired on
  this PR.

### Verification

```
bash build/test-release-notes.sh     # 23 passed, 0 failed
./build/release-notes.sh check       # silent on this branch, warns on develop
```

The three new ordering assertions were mutation-tested: reverting the logic to the old
present/absent boolean turns exactly those three red.
