### PR TITLE
feat(jetstream): add the missing security response headers

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,60 @@
+# ZAP baseline rule configuration.
+#
+# Format: <rule id> <TAB> <IGNORE|WARN|FAIL> <TAB> [url regex]
+# Used with: zap-baseline.py -c .zap/rules.tsv
+#
+# ZAP is a black-box scanner and never sees our source, so a finding it gets
+# wrong cannot be annotated at the call site the way gosec or semgrep findings
+# can. Suppression has to live here instead — which means each entry needs to
+# carry the evidence that justified it.
+#
+# Only add a rule here when the finding has been shown to be wrong. A real
+# finding belongs in an issue, not in this file.
+
+# 10096 Timestamp Disclosure - Unix.
+# The flagged values are MD5 algorithm constants in a bundled dependency, not
+# timestamps: 1732584193 and 4023233417 are 0x67452301 and 0xefcdab89, the MD5
+# initialisation vector, and 1804603682 is 0x6b901122 from its sine-derived T
+# table. Two of the five "timestamps" also decode to 2027 and 2028, which is a
+# giveaway on its own. Scoped to the bundle so a real timestamp disclosed by an
+# API response would still be reported.
+10096	IGNORE	.*/main-.*\.js
+
+# 10110 Dangerous JS Functions.
+# Matches the string "bypassSecurityTrustHtml(" in the Angular framework code
+# that defines DomSanitizer. Stratos never calls it: the only sanitizer
+# bypasses in our source are bypassSecurityTrustResourceUrl (safe-img,
+# kubernetes dashboard) and bypassSecurityTrustUrl (a data: URL for a JSON
+# download). Scoped to the bundle for the same reason as above.
+10110	IGNORE	.*/main-.*\.js
+
+# 10109 Modern Web Application.
+# Not a finding. It tells whoever is running the scan that the client spider
+# would explore this application better than the standard one, which is advice
+# about the scan rather than about Stratos.
+10109	IGNORE	.*
+
+# 90004 Cross-Origin-Embedder-Policy Header Missing or Invalid.
+# COEP is NOT IMPLEMENTED, deliberately — require-corp would refuse the Google
+# Fonts stylesheet and font files the Content-Security-Policy permits, and it
+# mainly exists to enable cross-origin isolation for features Stratos does not
+# use. Reasoning is in docs/advanced/content-security-policy.md and in
+# security_headers.go. Revisit only alongside a decision about remote fonts.
+#
+# This rule also covers COOP and CORP, which ARE sent — they share plugin id
+# 90004. Both are asserted by tests in security_headers_test.go, so suppressing
+# the shared id here does not leave them unguarded.
+90004	IGNORE	.*
+
+# DELIBERATELY NOT SUPPRESSED, so the next person does not re-litigate it:
+#
+#   10015 Re-examine Cache-control Directives
+#   10049 Non-Storable / Storable and Cacheable / Storable but Non-Cacheable
+#
+# Both are informational, and one is self-inflicted on purpose: the console
+# document is Cache-Control: no-store because the CSP nonce requires it, so
+# "Non-Storable Content" is the scanner correctly observing a deliberate
+# choice. They stay as warnings anyway, because cache directives are exactly
+# where a future real mistake would surface — an API response caching
+# per-user data would report under these same rules, and a blanket IGNORE
+# would hide it.

--- a/docs/advanced/content-security-policy.md
+++ b/docs/advanced/content-security-policy.md
@@ -98,7 +98,71 @@ browser would block the page's styles.
 
 ## Other security headers
 
-Stratos also sends `X-Frame-Options: SAMEORIGIN`, which stops the console being
-framed by another site, and `X-Content-Type-Options: nosniff`, which stops a
-browser second-guessing the content type a response declares. Neither is
-configurable.
+Every response also carries the following. Unlike the policy above they are the
+same on every response, so none of them involves a nonce.
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Frame-Options` | `SAMEORIGIN` | Stops the console being framed by another site. |
+| `X-Content-Type-Options` | `nosniff` | Stops a browser second-guessing the content type a response declares. |
+| `Cross-Origin-Opener-Policy` | `same-origin` | Puts the console in its own browsing-context group, so a cross-origin document cannot reach into it through `window.opener`. |
+| `Cross-Origin-Resource-Policy` | `same-origin` | Stops another origin embedding Stratos responses as subresources. |
+| `Permissions-Policy` | see below | Switches off browser features the console does not use. |
+
+None of these is configurable. The `Permissions-Policy` denies access to the
+camera, microphone, geolocation, payment, USB, MIDI, screen capture and the
+motion sensors, among others.
+
+Reading and writing the clipboard are both deliberately still permitted for the
+console's own origin. The console copies to the clipboard in a good many
+places — endpoint addresses, service-key and other credentials, the diagnostics
+reports, the foundation report export — and the code editor reads the clipboard
+when you paste into it. Denying either fails silently: the copy button appears
+to work and nothing is copied.
+
+These two entries cover only the asynchronous Clipboard API. Ordinary cut,
+copy and paste in a text box, in the terminal, and in much of the code editor
+use older browser mechanisms that no permissions policy governs, and they keep
+working whatever this header says. So if you are checking whether a change here
+broke anything, pasting into a text field will not tell you — use one of the
+copy buttons.
+
+### HTTP Strict Transport Security
+
+`Strict-Transport-Security` is **off unless you ask for it**, because it is a
+promise about your domain rather than about Stratos: once a browser has seen
+the header, that whole domain is HTTPS-only for the lifetime of the `max-age`,
+whether or not Stratos is still serving it. Only you know whether that is safe
+to say.
+
+The `CONSOLE_HSTS` environment variable controls it, using the same vocabulary
+as `CONSOLE_CSP`.
+
+| Value | Effect |
+|-------|--------|
+| unset, `off`, `none`, `false`, `disabled` | No header is sent. This is the default. |
+| `on` or `default` | `max-age=63072000; includeSubDomains` |
+| anything else | Used verbatim as the header value. |
+
+Values are matched without regard to case.
+
+The built-in value is two years including subdomains, which is what the HSTS
+preload list requires, but it deliberately stops short of adding `preload`.
+Preloading is close to irreversible and is a decision about your domain, so add
+that token yourself if you want it.
+
+The header is sent whenever you enable it, without checking whether the
+connection Jetstream itself received was TLS. In most deployments TLS
+terminates at a router in front of Jetstream, which then forwards the header to
+the browser over HTTPS; testing the local connection would suppress it in
+exactly that case. Browsers ignore HSTS received over plain HTTP, so sending it
+there is harmless.
+
+### Cross-Origin-Embedder-Policy is not implemented
+
+`Cross-Origin-Embedder-Policy` is intentionally absent. Setting it to
+`require-corp` makes the browser refuse every cross-origin subresource that
+does not explicitly opt in, which would block the Google Fonts stylesheet and
+font files the policy above permits. It also gains little on its own: its main
+purpose is to enable cross-origin isolation for features such as
+`SharedArrayBuffer`, which the console does not use.

--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -441,6 +441,7 @@ type PortalConfig struct {
 	CFClientSecret                     string   `configName:"CF_CLIENT_SECRET"`
 	AllowedOrigins                     []string `configName:"ALLOWED_ORIGINS"`
 	CSPPolicy                          string   `configName:"CONSOLE_CSP"`
+	HSTSPolicy                         string   `configName:"CONSOLE_HSTS"`
 	SessionStoreSecret                 string   `configName:"SESSION_STORE_SECRET"`
 	EncryptionKeyVolume                string   `configName:"ENCRYPTION_KEY_VOLUME"`
 	EncryptionKeyFilename              string   `configName:"ENCRYPTION_KEY_FILENAME"`

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -674,6 +674,26 @@ func loadPortalConfig(pc api.PortalConfig, env *env.VarSet) (api.PortalConfig, e
 		pc.CSPPolicy = ""
 	}
 
+	// HSTS. The same vocabulary as CONSOLE_CSP above, with the opposite
+	// default: unset means no header.
+	//   - unset / "off" / "none" / "false" / "disabled" -> no header
+	//   - "on" / "default" -> defaultHSTSPolicy
+	//   - anything else -> a full directive string, used verbatim
+	// Off by default because HSTS is a promise about a domain, not about
+	// Stratos: once a browser has seen it, that domain is HTTPS-only for the
+	// max-age whether or not Stratos is still there. Only the operator knows
+	// if that is safe to say, so nothing is asserted on their behalf.
+	switch {
+	case strings.EqualFold(pc.HSTSPolicy, "on"),
+		strings.EqualFold(pc.HSTSPolicy, "default"):
+		pc.HSTSPolicy = defaultHSTSPolicy
+	case strings.EqualFold(pc.HSTSPolicy, "off"),
+		strings.EqualFold(pc.HSTSPolicy, "none"),
+		strings.EqualFold(pc.HSTSPolicy, "false"),
+		strings.EqualFold(pc.HSTSPolicy, "disabled"):
+		pc.HSTSPolicy = ""
+	}
+
 	return pc, nil
 }
 
@@ -881,6 +901,10 @@ func start(config api.PortalConfig, p *portalProxy, needSetupMiddleware bool, is
 		// accompanies the console document.
 		ContentTypeNosniff: "nosniff",
 	}))
+
+	// The headers Echo's Secure middleware has no setting for, plus HSTS,
+	// which it can only express as a max-age. See security_headers.go.
+	e.Use(p.securityHeaders)
 
 	if !isUpgrade {
 		e.Use(errorLoggingMiddleware)

--- a/src/jetstream/main_test.go
+++ b/src/jetstream/main_test.go
@@ -211,3 +211,66 @@ func TestLoadDatabaseConfigWithInvalidSSLMode(t *testing.T) {
 		t.Errorf("Unexpected success - should not be able to load database configs with an invalid SSL Mode specified.")
 	}
 }
+
+// HSTS is the mirror image of CSP: same vocabulary, opposite default. Nothing
+// is asserted about the operator's domain unless they ask for it.
+func TestLoadPortalConfigHSTSIsOffByDefault(t *testing.T) {
+	var pc api.PortalConfig
+
+	result, err := loadPortalConfig(pc, env.NewVarSet(env.WithMapLookup(map[string]string{})))
+	if err != nil {
+		t.Fatalf("Unable to load portal config: %v", err)
+	}
+	if result.HSTSPolicy != "" {
+		t.Errorf("Expected no HSTS policy when CONSOLE_HSTS unset, got %q", result.HSTSPolicy)
+	}
+}
+
+func TestLoadPortalConfigHSTSOnValues(t *testing.T) {
+	var pc api.PortalConfig
+
+	for _, val := range []string{"on", "ON", "default", "Default"} {
+		result, err := loadPortalConfig(pc, env.NewVarSet(env.WithMapLookup(map[string]string{
+			"CONSOLE_HSTS": val,
+		})))
+		if err != nil {
+			t.Fatalf("Unable to load portal config for CONSOLE_HSTS=%q: %v", val, err)
+		}
+		if result.HSTSPolicy != defaultHSTSPolicy {
+			t.Errorf("Expected default HSTS policy for CONSOLE_HSTS=%q, got %q", val, result.HSTSPolicy)
+		}
+	}
+}
+
+// The off-values must normalize to empty, or a well-meaning CONSOLE_HSTS=off
+// ships as a literal Strict-Transport-Security: off header.
+func TestLoadPortalConfigHSTSOffValues(t *testing.T) {
+	var pc api.PortalConfig
+
+	for _, val := range []string{"off", "OFF", "none", "false", "disabled"} {
+		result, err := loadPortalConfig(pc, env.NewVarSet(env.WithMapLookup(map[string]string{
+			"CONSOLE_HSTS": val,
+		})))
+		if err != nil {
+			t.Fatalf("Unable to load portal config for CONSOLE_HSTS=%q: %v", val, err)
+		}
+		if result.HSTSPolicy != "" {
+			t.Errorf("Expected no HSTS policy for CONSOLE_HSTS=%q, got %q", val, result.HSTSPolicy)
+		}
+	}
+}
+
+func TestLoadPortalConfigCustomHSTS(t *testing.T) {
+	var pc api.PortalConfig
+	const custom = "max-age=300"
+
+	result, err := loadPortalConfig(pc, env.NewVarSet(env.WithMapLookup(map[string]string{
+		"CONSOLE_HSTS": custom,
+	})))
+	if err != nil {
+		t.Fatalf("Unable to load portal config: %v", err)
+	}
+	if result.HSTSPolicy != custom {
+		t.Errorf("Expected the custom HSTS policy verbatim, got %q", result.HSTSPolicy)
+	}
+}

--- a/src/jetstream/security_headers.go
+++ b/src/jetstream/security_headers.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+// permissionsPolicy switches off the browser features Stratos never uses, so
+// injected script cannot reach them either. A feature named with an empty
+// allowlist is denied outright; a feature not named here keeps its browser
+// default, which is why the list only has to cover what is worth denying.
+//
+// clipboard-read and clipboard-write are deliberately ALLOWED for this origin,
+// and both are used far more widely than the copy buttons suggest. Seven call
+// sites reach navigator.clipboard.writeText directly — endpoint addresses,
+// service-key credentials, masked CF credentials, the two diagnostics reports,
+// the foundation-shape export and the shared copy-to-clipboard component,
+// which is itself embedded in four more places. The Monaco editor calls
+// navigator.clipboard.read/readText to paste, which is what clipboard-read
+// covers. Denying either fails silently: the button does nothing, paste does
+// nothing, and no error is raised.
+//
+// These two directives govern the asynchronous Clipboard API and nothing else.
+// Most copying in a browser never touches it: cut, copy and paste in a plain
+// input or textarea is native editing, xterm moves terminal text through
+// ClipboardEvent.clipboardData, and Monaco also uses document.execCommand.
+// None of those is affected by Permissions-Policy and all keep working however
+// this is set — which is exactly why the gated paths are easy to break without
+// noticing. Testing "can I still paste into a text box" proves nothing here.
+const permissionsPolicy = "accelerometer=(), autoplay=(), camera=(), " +
+	"display-capture=(), encrypted-media=(), geolocation=(), gyroscope=(), " +
+	"magnetometer=(), microphone=(), midi=(), payment=(), " +
+	"publickey-credentials-get=(), screen-wake-lock=(), usb=(), " +
+	"xr-spatial-tracking=(), clipboard-read=(self), clipboard-write=(self)"
+
+// crossOriginOpenerPolicy puts the console in its own browsing-context group,
+// so a cross-origin document can neither reach into it through window.opener
+// nor be reached by it. Safe here because Stratos opens no popups: every
+// external link is target="_blank" rel="noopener noreferrer", which already
+// severs that relationship.
+const crossOriginOpenerPolicy = "same-origin"
+
+// crossOriginResourcePolicy stops another origin embedding Stratos responses
+// as subresources. Stratos serves an application rather than a CDN, so nothing
+// legitimate needs to.
+const crossOriginResourcePolicy = "same-origin"
+
+// Cross-Origin-Embedder-Policy: NOT IMPLEMENTED, deliberately.
+//
+// COEP "require-corp" refuses every cross-origin subresource that does not opt
+// in via CORP or CORS. The policy permits Google Fonts — fonts.googleapis.com
+// for the stylesheet, fonts.gstatic.com for the font files — and the branding
+// work intends to let users pick a font from there, so turning COEP on would
+// break that.
+//
+// It would also buy little on its own. COEP exists chiefly to establish
+// cross-origin isolation, which unlocks SharedArrayBuffer and high-resolution
+// timers; Stratos uses neither. Revisit it only together with a decision about
+// remote fonts, not as a standalone hardening step.
+
+// defaultHSTSPolicy is what CONSOLE_HSTS=on selects. Two years with subdomains
+// is the value the HSTS preload list requires, but preload itself is left out:
+// it is effectively irreversible, and that is an operator's call to make for
+// their own domain rather than a default Stratos imposes.
+const defaultHSTSPolicy = "max-age=63072000; includeSubDomains"
+
+// securityHeaders sets the response headers that are identical on every
+// response.
+//
+// The Content-Security-Policy is deliberately not among them: it carries a
+// per-response nonce, so serveIndexHTML sets it on the single document that
+// needs one. See csp.go.
+func (p *portalProxy) securityHeaders(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		header := c.Response().Header()
+		header.Set("Permissions-Policy", permissionsPolicy)
+		header.Set("Cross-Origin-Opener-Policy", crossOriginOpenerPolicy)
+		header.Set("Cross-Origin-Resource-Policy", crossOriginResourcePolicy)
+
+		// Sent whenever the operator has opted in, without checking whether
+		// this particular connection is TLS. In most deployments TLS
+		// terminates at a router in front of Jetstream, which then forwards
+		// these headers to the browser over HTTPS — so gating on c.IsTLS()
+		// would suppress the header in exactly the topology that needs it.
+		// Sending it over plain HTTP costs nothing: browsers are required to
+		// ignore HSTS received over an insecure transport.
+		if policy := p.GetConfig().HSTSPolicy; policy != "" {
+			header.Set("Strict-Transport-Security", policy)
+		}
+
+		return next(c)
+	}
+}

--- a/src/jetstream/security_headers_test.go
+++ b/src/jetstream/security_headers_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func serveThroughSecurityHeaders(t *testing.T, p *portalProxy) http.Header {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+	handler := p.securityHeaders(func(echo.Context) error { return nil })
+	if err := handler(c); err != nil {
+		t.Fatalf("securityHeaders: %v", err)
+	}
+	return rec.Header()
+}
+
+func TestSecurityHeadersAreSetOnEveryResponse(t *testing.T) {
+	header := serveThroughSecurityHeaders(t, &portalProxy{})
+
+	for name, want := range map[string]string{
+		"Permissions-Policy":           permissionsPolicy,
+		"Cross-Origin-Opener-Policy":   crossOriginOpenerPolicy,
+		"Cross-Origin-Resource-Policy": crossOriginResourcePolicy,
+	} {
+		if got := header.Get(name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// Seven call sites copy with navigator.clipboard.writeText — credentials,
+// endpoint addresses, diagnostics reports, the foundation-shape export — and
+// Monaco pastes with navigator.clipboard.read/readText. Denying either breaks
+// silently: the button does nothing and no error is raised. Pinned here rather
+// than left to whoever next edits the policy string.
+func TestPermissionsPolicyStillAllowsClipboard(t *testing.T) {
+	for _, feature := range []string{"clipboard-read=(self)", "clipboard-write=(self)"} {
+		if !strings.Contains(permissionsPolicy, feature) {
+			t.Errorf("%s must stay allowed for this origin: %q", feature, permissionsPolicy)
+		}
+	}
+}
+
+// COEP is deliberately absent: require-corp would refuse the Google Fonts
+// subresources the policy permits. If it is ever added, that decision has to
+// be made together with one about remote fonts, so this fails loudly rather
+// than letting it arrive as an unnoticed hardening tweak.
+func TestCrossOriginEmbedderPolicyIsNotSent(t *testing.T) {
+	if got := serveThroughSecurityHeaders(t, &portalProxy{}).Get("Cross-Origin-Embedder-Policy"); got != "" {
+		t.Errorf("COEP is not implemented; got %q", got)
+	}
+}
+
+func TestHSTSIsAbsentUnlessConfigured(t *testing.T) {
+	if got := serveThroughSecurityHeaders(t, &portalProxy{}).Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("HSTS must be off by default, got %q", got)
+	}
+}
+
+// Deliberately not gated on the connection being TLS. In most deployments TLS
+// terminates upstream and Jetstream sees plain HTTP, so a c.IsTLS() gate would
+// suppress the header in exactly the topology that needs it. The request built
+// by the helper is not TLS, which is the point.
+func TestHSTSIsSentEvenWhenJetstreamItselfIsNotTLS(t *testing.T) {
+	p := &portalProxy{}
+	p.Config.HSTSPolicy = "max-age=1234"
+
+	if got := serveThroughSecurityHeaders(t, p).Get("Strict-Transport-Security"); got != "max-age=1234" {
+		t.Errorf("HSTS = %q, want the configured value", got)
+	}
+}


### PR DESCRIPTION
Adds the response headers Stratos was missing, and triages the residual ZAP
findings so the ones that remain are the ones worth looking at.

Follows #5742. Contributes to #5743 and #5679.

## Headers added

| Header | Value | Why |
|---|---|---|
| `Cross-Origin-Opener-Policy` | `same-origin` | Puts the console in its own browsing-context group. Safe because Stratos opens no popups — every external link is already `target="_blank" rel="noopener noreferrer"`. |
| `Cross-Origin-Resource-Policy` | `same-origin` | Stops other origins embedding Stratos responses. It serves an application, not a CDN. |
| `Permissions-Policy` | see below | Switches off browser features the console never uses. |
| `Strict-Transport-Security` | `CONSOLE_HSTS` | Off by default. |

### HSTS is off by default, and configurable

HSTS is a promise about the operator's **domain**, not about Stratos: once a
browser has seen the header, that domain is HTTPS-only for the `max-age`
whether or not Stratos is still serving it. Nothing is asserted on the
operator's behalf. `CONSOLE_HSTS` takes the same vocabulary as `CONSOLE_CSP` —
`on`/`default`, the off-values, or a verbatim directive string. The built-in
value is two years with subdomains and deliberately stops short of `preload`,
which is close to irreversible and is the operator's call.

One deliberate choice worth flagging for review: the header is sent whenever it
is enabled, **without** checking whether the connection Jetstream received was
TLS. In most deployments TLS terminates at a router in front of Jetstream,
which forwards headers to the browser over HTTPS, so a `c.IsTLS()` gate would
suppress it in exactly the topology that needs it. Browsers are required to
ignore HSTS received over plain HTTP, so sending it there costs nothing.

### Permissions-Policy allows clipboard read *and* write

This is the entry most likely to be "tidied up" later and it deserves the
detail. Both are allowed for this origin because both are used:

- Seven call sites reach `navigator.clipboard.writeText` — service-key
  credentials, masked CF credentials, endpoint addresses, code blocks, the two
  diagnostics reports, the foundation-shape export — plus the shared
  `app-copy-to-clipboard` component, itself embedded in four more places.
- Monaco calls `navigator.clipboard.read`/`readText` to paste, which is what
  `clipboard-read` covers.

`clipboard-read` was very nearly omitted. It would have kept working anyway,
because Chrome's default allowlist for it is `self` — correct by accident
rather than by intent, and one "unused directive" cleanup away from silently
breaking editor paste.

**These directives govern only the asynchronous Clipboard API.** Native cut and
paste in an input or textarea, xterm's terminal copy/paste through
`ClipboardEvent.clipboardData`, and Monaco's `execCommand` path are all
unaffected and keep working however this is set. That matters for reviewing
this: pasting into a text box does **not** verify the policy. Use one of the
copy buttons. Both allowances are pinned by a test, and the reasoning is in the
code and the operator docs so it survives the next edit.

### COEP is deliberately not implemented

Labelled as such in three places — `security_headers.go`, the operator docs and
`.zap/rules.tsv` — so it reads as a decision rather than an oversight.
`require-corp` would refuse every cross-origin subresource that does not opt
in, which includes the Google Fonts stylesheet and font files the CSP permits
and the branding work intends to use. It also buys little alone: its purpose is
cross-origin isolation for features such as `SharedArrayBuffer`, which Stratos
does not use. Revisit only alongside a decision about remote fonts.

## ZAP triage

`.zap/rules.tsv` suppresses two findings that were shown to be wrong. Each
entry carries its evidence, because a bare rule number is indistinguishable
from someone silencing something real.

- **Timestamp Disclosure [10096] ×5** — the flagged values are MD5 constants in
  a bundled dependency: `1732584193` and `4023233417` are `0x67452301` and
  `0xefcdab89`, the MD5 initialisation vector, and `1804603682` is `0x6b901122`
  from its sine-derived T table. Two of the five "timestamps" also decode to
  2027 and 2028.
- **Dangerous JS Functions [10110]** — matches the string
  `bypassSecurityTrustHtml(` in Angular's own `DomSanitizer` definition.
  Stratos never calls it; our only sanitizer bypasses are
  `bypassSecurityTrustResourceUrl` and `bypassSecurityTrustUrl`.

Both are scoped to the bundle URL, so a real timestamp disclosed by an API
response would still be reported.

**The cache-related rules [10015] and [10049] are deliberately left as
warnings**, with the reasoning recorded in the file. One of them is
self-inflicted on purpose — the console document is `Cache-Control: no-store`
because the CSP nonce requires it — but cache directives are exactly where a
future real mistake would surface, and a blanket ignore would hide it.

## Verification

Baseline scan against the built UI under Jetstream, ZAP 2.17.0:

| | Before #5742 | After #5742 | This PR |
|---|---|---|---|
| Warnings | 9 | 8 | **2** |
| Passes | 58 | 59 | **61** |
| Failures | 0 | 0 | 0 |

The two remaining are the cache informationals above. Headers confirmed present
on both the console document and static assets, and the application verified
unaffected — login and dashboard render, every style element nonced and live,
zero CSP violations, no console errors.

Full `make check gate` green: 3434 passed, 2 skipped.
