### PR TITLE
Foundational Shape: spreadsheet export and N-way comparison

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "rxjs-websockets": "9.0.0",
         "ts-md5": "2.0.1",
         "tslib": "2.8.1",
+        "write-excel-file": "^4.1.1",
         "xterm": "5.4.0-beta.37",
         "xterm-addon-fit": "0.9.0-beta.37",
       },
@@ -2876,6 +2877,8 @@
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "write-excel-file": ["write-excel-file@4.1.1", "", { "dependencies": { "fflate": "^0.8.2" } }, "sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A=="],
 
     "write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "^0.1.4", "is-typedarray": "^1.0.0", "signal-exit": "^3.0.2", "typedarray-to-buffer": "^3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "rxjs-websockets": "9.0.0",
     "ts-md5": "2.0.1",
     "tslib": "2.8.1",
+    "write-excel-file": "^4.1.1",
     "xterm": "5.4.0-beta.37",
     "xterm-addon-fit": "0.9.0-beta.37"
   },

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
@@ -207,6 +207,11 @@
               (click)="downloadJson(section)">
               Download JSON
             </button>
+            <button data-test="export-xlsx" type="button"
+              class="px-2.5 py-1 text-xs font-medium rounded border border-content-border hover:bg-content-secondary transition-colors"
+              (click)="downloadXlsx(section)">
+              Download spreadsheet
+            </button>
             <button data-test="export-markdown" type="button"
               class="px-2.5 py-1 text-xs font-medium rounded border border-content-border hover:bg-content-secondary transition-colors"
               (click)="copyMarkdown(section)">

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
@@ -49,6 +49,9 @@
           </span>
         }
         <label class="ml-auto flex items-center gap-1.5 text-xs cursor-pointer">
+          @if (compare.dotFor(section.guid); as dot) {
+            <span class="inline-block w-2 h-2 rounded-full" [class]="dot" data-test="compare-select-dot"></span>
+          }
           <input type="checkbox" data-test="compare-select"
             [checked]="compare.isSelected(section.guid)" (change)="compare.toggleLive(section.guid)">
           Compare

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
@@ -16,8 +16,46 @@
     </div>
   }
 
+  <!-- Selection summary: appears once a comparison is possible -->
+  @if (compare.sideCount() >= 2) {
+    <div class="sticky top-0 z-10 flex items-center gap-3 px-3 py-2 rounded border border-content-border bg-content-secondary/95 backdrop-blur text-sm"
+      data-test="compare-now-strip">
+      <span class="tabular-nums">{{ compare.sideCount() }} sides selected</span>
+      <button type="button" data-test="compare-now"
+        class="px-2.5 py-1 text-xs font-medium rounded border border-content-border hover:bg-content-secondary transition-colors"
+        (click)="scrollToCompare()">
+        Compare now
+      </button>
+    </div>
+  }
+
   @for (section of sections(); track section.guid) {
-    <app-info-card [title]="section.name">
+    <div class="border border-content-border rounded-lg overflow-hidden">
+      <!-- Endpoint bar: collapse toggle, compact stats, compare selection -->
+      <div class="bg-content-secondary px-4 py-2.5 flex flex-wrap items-center gap-x-4 gap-y-1"
+        [class.border-b]="!isCollapsed(section.guid)"
+        [class.border-content-border]="!isCollapsed(section.guid)"
+        data-test="section-bar">
+        <button type="button" class="flex items-center gap-2 min-w-0" data-test="section-toggle"
+          (click)="toggleCollapsed(section.guid)">
+          <span class="text-content-muted text-[10px]" aria-hidden="true">@if (isCollapsed(section.guid)) { &#9654; } @else { &#9660; }</span>
+          <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">{{ section.name }}</span>
+        </button>
+        @if (barStats(section); as stats) {
+          <span class="text-xs text-content-muted tabular-nums" data-test="section-bar-stats">
+            @if (stats.apps !== null) { {{ stats.apps | number }} apps }
+            @if (stats.apps !== null && stats.started) { &middot; }
+            @if (stats.started) { {{ stats.started }} }
+          </span>
+        }
+        <label class="ml-auto flex items-center gap-1.5 text-xs cursor-pointer">
+          <input type="checkbox" data-test="compare-select"
+            [checked]="compare.isSelected(section.guid)" (change)="compare.toggleLive(section.guid)">
+          Compare
+        </label>
+      </div>
+      @if (!isCollapsed(section.guid)) {
+      <div class="py-3">
       <div class="flex flex-col gap-4 px-4 py-1">
 
         <!-- Totals strip (fast counts; spaces from the full drain when it has run) -->
@@ -220,13 +258,13 @@
           </div>
         }
       </div>
-    </app-info-card>
+      </div>
+      }
+    </div>
   }
 
-  <!-- Promotion verification: diff two shape snapshots (live or imported) -->
-  @if (sections().length > 0) {
-    <app-info-card title="Compare shapes">
-      <app-shape-compare-card [sections]="sections()" />
-    </app-info-card>
-  }
+  <!-- Promotion verification: diff N shape snapshots (live or imported files) -->
+  <app-info-card title="Compare shapes" id="shape-compare-anchor">
+    <app-shape-compare-card #compare [sections]="sections()" />
+  </app-info-card>
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
@@ -222,4 +222,11 @@
       </div>
     </app-info-card>
   }
+
+  <!-- Promotion verification: diff two shape snapshots (live or imported) -->
+  @if (sections().length > 0) {
+    <app-info-card title="Compare shapes">
+      <app-shape-compare-card [sections]="sections()" />
+    </app-info-card>
+  }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
@@ -50,7 +50,7 @@
         }
         <label class="ml-auto flex items-center gap-1.5 text-xs cursor-pointer">
           @if (compare.dotFor(section.guid); as dot) {
-            <span class="inline-block w-2 h-2 rounded-full" [class]="dot" data-test="compare-select-dot"></span>
+            <span class="inline-block w-2 h-2 rounded-full" [style.background-color]="dot" data-test="compare-select-dot"></span>
           }
           <input type="checkbox" data-test="compare-select"
             [checked]="compare.isSelected(section.guid)" (change)="compare.toggleLive(section.guid)">

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.spec.ts
@@ -256,6 +256,8 @@ describe('FoundationShapePageComponent', () => {
       const strip = root.querySelector('[data-test="compare-now-strip"]');
       expect(strip?.textContent).toContain('2 sides selected');
       expect(root.querySelector('[data-test="compare-totals"]')).not.toBeNull();
+      // each selected bar shows its side's identity color chip
+      expect(root.querySelectorAll('[data-test="compare-select-dot"]')).toHaveLength(2);
     });
 
     it('renders defined stacks and buildpacks with unused stacks called out', async () => {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.spec.ts
@@ -223,6 +223,41 @@ describe('FoundationShapePageComponent', () => {
       expect(payload.distributions.spaces_per_org).toMatchObject({ n: 2 });
     });
 
+    it('shows compact bar stats from loaded data', () => {
+      const bar = (fixture.nativeElement as HTMLElement).querySelector('[data-test="section-bar-stats"]');
+      expect(bar?.textContent).toContain('1 apps');
+      expect(bar?.textContent).toContain('100.0% started');
+    });
+
+    it('starts expanded with a single endpoint and collapses on bar toggle', async () => {
+      const root = fixture.nativeElement as HTMLElement;
+      expect(root.querySelector('[data-test="shape-totals"]')).not.toBeNull();
+      root.querySelector<HTMLButtonElement>('[data-test="section-toggle"]').click();
+      await fixture.whenStable();
+      expect(root.querySelector('[data-test="shape-totals"]')).toBeNull();
+      root.querySelector<HTMLButtonElement>('[data-test="section-toggle"]').click();
+      await fixture.whenStable();
+      expect(root.querySelector('[data-test="shape-totals"]')).not.toBeNull();
+    });
+
+    it('collapses by default with several endpoints; selecting two shows the compare strip', async () => {
+      endpoints.set([cfEndpoint, { guid: 'cf-2', name: 'Second CF', cnsi_type: 'cf' } as EndpointModel]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const root = fixture.nativeElement as HTMLElement;
+      expect(root.querySelector('[data-test="shape-totals"]')).toBeNull();
+      expect(root.querySelector('[data-test="compare-now-strip"]')).toBeNull();
+
+      const boxes = root.querySelectorAll<HTMLInputElement>('[data-test="compare-select"]');
+      expect(boxes).toHaveLength(2);
+      boxes[0].click();
+      boxes[1].click();
+      await fixture.whenStable();
+      const strip = root.querySelector('[data-test="compare-now-strip"]');
+      expect(strip?.textContent).toContain('2 sides selected');
+      expect(root.querySelector('[data-test="compare-totals"]')).not.toBeNull();
+    });
+
     it('renders defined stacks and buildpacks with unused stacks called out', async () => {
       measure.ecosystem.set(new Map([
         ['cf-1', {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
@@ -141,6 +141,35 @@ export class FoundationShapePageComponent implements OnDestroy {
     return ageLabel(stamp.fetchedAt, new Date());
   }
 
+  /** Per-endpoint collapse; untouched sections default open only when the page has a single endpoint. */
+  private readonly collapsedOverrides = signal<ReadonlyMap<string, boolean>>(new Map());
+
+  isCollapsed(guid: string): boolean {
+    return this.collapsedOverrides().get(guid) ?? this.sections().length > 1;
+  }
+
+  toggleCollapsed(guid: string): void {
+    const next = new Map(this.collapsedOverrides());
+    next.set(guid, !this.isCollapsed(guid));
+    this.collapsedOverrides.set(next);
+  }
+
+  /** Compact bar stats from already-loaded data: apps count + started share; nulls render as nothing. */
+  barStats(section: ShapeSection): { apps: number | null; started: string | null } {
+    const apps = section.countsLoaded ? section.totals.apps : null;
+    const states = section.shape.composition.app_state;
+    const total = Object.values(states).reduce((acc, value) => acc + value, 0);
+    const started =
+      section.drains.apps.fetchedAt !== null && total > 0
+        ? `${(((states['STARTED'] ?? 0) / total) * 100).toFixed(1)}% started`
+        : null;
+    return { apps, started };
+  }
+
+  scrollToCompare(): void {
+    document.getElementById('shape-compare-anchor')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
   /** Occupied vs empty spaces, from the apps-per-space zero count. */
   occupancy(section: ShapeSection): SharePart[] | null {
     const d = section.shape.distributions.apps_per_space;

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
@@ -14,9 +14,10 @@ import writeXlsxFile from 'write-excel-file/browser';
 
 import { EndpointDataRegistry } from '../../services/endpoint-data/endpoint-data.registry';
 import { EndpointDataService } from '../../services/endpoint-data/endpoint-data.service';
-import { computeSessionShape, SessionShape } from './session-shape';
+import { computeSessionShape } from './session-shape';
+import { ShapeCompareCardComponent } from './shape-compare-card.component';
 import { ShapeDistCardComponent } from './shape-dist-card.component';
-import { AgnosticExport, buildAgnosticExport, exportMarkdown } from './shape-export';
+import { AgnosticExport, exportMarkdown } from './shape-export';
 import { buildShapeWorkbook } from './shape-export-xlsx';
 import {
   MeasuredEcosystem,
@@ -24,39 +25,10 @@ import {
   ShapeMeasureService,
   TOTALS_PROBES,
 } from './shape-measure.service';
+import { DrainStamp, sectionExportPayload, ShapeSection } from './shape-section';
 import { ShapeShareBarComponent, SharePart } from './shape-share-bar.component';
 
-interface DrainStamp {
-  fetchedAt: Date | null;
-  stale: boolean;
-}
-
-export interface ShapeSection {
-  guid: string;
-  name: string;
-  shape: SessionShape;
-  totals: {
-    orgs: number;
-    /** null = spaces drain never ran this session (distinct from an empty foundation). */
-    spaces: number | null;
-    apps: number;
-    routes: number;
-    serviceInstances: number;
-    serviceOfferings: number;
-    servicePlans: number;
-    serviceBrokers: number;
-  };
-  drains: { orgs: DrainStamp; spaces: DrainStamp; apps: DrainStamp };
-  loading: boolean;
-  /** At least one full drain landed, so the shape cards mean something. */
-  hasDrains: boolean;
-  /** The fast counts pass has run, so the totals row is real data. */
-  countsLoaded: boolean;
-  /** The services counts pass (a later, separate fetch) has run. */
-  servicesCountsLoaded: boolean;
-  /** The connected user is a CF admin on this endpoint — gates export. */
-  admin: boolean;
-}
+export type { ShapeSection } from './shape-section';
 
 /** Human age of a drain timestamp; the ambiguity note in one place. */
 export const ageLabel = (date: Date | null, now: Date): string => {
@@ -83,7 +55,7 @@ export const ageLabel = (date: Date | null, now: Date): string => {
   selector: 'app-foundation-shape-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DecimalPipe, InfoCardComponent, ShapeDistCardComponent, ShapeShareBarComponent],
+  imports: [DecimalPipe, InfoCardComponent, ShapeCompareCardComponent, ShapeDistCardComponent, ShapeShareBarComponent],
   templateUrl: './foundation-shape-page.component.html',
 })
 export class FoundationShapePageComponent implements OnDestroy {
@@ -221,20 +193,7 @@ export class FoundationShapePageComponent implements OnDestroy {
 
   /** The anonymous projection (#5703) of everything this section has measured. */
   exportPayload(section: ShapeSection): AgnosticExport {
-    return buildAgnosticExport({
-      shape: section.shape,
-      sessionTotals: section.totals,
-      drains: {
-        counts: section.countsLoaded,
-        servicesCounts: section.servicesCountsLoaded,
-        orgs: section.drains.orgs.fetchedAt !== null,
-        spaces: section.drains.spaces.fetchedAt !== null,
-        apps: section.drains.apps.fetchedAt !== null,
-      },
-      collectedAt: new Date(),
-      measuredTotals: this.measuredTotals(section),
-      measuredEcosystem: this.measuredEcosystem(section),
-    });
+    return sectionExportPayload(section, this.measuredTotals(section), this.measuredEcosystem(section));
   }
 
   // <endpoint>-foundational-shape-<mode>-<date>: the name says which

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
@@ -10,12 +10,14 @@ import {
   untracked,
 } from '@angular/core';
 import { EndpointsSignalService, InfoCardComponent } from '@stratosui/core';
+import writeXlsxFile from 'write-excel-file/browser';
 
 import { EndpointDataRegistry } from '../../services/endpoint-data/endpoint-data.registry';
 import { EndpointDataService } from '../../services/endpoint-data/endpoint-data.service';
 import { computeSessionShape, SessionShape } from './session-shape';
 import { ShapeDistCardComponent } from './shape-dist-card.component';
 import { AgnosticExport, buildAgnosticExport, exportMarkdown } from './shape-export';
+import { buildShapeWorkbook } from './shape-export-xlsx';
 import {
   MeasuredEcosystem,
   MeasuredTotals,
@@ -235,19 +237,29 @@ export class FoundationShapePageComponent implements OnDestroy {
     });
   }
 
+  // <endpoint>-foundational-shape-<mode>-<date>: the name says which
+  // endpoint it came from and that the content is anonymized (a future
+  // detail-mode export will say "detail" in the same slot).
+  private exportFileName(section: ShapeSection, extension: 'json' | 'xlsx'): string {
+    const endpoint = section.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    return `${endpoint}-foundational-shape-anonymous-${new Date().toISOString().slice(0, 10)}.${extension}`;
+  }
+
   downloadJson(section: ShapeSection): void {
     const payload = JSON.stringify(this.exportPayload(section), null, 2);
     const blob = new Blob([payload], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = url;
-    // <endpoint>-foundational-shape-<mode>-<date>: the name says which
-    // endpoint it came from and that the content is anonymized (a future
-    // detail-mode export will say "detail" in the same slot).
-    const endpoint = section.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-    anchor.download = `${endpoint}-foundational-shape-anonymous-${new Date().toISOString().slice(0, 10)}.json`;
+    anchor.download = this.exportFileName(section, 'json');
     anchor.click();
     URL.revokeObjectURL(url);
+  }
+
+  downloadXlsx(section: ShapeSection): void {
+    const sheets = buildShapeWorkbook(this.exportPayload(section))
+      .map(({ name, rows }) => ({ sheet: name, data: rows }));
+    void writeXlsxFile(sheets).toFile(this.exportFileName(section, 'xlsx'));
   }
 
   copyMarkdown(section: ShapeSection): void {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.html
@@ -1,61 +1,36 @@
 <div class="flex flex-col gap-4 px-4 py-1" data-test="shape-compare">
   <span class="text-xs text-content-muted">
-    Diff two snapshots &mdash; a live endpoint section or an imported shape export file. Sides show only
-    what each snapshot measured; nothing here issues Cloud Foundry requests.
+    Diff the selected snapshots &mdash; pick endpoints with the Compare box on their section bars, or import
+    exported shape files. Sides are ordered; the first is the baseline for added/removed and &Delta;.
+    Nothing here issues Cloud Foundry requests.
   </span>
 
-  <!-- Slot pickers: A (blue) vs B (amber) -->
-  <div class="flex flex-wrap items-stretch gap-3">
-    <div class="flex-1 min-w-[220px] rounded border border-content-border border-l-4 border-l-[#2a78d6] dark:border-l-[#3987e5] p-3 flex flex-col gap-1.5"
-      data-test="compare-slot-a">
-      <select class="text-sm bg-transparent border border-content-border rounded px-2 py-1"
-        aria-label="Comparison side A"
-        [value]="effectiveChoice('a') ?? ''" (change)="onSelect('a', $any($event.target).value)">
-        <option value="" disabled>choose a source&hellip;</option>
-        @for (section of sections(); track section.guid) {
-          <option [value]="'live:' + section.guid">{{ section.name }} &mdash; live</option>
+  <!-- Ordered sides: chips + file import -->
+  <div class="flex flex-wrap items-center gap-2" data-test="compare-sides">
+    @for (side of sideVms(); track side.id) {
+      <span class="flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full border border-content-border text-xs"
+        [attr.data-test]="'compare-side-' + side.id">
+        <span class="inline-block w-2 h-2 rounded-full" [class]="side.dotClass"></span>
+        <span class="max-w-48 truncate" [title]="side.label">{{ side.label }}</span>
+        @if (side.isBaseline) {
+          <span class="text-[10px] uppercase text-content-muted">baseline</span>
+        } @else {
+          <button type="button" class="text-content-muted hover:underline" title="Make baseline"
+            data-test="compare-make-baseline" (click)="makeBaseline(side.id)">&#8676;</button>
         }
-        @if (fileA(); as file) {
-          <option value="file">{{ file.label }} &mdash; imported</option>
-        }
-      </select>
-      <label class="text-xs text-content-muted cursor-pointer hover:underline">
-        Import export file&hellip;
-        <input type="file" accept=".json,application/json" class="hidden" data-test="compare-import-a"
-          (change)="importFile('a', $event)">
-      </label>
-      @if (errorA(); as error) {
-        <span class="text-xs text-danger-shade-600 dark:text-danger-shade-300" data-test="compare-error-a">{{ error }}</span>
-      }
-    </div>
-
-    <button type="button" data-test="compare-swap" title="Swap sides"
-      class="self-center px-2.5 py-1 text-sm rounded border border-content-border hover:bg-content-secondary transition-colors"
-      (click)="swap()">&#8646;</button>
-
-    <div class="flex-1 min-w-[220px] rounded border border-content-border border-l-4 border-l-[#d97706] dark:border-l-[#f59e0b] p-3 flex flex-col gap-1.5"
-      data-test="compare-slot-b">
-      <select class="text-sm bg-transparent border border-content-border rounded px-2 py-1"
-        aria-label="Comparison side B"
-        [value]="effectiveChoice('b') ?? ''" (change)="onSelect('b', $any($event.target).value)">
-        <option value="" disabled>choose a source&hellip;</option>
-        @for (section of sections(); track section.guid) {
-          <option [value]="'live:' + section.guid">{{ section.name }} &mdash; live</option>
-        }
-        @if (fileB(); as file) {
-          <option value="file">{{ file.label }} &mdash; imported</option>
-        }
-      </select>
-      <label class="text-xs text-content-muted cursor-pointer hover:underline">
-        Import export file&hellip;
-        <input type="file" accept=".json,application/json" class="hidden" data-test="compare-import-b"
-          (change)="importFile('b', $event)">
-      </label>
-      @if (errorB(); as error) {
-        <span class="text-xs text-danger-shade-600 dark:text-danger-shade-300" data-test="compare-error-b">{{ error }}</span>
-      }
-    </div>
+        <button type="button" class="text-content-muted hover:underline px-0.5" title="Remove side"
+          data-test="compare-remove-side" (click)="remove(side.id)">&#10005;</button>
+      </span>
+    }
+    <label class="text-xs text-content-muted cursor-pointer hover:underline">
+      Import export file&hellip;
+      <input type="file" accept=".json,application/json" class="hidden" data-test="compare-import"
+        (change)="importFile($event)">
+    </label>
   </div>
+  @if (importError(); as error) {
+    <span class="text-xs text-danger-shade-600 dark:text-danger-shade-300" data-test="compare-error">{{ error }}</span>
+  }
 
   @if (comparison(); as cmp) {
     <!-- Ecosystem: the promotion tell -->
@@ -63,37 +38,61 @@
       <div class="flex flex-col gap-2" data-test="compare-ecosystem">
         <div>
           <span class="text-sm font-semibold">Ecosystem</span>
-          <span class="text-xs text-content-muted ml-2">defined stacks and buildpacks &mdash; added / removed / unchanged</span>
+          <span class="text-xs text-content-muted ml-2">defined stacks and buildpacks per side; +/&minus; judged against the baseline</span>
         </div>
         @for (list of listVms(); track list.key) {
-          <div class="flex flex-wrap items-center gap-1.5 text-xs">
-            <span class="font-semibold uppercase tracking-wider text-content-muted mr-1">{{ list.title }}</span>
-            @for (label of list.removed; track label) {
-              <span class="px-2 py-0.5 rounded-full border line-through border-danger-shade-300 text-danger-shade-700 dark:border-danger-shade-700 dark:text-danger-shade-300">&minus; {{ label }}</span>
-            }
-            @for (label of list.added; track label) {
-              <span class="px-2 py-0.5 rounded-full border border-success-shade-300 text-success-shade-700 dark:border-success-shade-700 dark:text-success-shade-300">+ {{ label }}</span>
-            }
-            @for (label of list.shown; track label) {
-              <span class="px-2 py-0.5 rounded-full border border-content-border text-content-muted">{{ label }}</span>
-            }
-            @if (list.more > 0 || list.isOpen) {
-              <button type="button" class="px-2 py-0.5 rounded-full border border-content-border text-content-muted hover:bg-content-secondary transition-colors"
-                (click)="toggleList(list.key)">
-                @if (list.isOpen) { show fewer } @else { {{ list.more }} more unchanged }
-              </button>
-            }
+          <div class="overflow-x-auto">
+            <table class="text-xs">
+              <thead>
+                <tr class="text-content-muted">
+                  <td class="pr-4 pb-1 font-semibold uppercase tracking-wider">{{ list.title }}</td>
+                  @for (side of sideVms(); track side.id; let i = $index) {
+                    <td class="px-3 pb-1 text-center">
+                      <span class="inline-block w-2 h-2 rounded-full" [class]="sideDot(i)"></span>
+                    </td>
+                  }
+                </tr>
+              </thead>
+              <tbody>
+                @for (row of list.rows; track row.label) {
+                  <tr>
+                    <td class="pr-4 py-0.5">{{ row.label }}</td>
+                    @for (cell of row.cells; track $index) {
+                      <td class="px-3 py-0.5 text-center">
+                        @switch (cell) {
+                          @case ('added') { <span class="text-success-shade-700 dark:text-success-shade-300">+&#10003;</span> }
+                          @case ('removed') { <span class="text-danger-shade-700 dark:text-danger-shade-300">&minus;</span> }
+                          @case ('present') { <span class="text-content-muted">&#10003;</span> }
+                          @case ('absent') { <span class="text-content-muted">&middot;</span> }
+                          @case ('unmeasured') { <span class="text-content-muted text-[10px]">n/m</span> }
+                        }
+                      </td>
+                    }
+                  </tr>
+                }
+                @if (list.more > 0 || list.isOpen) {
+                  <tr>
+                    <td colspan="99" class="py-0.5">
+                      <button type="button" class="text-content-muted hover:underline"
+                        (click)="toggleList(list.key)">
+                        @if (list.isOpen) { show fewer } @else { {{ list.more }} more unchanged }
+                      </button>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
           </div>
         }
       </div>
     }
 
-    <!-- Composition: paired share bars, delta in share points -->
+    <!-- Composition: share bars per side, delta vs baseline -->
     @if (categoricalVms().length) {
       <div class="flex flex-col gap-2" data-test="compare-composition">
         <div>
           <span class="text-sm font-semibold">Composition</span>
-          <span class="text-xs text-content-muted ml-2">share of each side's own total; &Delta; in share points</span>
+          <span class="text-xs text-content-muted ml-2">share of each side's own total; &Delta; in share points vs the baseline</span>
         </div>
         @for (group of categoricalVms(); track group.dimension) {
           <div class="text-xs font-semibold uppercase tracking-wider text-content-muted">{{ group.title }}</div>
@@ -101,28 +100,19 @@
             <div class="flex items-center gap-3">
               <div class="w-32 text-xs truncate" [title]="row.category">{{ row.category }}</div>
               <div class="flex-1 flex flex-col gap-0.5">
-                @if (row.a; as bar) {
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-2.5 rounded bg-content-secondary overflow-hidden">
-                      <div class="h-full rounded bg-[#2a78d6] dark:bg-[#3987e5]" [style.width.%]="bar.width"></div>
+                @for (bar of row.bars; track $index) {
+                  @if (bar) {
+                    <div class="flex items-center gap-2">
+                      <div class="flex-1 h-2.5 rounded bg-content-secondary overflow-hidden">
+                        <div class="h-full rounded" [class]="bar.fillClass" [style.width.%]="bar.width"></div>
+                      </div>
+                      <div class="w-36 text-right text-[11px] text-content-muted tabular-nums">{{ bar.label }}</div>
                     </div>
-                    <div class="w-24 text-right text-[11px] text-content-muted tabular-nums">{{ bar.label }}</div>
-                  </div>
-                } @else {
-                  <div class="text-[11px] text-content-muted">not measured</div>
-                }
-                @if (row.b; as bar) {
-                  <div class="flex items-center gap-2">
-                    <div class="flex-1 h-2.5 rounded bg-content-secondary overflow-hidden">
-                      <div class="h-full rounded bg-[#d97706] dark:bg-[#f59e0b]" [style.width.%]="bar.width"></div>
-                    </div>
-                    <div class="w-24 text-right text-[11px] text-content-muted tabular-nums">{{ bar.label }}</div>
-                  </div>
-                } @else {
-                  <div class="text-[11px] text-content-muted">not measured</div>
+                  } @else {
+                    <div class="text-[11px] text-content-muted">not measured</div>
+                  }
                 }
               </div>
-              <div class="w-16 text-right text-xs tabular-nums">{{ row.delta }}</div>
             </div>
           }
         }
@@ -137,12 +127,16 @@
           @for (tile of tileVms(); track tile.label) {
             <div class="flex-1 min-w-[160px] rounded border border-content-border p-3">
               <div class="text-base font-semibold tabular-nums">
-                <span class="text-[#2a78d6] dark:text-[#3987e5]">{{ tile.a }}</span>
-                <span class="text-content-muted font-normal"> &rarr; </span>
-                <span class="text-[#d97706] dark:text-[#f59e0b]">{{ tile.b }}</span>
+                @for (part of tile.parts; track $index; let last = $last) {
+                  <span [class]="part.colorClass">{{ part.text }}</span>@if (!last) {
+                    <span class="text-content-muted font-normal"> &rarr; </span>
+                  }
+                }
               </div>
               <div class="text-[11px] text-content-muted mt-0.5">{{ tile.label }}</div>
-              <div class="text-[11px] tabular-nums mt-0.5">{{ tile.delta }}</div>
+              @if (tile.deltas) {
+                <div class="text-[11px] tabular-nums mt-0.5">{{ tile.deltas }}</div>
+              }
             </div>
           }
         </div>
@@ -154,28 +148,32 @@
       <div class="flex flex-col gap-2" data-test="compare-totals">
         <div>
           <span class="text-sm font-semibold">Totals</span>
-          <span class="text-xs text-content-muted ml-2">&Delta; = right minus left</span>
+          <span class="text-xs text-content-muted ml-2">&Delta; vs the baseline column</span>
         </div>
-        <table class="text-xs w-auto">
-          <thead>
-            <tr class="text-content-muted">
-              <th class="text-left font-normal pr-4 pb-1"></th>
-              <th class="text-right font-normal px-3 pb-1">{{ cmp.a.label }}</th>
-              <th class="text-right font-normal px-3 pb-1">{{ cmp.b.label }}</th>
-              <th class="text-right font-normal pl-3 pb-1">&Delta;</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (row of totalsVms(); track row.label) {
-              <tr>
-                <td class="pr-4 py-0.5">{{ row.label }}</td>
-                <td class="text-right px-3 py-0.5 tabular-nums text-[#2a78d6] dark:text-[#3987e5]">{{ row.a }}</td>
-                <td class="text-right px-3 py-0.5 tabular-nums text-[#d97706] dark:text-[#f59e0b]">{{ row.b }}</td>
-                <td class="text-right pl-3 py-0.5 tabular-nums">{{ row.delta }}</td>
+        <div class="overflow-x-auto">
+          <table class="text-xs w-auto">
+            <thead>
+              <tr class="text-content-muted">
+                <th class="text-left font-normal pr-4 pb-1"></th>
+                @for (side of cmp.sides; track $index; let i = $index) {
+                  <th class="text-right font-normal px-3 pb-1" [class]="sideText(i)">{{ side.label }}</th>
+                }
               </tr>
-            }
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              @for (row of totalsVms(); track row.label) {
+                <tr>
+                  <td class="pr-4 py-0.5">{{ row.label }}</td>
+                  @for (cell of row.cells; track $index) {
+                    <td class="text-right px-3 py-0.5 tabular-nums">
+                      {{ cell.text }}@if (cell.delta) { <span class="text-content-muted text-[10px]"> ({{ cell.delta }})</span> }
+                    </td>
+                  }
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
       </div>
     }
 
@@ -202,11 +200,10 @@
             <tbody>
               @for (row of distVms(); track row.key) {
                 <tr><td colspan="7" class="pt-2 pb-0.5 font-semibold">{{ row.title }}</td></tr>
-                @for (side of [row.a, row.b]; track $index; let first = $first) {
+                @for (side of row.sides; track $index) {
                   <tr>
                     <td class="py-0.5 pl-4">
-                      <span class="inline-block w-2 h-2 rounded-full mr-1.5"
-                        [class]="first ? 'bg-[#2a78d6] dark:bg-[#3987e5]' : 'bg-[#d97706] dark:bg-[#f59e0b]'"></span>{{ side.label }}
+                      <span class="inline-block w-2 h-2 rounded-full mr-1.5" [class]="side.dotClass"></span>{{ side.label }}
                     </td>
                     @if (side.state === 'data') {
                       @for (cell of side.cells; track $index) {
@@ -226,6 +223,8 @@
       </div>
     }
   } @else {
-    <div class="text-xs text-content-muted" data-test="compare-prompt">Choose a source for each side to compare.</div>
+    <div class="text-xs text-content-muted" data-test="compare-prompt">
+      Select at least two sides &mdash; tick Compare on endpoint section bars or import export files.
+    </div>
   }
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.html
@@ -1,0 +1,231 @@
+<div class="flex flex-col gap-4 px-4 py-1" data-test="shape-compare">
+  <span class="text-xs text-content-muted">
+    Diff two snapshots &mdash; a live endpoint section or an imported shape export file. Sides show only
+    what each snapshot measured; nothing here issues Cloud Foundry requests.
+  </span>
+
+  <!-- Slot pickers: A (blue) vs B (amber) -->
+  <div class="flex flex-wrap items-stretch gap-3">
+    <div class="flex-1 min-w-[220px] rounded border border-content-border border-l-4 border-l-[#2a78d6] dark:border-l-[#3987e5] p-3 flex flex-col gap-1.5"
+      data-test="compare-slot-a">
+      <select class="text-sm bg-transparent border border-content-border rounded px-2 py-1"
+        aria-label="Comparison side A"
+        [value]="effectiveChoice('a') ?? ''" (change)="onSelect('a', $any($event.target).value)">
+        <option value="" disabled>choose a source&hellip;</option>
+        @for (section of sections(); track section.guid) {
+          <option [value]="'live:' + section.guid">{{ section.name }} &mdash; live</option>
+        }
+        @if (fileA(); as file) {
+          <option value="file">{{ file.label }} &mdash; imported</option>
+        }
+      </select>
+      <label class="text-xs text-content-muted cursor-pointer hover:underline">
+        Import export file&hellip;
+        <input type="file" accept=".json,application/json" class="hidden" data-test="compare-import-a"
+          (change)="importFile('a', $event)">
+      </label>
+      @if (errorA(); as error) {
+        <span class="text-xs text-danger-shade-600 dark:text-danger-shade-300" data-test="compare-error-a">{{ error }}</span>
+      }
+    </div>
+
+    <button type="button" data-test="compare-swap" title="Swap sides"
+      class="self-center px-2.5 py-1 text-sm rounded border border-content-border hover:bg-content-secondary transition-colors"
+      (click)="swap()">&#8646;</button>
+
+    <div class="flex-1 min-w-[220px] rounded border border-content-border border-l-4 border-l-[#d97706] dark:border-l-[#f59e0b] p-3 flex flex-col gap-1.5"
+      data-test="compare-slot-b">
+      <select class="text-sm bg-transparent border border-content-border rounded px-2 py-1"
+        aria-label="Comparison side B"
+        [value]="effectiveChoice('b') ?? ''" (change)="onSelect('b', $any($event.target).value)">
+        <option value="" disabled>choose a source&hellip;</option>
+        @for (section of sections(); track section.guid) {
+          <option [value]="'live:' + section.guid">{{ section.name }} &mdash; live</option>
+        }
+        @if (fileB(); as file) {
+          <option value="file">{{ file.label }} &mdash; imported</option>
+        }
+      </select>
+      <label class="text-xs text-content-muted cursor-pointer hover:underline">
+        Import export file&hellip;
+        <input type="file" accept=".json,application/json" class="hidden" data-test="compare-import-b"
+          (change)="importFile('b', $event)">
+      </label>
+      @if (errorB(); as error) {
+        <span class="text-xs text-danger-shade-600 dark:text-danger-shade-300" data-test="compare-error-b">{{ error }}</span>
+      }
+    </div>
+  </div>
+
+  @if (comparison(); as cmp) {
+    <!-- Ecosystem: the promotion tell -->
+    @if (listVms().length) {
+      <div class="flex flex-col gap-2" data-test="compare-ecosystem">
+        <div>
+          <span class="text-sm font-semibold">Ecosystem</span>
+          <span class="text-xs text-content-muted ml-2">defined stacks and buildpacks &mdash; added / removed / unchanged</span>
+        </div>
+        @for (list of listVms(); track list.key) {
+          <div class="flex flex-wrap items-center gap-1.5 text-xs">
+            <span class="font-semibold uppercase tracking-wider text-content-muted mr-1">{{ list.title }}</span>
+            @for (label of list.removed; track label) {
+              <span class="px-2 py-0.5 rounded-full border line-through border-danger-shade-300 text-danger-shade-700 dark:border-danger-shade-700 dark:text-danger-shade-300">&minus; {{ label }}</span>
+            }
+            @for (label of list.added; track label) {
+              <span class="px-2 py-0.5 rounded-full border border-success-shade-300 text-success-shade-700 dark:border-success-shade-700 dark:text-success-shade-300">+ {{ label }}</span>
+            }
+            @for (label of list.shown; track label) {
+              <span class="px-2 py-0.5 rounded-full border border-content-border text-content-muted">{{ label }}</span>
+            }
+            @if (list.more > 0 || list.isOpen) {
+              <button type="button" class="px-2 py-0.5 rounded-full border border-content-border text-content-muted hover:bg-content-secondary transition-colors"
+                (click)="toggleList(list.key)">
+                @if (list.isOpen) { show fewer } @else { {{ list.more }} more unchanged }
+              </button>
+            }
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Composition: paired share bars, delta in share points -->
+    @if (categoricalVms().length) {
+      <div class="flex flex-col gap-2" data-test="compare-composition">
+        <div>
+          <span class="text-sm font-semibold">Composition</span>
+          <span class="text-xs text-content-muted ml-2">share of each side's own total; &Delta; in share points</span>
+        </div>
+        @for (group of categoricalVms(); track group.dimension) {
+          <div class="text-xs font-semibold uppercase tracking-wider text-content-muted">{{ group.title }}</div>
+          @for (row of group.rows; track row.category) {
+            <div class="flex items-center gap-3">
+              <div class="w-32 text-xs truncate" [title]="row.category">{{ row.category }}</div>
+              <div class="flex-1 flex flex-col gap-0.5">
+                @if (row.a; as bar) {
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2.5 rounded bg-content-secondary overflow-hidden">
+                      <div class="h-full rounded bg-[#2a78d6] dark:bg-[#3987e5]" [style.width.%]="bar.width"></div>
+                    </div>
+                    <div class="w-24 text-right text-[11px] text-content-muted tabular-nums">{{ bar.label }}</div>
+                  </div>
+                } @else {
+                  <div class="text-[11px] text-content-muted">not measured</div>
+                }
+                @if (row.b; as bar) {
+                  <div class="flex items-center gap-2">
+                    <div class="flex-1 h-2.5 rounded bg-content-secondary overflow-hidden">
+                      <div class="h-full rounded bg-[#d97706] dark:bg-[#f59e0b]" [style.width.%]="bar.width"></div>
+                    </div>
+                    <div class="w-24 text-right text-[11px] text-content-muted tabular-nums">{{ bar.label }}</div>
+                  </div>
+                } @else {
+                  <div class="text-[11px] text-content-muted">not measured</div>
+                }
+              </div>
+              <div class="w-16 text-right text-xs tabular-nums">{{ row.delta }}</div>
+            </div>
+          }
+        }
+      </div>
+    }
+
+    <!-- Concentration: top-share fractions side by side -->
+    @if (tileVms().length) {
+      <div class="flex flex-col gap-2" data-test="compare-concentration">
+        <span class="text-sm font-semibold">Concentration</span>
+        <div class="flex flex-wrap gap-3">
+          @for (tile of tileVms(); track tile.label) {
+            <div class="flex-1 min-w-[160px] rounded border border-content-border p-3">
+              <div class="text-base font-semibold tabular-nums">
+                <span class="text-[#2a78d6] dark:text-[#3987e5]">{{ tile.a }}</span>
+                <span class="text-content-muted font-normal"> &rarr; </span>
+                <span class="text-[#d97706] dark:text-[#f59e0b]">{{ tile.b }}</span>
+              </div>
+              <div class="text-[11px] text-content-muted mt-0.5">{{ tile.label }}</div>
+              <div class="text-[11px] tabular-nums mt-0.5">{{ tile.delta }}</div>
+            </div>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Totals -->
+    @if (totalsVms().length) {
+      <div class="flex flex-col gap-2" data-test="compare-totals">
+        <div>
+          <span class="text-sm font-semibold">Totals</span>
+          <span class="text-xs text-content-muted ml-2">&Delta; = right minus left</span>
+        </div>
+        <table class="text-xs w-auto">
+          <thead>
+            <tr class="text-content-muted">
+              <th class="text-left font-normal pr-4 pb-1"></th>
+              <th class="text-right font-normal px-3 pb-1">{{ cmp.a.label }}</th>
+              <th class="text-right font-normal px-3 pb-1">{{ cmp.b.label }}</th>
+              <th class="text-right font-normal pl-3 pb-1">&Delta;</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (row of totalsVms(); track row.label) {
+              <tr>
+                <td class="pr-4 py-0.5">{{ row.label }}</td>
+                <td class="text-right px-3 py-0.5 tabular-nums text-[#2a78d6] dark:text-[#3987e5]">{{ row.a }}</td>
+                <td class="text-right px-3 py-0.5 tabular-nums text-[#d97706] dark:text-[#f59e0b]">{{ row.b }}</td>
+                <td class="text-right pl-3 py-0.5 tabular-nums">{{ row.delta }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+
+    <!-- Distribution key stats -->
+    @if (distVms().length) {
+      <div class="flex flex-col gap-2" data-test="compare-distributions">
+        <div>
+          <span class="text-sm font-semibold">Distributions</span>
+          <span class="text-xs text-content-muted ml-2">measured-but-empty and not-measured stay distinct</span>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="text-xs w-full">
+            <thead>
+              <tr class="text-content-muted">
+                <th class="text-left font-normal pb-1">side</th>
+                <th class="text-right font-normal px-3 pb-1">n</th>
+                <th class="text-right font-normal px-3 pb-1">median</th>
+                <th class="text-right font-normal px-3 pb-1">p90</th>
+                <th class="text-right font-normal px-3 pb-1">max</th>
+                <th class="text-right font-normal px-3 pb-1">mean</th>
+                <th class="text-right font-normal px-3 pb-1">sum</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (row of distVms(); track row.key) {
+                <tr><td colspan="7" class="pt-2 pb-0.5 font-semibold">{{ row.title }}</td></tr>
+                @for (side of [row.a, row.b]; track $index; let first = $first) {
+                  <tr>
+                    <td class="py-0.5 pl-4">
+                      <span class="inline-block w-2 h-2 rounded-full mr-1.5"
+                        [class]="first ? 'bg-[#2a78d6] dark:bg-[#3987e5]' : 'bg-[#d97706] dark:bg-[#f59e0b]'"></span>{{ side.label }}
+                    </td>
+                    @if (side.state === 'data') {
+                      @for (cell of side.cells; track $index) {
+                        <td class="text-right px-3 py-0.5 tabular-nums">{{ cell }}</td>
+                      }
+                    } @else {
+                      <td colspan="6" class="px-3 py-0.5 text-content-muted">
+                        @if (side.state === 'empty') { measured &mdash; empty } @else { not measured }
+                      </td>
+                    }
+                  </tr>
+                }
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+    }
+  } @else {
+    <div class="text-xs text-content-muted" data-test="compare-prompt">Choose a source for each side to compare.</div>
+  }
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.html
@@ -10,7 +10,7 @@
     @for (side of sideVms(); track side.id) {
       <span class="flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full border border-content-border text-xs"
         [attr.data-test]="'compare-side-' + side.id">
-        <span class="inline-block w-2 h-2 rounded-full" [class]="side.dotClass"></span>
+        <span class="inline-block w-2 h-2 rounded-full" [style.background-color]="side.dotColor"></span>
         <span class="max-w-48 truncate" [title]="side.label">{{ side.label }}</span>
         @if (side.isBaseline) {
           <span class="text-[10px] uppercase text-content-muted">baseline</span>
@@ -48,7 +48,7 @@
                   <td class="pr-4 pb-1 font-semibold uppercase tracking-wider">{{ list.title }}</td>
                   @for (side of sideVms(); track side.id; let i = $index) {
                     <td class="px-3 pb-1 text-center">
-                      <span class="inline-block w-2 h-2 rounded-full" [class]="sideDot(i)"></span>
+                      <span class="inline-block w-2 h-2 rounded-full" [style.background-color]="sideColor(i)"></span>
                     </td>
                   }
                 </tr>
@@ -104,7 +104,7 @@
                   @if (bar) {
                     <div class="flex items-center gap-2">
                       <div class="flex-1 h-2.5 rounded bg-content-secondary overflow-hidden">
-                        <div class="h-full rounded" [class]="bar.fillClass" [style.width.%]="bar.width"></div>
+                        <div class="h-full rounded" [style.background-color]="bar.fill" [style.width.%]="bar.width"></div>
                       </div>
                       <div class="w-36 text-right text-[11px] text-content-muted tabular-nums">{{ bar.label }}</div>
                     </div>
@@ -128,7 +128,7 @@
             <div class="flex-1 min-w-[160px] rounded border border-content-border p-3">
               <div class="text-base font-semibold tabular-nums">
                 @for (part of tile.parts; track $index; let last = $last) {
-                  <span [class]="part.colorClass">{{ part.text }}</span>@if (!last) {
+                  <span [style.color]="part.color">{{ part.text }}</span>@if (!last) {
                     <span class="text-content-muted font-normal"> &rarr; </span>
                   }
                 }
@@ -156,7 +156,7 @@
               <tr class="text-content-muted">
                 <th class="text-left font-normal pr-4 pb-1"></th>
                 @for (side of cmp.sides; track $index; let i = $index) {
-                  <th class="text-right font-normal px-3 pb-1" [class]="sideText(i)">{{ side.label }}</th>
+                  <th class="text-right font-normal px-3 pb-1" [style.color]="sideColor(i)">{{ side.label }}</th>
                 }
               </tr>
             </thead>
@@ -203,7 +203,7 @@
                 @for (side of row.sides; track $index) {
                   <tr>
                     <td class="py-0.5 pl-4">
-                      <span class="inline-block w-2 h-2 rounded-full mr-1.5" [class]="side.dotClass"></span>{{ side.label }}
+                      <span class="inline-block w-2 h-2 rounded-full mr-1.5" [style.background-color]="side.dotColor"></span>{{ side.label }}
                     </td>
                     @if (side.state === 'data') {
                       @for (cell of side.cells; track $index) {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
@@ -1,0 +1,171 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { computeSessionShape } from './session-shape';
+import { ShapeCompareCardComponent } from './shape-compare-card.component';
+import { AgnosticExport, buildAgnosticExport } from './shape-export';
+import { MeasuredEcosystem, MeasuredTotals, ShapeMeasureService } from './shape-measure.service';
+import { ShapeSection } from './shape-section';
+import { app, org, space } from './testing/entity-builders';
+
+const stamp = { fetchedAt: new Date('2026-08-01T10:00:00Z'), stale: false };
+
+const makeSection = (guid: string, name: string, stackName: string): ShapeSection => ({
+  guid,
+  name,
+  shape: computeSessionShape(
+    [org('o1'), org('o2')],
+    [space('s1', 'o1')],
+    [app(`${guid}-a1`, { spaceGuid: 's1', orgGuid: 'o1', memory: 256, diskQuota: 1024, stackName })]
+  ),
+  totals: {
+    orgs: 2, spaces: 1, apps: 1, routes: 5,
+    serviceInstances: 3, serviceOfferings: 4, servicePlans: 6, serviceBrokers: 1,
+  },
+  drains: { orgs: stamp, spaces: stamp, apps: stamp },
+  loading: false,
+  hasDrains: true,
+  countsLoaded: true,
+  servicesCountsLoaded: true,
+  admin: true,
+});
+
+const exportFile = (name: string, exported: object): File =>
+  new File([JSON.stringify(exported)], name, { type: 'application/json' });
+
+const sampleExport = (): AgnosticExport =>
+  buildAgnosticExport({
+    shape: computeSessionShape([org('o1'), org('o2')], [space('s1', 'o1')], [
+      app('f-a1', { spaceGuid: 's1', orgGuid: 'o1', memory: 512, stackName: 'cflinuxfs3' }),
+    ]),
+    sessionTotals: {
+      orgs: 2, spaces: 1, apps: 1, routes: 9,
+      serviceInstances: 0, serviceOfferings: 0, servicePlans: 0, serviceBrokers: 0,
+    },
+    drains: { counts: true, servicesCounts: true, orgs: true, spaces: true, apps: true },
+    collectedAt: new Date('2026-07-31T12:00:00Z'),
+  });
+
+describe('ShapeCompareCardComponent', () => {
+  let fixture: ComponentFixture<ShapeCompareCardComponent>;
+  let component: ShapeCompareCardComponent;
+  let measure: {
+    totals: ReturnType<typeof signal<ReadonlyMap<string, MeasuredTotals>>>;
+    ecosystem: ReturnType<typeof signal<ReadonlyMap<string, MeasuredEcosystem>>>;
+  };
+
+  const text = (): string => (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+  beforeEach(async () => {
+    measure = {
+      totals: signal<ReadonlyMap<string, MeasuredTotals>>(new Map()),
+      ecosystem: signal<ReadonlyMap<string, MeasuredEcosystem>>(new Map()),
+    };
+    await TestBed.configureTestingModule({
+      imports: [ShapeCompareCardComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: ShapeMeasureService, useValue: measure },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShapeCompareCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('sections', [
+      makeSection('cf-1', 'Lab CF', 'cflinuxfs4'),
+      makeSection('cf-2', 'AWS CF', 'cflinuxfs3'),
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('defaults side A to the first live section and prompts until B is chosen', () => {
+    expect(component.effectiveChoice('a')).toBe('live:cf-1');
+    expect(component.comparison()).toBeNull();
+    expect(text()).toContain('Choose a source for each side');
+  });
+
+  it('compares two live sections once side B is chosen', async () => {
+    component.onSelect('b', 'live:cf-2');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const cmp = component.comparison();
+    expect(cmp?.a.label).toBe('Lab CF');
+    expect(cmp?.b.label).toBe('AWS CF');
+    // each side pins a different stack: both categories appear with zero-fill
+    const stacks = cmp?.categorical.find(c => c.dimension === 'stacks_pinned_by_apps');
+    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs4', a: 1, aShare: 1, b: 0, bShare: 0 });
+    expect(text()).toContain('Totals');
+  });
+
+  it('imports a valid export file, labelling it from the filename', async () => {
+    await component.importFrom('b', exportFile('aws-foundational-shape-anonymous-2026-07-31.json', sampleExport()));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.effectiveChoice('b')).toBe('file');
+    expect(component.comparison()?.b.label).toBe('aws-foundational-shape-anonymous-2026-07-31');
+    expect(component.errorB()).toBeNull();
+  });
+
+  it('prefers the file foundation_label when the export carries one', async () => {
+    await component.importFrom('b', exportFile('x.json', { ...sampleExport(), foundation_label: 'prod-east' }));
+    expect(component.comparison()?.b.label).toBe('prod-east');
+  });
+
+  it('rejects an invalid file with a reason and leaves the slot unchanged', async () => {
+    await component.importFrom('b', exportFile('bad.json', { schema_version: 2 }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.errorB()).toContain('schema_version');
+    expect(component.comparison()).toBeNull();
+    expect(text()).toContain('bad.json');
+  });
+
+  it('swaps the two sides including imported files', async () => {
+    await component.importFrom('b', exportFile('imported.json', sampleExport()));
+    component.swap();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const cmp = component.comparison();
+    expect(cmp?.a.label).toBe('imported');
+    expect(cmp?.b.label).toBe('Lab CF');
+  });
+
+  it('accepts imported files in both slots', async () => {
+    await component.importFrom('a', exportFile('one.json', sampleExport()));
+    await component.importFrom('b', exportFile('two.json', sampleExport()));
+    const cmp = component.comparison();
+    expect(cmp?.a.label).toBe('one');
+    expect(cmp?.b.label).toBe('two');
+  });
+
+  it('collapses long unchanged lists behind a toggle', async () => {
+    const buildpacks = ['a_bp', 'b_bp', 'c_bp', 'd_bp', 'e_bp', 'f_bp', 'g_bp'];
+    const withEco = { ...sampleExport(), composition: { buildpacks_defined: buildpacks } };
+    await component.importFrom('a', exportFile('one.json', withEco));
+    await component.importFrom('b', exportFile('two.json', withEco));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const list = component.listVms().find(l => l.key === 'buildpacks_defined');
+    expect(list?.shown).toHaveLength(5);
+    expect(list?.more).toBe(2);
+    expect(text()).toContain('2 more unchanged');
+    component.toggleList('buildpacks_defined');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.listVms().find(l => l.key === 'buildpacks_defined')?.shown).toHaveLength(7);
+  });
+
+  it('folds measured ecosystem data of a live section into its side', async () => {
+    measure.ecosystem.set(new Map([
+      ['cf-1', { stacksDefined: ['cflinuxfs4'], buildpacksDefined: ['ruby_buildpack'], fetchedAt: new Date() }],
+    ]));
+    component.onSelect('b', 'live:cf-2');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const lists = component.comparison()?.lists;
+    // cf-1 measured its definitions, cf-2 did not: the diff shows them as removed-side-only
+    expect(lists?.find(l => l.key === 'stacks_defined')?.removed).toEqual(['cflinuxfs4']);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
@@ -80,92 +80,145 @@ describe('ShapeCompareCardComponent', () => {
     await fixture.whenStable();
   });
 
-  it('defaults side A to the first live section and prompts until B is chosen', () => {
-    expect(component.effectiveChoice('a')).toBe('live:cf-1');
+  it('prompts until two sides are selected', () => {
+    expect(component.sideCount()).toBe(0);
     expect(component.comparison()).toBeNull();
-    expect(text()).toContain('Choose a source for each side');
+    expect(text()).toContain('Select at least two sides');
+    component.toggleLive('cf-1');
+    expect(component.comparison()).toBeNull();
   });
 
-  it('compares two live sections once side B is chosen', async () => {
-    component.onSelect('b', 'live:cf-2');
+  it('compares live sections in selection order, first selected as baseline', async () => {
+    component.toggleLive('cf-2');
+    component.toggleLive('cf-1');
     fixture.detectChanges();
     await fixture.whenStable();
     const cmp = component.comparison();
-    expect(cmp?.a.label).toBe('Lab CF');
-    expect(cmp?.b.label).toBe('AWS CF');
+    expect(cmp?.sides.map(s => s.label)).toEqual(['AWS CF', 'Lab CF']);
+    expect(component.sideVms()[0].isBaseline).toBe(true);
     // each side pins a different stack: both categories appear with zero-fill
     const stacks = cmp?.categorical.find(c => c.dimension === 'stacks_pinned_by_apps');
-    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs4', a: 1, aShare: 1, b: 0, bShare: 0 });
+    expect(stacks?.rows.find(r => r.category === 'cflinuxfs3')?.counts).toEqual([1, 0]);
     expect(text()).toContain('Totals');
   });
 
-  it('imports a valid export file, labelling it from the filename', async () => {
-    await component.importFrom('b', exportFile('aws-foundational-shape-anonymous-2026-07-31.json', sampleExport()));
+  it('unselecting on the bar removes the side again', () => {
+    component.toggleLive('cf-1');
+    component.toggleLive('cf-2');
+    expect(component.comparison()).not.toBeNull();
+    component.toggleLive('cf-1');
+    expect(component.isSelected('cf-1')).toBe(false);
+    expect(component.comparison()).toBeNull();
+  });
+
+  it('imports a valid export file as a side, labelling it from the filename', async () => {
+    component.toggleLive('cf-1');
+    await component.importFrom(exportFile('aws-foundational-shape-anonymous-2026-07-31.json', sampleExport()));
     fixture.detectChanges();
     await fixture.whenStable();
-    expect(component.effectiveChoice('b')).toBe('file');
-    expect(component.comparison()?.b.label).toBe('aws-foundational-shape-anonymous-2026-07-31');
-    expect(component.errorB()).toBeNull();
+    const cmp = component.comparison();
+    expect(cmp?.sides.map(s => s.label)).toEqual(['Lab CF', 'aws-foundational-shape-anonymous-2026-07-31']);
+    expect(component.importError()).toBeNull();
   });
 
   it('prefers the file foundation_label when the export carries one', async () => {
-    await component.importFrom('b', exportFile('x.json', { ...sampleExport(), foundation_label: 'prod-east' }));
-    expect(component.comparison()?.b.label).toBe('prod-east');
+    component.toggleLive('cf-1');
+    await component.importFrom(exportFile('x.json', { ...sampleExport(), foundation_label: 'prod-east' }));
+    expect(component.comparison()?.sides[1].label).toBe('prod-east');
   });
 
-  it('rejects an invalid file with a reason and leaves the slot unchanged', async () => {
-    await component.importFrom('b', exportFile('bad.json', { schema_version: 2 }));
+  it('rejects an invalid file with a reason and adds no side', async () => {
+    await component.importFrom(exportFile('bad.json', { schema_version: 2 }));
     fixture.detectChanges();
     await fixture.whenStable();
-    expect(component.errorB()).toContain('schema_version');
-    expect(component.comparison()).toBeNull();
+    expect(component.importError()).toContain('schema_version');
+    expect(component.sideCount()).toBe(0);
     expect(text()).toContain('bad.json');
   });
 
-  it('swaps the two sides including imported files', async () => {
-    await component.importFrom('b', exportFile('imported.json', sampleExport()));
-    component.swap();
+  it('compares three sides and re-baselines on demand', async () => {
+    component.toggleLive('cf-1');
+    component.toggleLive('cf-2');
+    await component.importFrom(exportFile('imported.json', sampleExport()));
     fixture.detectChanges();
     await fixture.whenStable();
-    const cmp = component.comparison();
-    expect(cmp?.a.label).toBe('imported');
-    expect(cmp?.b.label).toBe('Lab CF');
+    expect(component.comparison()?.sides.map(s => s.label)).toEqual(['Lab CF', 'AWS CF', 'imported']);
+
+    const fileId = component.sideVms()[2].id;
+    component.makeBaseline(fileId);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.comparison()?.sides.map(s => s.label)).toEqual(['imported', 'Lab CF', 'AWS CF']);
+    expect(component.sideVms()[0].isBaseline).toBe(true);
   });
 
-  it('accepts imported files in both slots', async () => {
-    await component.importFrom('a', exportFile('one.json', sampleExport()));
-    await component.importFrom('b', exportFile('two.json', sampleExport()));
-    const cmp = component.comparison();
-    expect(cmp?.a.label).toBe('one');
-    expect(cmp?.b.label).toBe('two');
+  it('removes a side by chip', async () => {
+    component.toggleLive('cf-1');
+    component.toggleLive('cf-2');
+    const id = component.sideVms()[1].id;
+    component.remove(id);
+    expect(component.sideCount()).toBe(1);
+    expect(component.comparison()).toBeNull();
   });
 
-  it('collapses long unchanged lists behind a toggle', async () => {
-    const buildpacks = ['a_bp', 'b_bp', 'c_bp', 'd_bp', 'e_bp', 'f_bp', 'g_bp'];
-    const withEco = { ...sampleExport(), composition: { buildpacks_defined: buildpacks } };
-    await component.importFrom('a', exportFile('one.json', withEco));
-    await component.importFrom('b', exportFile('two.json', withEco));
+  it('collapses unchanged matrix rows behind a toggle, keeping changed rows visible', async () => {
+    const shared = ['a_bp', 'b_bp', 'c_bp', 'd_bp', 'e_bp', 'f_bp', 'g_bp'];
+    await component.importFrom(exportFile('one.json', {
+      ...sampleExport(), composition: { buildpacks_defined: [...shared, 'only_in_one'] },
+    }));
+    await component.importFrom(exportFile('two.json', {
+      ...sampleExport(), composition: { buildpacks_defined: shared },
+    }));
     fixture.detectChanges();
     await fixture.whenStable();
     const list = component.listVms().find(l => l.key === 'buildpacks_defined');
-    expect(list?.shown).toHaveLength(5);
+    // the changed row survives the collapse; 5 of 7 unchanged show
+    expect(list?.rows.some(row => row.label === 'only_in_one')).toBe(true);
+    expect(list?.rows).toHaveLength(6);
     expect(list?.more).toBe(2);
     expect(text()).toContain('2 more unchanged');
     component.toggleList('buildpacks_defined');
     fixture.detectChanges();
     await fixture.whenStable();
-    expect(component.listVms().find(l => l.key === 'buildpacks_defined')?.shown).toHaveLength(7);
+    expect(component.listVms().find(l => l.key === 'buildpacks_defined')?.rows).toHaveLength(8);
+  });
+
+  it('judges added and removed against the baseline side', async () => {
+    await component.importFrom(exportFile('base.json', {
+      ...sampleExport(), composition: { stacks_defined: ['cflinuxfs3', 'cflinuxfs4'] },
+    }));
+    await component.importFrom(exportFile('next.json', {
+      ...sampleExport(), composition: { stacks_defined: ['cflinuxfs4', 'windows'] },
+    }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const list = component.listVms().find(l => l.key === 'stacks_defined');
+    expect(list?.rows.find(r => r.label === 'windows')?.cells).toEqual(['absent', 'added']);
+    expect(list?.rows.find(r => r.label === 'cflinuxfs3')?.cells).toEqual(['present', 'removed']);
+    expect(list?.rows.find(r => r.label === 'cflinuxfs4')?.cells).toEqual(['present', 'present']);
+  });
+
+  it('marks a side that never measured a list as unmeasured, not empty', async () => {
+    component.toggleLive('cf-1'); // live section without measured ecosystem
+    await component.importFrom(exportFile('file.json', {
+      ...sampleExport(), composition: { stacks_defined: ['cflinuxfs4'] },
+    }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const list = component.listVms().find(l => l.key === 'stacks_defined');
+    expect(list?.rows.find(r => r.label === 'cflinuxfs4')?.cells[0]).toBe('unmeasured');
   });
 
   it('folds measured ecosystem data of a live section into its side', async () => {
     measure.ecosystem.set(new Map([
       ['cf-1', { stacksDefined: ['cflinuxfs4'], buildpacksDefined: ['ruby_buildpack'], fetchedAt: new Date() }],
     ]));
-    component.onSelect('b', 'live:cf-2');
+    component.toggleLive('cf-1');
+    component.toggleLive('cf-2');
     fixture.detectChanges();
     await fixture.whenStable();
-    const lists = component.comparison()?.lists;
-    // cf-1 measured its definitions, cf-2 did not: the diff shows them as removed-side-only
-    expect(lists?.find(l => l.key === 'stacks_defined')?.removed).toEqual(['cflinuxfs4']);
+    const list = component.listVms().find(l => l.key === 'stacks_defined');
+    expect(list?.measured).toEqual([true, false]);
+    expect(list?.rows.find(r => r.label === 'cflinuxfs4')?.cells[0]).toBe('present');
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
@@ -155,10 +155,10 @@ describe('ShapeCompareCardComponent', () => {
   it('keeps each side its identity color across re-baselining', async () => {
     component.toggleLive('cf-1');
     component.toggleLive('cf-2');
-    const colorsBefore = new Map(component.sideVms().map(vm => [vm.id, vm.dotClass]));
+    const colorsBefore = new Map(component.sideVms().map(vm => [vm.id, vm.dotColor]));
     expect(colorsBefore.get('cf-1')).not.toBe(colorsBefore.get('cf-2'));
     component.makeBaseline(component.sideVms()[1].id);
-    const colorsAfter = new Map(component.sideVms().map(vm => [vm.id, vm.dotClass]));
+    const colorsAfter = new Map(component.sideVms().map(vm => [vm.id, vm.dotColor]));
     expect(colorsAfter).toEqual(colorsBefore);
     // the bar chip matches the side's color everywhere
     expect(component.dotFor('cf-2')).toBe(colorsBefore.get('cf-2'));
@@ -171,9 +171,23 @@ describe('ShapeCompareCardComponent', () => {
     for (let i = 0; i < 4; i++) {
       await component.importFrom(exportFile(`snap-${i}.json`, sampleExport()));
     }
-    const colors = component.sideVms().map(vm => vm.dotClass);
+    const colors = component.sideVms().map(vm => vm.dotColor);
     expect(colors).toHaveLength(6);
     expect(new Set(colors).size).toBe(6);
+  });
+
+  it('sizes the color range to contain the endpoint count', async () => {
+    expect(component.paletteSize()).toBe(8); // floor, even with only two endpoints
+    const many = Array.from({ length: 10 }, (_, i) => makeSection(`cf-${i}`, `CF ${i}`, 'cflinuxfs4'));
+    fixture.componentRef.setInput('sections', many);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.paletteSize()).toBe(12); // contains 10, never an exact fit
+    for (const section of many) {
+      component.toggleLive(section.guid);
+    }
+    const colors = component.sideVms().map(vm => vm.dotColor);
+    expect(new Set(colors).size).toBe(10);
   });
 
   it('frees a removed side color for the next selection', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
@@ -152,6 +152,29 @@ describe('ShapeCompareCardComponent', () => {
     expect(component.sideVms()[0].isBaseline).toBe(true);
   });
 
+  it('keeps each side its identity color across re-baselining', async () => {
+    component.toggleLive('cf-1');
+    component.toggleLive('cf-2');
+    const colorsBefore = new Map(component.sideVms().map(vm => [vm.id, vm.dotClass]));
+    expect(colorsBefore.get('cf-1')).not.toBe(colorsBefore.get('cf-2'));
+    component.makeBaseline(component.sideVms()[1].id);
+    const colorsAfter = new Map(component.sideVms().map(vm => [vm.id, vm.dotClass]));
+    expect(colorsAfter).toEqual(colorsBefore);
+    // the bar chip matches the side's color everywhere
+    expect(component.dotFor('cf-2')).toBe(colorsBefore.get('cf-2'));
+    expect(component.dotFor('cf-1')).toBe(colorsBefore.get('cf-1'));
+  });
+
+  it('frees a removed side color for the next selection', () => {
+    component.toggleLive('cf-1');
+    component.toggleLive('cf-2');
+    const first = component.dotFor('cf-1');
+    component.toggleLive('cf-1'); // unselect: frees the first color
+    component.toggleLive('cf-1'); // reselect: takes the freed slot again
+    expect(component.dotFor('cf-1')).toBe(first);
+    expect(component.dotFor('cf-1')).not.toBe(component.dotFor('cf-2'));
+  });
+
   it('removes a side by chip', async () => {
     component.toggleLive('cf-1');
     component.toggleLive('cf-2');

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.spec.ts
@@ -165,6 +165,17 @@ describe('ShapeCompareCardComponent', () => {
     expect(component.dotFor('cf-1')).toBe(colorsBefore.get('cf-1'));
   });
 
+  it('gives six concurrent sides six distinct colors', async () => {
+    component.toggleLive('cf-1');
+    component.toggleLive('cf-2');
+    for (let i = 0; i < 4; i++) {
+      await component.importFrom(exportFile(`snap-${i}.json`, sampleExport()));
+    }
+    const colors = component.sideVms().map(vm => vm.dotClass);
+    expect(colors).toHaveLength(6);
+    expect(new Set(colors).size).toBe(6);
+  });
+
   it('frees a removed side color for the next selection', () => {
     component.toggleLive('cf-1');
     component.toggleLive('cf-2');

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
@@ -14,20 +14,30 @@ import { TopShare } from './shape-stats';
 const UNCHANGED_SHOWN = 5;
 
 /**
- * Side colors by position, cycling: blue, amber, teal, slate. Literal class
- * strings so the Tailwind scanner picks every variant up.
+ * Identity color slots: blue, amber, teal, slate, violet, rose, green, lime —
+ * eight distinct hues so a side's color stays unique well past the usual
+ * endpoint count (colors repeat only from the ninth concurrent side).
+ * Literal class strings so the Tailwind scanner picks every variant up.
  */
 const SIDE_BG = [
   'bg-[#2a78d6] dark:bg-[#3987e5]',
   'bg-[#d97706] dark:bg-[#f59e0b]',
   'bg-[#0d9488] dark:bg-[#14b8a6]',
   'bg-[#64748b] dark:bg-[#94a3b8]',
+  'bg-[#7c3aed] dark:bg-[#8b5cf6]',
+  'bg-[#db2777] dark:bg-[#ec4899]',
+  'bg-[#16a34a] dark:bg-[#22c55e]',
+  'bg-[#65a30d] dark:bg-[#84cc16]',
 ];
 const SIDE_TEXT = [
   'text-[#2a78d6] dark:text-[#3987e5]',
   'text-[#d97706] dark:text-[#f59e0b]',
   'text-[#0d9488] dark:text-[#14b8a6]',
   'text-[#64748b] dark:text-[#94a3b8]',
+  'text-[#7c3aed] dark:text-[#8b5cf6]',
+  'text-[#db2777] dark:text-[#ec4899]',
+  'text-[#16a34a] dark:text-[#22c55e]',
+  'text-[#65a30d] dark:text-[#84cc16]',
 ];
 
 const humanize = (key: string): string => key.replace(/_/g, ' ');

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
@@ -1,36 +1,55 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, signal, WritableSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
 
 import {
-  CategoryRow,
   compareExports,
-  ComparedValue,
   LabelledExport,
   parseImportedExport,
   ShapeComparison,
 } from './shape-compare';
 import { ShapeMeasureService } from './shape-measure.service';
 import { sectionExportPayload, ShapeSection } from './shape-section';
-import { Distribution, TopShare } from './shape-stats';
+import { TopShare } from './shape-stats';
 
-type SlotId = 'a' | 'b';
-
-/** How many unchanged chips a list shows before collapsing behind "n more". */
+/** How many unchanged matrix rows a list shows before collapsing behind "n more". */
 const UNCHANGED_SHOWN = 5;
+
+/**
+ * Side colors by position, cycling: blue, amber, teal, slate. Literal class
+ * strings so the Tailwind scanner picks every variant up.
+ */
+const SIDE_BG = [
+  'bg-[#2a78d6] dark:bg-[#3987e5]',
+  'bg-[#d97706] dark:bg-[#f59e0b]',
+  'bg-[#0d9488] dark:bg-[#14b8a6]',
+  'bg-[#64748b] dark:bg-[#94a3b8]',
+];
+const SIDE_TEXT = [
+  'text-[#2a78d6] dark:text-[#3987e5]',
+  'text-[#d97706] dark:text-[#f59e0b]',
+  'text-[#0d9488] dark:text-[#14b8a6]',
+  'text-[#64748b] dark:text-[#94a3b8]',
+];
 
 const humanize = (key: string): string => key.replace(/_/g, ' ');
 const pctText = (fraction: number): string => `${(fraction * 100).toFixed(1)}%`;
 const ptsText = (delta: number): string => `${delta >= 0 ? '+' : ''}${(delta * 100).toFixed(1)} pts`;
 
-interface BarVm {
-  width: number;
-  label: string;
+/** One comparison side: a live endpoint section (by guid) or an imported export file. */
+interface CompareSide {
+  id: string;
+  kind: 'live' | 'file';
+  guid?: string;
+  file?: LabelledExport;
 }
 
+type MatrixCell = 'present' | 'absent' | 'added' | 'removed' | 'unmeasured';
+
 /**
- * Promotion-verification comparison (GH #5702 follow-on): two slots, each a
- * live endpoint section or an imported schema_version 1 export file, diffed
- * with ecosystem and composition emphasis. Reads only what both sides
- * measured; nothing here issues CF requests.
+ * Promotion-verification comparison (GH #5702 follow-on): N ordered sides —
+ * live endpoint sections selected on their bars, plus imported schema_version
+ * 1 export files — diffed with ecosystem and composition emphasis. The first
+ * side is the baseline; added/removed and deltas are judged against it.
+ * Reads only what each side measured; nothing here issues CF requests.
  */
 @Component({
   selector: 'app-shape-compare-card',
@@ -41,103 +60,110 @@ interface BarVm {
 export class ShapeCompareCardComponent {
   private readonly measure = inject(ShapeMeasureService);
 
-  readonly sections = input.required<ShapeSection[]>();
+  /** Defaulted (not required): the page's selection strip reads sideCount() before the first binding lands. */
+  readonly sections = input<ShapeSection[]>([]);
 
-  readonly choiceA = signal<string | null>(null);
-  readonly choiceB = signal<string | null>(null);
-  readonly fileA = signal<LabelledExport | null>(null);
-  readonly fileB = signal<LabelledExport | null>(null);
-  readonly errorA = signal<string | null>(null);
-  readonly errorB = signal<string | null>(null);
+  private readonly sides = signal<readonly CompareSide[]>([]);
+  readonly importError = signal<string | null>(null);
   private readonly expandedLists = signal<ReadonlySet<string>>(new Set());
+  private fileSeq = 0;
 
-  choice(slot: SlotId): WritableSignal<string | null> {
-    return slot === 'a' ? this.choiceA : this.choiceB;
+  /** Sides whose live section still exists (an endpoint may disconnect while selected). */
+  private readonly liveSides = computed<CompareSide[]>(() => {
+    const byGuid = new Map(this.sections().map(section => [section.guid, section]));
+    return this.sides().filter(side => side.kind === 'file' || byGuid.has(side.guid as string));
+  });
+
+  readonly sideCount = computed(() => this.liveSides().length);
+
+  isSelected(guid: string): boolean {
+    return this.sides().some(side => side.guid === guid);
   }
 
-  file(slot: SlotId): WritableSignal<LabelledExport | null> {
-    return slot === 'a' ? this.fileA : this.fileB;
-  }
-
-  error(slot: SlotId): WritableSignal<string | null> {
-    return slot === 'a' ? this.errorA : this.errorB;
-  }
-
-  /** Side A defaults to the first live section; B stays unset until chosen. */
-  effectiveChoice(slot: SlotId): string | null {
-    const choice = this.choice(slot)();
-    if (choice) {
-      return choice;
-    }
-    return slot === 'a' && this.sections().length ? `live:${this.sections()[0].guid}` : null;
-  }
-
-  onSelect(slot: SlotId, value: string): void {
-    this.choice(slot).set(value || null);
-    this.error(slot).set(null);
+  /** Bar checkbox hook: select order is baseline order (first selected = baseline). */
+  toggleLive(guid: string): void {
+    const current = this.sides();
+    this.sides.set(
+      this.isSelected(guid)
+        ? current.filter(side => side.guid !== guid)
+        : [...current, { id: guid, kind: 'live', guid }]
+    );
   }
 
   /** Template hook for the hidden file input; the parse work lives in importFrom. */
-  importFile(slot: SlotId, event: Event): void {
+  importFile(event: Event): void {
     const inputEl = event.target as HTMLInputElement;
     const file = inputEl.files?.[0];
     inputEl.value = '';
     if (file) {
-      void this.importFrom(slot, file);
+      void this.importFrom(file);
     }
   }
 
-  async importFrom(slot: SlotId, file: File): Promise<void> {
+  async importFrom(file: File): Promise<void> {
     const { exported, error } = parseImportedExport(await file.text());
     if (!exported) {
-      this.error(slot).set(`${file.name}: ${error}`);
+      this.importError.set(`${file.name}: ${error}`);
       return;
     }
     const label = exported.foundation_label || file.name.replace(/\.json$/i, '');
-    this.file(slot).set({ label, exported });
-    this.choice(slot).set('file');
-    this.error(slot).set(null);
+    this.sides.set([
+      ...this.sides(),
+      { id: `file-${++this.fileSeq}`, kind: 'file', file: { label, exported } },
+    ]);
+    this.importError.set(null);
   }
 
-  swap(): void {
-    const [choiceA, choiceB] = [this.effectiveChoice('a'), this.effectiveChoice('b')];
-    const [fileA, fileB] = [this.fileA(), this.fileB()];
-    this.choiceA.set(choiceB);
-    this.choiceB.set(choiceA);
-    this.fileA.set(fileB);
-    this.fileB.set(fileA);
-    this.errorA.set(null);
-    this.errorB.set(null);
+  remove(id: string): void {
+    this.sides.set(this.sides().filter(side => side.id !== id));
   }
 
-  private resolveSlot(slot: SlotId): LabelledExport | null {
-    const choice = this.effectiveChoice(slot);
-    if (!choice) {
-      return null;
+  makeBaseline(id: string): void {
+    const current = this.sides();
+    const side = current.find(s => s.id === id);
+    if (side) {
+      this.sides.set([side, ...current.filter(s => s.id !== id)]);
     }
-    if (choice === 'file') {
-      return this.file(slot)();
-    }
-    const guid = choice.slice('live:'.length);
-    const section = this.sections().find(s => s.guid === guid);
-    if (!section) {
-      return null;
-    }
-    return {
-      label: section.name,
-      exported: sectionExportPayload(section, this.measure.totals().get(guid), this.measure.ecosystem().get(guid)),
-    };
   }
 
-  readonly comparison = computed<ShapeComparison | null>(() => {
-    const a = this.resolveSlot('a');
-    const b = this.resolveSlot('b');
-    return a && b ? compareExports(a, b) : null;
+  private readonly resolved = computed<LabelledExport[]>(() => {
+    const byGuid = new Map(this.sections().map(section => [section.guid, section]));
+    return this.liveSides().map(side => {
+      if (side.kind === 'file') {
+        return side.file as LabelledExport;
+      }
+      const guid = side.guid as string;
+      const section = byGuid.get(guid) as ShapeSection;
+      return {
+        label: section.name,
+        exported: sectionExportPayload(section, this.measure.totals().get(guid), this.measure.ecosystem().get(guid)),
+      };
+    });
   });
 
-  /** Imported-file description for a slot header (live slots show their name in the select). */
-  fileNote(slot: SlotId): string | null {
-    return this.effectiveChoice(slot) === 'file' ? this.file(slot)()?.label ?? null : null;
+  readonly comparison = computed<ShapeComparison | null>(() =>
+    this.liveSides().length >= 2 ? compareExports(this.resolved()) : null
+  );
+
+  /** Ordered side chips; index drives the color pairing everywhere below. */
+  readonly sideVms = computed(() =>
+    this.liveSides().map((side, index) => ({
+      id: side.id,
+      kind: side.kind,
+      label: side.kind === 'file'
+        ? (side.file as LabelledExport).label
+        : this.sections().find(s => s.guid === side.guid)?.name ?? '',
+      dotClass: SIDE_BG[index % SIDE_BG.length],
+      isBaseline: index === 0,
+    }))
+  );
+
+  sideDot(index: number): string {
+    return SIDE_BG[index % SIDE_BG.length];
+  }
+
+  sideText(index: number): string {
+    return SIDE_TEXT[index % SIDE_TEXT.length];
   }
 
   readonly listVms = computed(() => {
@@ -147,15 +173,35 @@ export class ShapeCompareCardComponent {
     }
     const expanded = this.expandedLists();
     return cmp.lists.map(list => {
+      const baselineMeasured = list.measured[0];
+      const rows = list.rows.map(row => ({
+        label: row.label,
+        cells: row.present.map((present, i): MatrixCell => {
+          if (!list.measured[i]) {
+            return 'unmeasured';
+          }
+          if (i > 0 && baselineMeasured) {
+            if (present && !row.present[0]) {
+              return 'added';
+            }
+            if (!present && row.present[0]) {
+              return 'removed';
+            }
+          }
+          return present ? 'present' : 'absent';
+        }),
+      }));
+      // unchanged = same presence on every side that measured the list
+      const changed = rows.filter(row => row.cells.some(cell => cell === 'added' || cell === 'removed'));
+      const unchanged = rows.filter(row => !row.cells.some(cell => cell === 'added' || cell === 'removed'));
       const isOpen = expanded.has(list.key);
-      const shown = isOpen ? list.unchanged : list.unchanged.slice(0, UNCHANGED_SHOWN);
+      const shownUnchanged = isOpen ? unchanged : unchanged.slice(0, UNCHANGED_SHOWN);
       return {
         key: list.key,
         title: humanize(list.key),
-        added: list.added,
-        removed: list.removed,
-        shown,
-        more: list.unchanged.length - shown.length,
+        measured: list.measured,
+        rows: [...changed, ...shownUnchanged],
+        more: unchanged.length - shownUnchanged.length,
         isOpen,
       };
     });
@@ -171,13 +217,6 @@ export class ShapeCompareCardComponent {
     this.expandedLists.set(next);
   }
 
-  private barVm(count: number | undefined, share: number | undefined): BarVm | null {
-    if (share === undefined || count === undefined) {
-      return null;
-    }
-    return { width: Math.max(share * 100, 0.5), label: `${count} · ${pctText(share)}` };
-  }
-
   readonly categoricalVms = computed(() => {
     const cmp = this.comparison();
     if (!cmp) {
@@ -186,11 +225,19 @@ export class ShapeCompareCardComponent {
     return cmp.categorical.map(({ dimension, rows }) => ({
       dimension,
       title: humanize(dimension),
-      rows: rows.map((row: CategoryRow) => ({
+      rows: rows.map(row => ({
         category: row.category,
-        a: this.barVm(row.a, row.aShare),
-        b: this.barVm(row.b, row.bShare),
-        delta: row.aShare !== undefined && row.bShare !== undefined ? ptsText(row.bShare - row.aShare) : '—',
+        bars: row.shares.map((share, i) => {
+          if (share === undefined) {
+            return null;
+          }
+          const delta = i > 0 && row.shares[0] !== undefined ? ` · ${ptsText(share - row.shares[0])}` : '';
+          return {
+            width: Math.max(share * 100, 0.5),
+            fillClass: SIDE_BG[i % SIDE_BG.length],
+            label: `${row.counts[i]} · ${pctText(share)}${delta}`,
+          };
+        }),
       })),
     }));
   });
@@ -200,14 +247,19 @@ export class ShapeCompareCardComponent {
     if (!cmp) {
       return [];
     }
-    const text = (share: TopShare | null | undefined): string =>
-      share ? pctText(share.fraction) : share === null ? 'no data' : 'not measured';
-    return cmp.topShare.map((row: ComparedValue<TopShare>) => ({
-      label: humanize(row.key),
-      a: text(row.a),
-      b: text(row.b),
-      delta: row.a && row.b ? ptsText(row.b.fraction - row.a.fraction) : '',
-    }));
+    return cmp.topShare.map(row => {
+      const parts = row.values.map((share, i) => ({
+        text: share ? pctText(share.fraction) : share === null ? 'no data' : 'not measured',
+        colorClass: SIDE_TEXT[i % SIDE_TEXT.length],
+      }));
+      const baseline = row.values[0];
+      const deltas = row.values
+        .map((share, i) =>
+          i > 0 && share && baseline ? ptsText(share.fraction - (baseline as TopShare).fraction) : null
+        )
+        .filter((d): d is string => d !== null);
+      return { label: humanize(row.key), parts, deltas: deltas.join(' · ') };
+    });
   });
 
   readonly totalsVms = computed(() => {
@@ -215,15 +267,16 @@ export class ShapeCompareCardComponent {
     if (!cmp) {
       return [];
     }
-    const cell = (value: number | null | undefined): string => (value === undefined || value === null ? '—' : String(value));
-    return cmp.totals.map((row: ComparedValue<number>) => ({
+    return cmp.totals.map(row => ({
       label: humanize(row.key),
-      a: cell(row.a),
-      b: cell(row.b),
-      delta:
-        typeof row.a === 'number' && typeof row.b === 'number'
-          ? `${row.b - row.a >= 0 ? '+' : ''}${row.b - row.a}`
-          : '—',
+      cells: row.values.map((value, i) => {
+        const baseline = row.values[0];
+        const delta =
+          i > 0 && typeof value === 'number' && typeof baseline === 'number'
+            ? `${value - baseline >= 0 ? '+' : ''}${value - baseline}`
+            : null;
+        return { text: value === undefined || value === null ? '—' : String(value), delta };
+      }),
     }));
   });
 
@@ -232,16 +285,15 @@ export class ShapeCompareCardComponent {
     if (!cmp) {
       return [];
     }
-    const side = (label: string, d: Distribution | null | undefined) => ({
-      label,
-      state: d ? ('data' as const) : d === null ? ('empty' as const) : ('missing' as const),
-      cells: d ? [d.n, d.median, d.p90, d.max, d.mean, d.sum] : [],
-    });
-    return cmp.distributions.map((row: ComparedValue<Distribution>) => ({
+    return cmp.distributions.map(row => ({
       key: row.key,
       title: humanize(row.key),
-      a: side(cmp.a.label, row.a),
-      b: side(cmp.b.label, row.b),
+      sides: row.values.map((d, i) => ({
+        label: cmp.sides[i].label,
+        dotClass: SIDE_BG[i % SIDE_BG.length],
+        state: d ? ('data' as const) : d === null ? ('empty' as const) : ('missing' as const),
+        cells: d ? [d.n, d.median, d.p90, d.max, d.mean, d.sum] : [],
+      })),
     }));
   });
 }

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
@@ -40,6 +40,12 @@ interface CompareSide {
   kind: 'live' | 'file';
   guid?: string;
   file?: LabelledExport;
+  /**
+   * Identity color slot, taken when the side is added and kept until it is
+   * removed — reordering (re-baselining) never recolors a side, so an
+   * endpoint keeps one color everywhere it appears.
+   */
+  color: number;
 }
 
 type MatrixCell = 'present' | 'absent' | 'added' | 'removed' | 'unmeasured';
@@ -80,14 +86,30 @@ export class ShapeCompareCardComponent {
     return this.sides().some(side => side.guid === guid);
   }
 
+  /** Lowest palette slot not held by a current side; freed colors get reused. */
+  private nextColor(): number {
+    const used = new Set(this.sides().map(side => side.color));
+    let color = 0;
+    while (used.has(color)) {
+      color++;
+    }
+    return color;
+  }
+
   /** Bar checkbox hook: select order is baseline order (first selected = baseline). */
   toggleLive(guid: string): void {
     const current = this.sides();
     this.sides.set(
       this.isSelected(guid)
         ? current.filter(side => side.guid !== guid)
-        : [...current, { id: guid, kind: 'live', guid }]
+        : [...current, { id: guid, kind: 'live', guid, color: this.nextColor() }]
     );
+  }
+
+  /** The endpoint's identity color chip for its section bar; null when not selected. */
+  dotFor(guid: string): string | null {
+    const side = this.sides().find(s => s.guid === guid);
+    return side ? SIDE_BG[side.color % SIDE_BG.length] : null;
   }
 
   /** Template hook for the hidden file input; the parse work lives in importFrom. */
@@ -109,7 +131,7 @@ export class ShapeCompareCardComponent {
     const label = exported.foundation_label || file.name.replace(/\.json$/i, '');
     this.sides.set([
       ...this.sides(),
-      { id: `file-${++this.fileSeq}`, kind: 'file', file: { label, exported } },
+      { id: `file-${++this.fileSeq}`, kind: 'file', file: { label, exported }, color: this.nextColor() },
     ]);
     this.importError.set(null);
   }
@@ -145,7 +167,7 @@ export class ShapeCompareCardComponent {
     this.liveSides().length >= 2 ? compareExports(this.resolved()) : null
   );
 
-  /** Ordered side chips; index drives the color pairing everywhere below. */
+  /** Ordered side chips; each carries its side's identity color. */
   readonly sideVms = computed(() =>
     this.liveSides().map((side, index) => ({
       id: side.id,
@@ -153,17 +175,20 @@ export class ShapeCompareCardComponent {
       label: side.kind === 'file'
         ? (side.file as LabelledExport).label
         : this.sections().find(s => s.guid === side.guid)?.name ?? '',
-      dotClass: SIDE_BG[index % SIDE_BG.length],
+      dotClass: SIDE_BG[side.color % SIDE_BG.length],
       isBaseline: index === 0,
     }))
   );
 
+  /** Identity color of the side at comparison position `index` (values arrays are side-ordered). */
   sideDot(index: number): string {
-    return SIDE_BG[index % SIDE_BG.length];
+    const side = this.liveSides()[index];
+    return SIDE_BG[(side?.color ?? index) % SIDE_BG.length];
   }
 
   sideText(index: number): string {
-    return SIDE_TEXT[index % SIDE_TEXT.length];
+    const side = this.liveSides()[index];
+    return SIDE_TEXT[(side?.color ?? index) % SIDE_TEXT.length];
   }
 
   readonly listVms = computed(() => {
@@ -234,7 +259,7 @@ export class ShapeCompareCardComponent {
           const delta = i > 0 && row.shares[0] !== undefined ? ` · ${ptsText(share - row.shares[0])}` : '';
           return {
             width: Math.max(share * 100, 0.5),
-            fillClass: SIDE_BG[i % SIDE_BG.length],
+            fillClass: this.sideDot(i),
             label: `${row.counts[i]} · ${pctText(share)}${delta}`,
           };
         }),
@@ -250,7 +275,7 @@ export class ShapeCompareCardComponent {
     return cmp.topShare.map(row => {
       const parts = row.values.map((share, i) => ({
         text: share ? pctText(share.fraction) : share === null ? 'no data' : 'not measured',
-        colorClass: SIDE_TEXT[i % SIDE_TEXT.length],
+        colorClass: this.sideText(i),
       }));
       const baseline = row.values[0];
       const deltas = row.values
@@ -290,7 +315,7 @@ export class ShapeCompareCardComponent {
       title: humanize(row.key),
       sides: row.values.map((d, i) => ({
         label: cmp.sides[i].label,
-        dotClass: SIDE_BG[i % SIDE_BG.length],
+        dotClass: this.sideDot(i),
         state: d ? ('data' as const) : d === null ? ('empty' as const) : ('missing' as const),
         cells: d ? [d.n, d.median, d.p90, d.max, d.mean, d.sum] : [],
       })),

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
@@ -14,31 +14,13 @@ import { TopShare } from './shape-stats';
 const UNCHANGED_SHOWN = 5;
 
 /**
- * Identity color slots: blue, amber, teal, slate, violet, rose, green, lime —
- * eight distinct hues so a side's color stays unique well past the usual
- * endpoint count (colors repeat only from the ninth concurrent side).
- * Literal class strings so the Tailwind scanner picks every variant up.
+ * Identity color for a slot: hues spaced evenly around the OKLCH wheel over a
+ * range sized to CONTAIN the current side capacity (never an exact fit, so
+ * there is always headroom and never a repeat). Anchored at blue; mid-tone
+ * lightness/chroma reads on both the light and the dark theme.
  */
-const SIDE_BG = [
-  'bg-[#2a78d6] dark:bg-[#3987e5]',
-  'bg-[#d97706] dark:bg-[#f59e0b]',
-  'bg-[#0d9488] dark:bg-[#14b8a6]',
-  'bg-[#64748b] dark:bg-[#94a3b8]',
-  'bg-[#7c3aed] dark:bg-[#8b5cf6]',
-  'bg-[#db2777] dark:bg-[#ec4899]',
-  'bg-[#16a34a] dark:bg-[#22c55e]',
-  'bg-[#65a30d] dark:bg-[#84cc16]',
-];
-const SIDE_TEXT = [
-  'text-[#2a78d6] dark:text-[#3987e5]',
-  'text-[#d97706] dark:text-[#f59e0b]',
-  'text-[#0d9488] dark:text-[#14b8a6]',
-  'text-[#64748b] dark:text-[#94a3b8]',
-  'text-[#7c3aed] dark:text-[#8b5cf6]',
-  'text-[#db2777] dark:text-[#ec4899]',
-  'text-[#16a34a] dark:text-[#22c55e]',
-  'text-[#65a30d] dark:text-[#84cc16]',
-];
+const sideColorAt = (slot: number, rangeSize: number): string =>
+  `oklch(62% 0.16 ${(262 + (slot * 360) / rangeSize) % 360}deg)`;
 
 const humanize = (key: string): string => key.replace(/_/g, ' ');
 const pctText = (fraction: number): string => `${(fraction * 100).toFixed(1)}%`;
@@ -116,10 +98,23 @@ export class ShapeCompareCardComponent {
     );
   }
 
-  /** The endpoint's identity color chip for its section bar; null when not selected. */
+  /**
+   * The color range is sized by the endpoints on the page (plus imported
+   * files): at least 8, grown in fours, always containing the capacity.
+   */
+  readonly paletteSize = computed(() => {
+    const capacity = this.sections().length + this.sides().filter(side => side.kind === 'file').length;
+    return Math.max(8, Math.ceil(capacity / 4) * 4);
+  });
+
+  private colorOfSlot(slot: number): string {
+    return sideColorAt(slot, this.paletteSize());
+  }
+
+  /** The endpoint's identity color for its section bar chip; null when not selected. */
   dotFor(guid: string): string | null {
     const side = this.sides().find(s => s.guid === guid);
-    return side ? SIDE_BG[side.color % SIDE_BG.length] : null;
+    return side ? this.colorOfSlot(side.color) : null;
   }
 
   /** Template hook for the hidden file input; the parse work lives in importFrom. */
@@ -185,20 +180,15 @@ export class ShapeCompareCardComponent {
       label: side.kind === 'file'
         ? (side.file as LabelledExport).label
         : this.sections().find(s => s.guid === side.guid)?.name ?? '',
-      dotClass: SIDE_BG[side.color % SIDE_BG.length],
+      dotColor: this.colorOfSlot(side.color),
       isBaseline: index === 0,
     }))
   );
 
   /** Identity color of the side at comparison position `index` (values arrays are side-ordered). */
-  sideDot(index: number): string {
+  sideColor(index: number): string {
     const side = this.liveSides()[index];
-    return SIDE_BG[(side?.color ?? index) % SIDE_BG.length];
-  }
-
-  sideText(index: number): string {
-    const side = this.liveSides()[index];
-    return SIDE_TEXT[(side?.color ?? index) % SIDE_TEXT.length];
+    return this.colorOfSlot(side?.color ?? index);
   }
 
   readonly listVms = computed(() => {
@@ -269,7 +259,7 @@ export class ShapeCompareCardComponent {
           const delta = i > 0 && row.shares[0] !== undefined ? ` · ${ptsText(share - row.shares[0])}` : '';
           return {
             width: Math.max(share * 100, 0.5),
-            fillClass: this.sideDot(i),
+            fill: this.sideColor(i),
             label: `${row.counts[i]} · ${pctText(share)}${delta}`,
           };
         }),
@@ -285,7 +275,7 @@ export class ShapeCompareCardComponent {
     return cmp.topShare.map(row => {
       const parts = row.values.map((share, i) => ({
         text: share ? pctText(share.fraction) : share === null ? 'no data' : 'not measured',
-        colorClass: this.sideText(i),
+        color: this.sideColor(i),
       }));
       const baseline = row.values[0];
       const deltas = row.values
@@ -325,7 +315,7 @@ export class ShapeCompareCardComponent {
       title: humanize(row.key),
       sides: row.values.map((d, i) => ({
         label: cmp.sides[i].label,
-        dotClass: this.sideDot(i),
+        dotColor: this.sideColor(i),
         state: d ? ('data' as const) : d === null ? ('empty' as const) : ('missing' as const),
         cells: d ? [d.n, d.median, d.p90, d.max, d.mean, d.sum] : [],
       })),

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare-card.component.ts
@@ -1,0 +1,247 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal, WritableSignal } from '@angular/core';
+
+import {
+  CategoryRow,
+  compareExports,
+  ComparedValue,
+  LabelledExport,
+  parseImportedExport,
+  ShapeComparison,
+} from './shape-compare';
+import { ShapeMeasureService } from './shape-measure.service';
+import { sectionExportPayload, ShapeSection } from './shape-section';
+import { Distribution, TopShare } from './shape-stats';
+
+type SlotId = 'a' | 'b';
+
+/** How many unchanged chips a list shows before collapsing behind "n more". */
+const UNCHANGED_SHOWN = 5;
+
+const humanize = (key: string): string => key.replace(/_/g, ' ');
+const pctText = (fraction: number): string => `${(fraction * 100).toFixed(1)}%`;
+const ptsText = (delta: number): string => `${delta >= 0 ? '+' : ''}${(delta * 100).toFixed(1)} pts`;
+
+interface BarVm {
+  width: number;
+  label: string;
+}
+
+/**
+ * Promotion-verification comparison (GH #5702 follow-on): two slots, each a
+ * live endpoint section or an imported schema_version 1 export file, diffed
+ * with ecosystem and composition emphasis. Reads only what both sides
+ * measured; nothing here issues CF requests.
+ */
+@Component({
+  selector: 'app-shape-compare-card',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './shape-compare-card.component.html',
+})
+export class ShapeCompareCardComponent {
+  private readonly measure = inject(ShapeMeasureService);
+
+  readonly sections = input.required<ShapeSection[]>();
+
+  readonly choiceA = signal<string | null>(null);
+  readonly choiceB = signal<string | null>(null);
+  readonly fileA = signal<LabelledExport | null>(null);
+  readonly fileB = signal<LabelledExport | null>(null);
+  readonly errorA = signal<string | null>(null);
+  readonly errorB = signal<string | null>(null);
+  private readonly expandedLists = signal<ReadonlySet<string>>(new Set());
+
+  choice(slot: SlotId): WritableSignal<string | null> {
+    return slot === 'a' ? this.choiceA : this.choiceB;
+  }
+
+  file(slot: SlotId): WritableSignal<LabelledExport | null> {
+    return slot === 'a' ? this.fileA : this.fileB;
+  }
+
+  error(slot: SlotId): WritableSignal<string | null> {
+    return slot === 'a' ? this.errorA : this.errorB;
+  }
+
+  /** Side A defaults to the first live section; B stays unset until chosen. */
+  effectiveChoice(slot: SlotId): string | null {
+    const choice = this.choice(slot)();
+    if (choice) {
+      return choice;
+    }
+    return slot === 'a' && this.sections().length ? `live:${this.sections()[0].guid}` : null;
+  }
+
+  onSelect(slot: SlotId, value: string): void {
+    this.choice(slot).set(value || null);
+    this.error(slot).set(null);
+  }
+
+  /** Template hook for the hidden file input; the parse work lives in importFrom. */
+  importFile(slot: SlotId, event: Event): void {
+    const inputEl = event.target as HTMLInputElement;
+    const file = inputEl.files?.[0];
+    inputEl.value = '';
+    if (file) {
+      void this.importFrom(slot, file);
+    }
+  }
+
+  async importFrom(slot: SlotId, file: File): Promise<void> {
+    const { exported, error } = parseImportedExport(await file.text());
+    if (!exported) {
+      this.error(slot).set(`${file.name}: ${error}`);
+      return;
+    }
+    const label = exported.foundation_label || file.name.replace(/\.json$/i, '');
+    this.file(slot).set({ label, exported });
+    this.choice(slot).set('file');
+    this.error(slot).set(null);
+  }
+
+  swap(): void {
+    const [choiceA, choiceB] = [this.effectiveChoice('a'), this.effectiveChoice('b')];
+    const [fileA, fileB] = [this.fileA(), this.fileB()];
+    this.choiceA.set(choiceB);
+    this.choiceB.set(choiceA);
+    this.fileA.set(fileB);
+    this.fileB.set(fileA);
+    this.errorA.set(null);
+    this.errorB.set(null);
+  }
+
+  private resolveSlot(slot: SlotId): LabelledExport | null {
+    const choice = this.effectiveChoice(slot);
+    if (!choice) {
+      return null;
+    }
+    if (choice === 'file') {
+      return this.file(slot)();
+    }
+    const guid = choice.slice('live:'.length);
+    const section = this.sections().find(s => s.guid === guid);
+    if (!section) {
+      return null;
+    }
+    return {
+      label: section.name,
+      exported: sectionExportPayload(section, this.measure.totals().get(guid), this.measure.ecosystem().get(guid)),
+    };
+  }
+
+  readonly comparison = computed<ShapeComparison | null>(() => {
+    const a = this.resolveSlot('a');
+    const b = this.resolveSlot('b');
+    return a && b ? compareExports(a, b) : null;
+  });
+
+  /** Imported-file description for a slot header (live slots show their name in the select). */
+  fileNote(slot: SlotId): string | null {
+    return this.effectiveChoice(slot) === 'file' ? this.file(slot)()?.label ?? null : null;
+  }
+
+  readonly listVms = computed(() => {
+    const cmp = this.comparison();
+    if (!cmp) {
+      return [];
+    }
+    const expanded = this.expandedLists();
+    return cmp.lists.map(list => {
+      const isOpen = expanded.has(list.key);
+      const shown = isOpen ? list.unchanged : list.unchanged.slice(0, UNCHANGED_SHOWN);
+      return {
+        key: list.key,
+        title: humanize(list.key),
+        added: list.added,
+        removed: list.removed,
+        shown,
+        more: list.unchanged.length - shown.length,
+        isOpen,
+      };
+    });
+  });
+
+  toggleList(key: string): void {
+    const next = new Set(this.expandedLists());
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    this.expandedLists.set(next);
+  }
+
+  private barVm(count: number | undefined, share: number | undefined): BarVm | null {
+    if (share === undefined || count === undefined) {
+      return null;
+    }
+    return { width: Math.max(share * 100, 0.5), label: `${count} · ${pctText(share)}` };
+  }
+
+  readonly categoricalVms = computed(() => {
+    const cmp = this.comparison();
+    if (!cmp) {
+      return [];
+    }
+    return cmp.categorical.map(({ dimension, rows }) => ({
+      dimension,
+      title: humanize(dimension),
+      rows: rows.map((row: CategoryRow) => ({
+        category: row.category,
+        a: this.barVm(row.a, row.aShare),
+        b: this.barVm(row.b, row.bShare),
+        delta: row.aShare !== undefined && row.bShare !== undefined ? ptsText(row.bShare - row.aShare) : '—',
+      })),
+    }));
+  });
+
+  readonly tileVms = computed(() => {
+    const cmp = this.comparison();
+    if (!cmp) {
+      return [];
+    }
+    const text = (share: TopShare | null | undefined): string =>
+      share ? pctText(share.fraction) : share === null ? 'no data' : 'not measured';
+    return cmp.topShare.map((row: ComparedValue<TopShare>) => ({
+      label: humanize(row.key),
+      a: text(row.a),
+      b: text(row.b),
+      delta: row.a && row.b ? ptsText(row.b.fraction - row.a.fraction) : '',
+    }));
+  });
+
+  readonly totalsVms = computed(() => {
+    const cmp = this.comparison();
+    if (!cmp) {
+      return [];
+    }
+    const cell = (value: number | null | undefined): string => (value === undefined || value === null ? '—' : String(value));
+    return cmp.totals.map((row: ComparedValue<number>) => ({
+      label: humanize(row.key),
+      a: cell(row.a),
+      b: cell(row.b),
+      delta:
+        typeof row.a === 'number' && typeof row.b === 'number'
+          ? `${row.b - row.a >= 0 ? '+' : ''}${row.b - row.a}`
+          : '—',
+    }));
+  });
+
+  readonly distVms = computed(() => {
+    const cmp = this.comparison();
+    if (!cmp) {
+      return [];
+    }
+    const side = (label: string, d: Distribution | null | undefined) => ({
+      label,
+      state: d ? ('data' as const) : d === null ? ('empty' as const) : ('missing' as const),
+      cells: d ? [d.n, d.median, d.p90, d.max, d.mean, d.sum] : [],
+    });
+    return cmp.distributions.map((row: ComparedValue<Distribution>) => ({
+      key: row.key,
+      title: humanize(row.key),
+      a: side(cmp.a.label, row.a),
+      b: side(cmp.b.label, row.b),
+    }));
+  });
+}

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeSessionShape } from './session-shape';
+import { AgnosticExport, buildAgnosticExport } from './shape-export';
+import { compareExports, parseImportedExport, ShapeComparison } from './shape-compare';
+import { app, org, space } from './testing/entity-builders';
+
+const SESSION_TOTALS = {
+  orgs: 2,
+  spaces: 1 as number | null,
+  apps: 1,
+  routes: 5,
+  serviceInstances: 3,
+  serviceOfferings: 4,
+  servicePlans: 6,
+  serviceBrokers: 1,
+};
+
+const ALL_DRAINS = { counts: true, servicesCounts: true, orgs: true, spaces: true, apps: true };
+
+const exportOf = (apps: ReturnType<typeof app>[], overrides: Partial<AgnosticExport> = {}): AgnosticExport => ({
+  ...buildAgnosticExport({
+    shape: computeSessionShape([org('o1'), org('o2')], [space('s1', 'o1')], apps),
+    sessionTotals: { ...SESSION_TOTALS, apps: apps.length },
+    drains: ALL_DRAINS,
+    collectedAt: new Date('2026-08-01T12:00:00Z'),
+  }),
+  ...overrides,
+});
+
+const A_APPS = [
+  app('a1', { spaceGuid: 's1', orgGuid: 'o1', memory: 256, stackName: 'cflinuxfs3' }),
+  app('a2', { spaceGuid: 's1', orgGuid: 'o1', memory: 512, stackName: 'cflinuxfs4', state: 'STOPPED' }),
+];
+const B_APPS = [
+  app('b1', { spaceGuid: 's1', orgGuid: 'o1', memory: 256, stackName: 'cflinuxfs4' }),
+  app('b2', { spaceGuid: 's1', orgGuid: 'o1', memory: 256, stackName: 'cflinuxfs4' }),
+];
+
+const compare = (a: AgnosticExport, b: AgnosticExport): ShapeComparison =>
+  compareExports({ label: 'lab', exported: a }, { label: 'aws', exported: b });
+
+describe('compareExports', () => {
+  it('labels both sides and unions totals keys, keeping one-sided keys visible', () => {
+    const a = exportOf(A_APPS);
+    const b = exportOf(B_APPS, { totals: { organizations: 5, quotas: 7 } });
+    const comparison = compare(a, b);
+    expect(comparison.a).toEqual({ label: 'lab', collectedAt: '2026-08-01T12:00:00.000Z' });
+    const orgsRow = comparison.totals.find(row => row.key === 'organizations');
+    expect(orgsRow).toEqual({ key: 'organizations', a: 2, b: 5 });
+    // quotas was measured on b only: the a side stays undefined, not 0
+    const quotasRow = comparison.totals.find(row => row.key === 'quotas');
+    expect(quotasRow).toEqual({ key: 'quotas', b: 7 });
+    expect(quotasRow && 'a' in quotasRow).toBe(false);
+  });
+
+  it('keeps measured-but-empty (null) distinct from never-measured (absent)', () => {
+    const a = exportOf([]); // apps drained, none exist: routes_per_app is null
+    const b = exportOf(B_APPS);
+    delete b.distributions.spaces_per_org; // never measured on b
+    const comparison = compare(a, b);
+    const routes = comparison.distributions.find(row => row.key === 'routes_per_app');
+    expect(routes?.a).toBeNull();
+    expect(routes?.b).toMatchObject({ n: 2 });
+    const spaces = comparison.distributions.find(row => row.key === 'spaces_per_org');
+    expect(spaces && 'b' in spaces).toBe(false);
+    expect(spaces?.a).toMatchObject({ n: 2 });
+  });
+
+  it('diffs categorical dimensions as counts and shares, zero-filling missing categories', () => {
+    const comparison = compare(exportOf(A_APPS), exportOf(B_APPS));
+    const stacks = comparison.categorical.find(c => c.dimension === 'stacks_pinned_by_apps');
+    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs3', a: 1, aShare: 0.5, b: 0, bShare: 0 });
+    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs4', a: 1, aShare: 0.5, b: 2, bShare: 1 });
+    const states = comparison.categorical.find(c => c.dimension === 'app_state');
+    expect(states?.rows).toContainEqual({ category: 'STOPPED', a: 1, aShare: 0.5, b: 0, bShare: 0 });
+  });
+
+  it('diffs defined lists as added/removed/unchanged with multiset multiplicity', () => {
+    const a = exportOf(A_APPS, {
+      composition: {
+        stacks_defined: ['cflinuxfs3', 'cflinuxfs4'],
+        buildpacks_defined: ['ruby_buildpack', 'go_buildpack'],
+      },
+    });
+    const b = exportOf(B_APPS, {
+      composition: {
+        stacks_defined: ['cflinuxfs4'],
+        buildpacks_defined: ['ruby_buildpack', 'ruby_buildpack', 'java_buildpack'],
+      },
+    });
+    const comparison = compare(a, b);
+    expect(comparison.lists).toContainEqual({
+      key: 'stacks_defined', added: [], removed: ['cflinuxfs3'], unchanged: ['cflinuxfs4'],
+    });
+    expect(comparison.lists).toContainEqual({
+      key: 'buildpacks_defined',
+      added: ['ruby_buildpack ×2', 'java_buildpack'],
+      removed: ['ruby_buildpack', 'go_buildpack'],
+      unchanged: [],
+    });
+  });
+
+  it('carries top-share pairs through', () => {
+    const comparison = compare(exportOf(A_APPS), exportOf(B_APPS));
+    const row = comparison.topShare.find(r => r.key === 'apps_in_largest_space');
+    expect(row?.a).toEqual({ largest_holds: 2, fraction: 1 });
+    expect(row?.b).toEqual({ largest_holds: 2, fraction: 1 });
+  });
+});
+
+describe('parseImportedExport', () => {
+  it('round-trips a real export', () => {
+    const { exported, error } = parseImportedExport(JSON.stringify(exportOf(A_APPS)));
+    expect(error).toBeUndefined();
+    expect(exported?.schema_version).toBe(1);
+    expect(compare(exported as AgnosticExport, exportOf(B_APPS)).totals.length).toBeGreaterThan(0);
+  });
+
+  it('rejects non-JSON, wrong schema versions, and non-export JSON with reasons', () => {
+    expect(parseImportedExport('nope{').error).toBe('not valid JSON');
+    expect(parseImportedExport('{"schema_version":2}').error).toContain('schema_version');
+    expect(parseImportedExport('{"schema_version":1}').error).toContain('missing totals');
+    expect(parseImportedExport('null').error).toBe('not a shape export');
+  });
+
+  it('defaults missing top_share and composition so comparison never trips', () => {
+    const raw = JSON.stringify({ schema_version: 1, collected_at: 'x', totals: { apps: 1 }, distributions: {} });
+    const { exported } = parseImportedExport(raw);
+    expect(exported?.distributions.top_share).toEqual({});
+    expect(exported?.composition).toEqual({});
+    expect(compare(exported as AgnosticExport, exportOf(B_APPS)).totals.length).toBeGreaterThan(0);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { computeSessionShape } from './session-shape';
 import { AgnosticExport, buildAgnosticExport } from './shape-export';
-import { compareExports, parseImportedExport, ShapeComparison } from './shape-compare';
+import { compareExports, parseImportedExport } from './shape-compare';
 import { app, org, space } from './testing/entity-builders';
 
 const SESSION_TOTALS = {
@@ -37,46 +37,60 @@ const B_APPS = [
   app('b2', { spaceGuid: 's1', orgGuid: 'o1', memory: 256, stackName: 'cflinuxfs4' }),
 ];
 
-const compare = (a: AgnosticExport, b: AgnosticExport): ShapeComparison =>
-  compareExports({ label: 'lab', exported: a }, { label: 'aws', exported: b });
-
 describe('compareExports', () => {
-  it('labels both sides and unions totals keys, keeping one-sided keys visible', () => {
-    const a = exportOf(A_APPS);
-    const b = exportOf(B_APPS, { totals: { organizations: 5, quotas: 7 } });
-    const comparison = compare(a, b);
-    expect(comparison.a).toEqual({ label: 'lab', collectedAt: '2026-08-01T12:00:00.000Z' });
-    const orgsRow = comparison.totals.find(row => row.key === 'organizations');
-    expect(orgsRow).toEqual({ key: 'organizations', a: 2, b: 5 });
-    // quotas was measured on b only: the a side stays undefined, not 0
-    const quotasRow = comparison.totals.find(row => row.key === 'quotas');
-    expect(quotasRow).toEqual({ key: 'quotas', b: 7 });
-    expect(quotasRow && 'a' in quotasRow).toBe(false);
+  it('labels the sides in order and unions totals keys, keeping one-sided keys visible', () => {
+    const comparison = compareExports([
+      { label: 'lab', exported: exportOf(A_APPS) },
+      { label: 'aws', exported: exportOf(B_APPS, { totals: { organizations: 5, quotas: 7 } }) },
+    ]);
+    expect(comparison.sides.map(s => s.label)).toEqual(['lab', 'aws']);
+    expect(comparison.totals.find(row => row.key === 'organizations')?.values).toEqual([2, 5]);
+    // quotas was measured on the second side only: the first stays undefined, not 0
+    expect(comparison.totals.find(row => row.key === 'quotas')?.values).toEqual([undefined, 7]);
   });
 
   it('keeps measured-but-empty (null) distinct from never-measured (absent)', () => {
     const a = exportOf([]); // apps drained, none exist: routes_per_app is null
     const b = exportOf(B_APPS);
     delete b.distributions.spaces_per_org; // never measured on b
-    const comparison = compare(a, b);
+    const comparison = compareExports([
+      { label: 'a', exported: a },
+      { label: 'b', exported: b },
+    ]);
     const routes = comparison.distributions.find(row => row.key === 'routes_per_app');
-    expect(routes?.a).toBeNull();
-    expect(routes?.b).toMatchObject({ n: 2 });
+    expect(routes?.values[0]).toBeNull();
+    expect(routes?.values[1]).toMatchObject({ n: 2 });
     const spaces = comparison.distributions.find(row => row.key === 'spaces_per_org');
-    expect(spaces && 'b' in spaces).toBe(false);
-    expect(spaces?.a).toMatchObject({ n: 2 });
+    expect(spaces?.values[0]).toMatchObject({ n: 2 });
+    expect(spaces?.values[1]).toBeUndefined();
   });
 
   it('diffs categorical dimensions as counts and shares, zero-filling missing categories', () => {
-    const comparison = compare(exportOf(A_APPS), exportOf(B_APPS));
+    const comparison = compareExports([
+      { label: 'a', exported: exportOf(A_APPS) },
+      { label: 'b', exported: exportOf(B_APPS) },
+    ]);
     const stacks = comparison.categorical.find(c => c.dimension === 'stacks_pinned_by_apps');
-    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs3', a: 1, aShare: 0.5, b: 0, bShare: 0 });
-    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs4', a: 1, aShare: 0.5, b: 2, bShare: 1 });
+    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs3', counts: [1, 0], shares: [0.5, 0] });
+    expect(stacks?.rows).toContainEqual({ category: 'cflinuxfs4', counts: [1, 2], shares: [0.5, 1] });
     const states = comparison.categorical.find(c => c.dimension === 'app_state');
-    expect(states?.rows).toContainEqual({ category: 'STOPPED', a: 1, aShare: 0.5, b: 0, bShare: 0 });
+    expect(states?.rows).toContainEqual({ category: 'STOPPED', counts: [1, 0], shares: [0.5, 0] });
   });
 
-  it('diffs defined lists as added/removed/unchanged with multiset multiplicity', () => {
+  it('marks an unmeasured dimension side undefined instead of zero-filling it', () => {
+    const b = exportOf(B_APPS);
+    delete b.composition.app_state;
+    const comparison = compareExports([
+      { label: 'a', exported: exportOf(A_APPS) },
+      { label: 'b', exported: b },
+    ]);
+    const states = comparison.categorical.find(c => c.dimension === 'app_state');
+    const started = states?.rows.find(row => row.category === 'STARTED');
+    expect(started?.counts).toEqual([1, undefined]);
+    expect(started?.shares).toEqual([0.5, undefined]);
+  });
+
+  it('builds a presence matrix over defined lists with multiset multiplicity', () => {
     const a = exportOf(A_APPS, {
       composition: {
         stacks_defined: ['cflinuxfs3', 'cflinuxfs4'],
@@ -89,32 +103,65 @@ describe('compareExports', () => {
         buildpacks_defined: ['ruby_buildpack', 'ruby_buildpack', 'java_buildpack'],
       },
     });
-    const comparison = compare(a, b);
-    expect(comparison.lists).toContainEqual({
-      key: 'stacks_defined', added: [], removed: ['cflinuxfs3'], unchanged: ['cflinuxfs4'],
-    });
-    expect(comparison.lists).toContainEqual({
-      key: 'buildpacks_defined',
-      added: ['ruby_buildpack ×2', 'java_buildpack'],
-      removed: ['ruby_buildpack', 'go_buildpack'],
-      unchanged: [],
-    });
+    const comparison = compareExports([
+      { label: 'a', exported: a },
+      { label: 'b', exported: b },
+    ]);
+    const stacks = comparison.lists.find(l => l.key === 'stacks_defined');
+    expect(stacks?.measured).toEqual([true, true]);
+    expect(stacks?.rows).toContainEqual({ label: 'cflinuxfs3', present: [true, false] });
+    expect(stacks?.rows).toContainEqual({ label: 'cflinuxfs4', present: [true, true] });
+    const buildpacks = comparison.lists.find(l => l.key === 'buildpacks_defined');
+    expect(buildpacks?.rows).toContainEqual({ label: 'ruby_buildpack', present: [true, false] });
+    expect(buildpacks?.rows).toContainEqual({ label: 'ruby_buildpack ×2', present: [false, true] });
+    expect(buildpacks?.rows).toContainEqual({ label: 'go_buildpack', present: [true, false] });
+    expect(buildpacks?.rows).toContainEqual({ label: 'java_buildpack', present: [false, true] });
   });
 
-  it('carries top-share pairs through', () => {
-    const comparison = compare(exportOf(A_APPS), exportOf(B_APPS));
+  it('flags a side that never measured a list instead of treating it as empty', () => {
+    const comparison = compareExports([
+      { label: 'a', exported: exportOf(A_APPS, { composition: { stacks_defined: ['cflinuxfs4'] } }) },
+      { label: 'b', exported: exportOf(B_APPS) },
+    ]);
+    const stacks = comparison.lists.find(l => l.key === 'stacks_defined');
+    expect(stacks?.measured).toEqual([true, false]);
+  });
+
+  it('carries top-share values through per side', () => {
+    const comparison = compareExports([
+      { label: 'a', exported: exportOf(A_APPS) },
+      { label: 'b', exported: exportOf(B_APPS) },
+    ]);
     const row = comparison.topShare.find(r => r.key === 'apps_in_largest_space');
-    expect(row?.a).toEqual({ largest_holds: 2, fraction: 1 });
-    expect(row?.b).toEqual({ largest_holds: 2, fraction: 1 });
+    expect(row?.values).toEqual([
+      { largest_holds: 2, fraction: 1 },
+      { largest_holds: 2, fraction: 1 },
+    ]);
+  });
+
+  it('compares three sides with index-aligned values', () => {
+    const comparison = compareExports([
+      { label: 'dev', exported: exportOf(A_APPS) },
+      { label: 'staging', exported: exportOf(B_APPS) },
+      { label: 'prod', exported: exportOf([]) },
+    ]);
+    expect(comparison.sides).toHaveLength(3);
+    expect(comparison.totals.find(row => row.key === 'apps')?.values).toEqual([2, 2, 0]);
+    const stacks = comparison.categorical.find(c => c.dimension === 'stacks_pinned_by_apps');
+    expect(stacks?.rows.find(r => r.category === 'cflinuxfs4')?.counts).toEqual([1, 2, 0]);
   });
 });
 
 describe('parseImportedExport', () => {
-  it('round-trips a real export', () => {
+  it('round-trips a real export into a comparison side', () => {
     const { exported, error } = parseImportedExport(JSON.stringify(exportOf(A_APPS)));
     expect(error).toBeUndefined();
     expect(exported?.schema_version).toBe(1);
-    expect(compare(exported as AgnosticExport, exportOf(B_APPS)).totals.length).toBeGreaterThan(0);
+    const comparison = compareExports([
+      { label: 'file', exported: exported as AgnosticExport },
+      { label: 'live', exported: exportOf(B_APPS) },
+    ]);
+    expect(comparison.totals.length).toBeGreaterThan(0);
   });
 
   it('rejects non-JSON, wrong schema versions, and non-export JSON with reasons', () => {
@@ -129,6 +176,10 @@ describe('parseImportedExport', () => {
     const { exported } = parseImportedExport(raw);
     expect(exported?.distributions.top_share).toEqual({});
     expect(exported?.composition).toEqual({});
-    expect(compare(exported as AgnosticExport, exportOf(B_APPS)).totals.length).toBeGreaterThan(0);
+    const comparison = compareExports([
+      { label: 'file', exported: exported as AgnosticExport },
+      { label: 'live', exported: exportOf(B_APPS) },
+    ]);
+    expect(comparison.totals.length).toBeGreaterThan(0);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
@@ -182,7 +182,7 @@ export const parseImportedExport = (raw: string): { exported?: AgnosticExport; e
   return {
     exported: {
       ...exported,
-      distributions: { top_share: {}, ...exported.distributions },
+      distributions: { ...exported.distributions, top_share: exported.distributions.top_share ?? {} },
       composition: exported.composition ?? {},
     },
   };

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
@@ -1,0 +1,189 @@
+/**
+ * Pure comparison of two foundation shapes (GH #5702 follow-on): the
+ * promotion-verification view. Both sides are schema_version 1 exports —
+ * a live section's projection or an imported file — and the comparison
+ * walks what each side actually measured: an absent key means "not
+ * measured" on that side (never-loaded ≠ empty), a null distribution
+ * means measured-but-empty, and neither is ever presented as a zero.
+ *
+ * Emphasis follows the promotion question — did a stack migration,
+ * buildpack update, or app rollout propagate — so ecosystem lists diff as
+ * added/removed and categorical compositions diff as share deltas, with
+ * totals and distribution key-stats as the secondary table.
+ */
+import { AgnosticExport, isDist } from './shape-export';
+import { Distribution, TopShare } from './shape-stats';
+
+/** undefined = that side never measured this; null = measured, empty. */
+export interface ComparedValue<T> {
+  key: string;
+  a?: T | null;
+  b?: T | null;
+}
+
+export interface CategoryRow {
+  category: string;
+  /** undefined = dimension unmeasured on that side; counts are real zeros otherwise. */
+  a?: number;
+  b?: number;
+  /** Share of the side's dimension total, 0..1; undefined when unmeasured. */
+  aShare?: number;
+  bShare?: number;
+}
+
+export interface ListDiff {
+  key: string;
+  added: string[];
+  removed: string[];
+  unchanged: string[];
+}
+
+export interface ShapeComparison {
+  a: { label: string; collectedAt: string };
+  b: { label: string; collectedAt: string };
+  totals: ComparedValue<number>[];
+  distributions: ComparedValue<Distribution>[];
+  topShare: ComparedValue<TopShare>[];
+  /** One entry per categorical dimension measured on at least one side. */
+  categorical: { dimension: string; rows: CategoryRow[] }[];
+  /** Defined-list diffs; multiset entries render as "name ×n". */
+  lists: ListDiff[];
+}
+
+/** Union of both sides' keys, a-side order first — comparison rows never drop a key. */
+const unionKeys = (a: Record<string, unknown>, b: Record<string, unknown>): string[] => {
+  const keys = Object.keys(a);
+  for (const key of Object.keys(b)) {
+    if (!keys.includes(key)) {
+      keys.push(key);
+    }
+  }
+  return keys;
+};
+
+const comparedValues = <T>(
+  a: Record<string, T | null | undefined>,
+  b: Record<string, T | null | undefined>
+): ComparedValue<T>[] =>
+  unionKeys(a, b).map(key => {
+    const row: ComparedValue<T> = { key };
+    if (key in a) {
+      row.a = a[key] as T | null;
+    }
+    if (key in b) {
+      row.b = b[key] as T | null;
+    }
+    return row;
+  });
+
+const categoricalRows = (
+  a: Record<string, number> | undefined,
+  b: Record<string, number> | undefined
+): CategoryRow[] => {
+  const aTotal = Object.values(a ?? {}).reduce((acc, v) => acc + v, 0);
+  const bTotal = Object.values(b ?? {}).reduce((acc, v) => acc + v, 0);
+  return unionKeys(a ?? {}, b ?? {}).map(category => {
+    const row: CategoryRow = { category };
+    if (a) {
+      row.a = a[category] ?? 0;
+      row.aShare = aTotal ? row.a / aTotal : 0;
+    }
+    if (b) {
+      row.b = b[category] ?? 0;
+      row.bShare = bTotal ? row.b / bTotal : 0;
+    }
+    return row;
+  });
+};
+
+/** Multiset entries collapse to "name ×n" so a second stack's build of the same buildpack shows. */
+const multisetLabels = (names: string[]): string[] => {
+  const counts = new Map<string, number>();
+  for (const name of names) {
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([name, count]) => (count > 1 ? `${name} ×${count}` : name));
+};
+
+const listDiff = (key: string, a: string[] | undefined, b: string[] | undefined): ListDiff => {
+  const aLabels = multisetLabels(a ?? []);
+  const bLabels = multisetLabels(b ?? []);
+  return {
+    key,
+    added: bLabels.filter(label => !aLabels.includes(label)),
+    removed: aLabels.filter(label => !bLabels.includes(label)),
+    unchanged: aLabels.filter(label => bLabels.includes(label)),
+  };
+};
+
+const distEntries = (exported: AgnosticExport): Record<string, Distribution | null> => {
+  const entries: Record<string, Distribution | null> = {};
+  for (const source of [exported.distributions, exported.composition]) {
+    for (const [key, value] of Object.entries(source)) {
+      if (isDist(value) || value === null) {
+        entries[key] = value as Distribution | null;
+      }
+    }
+  }
+  return entries;
+};
+
+export interface LabelledExport {
+  label: string;
+  exported: AgnosticExport;
+}
+
+export const compareExports = (a: LabelledExport, b: LabelledExport): ShapeComparison => {
+  const dimensions = ['app_state', 'stacks_pinned_by_apps'] as const;
+  const lists = ['stacks_defined', 'buildpacks_defined'] as const;
+  return {
+    a: { label: a.label, collectedAt: a.exported.collected_at },
+    b: { label: b.label, collectedAt: b.exported.collected_at },
+    totals: comparedValues(a.exported.totals, b.exported.totals),
+    distributions: comparedValues(distEntries(a.exported), distEntries(b.exported)),
+    topShare: comparedValues(
+      a.exported.distributions.top_share as Record<string, TopShare | null>,
+      b.exported.distributions.top_share as Record<string, TopShare | null>
+    ),
+    categorical: dimensions
+      .filter(dimension => a.exported.composition[dimension] || b.exported.composition[dimension])
+      .map(dimension => ({
+        dimension,
+        rows: categoricalRows(a.exported.composition[dimension], b.exported.composition[dimension]),
+      })),
+    lists: lists
+      .filter(key => a.exported.composition[key] || b.exported.composition[key])
+      .map(key => listDiff(key, a.exported.composition[key], b.exported.composition[key])),
+  };
+};
+
+/**
+ * Parse an imported export file (the trust boundary for the file slot).
+ * Returns the export or a reason it was rejected — never throws.
+ */
+export const parseImportedExport = (raw: string): { exported?: AgnosticExport; error?: string } => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { error: 'not valid JSON' };
+  }
+  const candidate = parsed as Partial<AgnosticExport> | null;
+  if (!candidate || typeof candidate !== 'object') {
+    return { error: 'not a shape export' };
+  }
+  if (candidate.schema_version !== 1) {
+    return { error: `unsupported schema_version (${String(candidate.schema_version)})` };
+  }
+  if (typeof candidate.totals !== 'object' || typeof candidate.distributions !== 'object') {
+    return { error: 'missing totals or distributions blocks' };
+  }
+  const exported = candidate as AgnosticExport;
+  return {
+    exported: {
+      ...exported,
+      distributions: { top_share: {}, ...exported.distributions },
+      composition: exported.composition ?? {},
+    },
+  };
+};

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
@@ -1,99 +1,86 @@
 /**
- * Pure comparison of two foundation shapes (GH #5702 follow-on): the
- * promotion-verification view. Both sides are schema_version 1 exports —
+ * Pure N-way comparison of foundation shapes (GH #5702 follow-on): the
+ * promotion-verification view. Every side is a schema_version 1 export —
  * a live section's projection or an imported file — and the comparison
  * walks what each side actually measured: an absent key means "not
  * measured" on that side (never-loaded ≠ empty), a null distribution
  * means measured-but-empty, and neither is ever presented as a zero.
  *
- * Emphasis follows the promotion question — did a stack migration,
- * buildpack update, or app rollout propagate — so ecosystem lists diff as
- * added/removed and categorical compositions diff as share deltas, with
- * totals and distribution key-stats as the secondary table.
+ * Sides are ordered; the first is the baseline. Values come back as
+ * index-aligned arrays (one entry per side) — judgment against the
+ * baseline (added/removed, deltas) is the view's concern, not computed
+ * here, so the same comparison serves tables, bars, and matrices.
  */
 import { AgnosticExport, isDist } from './shape-export';
 import { Distribution, TopShare } from './shape-stats';
 
-/** undefined = that side never measured this; null = measured, empty. */
-export interface ComparedValue<T> {
+export interface LabelledExport {
+  label: string;
+  exported: AgnosticExport;
+}
+
+/** Per-key row: values[i] belongs to sides[i]; undefined = that side never measured it, null = measured, empty. */
+export interface ComparedRow<T> {
   key: string;
-  a?: T | null;
-  b?: T | null;
+  values: (T | null | undefined)[];
 }
 
 export interface CategoryRow {
   category: string;
   /** undefined = dimension unmeasured on that side; counts are real zeros otherwise. */
-  a?: number;
-  b?: number;
+  counts: (number | undefined)[];
   /** Share of the side's dimension total, 0..1; undefined when unmeasured. */
-  aShare?: number;
-  bShare?: number;
+  shares: (number | undefined)[];
 }
 
-export interface ListDiff {
+export interface ListMatrix {
   key: string;
-  added: string[];
-  removed: string[];
-  unchanged: string[];
+  /** Side-level: whether this side measured the list at all. */
+  measured: boolean[];
+  /** One row per union label ("name" or "name ×n"); present[i] only meaningful where measured[i]. */
+  rows: { label: string; present: boolean[] }[];
 }
 
 export interface ShapeComparison {
-  a: { label: string; collectedAt: string };
-  b: { label: string; collectedAt: string };
-  totals: ComparedValue<number>[];
-  distributions: ComparedValue<Distribution>[];
-  topShare: ComparedValue<TopShare>[];
+  sides: { label: string; collectedAt: string }[];
+  totals: ComparedRow<number>[];
+  distributions: ComparedRow<Distribution>[];
+  topShare: ComparedRow<TopShare>[];
   /** One entry per categorical dimension measured on at least one side. */
   categorical: { dimension: string; rows: CategoryRow[] }[];
-  /** Defined-list diffs; multiset entries render as "name ×n". */
-  lists: ListDiff[];
+  lists: ListMatrix[];
 }
 
-/** Union of both sides' keys, a-side order first — comparison rows never drop a key. */
-const unionKeys = (a: Record<string, unknown>, b: Record<string, unknown>): string[] => {
-  const keys = Object.keys(a);
-  for (const key of Object.keys(b)) {
-    if (!keys.includes(key)) {
-      keys.push(key);
+/** Union of every side's keys, first-seen order — comparison rows never drop a key. */
+const unionKeys = (sources: Record<string, unknown>[]): string[] => {
+  const keys: string[] = [];
+  for (const source of sources) {
+    for (const key of Object.keys(source)) {
+      if (!keys.includes(key)) {
+        keys.push(key);
+      }
     }
   }
   return keys;
 };
 
-const comparedValues = <T>(
-  a: Record<string, T | null | undefined>,
-  b: Record<string, T | null | undefined>
-): ComparedValue<T>[] =>
-  unionKeys(a, b).map(key => {
-    const row: ComparedValue<T> = { key };
-    if (key in a) {
-      row.a = a[key] as T | null;
-    }
-    if (key in b) {
-      row.b = b[key] as T | null;
-    }
-    return row;
-  });
+const comparedRows = <T>(sources: Record<string, T | null | undefined>[]): ComparedRow<T>[] =>
+  unionKeys(sources).map(key => ({
+    key,
+    values: sources.map(source => (key in source ? (source[key] as T | null) : undefined)),
+  }));
 
-const categoricalRows = (
-  a: Record<string, number> | undefined,
-  b: Record<string, number> | undefined
-): CategoryRow[] => {
-  const aTotal = Object.values(a ?? {}).reduce((acc, v) => acc + v, 0);
-  const bTotal = Object.values(b ?? {}).reduce((acc, v) => acc + v, 0);
-  return unionKeys(a ?? {}, b ?? {}).map(category => {
-    const row: CategoryRow = { category };
-    if (a) {
-      row.a = a[category] ?? 0;
-      row.aShare = aTotal ? row.a / aTotal : 0;
-    }
-    if (b) {
-      row.b = b[category] ?? 0;
-      row.bShare = bTotal ? row.b / bTotal : 0;
-    }
-    return row;
-  });
+const categoricalRows = (sources: (Record<string, number> | undefined)[]): CategoryRow[] => {
+  const totals = sources.map(source =>
+    source ? Object.values(source).reduce((acc, v) => acc + v, 0) : 0
+  );
+  return unionKeys(sources.filter((s): s is Record<string, number> => !!s)).map(category => ({
+    category,
+    counts: sources.map(source => (source ? source[category] ?? 0 : undefined)),
+    shares: sources.map((source, i) =>
+      source ? (totals[i] ? (source[category] ?? 0) / totals[i] : 0) : undefined
+    ),
+  }));
 };
 
 /** Multiset entries collapse to "name ×n" so a second stack's build of the same buildpack shows. */
@@ -105,14 +92,23 @@ const multisetLabels = (names: string[]): string[] => {
   return [...counts.entries()].map(([name, count]) => (count > 1 ? `${name} ×${count}` : name));
 };
 
-const listDiff = (key: string, a: string[] | undefined, b: string[] | undefined): ListDiff => {
-  const aLabels = multisetLabels(a ?? []);
-  const bLabels = multisetLabels(b ?? []);
+const listMatrix = (key: string, sources: (string[] | undefined)[]): ListMatrix => {
+  const labelled = sources.map(names => (names ? multisetLabels(names) : undefined));
+  const union: string[] = [];
+  for (const labels of labelled) {
+    for (const label of labels ?? []) {
+      if (!union.includes(label)) {
+        union.push(label);
+      }
+    }
+  }
   return {
     key,
-    added: bLabels.filter(label => !aLabels.includes(label)),
-    removed: aLabels.filter(label => !bLabels.includes(label)),
-    unchanged: aLabels.filter(label => bLabels.includes(label)),
+    measured: labelled.map(labels => labels !== undefined),
+    rows: union.map(label => ({
+      label,
+      present: labelled.map(labels => !!labels?.includes(label)),
+    })),
   };
 };
 
@@ -128,32 +124,25 @@ const distEntries = (exported: AgnosticExport): Record<string, Distribution | nu
   return entries;
 };
 
-export interface LabelledExport {
-  label: string;
-  exported: AgnosticExport;
-}
+const CATEGORICAL_DIMENSIONS = ['app_state', 'stacks_pinned_by_apps'] as const;
+const DEFINED_LISTS = ['stacks_defined', 'buildpacks_defined'] as const;
 
-export const compareExports = (a: LabelledExport, b: LabelledExport): ShapeComparison => {
-  const dimensions = ['app_state', 'stacks_pinned_by_apps'] as const;
-  const lists = ['stacks_defined', 'buildpacks_defined'] as const;
+export const compareExports = (sides: LabelledExport[]): ShapeComparison => {
+  const exports = sides.map(side => side.exported);
   return {
-    a: { label: a.label, collectedAt: a.exported.collected_at },
-    b: { label: b.label, collectedAt: b.exported.collected_at },
-    totals: comparedValues(a.exported.totals, b.exported.totals),
-    distributions: comparedValues(distEntries(a.exported), distEntries(b.exported)),
-    topShare: comparedValues(
-      a.exported.distributions.top_share as Record<string, TopShare | null>,
-      b.exported.distributions.top_share as Record<string, TopShare | null>
-    ),
-    categorical: dimensions
-      .filter(dimension => a.exported.composition[dimension] || b.exported.composition[dimension])
+    sides: sides.map(side => ({ label: side.label, collectedAt: side.exported.collected_at })),
+    totals: comparedRows(exports.map(e => e.totals)),
+    distributions: comparedRows(exports.map(distEntries)),
+    topShare: comparedRows(exports.map(e => e.distributions.top_share as Record<string, TopShare | null>)),
+    categorical: CATEGORICAL_DIMENSIONS
+      .filter(dimension => exports.some(e => e.composition[dimension]))
       .map(dimension => ({
         dimension,
-        rows: categoricalRows(a.exported.composition[dimension], b.exported.composition[dimension]),
+        rows: categoricalRows(exports.map(e => e.composition[dimension])),
       })),
-    lists: lists
-      .filter(key => a.exported.composition[key] || b.exported.composition[key])
-      .map(key => listDiff(key, a.exported.composition[key], b.exported.composition[key])),
+    lists: DEFINED_LISTS
+      .filter(key => exports.some(e => e.composition[key]))
+      .map(key => listMatrix(key, exports.map(e => e.composition[key]))),
   };
 };
 

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-export-xlsx.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-export-xlsx.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeSessionShape } from './session-shape';
+import { AgnosticExportInput, buildAgnosticExport, COVERAGE_NOTE } from './shape-export';
+import { buildShapeWorkbook, ShapeSheet } from './shape-export-xlsx';
+import { app, org, space } from './testing/entity-builders';
+
+const ORGS = [org('o1'), org('o2')];
+const SPACES = [space('s1', 'o1')];
+const APPS = [
+  app('a1', { spaceGuid: 's1', orgGuid: 'o1', memory: 256, diskQuota: 1024, stackName: 'cflinuxfs4' }),
+];
+
+const SESSION_TOTALS = {
+  orgs: 2,
+  spaces: 1 as number | null,
+  apps: 1,
+  routes: 5,
+  serviceInstances: 3,
+  serviceOfferings: 4,
+  servicePlans: 6,
+  serviceBrokers: 1,
+};
+
+const ALL_DRAINS = { counts: true, servicesCounts: true, orgs: true, spaces: true, apps: true };
+
+const baseInput = (): AgnosticExportInput => ({
+  shape: computeSessionShape(ORGS, SPACES, APPS),
+  sessionTotals: SESSION_TOTALS,
+  drains: ALL_DRAINS,
+  collectedAt: new Date('2026-08-01T12:00:00Z'),
+});
+
+const sheet = (workbook: ShapeSheet[], name: string): ShapeSheet => {
+  const found = workbook.find(s => s.name === name);
+  expect(found, `sheet ${name}`).toBeDefined();
+  return found as ShapeSheet;
+};
+
+describe('buildShapeWorkbook', () => {
+  it('emits one sheet per measured data type, Totals first', () => {
+    const workbook = buildShapeWorkbook(buildAgnosticExport({
+      ...baseInput(),
+      measuredEcosystem: { stacksDefined: ['cflinuxfs4'], buildpacksDefined: ['ruby_buildpack'], fetchedAt: new Date() },
+    }));
+    expect(workbook.map(s => s.name)).toEqual([
+      'Totals', 'Distributions', 'Histograms', 'Top share', 'Composition', 'Ecosystem',
+    ]);
+  });
+
+  it('Totals carries the export metadata block and the entity counts', () => {
+    const rows = sheet(buildShapeWorkbook(buildAgnosticExport(baseInput())), 'Totals').rows;
+    expect(rows).toContainEqual(['Collected at', '2026-08-01T12:00:00.000Z']);
+    expect(rows).toContainEqual(['Coverage note', COVERAGE_NOTE]);
+    expect(rows).toContainEqual(['entity', 'count']);
+    expect(rows).toContainEqual(['organizations', 2]);
+    expect(rows).toContainEqual(['service_instances', 3]);
+  });
+
+  it('Distributions rows carry every Distribution field under schema keys', () => {
+    const rows = sheet(buildShapeWorkbook(buildAgnosticExport(baseInput())), 'Distributions').rows;
+    expect(rows[0]).toEqual(['metric', 'n', 'min', 'median', 'p90', 'p99', 'max', 'mean', 'zeros', 'sum']);
+    expect(rows).toContainEqual(['spaces_per_org', 2, 0, 0.5, 1, 1, 1, 0.5, 1, 1]);
+    // composition sizing dists fold into the same sheet, like the markdown table
+    expect(rows.some(r => r[0] === 'web_process_memory_mb')).toBe(true);
+  });
+
+  it('Histograms flattens each hist bucket to metric/bucket/count', () => {
+    const rows = sheet(buildShapeWorkbook(buildAgnosticExport(baseInput())), 'Histograms').rows;
+    expect(rows[0]).toEqual(['metric', 'bucket', 'count']);
+    expect(rows).toContainEqual(['spaces_per_org', '0', 1]);
+    expect(rows).toContainEqual(['spaces_per_org', '1', 1]);
+  });
+
+  it('Top share and Composition mirror the export objects', () => {
+    const workbook = buildShapeWorkbook(buildAgnosticExport(baseInput()));
+    expect(sheet(workbook, 'Top share').rows).toContainEqual(['apps_in_largest_space', 1, 1]);
+    const composition = sheet(workbook, 'Composition').rows;
+    expect(composition).toContainEqual(['app_state', 'STARTED', 1]);
+    expect(composition).toContainEqual(['stacks_pinned_by_apps', 'cflinuxfs4', 1]);
+  });
+
+  it('Ecosystem appears only when definitions were measured', () => {
+    expect(buildShapeWorkbook(buildAgnosticExport(baseInput())).map(s => s.name)).not.toContain('Ecosystem');
+    const workbook = buildShapeWorkbook(buildAgnosticExport({
+      ...baseInput(),
+      measuredEcosystem: {
+        stacksDefined: ['cflinuxfs4'],
+        buildpacksDefined: ['ruby_buildpack', 'ruby_buildpack'],
+        fetchedAt: new Date(),
+      },
+    }));
+    const rows = sheet(workbook, 'Ecosystem').rows;
+    expect(rows).toContainEqual(['stacks_defined', 'cflinuxfs4']);
+    // multiplicity preserved: one row per defined buildpack, like the JSON list
+    expect(rows.filter(r => r[1] === 'ruby_buildpack')).toHaveLength(2);
+  });
+
+  it('never-run drains collapse the workbook to the Totals sheet alone', () => {
+    const input = baseInput();
+    input.drains = { counts: true, servicesCounts: false, orgs: false, spaces: false, apps: false };
+    input.sessionTotals = { ...SESSION_TOTALS, spaces: null };
+    const workbook = buildShapeWorkbook(buildAgnosticExport(input));
+    expect(workbook.map(s => s.name)).toEqual(['Totals']);
+  });
+
+  it('a drained-but-empty (null) distribution produces no rows', () => {
+    const input = baseInput();
+    input.shape = computeSessionShape(ORGS, SPACES, []);
+    input.sessionTotals = { ...SESSION_TOTALS, apps: 0 };
+    const rows = sheet(buildShapeWorkbook(buildAgnosticExport(input)), 'Distributions').rows;
+    expect(rows.some(r => r[0] === 'routes_per_app')).toBe(false);
+    expect(rows.some(r => r[0] === 'spaces_per_org')).toBe(true);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-export-xlsx.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-export-xlsx.ts
@@ -1,0 +1,111 @@
+/**
+ * Spreadsheet form of the anonymous shape export (GH #5703): one workbook,
+ * one sheet per data type, flattened from the same AgnosticExport the JSON
+ * download emits. The JSON stays the schema_version 1 contract; the workbook
+ * is a rendering of it, so anything absent from the JSON (never-run drain)
+ * is absent here too, and a sheet with no data rows is not written at all.
+ */
+import { AgnosticExport, isDist } from './shape-export';
+import { Distribution, TopShare } from './shape-stats';
+
+/** First row is the header; cells land in the sheet exactly as given. */
+export interface ShapeSheet {
+  name: string;
+  rows: (string | number)[][];
+}
+
+/** Every measured distribution, schema keys intact: relationship dists first, then process sizing. */
+const namedDists = (exported: AgnosticExport): [string, Distribution][] => {
+  const found: [string, Distribution][] = [];
+  for (const source of [exported.distributions, exported.composition]) {
+    for (const [key, value] of Object.entries(source)) {
+      if (isDist(value)) {
+        found.push([key, value]);
+      }
+    }
+  }
+  return found;
+};
+
+const totalsSheet = (exported: AgnosticExport): ShapeSheet => ({
+  name: 'Totals',
+  rows: [
+    ['Collected at', exported.collected_at],
+    ['Schema version', exported.schema_version],
+    ['Coverage note', exported.coverage_note],
+    [],
+    ['entity', 'count'],
+    ...Object.entries(exported.totals),
+  ],
+});
+
+const distributionsSheet = (dists: [string, Distribution][]): ShapeSheet => ({
+  name: 'Distributions',
+  rows: [
+    ['metric', 'n', 'min', 'median', 'p90', 'p99', 'max', 'mean', 'zeros', 'sum'],
+    ...dists.map(([key, d]): (string | number)[] =>
+      [key, d.n, d.min, d.median, d.p90, d.p99, d.max, d.mean, d.zeros, d.sum]),
+  ],
+});
+
+const histogramsSheet = (dists: [string, Distribution][]): ShapeSheet => ({
+  name: 'Histograms',
+  rows: [
+    ['metric', 'bucket', 'count'],
+    ...dists.flatMap(([key, d]) =>
+      Object.entries(d.hist).map(([bucket, count]): (string | number)[] => [key, bucket, count])),
+  ],
+});
+
+const topShareSheet = (exported: AgnosticExport): ShapeSheet => ({
+  name: 'Top share',
+  rows: [
+    ['metric', 'largest_holds', 'fraction'],
+    ...Object.entries(exported.distributions.top_share)
+      .filter((entry): entry is [string, TopShare] => !!entry[1])
+      .map(([key, share]): (string | number)[] => [key, share.largest_holds, share.fraction]),
+  ],
+});
+
+const compositionSheet = (exported: AgnosticExport): ShapeSheet => {
+  const dimensions: [string, Record<string, number> | undefined][] = [
+    ['app_state', exported.composition.app_state],
+    ['stacks_pinned_by_apps', exported.composition.stacks_pinned_by_apps],
+  ];
+  return {
+    name: 'Composition',
+    rows: [
+      ['dimension', 'category', 'count'],
+      ...dimensions.flatMap(([dimension, categories]) =>
+        Object.entries(categories ?? {}).map(([category, count]): (string | number)[] =>
+          [dimension, category, count])),
+    ],
+  };
+};
+
+const ecosystemSheet = (exported: AgnosticExport): ShapeSheet => {
+  const kinds: [string, string[] | undefined][] = [
+    ['stacks_defined', exported.composition.stacks_defined],
+    ['buildpacks_defined', exported.composition.buildpacks_defined],
+  ];
+  return {
+    name: 'Ecosystem',
+    rows: [
+      ['kind', 'name'],
+      ...kinds.flatMap(([kind, names]) => (names ?? []).map((name): (string | number)[] => [kind, name])),
+    ],
+  };
+};
+
+/** Totals always (it carries the coverage note); every other sheet only when it has data rows. */
+export const buildShapeWorkbook = (exported: AgnosticExport): ShapeSheet[] => {
+  const dists = namedDists(exported);
+  return [
+    totalsSheet(exported),
+    distributionsSheet(dists),
+    histogramsSheet(dists),
+    topShareSheet(exported),
+    compositionSheet(exported),
+    ecosystemSheet(exported),
+  ].filter(sheet => sheet.name === 'Totals' || sheet.rows.length > 1);
+};

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-export.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-export.ts
@@ -143,7 +143,8 @@ export const buildAgnosticExport = (input: AgnosticExportInput): AgnosticExport 
   };
 };
 
-const isDist = (value: unknown): value is Distribution =>
+/** Distribution detector for walking export sections (null and share objects fail it). */
+export const isDist = (value: unknown): value is Distribution =>
   !!value && typeof value === 'object' && 'hist' in (value as object);
 
 export const exportMarkdown = (exported: AgnosticExport): string => {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-section.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-section.ts
@@ -1,0 +1,61 @@
+/**
+ * The per-endpoint section model the Foundational Shape page renders, and its
+ * projection to the schema_version 1 export — shared by the page's export
+ * actions and the comparison card's live-section slots.
+ */
+import { SessionShape } from './session-shape';
+import { AgnosticExport, buildAgnosticExport } from './shape-export';
+import { MeasuredEcosystem, MeasuredTotals } from './shape-measure.service';
+
+export interface DrainStamp {
+  fetchedAt: Date | null;
+  stale: boolean;
+}
+
+export interface ShapeSection {
+  guid: string;
+  name: string;
+  shape: SessionShape;
+  totals: {
+    orgs: number;
+    /** null = spaces drain never ran this session (distinct from an empty foundation). */
+    spaces: number | null;
+    apps: number;
+    routes: number;
+    serviceInstances: number;
+    serviceOfferings: number;
+    servicePlans: number;
+    serviceBrokers: number;
+  };
+  drains: { orgs: DrainStamp; spaces: DrainStamp; apps: DrainStamp };
+  loading: boolean;
+  /** At least one full drain landed, so the shape cards mean something. */
+  hasDrains: boolean;
+  /** The fast counts pass has run, so the totals row is real data. */
+  countsLoaded: boolean;
+  /** The services counts pass (a later, separate fetch) has run. */
+  servicesCountsLoaded: boolean;
+  /** The connected user is a CF admin on this endpoint — gates export. */
+  admin: boolean;
+}
+
+/** The anonymous projection (#5703) of everything a section has measured, stamped now. */
+export const sectionExportPayload = (
+  section: ShapeSection,
+  measuredTotals?: MeasuredTotals,
+  measuredEcosystem?: MeasuredEcosystem
+): AgnosticExport =>
+  buildAgnosticExport({
+    shape: section.shape,
+    sessionTotals: section.totals,
+    drains: {
+      counts: section.countsLoaded,
+      servicesCounts: section.servicesCountsLoaded,
+      orgs: section.drains.orgs.fetchedAt !== null,
+      spaces: section.drains.spaces.fetchedAt !== null,
+      apps: section.drains.apps.fetchedAt !== null,
+    },
+    collectedAt: new Date(),
+    measuredTotals,
+    measuredEcosystem,
+  });

--- a/src/frontend/packages/core/src/features/about/diagnostic-counts-page/diagnostic-counts-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-counts-page/diagnostic-counts-page.component.ts
@@ -76,6 +76,9 @@ export class DiagnosticCountsPageComponent {
   readonly heap = signal<HeapInfo>(readHeap());
   private readonly counts = signal<Record<string, EndpointCounts>>({});
 
+  // "Heap" here is the browser tab's JS heap (performance.memory, Chromium
+  // only) — on Firefox/WebKit-based browsers the line shows the fixed-budget
+  // fallback instead. Not jetstream/server memory.
   readonly heapLine = computed(() => {
     const heap = this.heap();
     const limit = formatBytes(heap.limitBytes);

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/entity-footprint.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/entity-footprint.ts
@@ -56,8 +56,11 @@ export interface HeapInfo {
 const FIXED_BUDGET_BYTES = 2 * 1024 ** 3; // 2 GiB when the heap API is unavailable
 
 /**
- * Read the JS heap via the non-standard performance.memory API (Chromium),
- * falling back to a fixed 2 GiB budget elsewhere.
+ * Read the BROWSER TAB's JS heap via the non-standard performance.memory
+ * API. Only Chromium-based browsers expose it; on Firefox and WebKit-based
+ * browsers (Safari) there is no equivalent, so those fall back to a fixed
+ * 2 GiB budget with usedBytes unknown — the heap line then reads "assuming
+ * a 2 GiB budget" and risk ratings compare estimates against that budget.
  */
 export function readHeap(): HeapInfo {
   const memory = (performance as any).memory;


### PR DESCRIPTION
Critique-round increments on the Foundational Shape diagnostics page (#5702, #5703 — prototype iteration, issues stay open).

## Spreadsheet export

The admin export row gains a Download spreadsheet action: one workbook via `write-excel-file` (MIT; sole transitive dependency `fflate`), one sheet per data type — Totals (with the collected-at / coverage-note metadata block), Distributions, Histograms, Top share, Composition, Ecosystem. Sheets flatten the same projection the JSON download emits, so the JSON stays the schema_version 1 contract: never-run drains stay absent, and a sheet with no data rows is not written. Filename follows `<endpoint>-foundational-shape-anonymous-<date>.xlsx`.

## N-way shape comparison (promotion verification)

- Endpoint sections collapse from their bar (default open only when a single endpoint is connected); the bar carries compact stats (apps count, started share) and a Compare checkbox.
- Selection order is baseline order; any side can be re-baselined. A sticky strip appears at two or more sides with a Compare-now jump.
- The comparison diffs N sides: ecosystem lists as a presence matrix judged against the baseline (changed rows always visible, unchanged rows collapse), composition as per-side share bars with share-point deltas, concentration tiles, totals with per-column deltas, and distribution key stats. Absent ("not measured") and null ("measured, empty") stay distinct throughout — a one-sided key is never zero-filled.
- Sides keep one identity color everywhere — assigned on selection, held until removal, shown on the endpoint's section bar beside its checkbox — so re-baselining never recolors an endpoint.
- Imported schema_version 1 export files join the same ordered side list (validated with reasons; `foundation_label` preferred over the filename), so live-vs-file and file-vs-file comparisons both work — the latter with no endpoints connected at all.

Also carries a small docs commit clarifying that the counts-page heap figures are the browser tab's JS heap.

Verified: 119 unit tests across the feature (golden fixtures unchanged), full `make check gate` green locally, and the flow exercised live against a six-endpoint dev session (selection, sticky strip, re-baseline color stability, xlsx workbook unzipped and sheet names checked).
