### PR TITLE
fix(sessiondata): reference http_sessions not sessions in expireSessionData

### DIFF
--- a/src/jetstream/repository/sessiondata/psql_sessiondata.go
+++ b/src/jetstream/repository/sessiondata/psql_sessiondata.go
@@ -18,8 +18,12 @@ var insertSessionDataValue = `INSERT INTO session_data (session, groupName, name
 
 var deleteSessionGroupData = `DELETE FROM session_data WHERE session=$1 AND groupName=$2`
 
-// Expire data for sessions that no longer exist
-var expireSessionData = `UPDATE session_data SET expired=true WHERE session NOT IN (SELECT CAST(id AS varchar) from sessions)`
+// Expire data for sessions that no longer exist.
+// The Postgres session store (pgstore) creates the sessions table as
+// "http_sessions" — not "sessions". Referencing "sessions" here causes a
+// "relation does not exist" error on every cleanup tick and leaves orphaned
+// session_data rows in the database indefinitely.
+var expireSessionData = `UPDATE session_data SET expired=true WHERE session NOT IN (SELECT CAST(id AS varchar) from http_sessions)`
 
 // Delete data for sessions that no longer exist
 var deleteSessionData = `DELETE FROM session_data WHERE expired=true AND keep_on_expire=false`

--- a/src/jetstream/repository/sessiondata/psql_sessiondata_test.go
+++ b/src/jetstream/repository/sessiondata/psql_sessiondata_test.go
@@ -1,0 +1,34 @@
+package sessiondata
+
+import (
+	"testing"
+)
+
+// TestExpireSessionDataTableName verifies that the expireSessionData SQL
+// references "http_sessions" (the table name pgstore actually creates) and
+// not the incorrect "sessions" name that caused
+// "pq: relation \"sessions\" does not exist" on every cleanup tick.
+func TestExpireSessionDataTableName(t *testing.T) {
+	const wrongTable = "from sessions"
+	const rightTable = "from http_sessions"
+
+	if contains(expireSessionData, wrongTable) {
+		t.Errorf("expireSessionData references %q — pgstore creates %q; this causes a DB error on every cleanup tick", wrongTable, rightTable)
+	}
+	if !contains(expireSessionData, rightTable) {
+		t.Errorf("expireSessionData does not reference %q — got: %s", rightTable, expireSessionData)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes a recurring error logged every 3 minutes on all Postgres-backed Stratos deployments:

```
SessionDataRepository: unable to delete expired sessions: pq: relation "sessions" does not exist
```

## Root cause

The `expireSessionData` cleanup query in `psql_sessiondata.go` referenced the table `sessions`:

```sql
UPDATE session_data SET expired=true
WHERE session NOT IN (SELECT CAST(id AS varchar) from sessions)
```

The Postgres session store library (`github.com/antonlindstrom/pgstore`) creates its table as **`http_sessions`**, not `sessions`. The mismatch caused every cleanup tick to fail with a `relation does not exist` error, leaving orphaned `session_data` rows in the database indefinitely — the cleanup that marks them expired and eventually deletes them never ran.

## Fix

Changed `sessions` → `http_sessions` in `expireSessionData` to match the table name pgstore actually creates. Added a regression test that asserts the query references `http_sessions`.

## Notes

- `isValidSession` (also in `psql_sessiondata.go`) already correctly references `http_sessions` — only `expireSessionData` was wrong.
- This is a pre-existing bug affecting all Postgres deployments regardless of CF API version. It is unrelated to the v2 capability probe work in #5728.
- Validated: after deploying the fix, the error no longer appears in logs (verified over 9+ minutes / 4 cleanup cycles with no `pq: relation "sessions" does not exist` output).
