### PR TITLE
docs: badge and CONTRIBUTING lifecycle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,11 @@ To send your code change, use GitHub pull requests. The workflow is as follows:
 
   1. Create a branch based on `develop`.
 
-  1. Implement your change, including tests and documentation.
+  1. Implement your change, including tests and documentation. See
+     [Requirements for a change](#requirements-for-a-change) below for what a
+     reviewable change has to include.
 
-  1. Run tests to make sure your change didn't break anything.
+  1. Run `make check gate` and make sure it passes before you publish.
 
   1. Publish the branch and create a pull request.
 
@@ -53,6 +55,69 @@ See also [GitHub's guide on contributing](https://help.github.com/articles/fork-
 If you want to do multiple unrelated changes, use separate branches and pull
 requests.
 
+### Requirements for a change
+
+A change is ready for review when all of the following hold. Continuous
+integration checks every one of them on your pull request, so running them
+locally first saves a round trip.
+
+**Tests.** New functionality must arrive with tests that cover it, and a bug
+fix must arrive with a test that fails without the fix. This is the project's
+test policy and it applies to every change, not only to large ones: a change
+that adds behaviour nothing exercises is not reviewable, because nothing will
+tell us when it breaks later.
+
+Tests live beside the code they cover — `*.spec.ts` for the frontend,
+`*_test.go` for Jetstream. Run them with:
+
+```bash
+make test                 # everything
+make test frontend        # the Angular packages only
+make test backend         # Jetstream only
+```
+
+**The quality gate.** `make check gate` runs lint, the unit tests and a
+production build. It must pass before you publish:
+
+```bash
+make check gate
+```
+
+Lint is not advisory. The gate fails on any ESLint or TypeScript error, and the
+project adds its own rules under `tools/eslint-rules/` on top of the standard
+sets. Warnings are worth clearing too, even where they do not fail the build.
+
+**Documentation.** If your change alters behaviour an operator or user can
+observe — a configuration variable, an API, a header, a screen — update the
+documentation in the same pull request. Configuration variables also belong in
+`src/jetstream/config.example`.
+
+**A release-notes fragment.** Each pull request carries its own fragment in
+`changelog.d/`, written for the person upgrading rather than for the reviewer:
+
+```bash
+./build/release-notes.sh new        # names it after your branch
+```
+
+See [`changelog.d/README.md`](changelog.d/README.md) for the format. This check
+is advisory rather than blocking, because purely internal changes with no
+user-visible effect do not need a fragment — but if yours changes anything a
+user would notice, add one.
+
+**Sign-off.** Every commit needs a `Signed-off-by` line — see
+[Sign your work](#sign-your-work).
+
+### Development environment
+
+| Tool | Version |
+|------|---------|
+| Node | `^24` or `^26` |
+| bun  | `>= 1.3.14` |
+| Go   | `1.26.3` |
+
+`bun install` at the repository root sets up the frontend and the build
+tooling. `make help` lists every available target.
+
 ### Commits
 
 Each commit in the pull request should do only one thing, which is clearly
@@ -60,6 +125,11 @@ described by its commit message. Especially avoid mixing formatting changes and
 functional changes into one commit. When writing commit messages, adhere to
 [widely used
 conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+Subjects follow the `type(scope): summary` form used throughout the history —
+`feat(jetstream):`, `fix(cloud-foundry):`, `docs:`, `ci:`, `chore(deps):`.
+Release tooling reads these prefixes, so keeping to them matters beyond
+tidiness.
 
 When the commit fixes a bug, put a message in the body of the commit message
 pointing to the number of the issue (e.g. "Fixes #123").

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Stratos
 
-<a style="padding-left: 4px" href="https://codeclimate.com/github/cloudfoundry-community/stratos/maintainability"><img src="https://api.codeclimate.com/v1/badges/61af8b605f385e894632/maintainability" /></a>
-<a href="https://goreportcard.com/report/github.com/cloudfoundry/stratos"><img src="https://goreportcard.com/badge/github.com/cloudfoundry-incubator/stratos"/></a>
-<a href="https://codecov.io/gh/cloudfoundry-community/stratos/branch/master"><img src="https://codecov.io/gh/cloudfoundry-community/stratos/branch/master/graph/badge.svg"/></a>
-[![GitHub release](https://img.shields.io/github/release/cloudfoundry-community/stratos.svg)](https://github.com/cloudfoundry/stratos/releases/latest)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/cloudfoundry/stratos/blob/main/LICENSE)
-[![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/messages/C80EP4Y57/)
+[![Frontend Tests](https://img.shields.io/github/actions/workflow/status/cloudfoundry/stratos/frontend_tests.yml?branch=develop&label=frontend%20tests)](https://github.com/cloudfoundry/stratos/actions/workflows/frontend_tests.yml)
+[![Backend Tests](https://img.shields.io/github/actions/workflow/status/cloudfoundry/stratos/backend_tests.yml?branch=develop&label=backend%20tests)](https://github.com/cloudfoundry/stratos/actions/workflows/backend_tests.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/cloudfoundry/stratos/codeql.yml?branch=develop&label=CodeQL)](https://github.com/cloudfoundry/stratos/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cloudfoundry/stratos/badge)](https://scorecard.dev/viewer/?uri=github.com/cloudfoundry/stratos)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13948/badge)](https://www.bestpractices.dev/projects/13948)
+[![Angular](https://img.shields.io/github/package-json/dependency-version/cloudfoundry/stratos/@angular/core?branch=develop&label=angular)](package.json)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/cloudfoundry/stratos?filename=src%2Fjetstream%2Fgo.mod&label=go)](src/jetstream/go.mod)
+[![Latest Release](https://img.shields.io/github/v/release/cloudfoundry/stratos)](https://github.com/cloudfoundry/stratos/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ Please visit our new [documentation site](https://stratos.app/). There you can d
 
 ### Prerequisites
 
-- **Node.js 24+** - Required for build system
-- **Bun** - Package manager ([installation guide](https://bun.sh))
-- **Go 1.21+** - For backend development
+- **Node.js 24 or 26** - Required for the build system. The `engines` field is
+  `^24 || ^26`, so 25 is not supported.
+- **Bun 1.3.14+** - Package manager ([installation guide](https://bun.sh))
+- **Go 1.26.3+** - For backend development
+
+These are taken from `engines` in `package.json` and the `go` directive in
+`src/jetstream/go.mod`, which are the versions the build and CI actually use.
 
 ### First-Time Setup
 


### PR DESCRIPTION
Lifecycle maintenance on the README badges. Five of the six were broken, not
just Go Report Card.

## What was there

Each was fetched before being removed, rather than assumed:

| Badge | Rendered | Problem |
|---|---|---|
| Go Report Card | `retired` | the service is gone; the badge says so literally |
| Code Climate | *(no grade)* | logo-only SVG — Code Climate Quality was sunset |
| Codecov | `unknown` | no workflow uploads coverage anywhere; also pointed at `cloudfoundry-community` and branch `master` |
| GitHub release | `v4.8.0` | pointed at `cloudfoundry-community`; this repo is at `v5.0.0-dev.147` |
| Slack | **404** | `slack.cloudfoundry.org/badge.svg` no longer exists |
| License MIT | `MIT` | correct — kept |

Three named `cloudfoundry-community/stratos` rather than `cloudfoundry/stratos`,
which is why the release badge sat a full major version behind.

## What replaces them

The set `cloudfoundry-community/go-cfenv` uses, adapted for a two-language repo
rather than a Go-only one — so the frontend gets a signal it never had:

- **Frontend Tests** and **Backend Tests** — workflow status, the real health
  indicators for the Angular and Go halves
- **CodeQL** — links to the workflow rather than the security tab, which GitHub
  serves as a 404 to anyone without repository access
- **OpenSSF Scorecard** — reads **7.6**; needs no registration, it scans public
  repos automatically
- **OpenSSF Best Practices** — project 13948
- **Angular** and **Go Version** — read live from `package.json` and
  `src/jetstream/go.mod`; currently **22.0.8** and **v1.26.3**. Self-maintaining,
  and a version skew becomes visible on the front page
- **Latest Release** and **License**

Every image and link was verified to resolve.

## Removals that are not repairs

Codecov is dropped rather than fixed: `make check coverage` exists, but nothing
publishes coverage to any service, so the badge has no source. Wiring that up is
separate work.

The Slack *badge* is dead; the community is not. If the pointer is wanted, it
belongs as a plain link in the text rather than as a badge.


---

## CONTRIBUTING.md — what a contribution has to include

Added in the same pull request because it is the same kind of maintenance: a
document that had drifted from what the project actually does.

`CONTRIBUTING.md` described the pull-request workflow well but said almost
nothing about what makes a change *acceptable*. The whole of it was two
bullets — "including tests and documentation" and "run tests" — leaving a
contributor to infer the test policy, the quality gate, the lint rules, the
changelog fragment and the supported toolchain by reading other people's pull
requests.

A new **Requirements for a change** section states the five things CI checks:

- **Tests** — new functionality arrives with tests that cover it; a bug fix
  arrives with a test that fails without the fix. Stated as the project's test
  policy, applying to every change rather than only to large ones.
- **The quality gate** — `make check gate` (lint, unit tests, production build)
  must pass before publishing. Lint is not advisory.
- **Documentation** — updated in the same pull request when observable
  behaviour changes; configuration variables also go in `config.example`.
- **A release-notes fragment** — `./build/release-notes.sh new`, marked
  advisory rather than blocking, which is what CI actually does.
- **Sign-off** — cross-linked to the existing DCO section.

Plus a **development environment** table — Node `^24` or `^26`, bun `>= 1.3.14`,
Go `1.26.3`, taken from `package.json` engines and `go.mod` — and a note that
commit subjects follow `type(scope):` because the release tooling reads those
prefixes.

Docs lint passes; both new anchors resolve.

## README prerequisites — corrected toolchain versions

Found while writing the CONTRIBUTING environment table, and fixed here since
this pull request already touches the README.

- **Go** was stated as `1.21+` while `src/jetstream/go.mod` requires
  **1.26.3** — five minor versions short, so anyone setting up from the README
  would fail to build the backend.
- **Node** was stated as `24+`, which reads as "anything newer is fine". The
  `engines` field is `^24 || ^26`, so **25 is not supported** and the plus sign
  was actively misleading.
- **Bun** carried no version at all, despite `engines` requiring **>= 1.3.14**.

Each entry now names where the number comes from, so the next drift is visible
rather than inferred. The `bun run` script names further down the README were
checked against `package.json` and are all still current.

