### PR TITLE
fix: events drain cap, immutable hashed assets, canonical summary paging

### DIFF
--- a/changelog.d/0037-events-drain-cap.md
+++ b/changelog.d/0037-events-drain-cap.md
@@ -1,0 +1,2 @@
+[Bug Fixes]
+- The Events tabs no longer drain a foundation's entire audit-event history into browser memory. The frontend loader fetches a bounded newest-first window — 50 pages of 500, the same 25k ceiling the pre-rewrite backend handler enforced — and the comments that still described the departed backend cap now describe the real mechanism (#5536).

--- a/changelog.d/0038-immutable-hashed-assets.md
+++ b/changelog.d/0038-immutable-hashed-assets.md
@@ -1,0 +1,2 @@
+[Performance Improvements]
+- Content-hashed build artifacts (the Angular bundles and hashed media files) are now served with `cache-control: public, max-age=31536000, immutable`, eliminating the per-asset revalidation round-trips (and Firefox's full re-downloads) that dominated warm page loads. The allowlist is filename-shaped and default-deny: `index.html`, `assets/`, plugin trees, and anything unversioned keep the conservative no-cache policy that guards against cached-data bleed (#5562).

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-events/cloud-foundry-events.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-events/cloud-foundry-events.component.ts
@@ -2,8 +2,9 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 import { CloudFoundryEventsListComponent } from '../../../../shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component';
 
-// CF foundation-wide Events tab. No scoping inputs — surfaces every
-// audit event the foundation emits (capped at 25k by the backend).
+// CF foundation-wide Events tab. No scoping inputs — surfaces the
+// foundation's audit events, newest first (the source caps the drain
+// at the most recent 25k).
 @Component({
   selector: 'app-cloud-foundry-events',
   templateUrl: './cloud-foundry-events.component.html',

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-audit-events-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-audit-events-source.ts
@@ -1,12 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+
 import { CnsiEntitySource } from './cnsi-entity-source';
 import type { StAuditEvent } from '../endpoint-data/stratos-types';
 
 // Per-CNSI source for the audit events list. Reads
-// /pp/v1/cf/audit_events/{cnsi} — the backend handler drains pagination
-// up to maxAuditEventPages (50 pages × 500 events = 25k events) so
-// busy foundations stay bounded. The list is approximated as "recent
-// activity"; deep historical retrieval is a future detail-screen
-// concern.
+// /pp/v1/cf/audit_events/{cnsi} — a per-page passthrough the handler
+// orders newest-first (-created_at). Audit history is unbounded on a
+// busy foundation, so unlike the catalog sources this one caps the
+// drain: maxPages × pageSize = 50 × 500 = 25k newest events, the same
+// ceiling the pre-passthrough backend handler enforced (#5536). The
+// list is approximated as "recent activity"; deep historical retrieval
+// is a future detail-screen concern.
 export class CnsiAuditEventsSource extends CnsiEntitySource<StAuditEvent> {
   protected readonly entityName = 'audit_events';
+  protected override readonly maxPages = 50;
+
+  constructor(cnsiGuid: string, http: HttpClient) {
+    super(cnsiGuid, http, 500);
+  }
 }

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-entity-source.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-entity-source.spec.ts
@@ -81,6 +81,27 @@ describe('CnsiEntitySource', () => {
     expect(src.fetchedPages()).toBe(5);
   });
 
+  it('load() honors maxPages — a capped source stops at its window and still reports done', async () => {
+    class CappedSource extends CnsiEntitySource<TestItem> {
+      protected readonly entityName = 'test';
+      protected override readonly maxPages = 3;
+    }
+    // totalPages=10, but the capped source must fetch only pages 1..3.
+    // (The drain-all test above proves the uncapped harness would issue
+    // all 10 — the 3-deep response queue only satisfies a capped drain.)
+    const mkPage = (id: string, page: number) => ({
+      resources: [new TestItem(id)],
+      pagination: { totalResults: 10, totalPages: 10, next: { href: '/?page=' + (page + 1) }, previous: null, first: { href: '...' }, last: { href: '...' } }
+    });
+    const http = makeHttp([mkPage('a', 1), mkPage('b', 2), mkPage('c', 3)]);
+    const src = new CappedSource('cnsi-1', http);
+    await src.load();
+    expect(http.get).toHaveBeenCalledTimes(3);
+    expect(src.items().map(i => i.guid).sort()).toEqual(['a', 'b', 'c']);
+    expect(src.done()).toBe(true);
+    expect(src.totalResults()).toBe(10);
+  });
+
   it('load() records error and preserves any items already streamed in', async () => {
     const page1 = {
       resources: [new TestItem('a')],

--- a/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-entity-source.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/data-sources/cnsi-entity-source.ts
@@ -21,6 +21,14 @@ export interface StratosPagedResponseLike<T> {
 export abstract class CnsiEntitySource<T> {
   protected abstract readonly entityName: string;
 
+  // Page ceiling for the drain. Undefined (the default) drains every
+  // page — right for catalog-sized collections (orgs, spaces, apps)
+  // whose full set the UI genuinely needs. Subclasses over unbounded
+  // historical collections (audit events) set this to keep browser
+  // memory bounded; the handler must order newest-first so the kept
+  // window is the recent one, not the oldest.
+  protected readonly maxPages?: number;
+
   protected readonly _items = signal<T[]>([]);
   private readonly _loading = signal(false);
   private readonly _error = signal<unknown | null>(null);
@@ -136,7 +144,12 @@ export abstract class CnsiEntitySource<T> {
       this._fetchedPages.set(1);
 
       const totalPages = first.pagination.totalPages ?? 1;
-      if (totalPages <= 1 || first.pagination.next == null) {
+      // done means "loaded everything this source intends to load" —
+      // for a capped source that's the newest maxPages-window, not the
+      // foundation's full history (totalResults still reports the real
+      // total for consumers that want to surface the difference).
+      const lastPage = this.maxPages ? Math.min(totalPages, this.maxPages) : totalPages;
+      if (lastPage <= 1 || first.pagination.next == null) {
         this._done.set(true);
         return;
       }
@@ -146,7 +159,7 @@ export abstract class CnsiEntitySource<T> {
       // long time" feedback on adepttech dev.84 — N sequential round-trips
       // for an N-page result, even when CAPI could serve them concurrently.
       // Matches the orgs/spaces drain pattern shipped in PR #5338.
-      const remainingPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
+      const remainingPages = Array.from({ length: lastPage - 1 }, (_, i) => i + 2);
       const concurrency = 4;
       let cursor = 0;
       let pageFetchErr: unknown = null;

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.ts
@@ -18,8 +18,9 @@ import { EventDetailComponent, hasEventMetadata, parseEventData } from './event-
 // targetGuid AND typeMustContain). The legacy server-side query-param
 // scoping (organization_guids, space_guids, target_guids) is replaced
 // by client-side filtering against the foundation-wide event stream.
-// The handler caps at 25k events so deep historical retrieval will
-// need a future detail-screen / search feature.
+// The source loads the newest 25k events at most (see
+// CnsiAuditEventsSource), so deep historical retrieval will need a
+// future detail-screen / search feature.
 @Component({
   selector: 'app-cloud-foundry-events-list',
   templateUrl: './cloud-foundry-events-list.component.html',

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-events/cf-audit-events-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/cf-events/cf-audit-events-signal-config.service.ts
@@ -111,10 +111,11 @@ export class CfAuditEventsSignalConfigService {
   }
 
   // Mirror source.items() directly so the UI re-renders incrementally as
-  // pages drain in. Audit events on a busy CF can span 50+ pages of 100;
-  // awaiting full drain before paint left the page in "Loading…" for
-  // 30-60s. Reading the source signal lets the first page render
-  // immediately and subsequent pages append as they arrive.
+  // pages drain in. Audit events on a busy CF can fill the source's full
+  // newest-25k window (50 pages × 500); awaiting full drain before paint
+  // left the page in "Loading…" for 30-60s. Reading the source signal
+  // lets the first page render immediately and subsequent pages append
+  // as they arrive.
   readonly auditEvents: Signal<StAuditEvent[]> = computed(() =>
     this.source ? this.source.items() : [],
   );

--- a/src/jetstream/middleware.go
+++ b/src/jetstream/middleware.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -216,10 +217,25 @@ func (p *portalProxy) urlCheckMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
+// immutableAssetPath matches the content-hashed files the Angular build
+// emits: root bundles (main|styles|polyfills|chunk|worker)-<8 char hash>
+// .js/.css and media/<name>-<8 char hash>.<ext>. A content change
+// produces a new filename, so these are immutable by construction and
+// safe to cache forever. Everything else — index.html (the pointer to
+// the hashed bundles), assets/, the plugin trees, Monaco's unversioned
+// files — keeps the conservative no-cache default: broader caching
+// historically caused cached-data bleed, so the allowlist stays
+// filename-shaped and default-deny (#5562).
+var immutableAssetPath = regexp.MustCompile(`(?:^|/)(?:(?:main|styles|polyfills|chunk|worker)-[A-Za-z0-9_-]{8}\.(?:js|css)|media/[A-Za-z0-9._-]+-[A-Z0-9]{8}\.[a-z0-9]+)$`)
+
 func (p *portalProxy) setStaticCacheContentMiddleware(h echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		c.Response().Header().Set("cache-control", "no-cache")
-		c.Response().Header().Set("pragma", "no-cache")
+		if immutableAssetPath.MatchString(c.Request().URL.Path) {
+			c.Response().Header().Set("cache-control", "public, max-age=31536000, immutable")
+		} else {
+			c.Response().Header().Set("cache-control", "no-cache")
+			c.Response().Header().Set("pragma", "no-cache")
+		}
 		return h(c)
 	}
 }

--- a/src/jetstream/middleware_test.go
+++ b/src/jetstream/middleware_test.go
@@ -53,6 +53,67 @@ func makeNewRequestWithParams(httpVerb string, formValues map[string]string) (ec
 	return ctx, rec
 }
 
+// Filenames mirror a real dist/frontend/browser build — including a hash
+// that itself contains a dash (chunk-B40-posg.js) and the uppercase media
+// hashes esbuild emits. Everything unhashed must keep the conservative
+// no-cache header; see immutableAssetPath in middleware.go (#5562).
+func TestStaticCacheMiddlewareImmutableAllowlist(t *testing.T) {
+	p := &portalProxy{}
+	mw := p.setStaticCacheContentMiddleware(func(c echo.Context) error { return nil })
+
+	serve := func(path string) http.Header {
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(httptest.NewRequest(http.MethodGet, path, nil), rec)
+		if err := mw(c); err != nil {
+			t.Fatalf("middleware(%s): %v", path, err)
+		}
+		return rec.Header()
+	}
+
+	immutable := []string{
+		"/main-Bv2flKV8.js",
+		"/main-Qw12_ab9.css",
+		"/styles-B5ABX2YE.css",
+		"/polyfills-AbCd12_x.js",
+		"/chunk-B40-posg.js",
+		"/chunk-_4dOh9uF.js",
+		"/worker-Zz9varAB.js",
+		"/media/roboto-v18-latin-300-5THLCT4U.woff2",
+		"/prefix/stripped/main-Bv2flKV8.js",
+	}
+	for _, path := range immutable {
+		h := serve(path)
+		if got := h.Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+			t.Errorf("%s: want immutable cache-control, got %q", path, got)
+		}
+		if got := h.Get("Pragma"); got != "" {
+			t.Errorf("%s: immutable asset must not carry pragma, got %q", path, got)
+		}
+	}
+
+	mutable := []string{
+		"/",
+		"/index.html",
+		"/favicon.ico",
+		"/assets/company-config.json",
+		"/core/plugin-bundle.js",
+		"/media/unhashed-font.woff2",
+		"/chunk-toolong123.js",
+		"/chunk-short.js",
+		"/hackchunk-AAAAAAAA.js",
+		"/applications/deep/link",
+	}
+	for _, path := range mutable {
+		h := serve(path)
+		if got := h.Get("Cache-Control"); got != "no-cache" {
+			t.Errorf("%s: want no-cache, got %q", path, got)
+		}
+		if got := h.Get("Pragma"); got != "no-cache" {
+			t.Errorf("%s: want pragma no-cache, got %q", path, got)
+		}
+	}
+}
+
 func Test_apiKeyMiddleware(t *testing.T) {
 	t.Parallel()
 

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/fivetwenty-io/capi/v3/pkg/capi"
@@ -34,14 +33,6 @@ func isDerivedSortField(orderBy string) (bool, string, bool) {
 	return derivedSortFields[field], field, desc
 }
 
-// Summary-tier defaults for the Stratos-shape paged response. CAPI V3's own
-// default per-page is 50; we match it so uninstrumented clients get a
-// reasonable page without surprise.
-const (
-	summaryDefaultPage    = 1
-	summaryDefaultPerPage = 50
-)
-
 // stratosReservedSummaryParams are the query-param keys the Stratos-shape
 // contract reserves for paging / sort / tier. Everything else in the query
 // string is passed through to CAPI as a filter per the "mirror CAPI filter
@@ -55,26 +46,21 @@ var stratosReservedSummaryParams = map[string]bool{
 }
 
 // parseSummaryQueryParams translates Stratos-shape query params into a
-// CAPI QueryParams struct. Stratos-shape separates sort field from sort
-// direction (order_by=<field>&direction=<asc|desc>); CAPI V3 combines them
-// in a single minus-prefix string. Filter fields are forwarded unchanged;
-// comma-separated values in a Stratos filter become the CAPI filter slice.
-func parseSummaryQueryParams(ctx echo.Context) *capi.QueryParams {
-	params := capi.NewQueryParams()
-
-	params.Page = summaryDefaultPage
-	if raw := ctx.QueryParam("page"); raw != "" {
-		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
-			params.Page = v
-		}
-	}
-
-	params.PerPage = summaryDefaultPerPage
-	if raw := ctx.QueryParam("per_page"); raw != "" {
-		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
-			params.PerPage = v
-		}
-	}
+// CAPI QueryParams struct via the canonical paging helpers
+// (parsePerPageAndPage / applyPagingParams — see stratos_paging.go), then
+// layers the two summary-specific concerns on top: Stratos-shape separates
+// sort field from sort direction (order_by=<field>&direction=<asc|desc>)
+// where CAPI V3 combines them in a single minus-prefix string, and filter
+// fields are forwarded unchanged (comma-separated values in a Stratos
+// filter become the CAPI filter slice).
+//
+// Returns the upstream params plus the resolved perPage/page the handler
+// needs for pagination meta and in-memory slicing — resolved because the
+// params only carry paging when the caller supplied per_page (absent
+// paging stays off the upstream call so V3 applies its own defaults).
+func parseSummaryQueryParams(ctx echo.Context) (*capi.QueryParams, int, int) {
+	perPage, page, present := parsePerPageAndPage(ctx)
+	params := applyPagingParams(capi.NewQueryParams(), perPage, page, present)
 
 	if orderBy := ctx.QueryParam("order_by"); orderBy != "" {
 		if ctx.QueryParam("direction") == "desc" {
@@ -100,7 +86,7 @@ func parseSummaryQueryParams(ctx echo.Context) *capi.QueryParams {
 		}
 	}
 
-	return params
+	return params, perPage, page
 }
 
 // processDerivedFields are the StApp fields sourced from /v3/processes/web —
@@ -397,10 +383,10 @@ func envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr error, affect
 // root causes.
 func (c *CloudFoundrySpecification) getNativeAppsSummary(ctx echo.Context, cfClient capi.Client) error {
 	cnsiGUID := ctx.Param("cnsiGuid")
-	params := parseSummaryQueryParams(ctx)
+	params, perPage, page := parseSummaryQueryParams(ctx)
 
 	if derived, field, desc := isDerivedSortField(params.OrderBy); derived {
-		return c.getNativeAppsSummaryDerivedSort(ctx, cfClient, params, field, desc)
+		return c.getNativeAppsSummaryDerivedSort(ctx, cfClient, params, field, desc, perPage, page)
 	}
 
 	raw, err := cfClient.Apps().List(ctx.Request().Context(), params)
@@ -480,7 +466,7 @@ func (c *CloudFoundrySpecification) getNativeAppsSummary(ctx echo.Context, cfCli
 
 	response := StratosPagedResponse[StApp]{
 		Resources:  resources,
-		Pagination: BuildPaginationMeta(ctx, params.Page, params.PerPage, raw.Pagination.TotalResults),
+		Pagination: BuildPaginationMeta(ctx, page, perPage, raw.Pagination.TotalResults),
 		Meta:       envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr, appGUIDs),
 	}
 
@@ -501,10 +487,9 @@ func (c *CloudFoundrySpecification) getNativeAppsSummaryDerivedSort(
 	params *capi.QueryParams,
 	sortField string,
 	desc bool,
+	requestedPerPage, requestedPage int,
 ) error {
 	cnsiGUID := ctx.Param("cnsiGuid")
-	requestedPage := params.Page
-	requestedPerPage := params.PerPage
 
 	// Fetch all matching apps (filters retained; page/per_page/order_by ignored)
 	allApps, err := fetchAllAppsWithFilters(ctx.Request().Context(), cfClient, params.Filters)

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
@@ -21,10 +21,12 @@ func TestParseSummaryQueryParams_Defaults(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, perPage, page := parseSummaryQueryParams(ctx)
 
-	assert.Equal(t, 1, params.Page)
-	assert.Equal(t, 50, params.PerPage)
+	assert.Equal(t, 1, page)
+	assert.Equal(t, 50, perPage)
+	assert.Zero(t, params.Page, "absent paging is not forwarded upstream — V3 applies its own defaults")
+	assert.Zero(t, params.PerPage, "absent paging is not forwarded upstream — V3 applies its own defaults")
 	assert.Empty(t, params.OrderBy)
 	assert.Empty(t, params.Filters)
 }
@@ -35,10 +37,12 @@ func TestParseSummaryQueryParams_PageAndPerPage(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, perPage, page := parseSummaryQueryParams(ctx)
 
 	assert.Equal(t, 3, params.Page)
 	assert.Equal(t, 25, params.PerPage)
+	assert.Equal(t, 3, page)
+	assert.Equal(t, 25, perPage)
 }
 
 func TestParseSummaryQueryParams_SortAscending(t *testing.T) {
@@ -47,7 +51,7 @@ func TestParseSummaryQueryParams_SortAscending(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, _, _ := parseSummaryQueryParams(ctx)
 
 	assert.Equal(t, "name", params.OrderBy, "direction omitted should be asc (no minus prefix)")
 }
@@ -58,7 +62,7 @@ func TestParseSummaryQueryParams_SortAscExplicit(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, _, _ := parseSummaryQueryParams(ctx)
 
 	assert.Equal(t, "name", params.OrderBy)
 }
@@ -69,7 +73,7 @@ func TestParseSummaryQueryParams_SortDescending(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, _, _ := parseSummaryQueryParams(ctx)
 
 	assert.Equal(t, "-created_at", params.OrderBy, "direction=desc should prepend minus")
 }
@@ -80,7 +84,7 @@ func TestParseSummaryQueryParams_FilterPassthrough(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, _, _ := parseSummaryQueryParams(ctx)
 
 	assert.Equal(t, []string{"app-a", "app-b"}, params.Filters["names"])
 	assert.Equal(t, []string{"STARTED"}, params.Filters["states"])
@@ -92,7 +96,7 @@ func TestParseSummaryQueryParams_ReservedParamsExcludedFromFilters(t *testing.T)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, _, _ := parseSummaryQueryParams(ctx)
 
 	for _, reserved := range []string{"page", "per_page", "order_by", "direction", "return"} {
 		_, ok := params.Filters[reserved]
@@ -107,10 +111,12 @@ func TestParseSummaryQueryParams_InvalidPageFallsBackToDefault(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
-	params := parseSummaryQueryParams(ctx)
+	params, perPage, page := parseSummaryQueryParams(ctx)
 
-	assert.Equal(t, 1, params.Page, "invalid page should fall back to default 1")
-	assert.Equal(t, 50, params.PerPage, "non-positive per_page should fall back to default 50")
+	assert.Equal(t, 1, page, "invalid page should fall back to default 1")
+	assert.Equal(t, 50, perPage, "non-positive per_page should fall back to default 50")
+	assert.Zero(t, params.Page, "malformed paging is not forwarded upstream")
+	assert.Zero(t, params.PerPage, "malformed paging is not forwarded upstream")
 }
 
 func TestGetNativeAppsSummary_ReturnsStratosPagedEnvelope(t *testing.T) {
@@ -238,6 +244,50 @@ func TestGetNativeAppsSummary_DescendingSortTranslatesToMinusPrefix(t *testing.T
 
 	require.NoError(t, plugin.getNativeApps(ctx))
 	assert.Equal(t, "-created_at", capturedQuery.Get("order_by"))
+}
+
+func TestGetNativeAppsSummary_AbsentPagingNotForwardedUpstream(t *testing.T) {
+	// Converged with the canonical helper chain (#5375): when the caller
+	// sends no per_page, the upstream CAPI call carries no paging at all
+	// and V3 applies its own defaults.
+	var capturedQuery url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			w.Write([]byte(`{"links":{}}`))
+		case "/v3/apps":
+			capturedQuery = r.URL.Query()
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/apps/test-cnsi?return=summary&states=STARTED", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("test-cnsi")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "test-cnsi", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getNativeApps(ctx))
+
+	assert.False(t, capturedQuery.Has("per_page"), "absent per_page must not be forwarded upstream")
+	assert.False(t, capturedQuery.Has("page"), "absent page must not be forwarded upstream")
+	assert.Equal(t, "STARTED", capturedQuery.Get("states"), "filters still pass through")
 }
 
 func TestGetNativeAppsSummary_EmptyResultSet(t *testing.T) {


### PR DESCRIPTION
Three queued issues resolved, one commit each.

**Events tabs drained every audit-event page into browser memory (#5536).** The backend's old 25k-capped full-drain was rewritten to a per-page passthrough because the full drain breached the gorouter ceiling — but that moved the unbounded drain client-side, while three comments still promised the departed backend cap. `CnsiEntitySource` gains an opt-in `maxPages` ceiling on its drain; catalog sources (orgs, spaces, apps) keep draining fully. The audit events source sets 50 pages at `per_page=500` — the same 25k ceiling the old handler enforced, and now it's the newest 25k since the handler orders `-created_at`. The stale comments now describe the real mechanism, and a capped-source unit test proves the drain stops at the window.

**Static assets revalidated on every warm load (#5562).** Every asset went out `cache-control: no-cache`, so warm visits paid a serialized revalidation round-trip per asset (~1.5s measured in the #5550 investigation) and Firefox re-downloaded ~2.2MB per visit. `setStaticCacheContentMiddleware` now matches an allowlist of the content-hashed filename shapes Angular emits — root `main|styles|polyfills|chunk|worker-<hash>.js/.css` bundles and hashed `media/` files — and serves those `public, max-age=31536000, immutable` (a content change mints a new filename, so staleness is impossible by construction). Everything else — `index.html`, `assets/`, plugin trees, anything unversioned, which covers the Monaco constraint — keeps the conservative no-cache default that guards against the historically observed cached-data bleed. API responses are untouched: their groups override to no-store after this middleware, and the nonce-carrying index document still overrides to no-store (both pinned by existing tests). Verified live against the built UI served by this jetstream: hashed chunk and media font immutable; `/`, `/index.html`, unhashed assets, and SPA deep links unchanged.

**apps-summary rolled its own params parser (#5375).** `parseSummaryQueryParams` was the one V3 params parser among the 39 native handlers not built on the `stratos_paging.go` helper chain. It now calls `parsePerPageAndPage`/`applyPagingParams` and layers only the summary-specific concerns on top: the Stratos-shape `direction` field folded into V3's minus-prefix `order_by`, and the filter passthrough. One deliberate behavioral convergence rides along, as the issue calls out: absent `per_page` no longer forwards default paging upstream — the CAPI call carries no paging and V3 applies its own defaults, matching the other 38 handlers. Response wire shape unchanged; a new handler test captures the upstream query to prove absent paging stays absent.

Closes #5536
Closes #5562
Closes #5375
