### PR TITLE
feat(csp): enforce style-src-elem with a per-response nonce

### DIFF
--- a/docs/advanced/content-security-policy.md
+++ b/docs/advanced/content-security-policy.md
@@ -31,6 +31,7 @@ Values are matched without regard to case.
 default-src 'self';
 script-src 'self';
 style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+style-src-elem 'self' 'nonce-PLACEHOLDER' https://fonts.googleapis.com;
 font-src 'self' data: https://fonts.gstatic.com;
 img-src 'self' data:;
 connect-src 'self';
@@ -51,7 +52,21 @@ A few of these are worth explaining:
   Stratos already sends.
 - The Google Fonts origins are permitted because the console can load its
   interface font from them.
-- `style-src` still permits `'unsafe-inline'`. Removing it is in progress.
+- `'nonce-PLACEHOLDER'` is not sent literally. Each response replaces it with a
+  freshly generated value that also appears on the styles in that response, so
+  only those styles are permitted. A policy you supply yourself gets the same
+  treatment: include the `'nonce-PLACEHOLDER'` token and it is substituted the
+  same way.
+- `style-src-elem` governs `<style>` elements and stylesheet links, and it
+  replaces `style-src` for them rather than adding to it. If you extend
+  `style-src` with an origin, add it to `style-src-elem` too or stylesheets
+  from that origin are still refused.
+- `style-src` continues to permit `'unsafe-inline'`, but with `style-src-elem`
+  declared, what that now covers is inline style *attributes* — the code editor
+  positions each line with one, and the terminal colours each cell with one.
+  CSP offers no nonce or hash for attributes whose values are computed at
+  runtime, so this cannot be tightened by configuration; it needs the libraries
+  to set those styles through the CSSOM instead, which CSP exempts.
 
 ## Overriding the policy
 

--- a/src/frontend/packages/core/src/csp-nonce.spec.ts
+++ b/src/frontend/packages/core/src/csp-nonce.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { installStyleNonce } from './csp-nonce';
+
+// installStyleNonce patches the shared document, so every test puts it back.
+// Without this the patches stack and a later assertion passes on an earlier
+// test's nonce. Deleting the own property restores the inherited method.
+describe('installStyleNonce', () => {
+  const inheritedCreateElement = document.createElement;
+
+  afterEach(() => {
+    delete (document as Partial<Document>).createElement;
+    document.body.innerHTML = '';
+  });
+
+  const withNoncedAppRoot = (nonce: string) => {
+    document.body.innerHTML = `<app-root ngCspNonce="${nonce}"></app-root>`;
+  };
+
+  it('nonces a style element from the ngCspNonce Jetstream injected', () => {
+    withNoncedAppRoot('N1');
+    installStyleNonce();
+
+    expect(document.createElement('style').getAttribute('nonce')).toBe('N1');
+  });
+
+  // The nonce has to be on the element before it is inserted, or its .sheet
+  // stays null and the rules never apply. Asserting on the attribute alone
+  // would still pass if the nonce were applied on insertion instead.
+  it('nonces the element at creation, before it is inserted', () => {
+    withNoncedAppRoot('N1');
+    installStyleNonce();
+
+    const style = document.createElement('style');
+
+    expect(style.isConnected).toBe(false);
+    expect(style.getAttribute('nonce')).toBe('N1');
+  });
+
+  // Monaco clones style elements into shadow roots. The .nonce property does
+  // not survive cloneNode; the attribute does.
+  it('carries the nonce through cloneNode', () => {
+    withNoncedAppRoot('N1');
+    installStyleNonce();
+
+    const clone = document.createElement('style').cloneNode(true) as Element;
+
+    expect(clone.getAttribute('nonce')).toBe('N1');
+  });
+
+  it('leaves other elements alone', () => {
+    withNoncedAppRoot('N1');
+    installStyleNonce();
+
+    expect(document.createElement('div').hasAttribute('nonce')).toBe(false);
+  });
+
+  // CSP off, or `ng serve` — which serves index.html itself, so Jetstream never
+  // stamps it. Nothing to apply, so nothing is patched at all.
+  it('does not patch createElement when the document carries no nonce', () => {
+    document.body.innerHTML = '<app-root></app-root>';
+
+    installStyleNonce();
+
+    expect(document.createElement).toBe(inheritedCreateElement);
+  });
+});

--- a/src/frontend/packages/core/src/csp-nonce.ts
+++ b/src/frontend/packages/core/src/csp-nonce.ts
@@ -1,0 +1,56 @@
+/**
+ * Applies the per-response CSP nonce to the <style> elements the application
+ * creates at runtime, so that style-src-elem can be enforced without
+ * 'unsafe-inline'.
+ *
+ * Monaco and xterm both inject <style> elements and neither accepts a nonce
+ * (cloudfoundry/stratos#5705), so there is no per-library seam to plumb one
+ * through. createElement is the call they do share.
+ *
+ * This is narrower than 'unsafe-inline'. Only styles created through the DOM
+ * API are nonced; a <style> arriving as markup — innerHTML, an injected
+ * fragment — never passes through createElement and stays blocked, which is
+ * the injection vector a nonced style-src-elem exists to close.
+ */
+
+/**
+ * installStyleNonce patches document.createElement so the <style> elements it
+ * returns carry the document's CSP nonce.
+ *
+ * The nonce is read from the ngCspNonce attribute Jetstream injects on
+ * <app-root>, using the same lookup Angular's own CSP_NONCE performs, so one
+ * server-injected value serves both. Jetstream stamps it on every document it
+ * serves, including when CSP is switched off — a nonce with no policy behind
+ * it is inert, so the patch installs there and does nothing observable. It is
+ * absent under `ng serve`, which serves index.html itself and never reaches
+ * Jetstream's document handler; with no nonce to apply, createElement is left
+ * alone entirely.
+ *
+ * Three details decide whether the nonce actually works:
+ *
+ * - It is set at creation, before insertion. A nonce set on an already
+ *   inserted <style> leaves its .sheet null permanently, so the rules never
+ *   apply while the element still looks correct in the inspector.
+ * - It is set as an attribute rather than through the .nonce property, because
+ *   only the attribute survives cloneNode.
+ * - It patches this document rather than Document.prototype. Every caller
+ *   reaches createElement through the document object — directly, or as the
+ *   ownerDocument of an element or shadow root — so the instance is the
+ *   narrower target that still covers all of them, and other documents keep
+ *   the unpatched method.
+ */
+export function installStyleNonce(): void {
+  const nonce = document.body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce');
+  if (!nonce) {
+    return;
+  }
+
+  const createElement = document.createElement.bind(document);
+  document.createElement = function (tagName: string, options?: ElementCreationOptions) {
+    const element = createElement(tagName, options);
+    if (element instanceof HTMLStyleElement) {
+      element.setAttribute('nonce', nonce);
+    }
+    return element;
+  } as typeof document.createElement;
+}

--- a/src/frontend/packages/core/src/polyfills.ts
+++ b/src/frontend/packages/core/src/polyfills.ts
@@ -24,6 +24,13 @@
  * APPLICATION IMPORTS
  */
 
+import { installStyleNonce } from './csp-nonce';
+
+// Nonce the <style> elements created at runtime so the Content-Security-Policy
+// can enforce style-src-elem. This runs here rather than in main.ts because it
+// has to be in place before any library creates one.
+installStyleNonce();
+
 // NOTE: Zone.js has been removed in favor of zoneless change detection (Angular 20+)
 // The provideZonelessChangeDetection() provider is configured in main.ts
 

--- a/src/jetstream/csp_test.go
+++ b/src/jetstream/csp_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -99,6 +100,66 @@ func TestCspHeaderWithNonceLeavesPolicyWithoutPlaceholderUnchanged(t *testing.T)
 	pol := "default-src 'self'; style-src 'self' 'unsafe-inline'"
 	if got := cspHeaderWithNonce(pol, "N1"); got != pol {
 		t.Errorf("custom policy must pass through verbatim: %q", got)
+	}
+}
+
+// directiveSources returns the source list of the named directive in policy.
+// Splitting on the directive name is what distinguishes style-src from
+// style-src-elem — a substring search matches both.
+func directiveSources(t *testing.T, policy, name string) []string {
+	t.Helper()
+	for _, directive := range strings.Split(policy, "; ") {
+		if fields := strings.Fields(directive); len(fields) > 0 && fields[0] == name {
+			return fields[1:]
+		}
+	}
+	t.Fatalf("policy has no %s directive: %q", name, policy)
+	return nil
+}
+
+// Nothing else proves the shipped policy participates in the nonce mechanism.
+// A style-src-elem without the placeholder is enforced against every <style>
+// in the document with no nonce able to satisfy it, which blocks the lot.
+func TestDefaultCSPPolicyNoncesStyleElements(t *testing.T) {
+	if !slices.Contains(directiveSources(t, defaultCSPPolicy, "style-src-elem"), cspNoncePlaceholder) {
+		t.Errorf("style-src-elem must carry the nonce placeholder: %q", defaultCSPPolicy)
+	}
+}
+
+// style-src-elem overrides style-src for elements wholesale rather than
+// intersecting with it, so a source added to style-src alone is silently
+// withdrawn from every <style> and <link rel=stylesheet>.
+func TestDefaultCSPPolicyStyleElemRepeatsEveryStyleSrcSource(t *testing.T) {
+	elem := directiveSources(t, defaultCSPPolicy, "style-src-elem")
+	for _, source := range directiveSources(t, defaultCSPPolicy, "style-src") {
+		// The one deliberate omission: dropping 'unsafe-inline' for elements is
+		// the entire purpose of the directive. Browsers ignore it beside a nonce
+		// anyway; it stays in style-src for attributes and pre-CSP3 browsers.
+		if source == "'unsafe-inline'" {
+			continue
+		}
+		if !slices.Contains(elem, source) {
+			t.Errorf("style-src grants %s but style-src-elem does not repeat it: %q", source, defaultCSPPolicy)
+		}
+	}
+}
+
+// The mechanism end to end on the policy that actually ships, rather than on a
+// synthetic one: the styles in the document must carry the value the header's
+// style-src-elem authorises.
+func TestServeIndexHTMLNoncesStyleElementsUnderTheDefaultPolicy(t *testing.T) {
+	p := &portalProxy{indexHTMLTemplate: `<style>a{}</style><app-root></app-root>`}
+	p.Config.CSPPolicy = defaultCSPPolicy
+
+	rec := serveIndex(t, p)
+	hdr := rec.Header().Get("Content-Security-Policy")
+	nonce := nonceFromHeader(t, hdr)
+
+	if !slices.Contains(directiveSources(t, hdr, "style-src-elem"), "'nonce-"+nonce+"'") {
+		t.Errorf("style-src-elem must carry the substituted nonce: %q", hdr)
+	}
+	if !strings.Contains(rec.Body.String(), `<style nonce="`+nonce+`">`) {
+		t.Errorf("document styles must carry the nonce %q: %q", nonce, rec.Body.String())
 	}
 }
 

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -84,8 +84,17 @@ const (
 // opts out or supplies its own. It is scoped to what the Stratos SPA needs:
 //   - default/script/connect from same origin ('self'); same-origin 'self'
 //     also permits the backend log/stream WebSockets (wss:// on the HTTPS page)
-//   - 'unsafe-inline' styles: Angular + the index.html loading splash inject
-//     inline <style>; Google Fonts stylesheet is allowed
+//   - style-src-elem carries a per-response nonce, so <style> elements are
+//     enforced without 'unsafe-inline'. serveIndexHTML nonces the ones in
+//     index.html; Angular nonces its own from ngCspNonce; installStyleNonce
+//     (frontend polyfills) nonces the ones Monaco and xterm create, neither of
+//     which accepts a nonce itself. A <style> arriving as markup carries none
+//     and is refused, which is the point.
+//   - style-src keeps 'unsafe-inline', but style-src-elem now overrides it for
+//     elements, so what it still permits is inline style ATTRIBUTES (Monaco's
+//     per-line positioning, xterm's truecolor cells). CSP has no nonce or hash
+//     mechanism for dynamic attributes, so no policy change can tighten this.
+//     It also remains the whole style policy on pre-CSP3 browsers.
 //   - data: images/fonts (inlined icons) and Google Fonts font files
 //   - worker-src blob: — the Monaco editor spins up its language web-workers
 //     from blob URLs
@@ -94,6 +103,9 @@ const (
 const defaultCSPPolicy = "default-src 'self'; " +
 	"script-src 'self'; " +
 	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+	// style-src-elem overrides style-src for elements wholesale, so it has to
+	// repeat every source style-src grants them or it silently withdraws one.
+	"style-src-elem 'self' " + cspNoncePlaceholder + " https://fonts.googleapis.com; " +
 	"font-src 'self' data: https://fonts.gstatic.com; " +
 	"img-src 'self' data:; " +
 	// 'self' also covers same-origin WebSocket (wss:// on an HTTPS page), so


### PR DESCRIPTION
Makes the CSP nonce plumbing from #5729 live: `style-src-elem` now carries a
per-response nonce, so `<style>` elements are enforced without
`'unsafe-inline'`.

Closes the shipping half of #5705 and unblocks #5689.

## The problem

Monaco and xterm both inject `<style>` elements, and neither accepts a nonce.
Monaco's style creation is not the single choke point the #5705 issue body
originally claimed — `contextview.js` appends into a shadow root, bypassing
`createStyleSheet` entirely — so there is no per-library seam to plumb a nonce
through without forking them.

They are also not the whole blast radius. Angular's component styles, the CDK
breakpoints observer, and the index.html splash all create style elements too.

## The approach

Patch `document.createElement` at bootstrap and stamp the document's nonce on
every `<style>` it returns. That is the one call all of these share.

The nonce comes from the `ngCspNonce` attribute Jetstream already injects on
`<app-root>`, read with the same lookup Angular's own `CSP_NONCE` uses, so a
single server-injected value serves both and `index.html` needs no change.

Three details decide whether it works, and each fails silently if wrong:

- Applied at **creation, before insertion**. A nonce set on an already-inserted
  `<style>` leaves `.sheet` permanently null — the element looks fine in the
  inspector and carries no rules.
- Applied via `setAttribute`, not the `.nonce` property, because only the
  attribute survives `cloneNode`.
- Applied to the document instance rather than `Document.prototype`. Every
  caller reaches `createElement` through the document — directly or as an
  element's `ownerDocument` — so the instance is the narrower target that still
  covers all of them.

## This is narrower than `'unsafe-inline'`

Only styles created through the DOM API are nonced. A `<style>` arriving as
**markup** — `innerHTML`, an injected fragment — never passes through
`createElement` and stays refused. That is precisely the injection vector a
nonced `style-src-elem` exists to close: an attacker with HTML injection can no
longer perform style-based exfiltration, and an attacker who can already run
script is past `script-src` and has better options.

The trust boundary is "scripts we run may create styles; markup may not."

## What this does not fix

`style-src` keeps `'unsafe-inline'`, which now covers only inline style
**attributes** — Monaco's per-line positioning, xterm's truecolor cells. CSP
has no nonce or hash mechanism for attributes computed at runtime, so no policy
change can tighten this. It needs upstream conversion of those writes to the
CSSOM, which CSP exempts (cf. microsoft/vscode#288813). Stated, not fixed.

`script-src` remains host-based `'self'` rather than CSP3-strict. The same
plumbing could carry it later; separate workstream.

## Verification

Against the **built UI under Jetstream** (`ng serve` never exercises the
document handler, so it cannot test this), Chrome 151, real
`xterm@5.4.0-beta.37` and Monaco instantiated inside the logged-in app:

| | With shim | Shim removed, same policy |
|---|---|---|
| CSP violations | **0** | 21 |
| Style elements | 13, all nonced | 6 nonced, **7 dead sheets** |
| xterm | correct colours, monospace | unstyled, wrong font/colour |
| Monaco | `vs-dark` live (`rgb(30,30,30)`) | theme dead (transparent) |

The negative control is what makes the passing run meaningful — it confirms the
policy has teeth and the shim is what satisfies it.

**ZAP 2.17.0 A/B**, two Jetstreams differing only in policy, official
`zap-baseline.py`:

- Old policy: `WARN-NEW: CSP: style-src unsafe-inline [10055] x 4` — 9 warnings, 58 passes
- This policy: `PASS: CSP [10055]` — 8 warnings, 59 passes

Every other warning identical in name and count. Exactly one rule changed
state. Corroborated by a second, independent run through ZAP's automation
framework.

**Google Fonts still works.** Measured, not assumed: a
`fonts.googleapis.com` stylesheet loads with no nonce — host sources and nonces
are alternatives in a source list — and the font file downloads from gstatic,
zero violations. `style-src-elem` replaces `style-src` for elements rather than
adding to it, so it must repeat every source `style-src` grants them; a test
pins that invariant so a host added to one and not the other turns red instead
of silently disappearing.

Full `make check gate` green: 3434 passed, 2 skipped.

## Notes for reviewers

- CSP is opt-in and off in every shipped deployment, so this changes nothing
  for operators who have not set `CONSOLE_CSP`.
- nginx topologies send no CSP at all; unchanged and out of scope here.
- The WebGL addon was considered and deliberately left out. With the shim the
  DOM renderer works under the policy, so WebGL is no longer load-bearing — it
  is worth its own PR on its own merits (GPU rendering, removing the four
  cosmetic per-open violations) rather than riding along here.

Refs #5705 #5689 #5729
