### PR TITLE
feat(core): add gated right-edge scroll fade to signal lists

### DIFF
--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -220,8 +220,10 @@
     </div>
   }
 
-  <!-- Body: loading / empty state / table -->
-  <div #scrollBody data-test="scroll-body" class="relative flex-1 overflow-auto">
+  <!-- Body: loading / empty state / table. The wrapper exists so the
+       horizontal edge fades can overlay exactly the scroll area. -->
+  <div class="relative flex-1 min-h-0 flex flex-col">
+  <div #scrollBody data-test="scroll-body" class="relative flex-1 overflow-auto scrollbar-none">
     @if ((config.isAnyLoading() || isRefreshing()) && config.totalFilteredResults() === 0) {
       <div data-test="loading" class="flex items-center justify-center p-8 h-full">
         <div class="flex items-center space-x-4 text-content-muted">
@@ -703,6 +705,17 @@
         </tbody>
       </table>
     }
+  </div>
+
+  <!-- Right scroll fade (prototype): horizontal twin of the bottom scroll
+       fade. Shows only while scrolling right would reveal more columns —
+       the leading (left) edge, like the top, never needs an affordance:
+       it is territory the user has already seen. Passive indicator only,
+       pointer-events-none. -->
+  @if (canScrollRight() && config.totalFilteredResults() > 0) {
+    <div data-test="scroll-fade-right" aria-hidden="true"
+         class="pointer-events-none absolute inset-y-0 right-0 z-20 w-10 bg-gradient-to-l from-black/30 via-black/10 to-transparent dark:from-white/25 dark:via-white/10"></div>
+  }
   </div>
 
   <!-- Scroll fade: sibling of body so it never moves with the data. Takes 0

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -472,6 +472,11 @@ export class SignalListComponent<T> implements AfterViewInit {
   // has reached the bottom of the list.
   readonly hasOverflow = signal(false);
 
+  // Horizontal twin of hasOverflow: true when more columns exist to the
+  // right of the current scroll position. Gates the right edge fade so it
+  // shows only when scrolling right would reveal more.
+  readonly canScrollRight = signal(false);
+
   // True while a refresh-button click is in flight. Used to drive the
   // inline button spinner uniformly across list pages — many config
   // services still wire isAnyLoading to !hasLoadedOnce() (which only
@@ -537,11 +542,17 @@ export class SignalListComponent<T> implements AfterViewInit {
     const el = this.scrollBody?.nativeElement;
     if (!el) {
       this.hasOverflow.set(false);
+      this.canScrollRight.set(false);
       return;
     }
+    // 2px tolerance: client/scroll sizes are integer-rounded while scroll
+    // position is fractional, and on hidpi/zoomed displays the rounding
+    // can stack past 1px — a too-tight bound leaves the fade stuck at the
+    // far edge, obscuring the last column/row.
     const overflowing = el.scrollHeight > el.clientHeight + 1;
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
     this.hasOverflow.set(overflowing && !atBottom);
+    this.canScrollRight.set(el.scrollLeft + el.clientWidth < el.scrollWidth - 2);
   }
 
   trackByRow = (_: number, row: T) => this.config.getRowKey(row);

--- a/src/frontend/packages/theme/styles/main.scss
+++ b/src/frontend/packages/theme/styles/main.scss
@@ -899,6 +899,21 @@ body.modal-open {
     background-color: var(--nav-tooltip);
   }
 
+  /* Hide native scrollbars on containers whose scroll affordance is
+     provided another way (edge fades). Scrolling is unaffected. Not
+     applied under forced colors (Windows High Contrast): that mode
+     strips background gradients, so the fades vanish — without this
+     guard the container would be left with no affordance at all. */
+  @media not (forced-colors: active) {
+    .scrollbar-none {
+      scrollbar-width: none;
+    }
+
+    .scrollbar-none::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
   /* Always-visible themed scrollbar. macOS overlay scrollbars are 0px wide
      when idle, leaving scrollable containers with no affordance. */
   .custom-scrollbar::-webkit-scrollbar {


### PR DESCRIPTION
## What

Wide list tables (org quotas, users, events, ...) gave no visual hint that more columns existed past the right edge: the fixed column layout ends on a clean edge so nothing peeks, and macOS overlay scrollbars are invisible until a scroll is already in progress. The columns beyond the fold were effectively undiscoverable.

This adds a right-edge gradient fade to the shared signal-list scroll body — the horizontal twin of the existing bottom scroll fade. It shows only while scrolling right would reveal more columns and disappears the moment the end is reached, so it never obscures data the user is trying to read. Native scrollbars are hidden on the list scroll body (new `.scrollbar-none` theme utility) so the fades act as the single, consistent affordance.

## Design notes

- There is deliberately no top or left shadow. An affordance is only needed for unknown territory: at load the unseen content is only below and to the right. Content behind the scroll position was already seen — the user's own scroll action plus the visibly cut-off data marks the way back. An indicator there would cover data to signal something already known. The same principle extinguishes the trailing fades at the far edge.
- The gate rides the existing `measureOverflow()` plumbing (scroll listener + ResizeObserver + MutationObserver) — no new events or dependencies, one extra comparison per scroll event.
- Edge detection uses a 2px tolerance: client/scroll sizes are integer-rounded while scroll position is fractional; on hidpi displays the rounding stacks past 1px and a tighter bound leaves the fade stuck over the last column at full scroll (observed on a Retina display during testing).

## Accessibility / portability

- The scrollbar hide is scoped to `@media not (forced-colors: active)`: forced colors (Windows High Contrast) strips background gradients, which would remove the fades and the bars together. Under forced colors the native scrollbars stay.
- `.scrollbar-none` carries both mechanisms (`scrollbar-width: none` for Firefox/new Chromium, `::-webkit-scrollbar` for Chromium/WebKit), so behavior is uniform across engines and platforms.
- This matches where the platform is heading: CSS scroll-state container queries (`container-type: scroll-state`, Chrome 133+) express this exact show/hide in pure CSS, and CSS Overflow 5 adds native `::scroll-button()`/`::scroll-marker()`. Neither is cross-browser yet (no Firefox/Safari support for scroll-state queries), hence the JS gating; the CSS variant can replace it when support fills in.

## Testing

- Live-verified against two CF endpoints (wide quota/users tables): fade appears at rest when columns overflow right, both-direction behavior mid-scroll, and disappears at each end; vertical fade behavior unchanged.
- Checked the two e2e specs that touch this DOM (`scroll-shadow.spec.ts`, `dashboard-scroll-shadow.spec.ts`): both use descendant selectors and assert on the untouched bottom fade / dashboard container, so they are unaffected by the new wrapper element. No dedicated assertion exists yet for the right fade — happy to add one if preferred.