### PR TITLE
fix(forms): restore full width on four text inputs

### DIFF
--- a/changelog.d/0044-fix-form-input-width.md
+++ b/changelog.d/0044-fix-form-input-width.md
@@ -1,0 +1,2 @@
+[BugFixes]
+- Text fields in the user-invite configuration dialog and the backup password step are full width again, rather than showing about twenty characters at a time. They carried a `form-input` class whose styling did not survive the move to Tailwind, and an input with no width falls back to the browser's default of roughly twenty characters — so a client secret or a long password scrolled out of sight as it was typed and looked truncated. Nothing was ever cut off; the value was always stored in full (#5758).

--- a/src/frontend/packages/cloud-foundry/src/features/cf/user-invites/configuration-dialog/user-invite-configuration-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/user-invites/configuration-dialog/user-invite-configuration-dialog.component.html
@@ -14,10 +14,10 @@
   <form class="connection-dialog__form" [formGroup]="endpointForm" (ngSubmit)="submit()">
     <div class="dialog-content connection-dialog__content">
       <div class="form-field">
-        <input class="form-input" placeholder="Client ID" formControlName="clientID">
+        <input class="w-full" placeholder="Client ID" formControlName="clientID">
       </div>
       <div class="form-field">
-        <input class="form-input" placeholder="Client Secret" formControlName="clientSecret"
+        <input class="w-full" placeholder="Client Secret" formControlName="clientSecret"
           [type]="!showSecret() ? 'password' : 'text'">
         <button class="btn-icon" (click)="toggleShowSecret()" [attr.aria-label]="'Hide Secret'"
           [attr.aria-pressed]="!showSecret()" type='button'>

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.html
@@ -34,7 +34,7 @@
       <form [formGroup]="passwordForm" class="stepper-form">
         <div class="form-field">
           <label class="form-label" for="backup-password">Password</label>
-          <input class="form-input" id="backup-password" formControlName="password" name="password" required
+          <input class="w-full" id="backup-password" formControlName="password" name="password" required
             [type]="!showPassword[1] ? 'password' : 'text'">
           <span class="form-suffix">
             <app-show-hide-button (changed)="showPassword[1] = $event"></app-show-hide-button>
@@ -51,7 +51,7 @@
         </div>
         <div class="form-field">
           <label class="form-label" for="backup-password2">Confirm Password</label>
-          <input class="form-input" id="backup-password2" formControlName="password2" name="password2" required
+          <input class="w-full" id="backup-password2" formControlName="password2" name="password2" required
             [type]="!showPassword[2] ? 'password' : 'text'">
           <span class="form-suffix">
             <app-show-hide-button (changed)="showPassword[2] = $event"></app-show-hide-button>


### PR DESCRIPTION
Closes #5758.

Reported as text truncating after about 23 characters when configuring user invites. Nothing was truncated — the value was always stored in full. The inputs render at the browser's default width, so text scrolled out of view as it was typed and looked cut off.

## Cause

The inputs carried `class="form-input"`. That class has **zero CSS rules anywhere in the codebase** — its styling did not survive the move to Tailwind, and the markup kept referencing it. An `<input>` with no width falls back to the browser default of `size=20`, which renders roughly 20–23 characters. That also explains why the `maxlength` theory in the issue found nothing: there is no length constraint, only a narrow box.

## Four inputs, not one

| File | Fields |
|---|---|
| `user-invite-configuration-dialog.component.html:17,20` | Client ID, Client Secret — the reported ones |
| `backup-endpoints.component.html:37,54` | backup password, confirm password |

The backup password fields had the identical defect and nobody had reported it. Fixing only the field named in the issue would have left them broken.

`form-input` no longer appears anywhere in the tree, so the dead class is gone rather than left to rot.

## Why `w-full` and not `appInput`

The obvious move was to copy the working idiom, `class="w-full …" appInput`. The directive turns out to be unnecessary here: `AppInputDirective` is only consumed by `custom-form-field`'s `@ContentChild`, neither of these components uses that wrapper, and the classes it applies (`mat-input-element`, `app-input-element`) have no CSS rules either. `w-full` is doing all the work, so that is all this adds.

## Related, deliberately not fixed here

`form-input` is one of a family of classes referenced in markup with no CSS behind them:

| class | CSS rules | HTML files |
|---|---|---|
| `form-label` | 0 | 4 |
| `form-suffix` | 0 | 1 |
| `form-error` | 0 | 2 |
| `password-step` | 0 | 1 |

The backup password step alone references five dead classes, so its labels and error messages are unstyled too. That is a separate defect from the width bug and wants its own change rather than being folded in here.

## Verification

`make check gate` green: 14 Go packages ok with 0 failures, 654 frontend test files and 3460 tests passed, 2 skipped.

Not reproduced in a browser — the mechanism is established from the markup and the absent CSS rather than from a running console.