### PR TITLE
feat(cf): last-refreshed column and range filter on app lists

### DIFF
--- a/changelog.d/0052-5770-last-refreshed.md
+++ b/changelog.d/0052-5770-last-refreshed.md
@@ -1,0 +1,2 @@
+[Features]
+- Application lists show when each app was last refreshed — the newest successful staging, so restages count and failed pushes don't — and can filter it by date range (before/after/between, inclusive or exclusive ends). The range filter mechanism is general and extends to numeric columns (#5770).

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.spec.ts
@@ -57,6 +57,7 @@ function makeStubSignalConfigService() {
     selectedSpace: signal<string | null>(null),
     selectedStacks: signal<string[] | null>(null),
     selectedStates: signal<string[] | null>(null),
+    lastRefreshedRange: signal<any>(null),
     nameFilter: signal(''),
     filterField: signal('name'),
     viewMode: signal<'table' | 'card'>('table'),
@@ -171,6 +172,36 @@ describe('ApplicationWallComponent', () => {
     expect(cfg!.filterDropdowns![0].selected).toBe(stubSignalConfig.selectedCnsi);
     expect(cfg!.filterDropdowns![1].selected).toBe(stubSignalConfig.selectedOrg);
     expect(cfg!.filterDropdowns![2].selected).toBe(stubSignalConfig.selectedSpace);
+  });
+
+  it('adds a Last Refreshed column directly after Created', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+    const headers = cfg!.columns.map(c => c.header);
+    const createdIdx = headers.indexOf('Created');
+    expect(createdIdx).toBeGreaterThanOrEqual(0);
+    expect(headers[createdIdx + 1]).toBe('Last Refreshed');
+
+    const lastRefreshedCol = cfg!.columns.find(c => c.header === 'Last Refreshed');
+    expect(lastRefreshedCol).toBeDefined();
+    expect(lastRefreshedCol!.key).toBe('lastRefreshedAt');
+    expect(lastRefreshedCol!.sortField).toBe('lastRefreshedAt');
+    expect(lastRefreshedCol!.render({ lastRefreshedAt: '2026-07-15T12:00:00Z' } as any))
+      .toBe(ApplicationWallComponent.formatDate('2026-07-15T12:00:00Z'));
+    expect(lastRefreshedCol!.render({} as any)).toBe('—');
+  });
+
+  it('includes lastRefreshedAt in filterColumns and wires filterRanges to appsConfig.lastRefreshedRange', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+    expect(cfg!.filterColumns).toContain('lastRefreshedAt');
+    expect(cfg!.filterRanges).toBeDefined();
+    const range = cfg!.filterRanges!.find(r => r.field === 'lastRefreshedAt');
+    expect(range).toBeDefined();
+    expect(range!.valueType).toBe('date');
+    expect(range!.selected).toBe(stubSignalConfig.lastRefreshedRange);
   });
 });
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.ts
@@ -302,6 +302,11 @@ export class ApplicationWallComponent implements OnInit {
       render: (app: StApp) => app.stackName || '—',
       widthHint: '9rem',
     };
+    const lastRefreshedColumn: SignalListColumn<StApp> = {
+      header: 'Last Refreshed', key: 'lastRefreshedAt', sortField: 'lastRefreshedAt',
+      render: (app: StApp) => app.lastRefreshedAt ? ApplicationWallComponent.formatDate(app.lastRefreshedAt) : '—',
+      widthHint: '12rem',
+    };
     const stateColor = (app: StApp): SignalListPillColor => {
       const s = (app.state ?? '').toUpperCase();
       if (s === 'STARTED') return 'success';
@@ -421,6 +426,7 @@ export class ApplicationWallComponent implements OnInit {
             render: (app: StApp) => ApplicationWallComponent.formatDate(app.createdAt),
             widthHint: '12rem',
           },
+          lastRefreshedColumn,
           {
             header: '', key: 'favorite',
             kind: 'favorite',
@@ -448,7 +454,9 @@ export class ApplicationWallComponent implements OnInit {
           card: [6, 12, 24, 48, 96],
         },
         nameFilter: this.appsConfig.nameFilter,
-        filterColumns: withStack ? ['name', 'state', 'cfOrgSpace', 'stackName'] : ['name', 'state', 'cfOrgSpace'],
+        filterColumns: withStack
+          ? ['name', 'state', 'cfOrgSpace', 'stackName', 'lastRefreshedAt']
+          : ['name', 'state', 'cfOrgSpace', 'lastRefreshedAt'],
         // Status has no visibility gate (always ≥2 possible states) so its
         // entry is unconditional; Stack's is only wired while its column
         // is actually in filterColumns — otherwise a filterField left
@@ -456,6 +464,11 @@ export class ApplicationWallComponent implements OnInit {
         // service's filter state is a shared singleton) would pop the
         // checklist for a column not shown here.
         filterMultis: withStack ? [statusFilterMulti, stackFilterMulti] : [statusFilterMulti],
+        filterRanges: [{
+          field: 'lastRefreshedAt',
+          valueType: 'date' as const,
+          selected: this.appsConfig.lastRefreshedRange,
+        }],
         filterField: this.appsConfig.filterField,
         filterDropdowns: dropdowns,
         onRefresh: () => this.appsConfig.refresh(),

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
@@ -148,6 +148,7 @@ function makeStubAppsConfig() {
     selectedSpace: signal<string | null>(null),
     selectedStacks: signal<string[] | null>(null),
     selectedStates: signal<string[] | null>(null),
+    lastRefreshedRange: signal<any>(null),
     nameFilter: signal(''),
     filterField: signal('name'),
     viewMode: signal<'card' | 'table'>('card'),
@@ -205,6 +206,36 @@ describe('CloudFoundryApplicationsSignalComponent (component)', () => {
     expect(cfg!.filterDropdowns!.map(d => d.label)).toEqual(['Organization', 'Space']);
     expect(cfg!.filterDropdowns![0].selected).toBe(stubAppsConfig.selectedOrg);
     expect(cfg!.filterDropdowns![1].selected).toBe(stubAppsConfig.selectedSpace);
+  });
+
+  it('adds a Last Refreshed column directly after Created', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+    const headers = cfg!.columns.map(c => c.header);
+    const createdIdx = headers.indexOf('Created');
+    expect(createdIdx).toBeGreaterThanOrEqual(0);
+    expect(headers[createdIdx + 1]).toBe('Last Refreshed');
+
+    const lastRefreshedCol = cfg!.columns.find(c => c.header === 'Last Refreshed');
+    expect(lastRefreshedCol).toBeDefined();
+    expect(lastRefreshedCol!.key).toBe('lastRefreshedAt');
+    expect(lastRefreshedCol!.sortField).toBe('lastRefreshedAt');
+    expect(lastRefreshedCol!.render(app({ lastRefreshedAt: '2026-07-15T12:00:00Z' })))
+      .toBe(Cmp.formatDate('2026-07-15T12:00:00Z'));
+    expect(lastRefreshedCol!.render(app({ lastRefreshedAt: undefined }))).toBe('—');
+  });
+
+  it('includes lastRefreshedAt in filterColumns and wires filterRanges to appsConfig.lastRefreshedRange', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg).toBeDefined();
+    expect(cfg!.filterColumns).toContain('lastRefreshedAt');
+    expect(cfg!.filterRanges).toBeDefined();
+    const range = cfg!.filterRanges!.find(r => r.field === 'lastRefreshedAt');
+    expect(range).toBeDefined();
+    expect(range!.valueType).toBe('date');
+    expect(range!.selected).toBe(stubAppsConfig.lastRefreshedRange);
   });
 
   it('lazily loads this CF’s org/space catalog when a dropdown is first opened', async () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.ts
@@ -175,6 +175,12 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
       render: (app: StApp) => app.stackName || '—',
       widthHint: '9rem',
     };
+    const lastRefreshedColumn: SignalListColumn<StApp> = {
+      header: 'Last Refreshed', key: 'lastRefreshedAt', sortField: 'lastRefreshedAt',
+      render: (app: StApp) => app.lastRefreshedAt
+        ? CloudFoundryApplicationsSignalComponent.formatDate(app.lastRefreshedAt) : '—',
+      widthHint: '12rem',
+    };
 
     const stateColor = (app: StApp): SignalListPillColor => {
       const s = (app.state ?? '').toUpperCase();
@@ -275,6 +281,7 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
             render: (app: StApp) => CloudFoundryApplicationsSignalComponent.formatDate(app.createdAt),
             widthHint: '12rem',
           },
+          lastRefreshedColumn,
           {
             header: '', key: 'favorite',
             kind: 'favorite',
@@ -305,7 +312,9 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
         // Filter-by-field parity with the wall: the text filter can target
         // Name, Status, or the Org/Space column; Stack joins the list
         // (as a checklist, not text) once its column is visible.
-        filterColumns: withStack ? ['name', 'state', 'orgSpace', 'stackName'] : ['name', 'state', 'orgSpace'],
+        filterColumns: withStack
+          ? ['name', 'state', 'orgSpace', 'stackName', 'lastRefreshedAt']
+          : ['name', 'state', 'orgSpace', 'lastRefreshedAt'],
         // Status has no visibility gate (always ≥2 possible states) so its
         // entry is unconditional; Stack's is only wired while its column
         // is actually in filterColumns — otherwise a filterField left
@@ -313,6 +322,11 @@ export class CloudFoundryApplicationsSignalComponent implements OnInit {
         // service's filter state is a shared singleton) would pop the
         // checklist for a column not shown here.
         filterMultis: withStack ? [statusFilterMulti, stackFilterMulti] : [statusFilterMulti],
+        filterRanges: [{
+          field: 'lastRefreshedAt',
+          valueType: 'date' as const,
+          selected: this.appsConfig.lastRefreshedRange,
+        }],
         filterField: this.appsConfig.filterField,
         filterDropdowns: dropdowns,
         onRefresh: () => this.appsConfig.refresh(),

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
@@ -65,6 +65,7 @@ function makeStubAppsConfig() {
     viewMode: signal<'card' | 'table'>('card'),
     selectedStacks: signal<string[] | null>(null),
     selectedStates: signal<string[] | null>(null),
+    lastRefreshedRange: signal<any>(null),
     stackUiVisible: signal(false).asReadonly(),
     stackOptions: signal([allOption]).asReadonly(),
     statusOptions: signal(['Deployed - Online', 'Stopped', 'Crashed', 'Failed']).asReadonly(),
@@ -129,7 +130,7 @@ describe('CloudFoundrySpaceAppsSignalComponent', () => {
     const cfg = component.listConfig();
     expect(cfg).toBeDefined();
     expect(cfg!.columns.map(c => c.header)).toEqual([
-      '', 'Name', 'Status', 'Instances', 'Memory', 'Disk', 'Created', '', '',
+      '', 'Name', 'Status', 'Instances', 'Memory', 'Disk', 'Created', 'Last Refreshed', '', '',
     ]);
     // No filter dropdowns — single-CNSI single-space tab.
     expect(cfg!.filterDropdowns).toBeUndefined();
@@ -138,6 +139,35 @@ describe('CloudFoundrySpaceAppsSignalComponent', () => {
       cnsiGuid: 'cnsi-1', guid: 'app-1', name: 'a', state: 'STARTED',
       spaceGuid: 'space-1', instances: 1, createdAt: '', updatedAt: '',
     } as any)).toBe('cnsi-1:app-1');
+  });
+
+  it('renders the Last Refreshed column via the component formatter, em-dash when absent', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    const lastRefreshedCol = cfg!.columns.find(c => c.header === 'Last Refreshed');
+    expect(lastRefreshedCol).toBeDefined();
+    expect(lastRefreshedCol!.key).toBe('lastRefreshedAt');
+    expect(lastRefreshedCol!.sortField).toBe('lastRefreshedAt');
+    const withRefresh: any = {
+      cnsiGuid: 'cnsi-1', guid: 'app-1', name: 'a', state: 'STARTED',
+      spaceGuid: 'space-1', instances: 1, createdAt: '', updatedAt: '',
+      lastRefreshedAt: '2026-07-15T12:00:00Z',
+    };
+    expect(lastRefreshedCol!.render(withRefresh))
+      .toBe(CloudFoundrySpaceAppsSignalComponent.formatDate('2026-07-15T12:00:00Z'));
+    const withoutRefresh: any = { ...withRefresh, lastRefreshedAt: undefined };
+    expect(lastRefreshedCol!.render(withoutRefresh)).toBe('—');
+  });
+
+  it('includes lastRefreshedAt in filterColumns and wires filterRanges to appsConfig.lastRefreshedRange', async () => {
+    await component.ngOnInit();
+    const cfg = component.listConfig();
+    expect(cfg!.filterColumns).toContain('lastRefreshedAt');
+    expect(cfg!.filterRanges).toBeDefined();
+    const range = cfg!.filterRanges!.find(r => r.field === 'lastRefreshedAt');
+    expect(range).toBeDefined();
+    expect(range!.valueType).toBe('date');
+    expect(range!.selected).toBe(stubAppsConfig.lastRefreshedRange);
   });
 
   it('defaults to card view at page size 6 for the per-space presentation', async () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.ts
@@ -156,6 +156,12 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
       render: (app: StApp) => app.stackName || '—',
       widthHint: '9rem',
     };
+    const lastRefreshedColumn: SignalListColumn<StApp> = {
+      header: 'Last Refreshed', key: 'lastRefreshedAt', sortField: 'lastRefreshedAt',
+      render: (app: StApp) => app.lastRefreshedAt
+        ? CloudFoundrySpaceAppsSignalComponent.formatDate(app.lastRefreshedAt) : '—',
+      widthHint: '12rem',
+    };
 
     const stateColor = (app: StApp): SignalListPillColor => {
       const s = (app.state ?? '').toUpperCase();
@@ -239,6 +245,7 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
             render: (app: StApp) => CloudFoundrySpaceAppsSignalComponent.formatDate(app.createdAt),
             widthHint: '12rem',
           },
+          lastRefreshedColumn,
           {
             header: '', key: 'favorite',
             kind: 'favorite',
@@ -273,7 +280,9 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
         // visibility gate); Stack joins the selector's option list too
         // once this CF has 2+ installed stacks, and picking any of them
         // swaps in the corresponding checklist popup.
-        filterColumns: withStack ? ['name', 'state', 'stackName'] : ['name', 'state'],
+        filterColumns: withStack
+          ? ['name', 'state', 'stackName', 'lastRefreshedAt']
+          : ['name', 'state', 'lastRefreshedAt'],
         // Status is unconditional (no visibility gate); Stack's entry is
         // only wired while its column is actually in filterColumns —
         // otherwise a filterField left over at 'stackName' from a
@@ -281,6 +290,11 @@ export class CloudFoundrySpaceAppsSignalComponent implements OnInit {
         // shared singleton) would pop the checklist for a column this
         // page isn't even showing.
         filterMultis: withStack ? [statusFilterMulti, stackFilterMulti] : [statusFilterMulti],
+        filterRanges: [{
+          field: 'lastRefreshedAt',
+          valueType: 'date' as const,
+          selected: this.appsConfig.lastRefreshedRange,
+        }],
         filterField: this.appsConfig.filterField,
         onRefresh: () => this.appsConfig.refresh(),
         onClear: () => this.appsConfig.clearFilters(),

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/stratos-types.ts
@@ -46,6 +46,9 @@ export interface StApp {
   spaceGuid: string;
   spaceName?: string;
   stackName?: string;
+  // Newest STAGED droplet's created_at — jetstream-enriched "last
+  // refreshed" (#5770). Absent when the app never successfully staged.
+  lastRefreshedAt?: string;
   instances: number;
   memory?: number;
   diskQuota?: number;

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.spec.ts
@@ -1458,3 +1458,42 @@ describe('CfAppsSignalConfigService — space catalog shares the endpoint load',
     expect(fanout.length).toBeGreaterThan(0);
   });
 });
+
+function makeRefreshedApp(guid: string, lastRefreshedAt: string | undefined): StApp {
+  return {
+    guid, name: guid, state: 'STARTED', cnsiGuid: 'cf-1', spaceGuid: 'sp-1',
+    instances: 1, routes: [], createdAt: '', updatedAt: '',
+    ...(lastRefreshedAt !== undefined ? { lastRefreshedAt } : {}),
+  } as StApp;
+}
+
+describe('CfAppsSignalConfigService last-refreshed range', () => {
+  it('predicate keeps only apps inside the active range', async () => {
+    const svc = makeSvc(makeHttp());
+    svc.initialize(['cf-1']);
+    const fresh = makeRefreshedApp('fresh', '2026-07-01T00:00:00Z');
+    const stale = makeRefreshedApp('stale', '2026-01-01T00:00:00Z');
+    svc.lastRefreshedRange.set({ op: 'gte', a: '2026-06-01' });
+    await drainUntil(() => !svc.filter()(stale));
+    expect(svc.filter()(fresh)).toBe(true);
+    expect(svc.filter()(stale)).toBe(false);
+  });
+
+  it('never-staged apps match only an inert range', async () => {
+    const svc = makeSvc(makeHttp());
+    svc.initialize(['cf-1']);
+    const never = makeRefreshedApp('never', undefined);
+    expect(svc.filter()(never)).toBe(true);
+    svc.lastRefreshedRange.set({ op: 'lt', a: '2099-01-01' });
+    await drainUntil(() => !svc.filter()(never));
+    expect(svc.filter()(never)).toBe(false);
+  });
+
+  it('clearFilters resets the range', () => {
+    const svc = makeSvc(makeHttp());
+    svc.initialize(['cf-1']);
+    svc.lastRefreshedRange.set({ op: 'lt', a: '2026-01-01' });
+    svc.clearFilters();
+    expect(svc.lastRefreshedRange()).toBeNull();
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/signal-list-configs/app/cf-apps-signal-config.service.ts
@@ -18,8 +18,8 @@ import type { StApp, StAppRoutesResponse, StOrg, StOrgsResponse, StRoute, StServ
 import { CloudFoundryService } from '../../data-services/cloud-foundry.service';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import type { StratosJob } from '../../../services/async-jobs/async-job.types';
-import type { SignalListDropdownOption } from '@stratosui/core';
-import { ListStateStore, naturalCompare } from '@stratosui/core';
+import type { SignalListDropdownOption, SignalListRangeValue } from '@stratosui/core';
+import { ListStateStore, naturalCompare, rangeMatches } from '@stratosui/core';
 
 // Re-export the bulk-endpoint response shapes so per-space app consumers
 // import a single BulkResult type without reaching across into the routes
@@ -140,6 +140,12 @@ export class CfAppsSignalConfigService {
   // constraint); an explicitly empty array is ALSO treated as all — the
   // popup shows a note rather than silently emptying the app list.
   readonly selectedStacks: WritableSignal<string[] | null> = signal(null);
+
+  // Range constraint on lastRefreshedAt, shared by all three list
+  // variants (root singleton, same as selectedStacks). null = no
+  // constraint. Unlike stack there is no visibility gate to go stale
+  // against — the column and control are always shown.
+  readonly lastRefreshedRange: WritableSignal<SignalListRangeValue | null> = signal(null);
 
   // Stack UI (column + dropdown) shows when ANY scoped endpoint has 2+
   // installed stacks; a single-stack foundation would render a constant
@@ -448,6 +454,7 @@ export class CfAppsSignalConfigService {
       const stacks = this.selectedStacks();
       const stackUiVisible = this.stackUiVisible();
       const states = this.selectedStates();
+      const refreshed = this.lastRefreshedRange();
       const q = this.nameFilter().trim().toLowerCase();
       const field = this.filterField();
       const extractors = this._filterExtractors();
@@ -473,6 +480,7 @@ export class CfAppsSignalConfigService {
         // it has no visibility condition to go stale against, since it's
         // always shown.
         if (stackUiVisible && stacks && stacks.length > 0 && (!app.stackName || !stacks.includes(app.stackName))) return false;
+        if (!rangeMatches(app.lastRefreshedAt, refreshed, 'date')) return false;
         // Same posture: an app whose label isn't one of the four known
         // options (raw/unknown CF state, extractor unregistered) only
         // fails to match while the filter is actually narrowed — it
@@ -968,6 +976,7 @@ export class CfAppsSignalConfigService {
     this.selectedOrg.set(null);
     this.selectedSpace.set(null);
     this.selectedStacks.set(null);
+    this.lastRefreshedRange.set(null);
     this.selectedStates.set(null);
     this.nameFilter.set('');
     this.filterField.set('name');

--- a/src/frontend/packages/core/src/public-api.ts
+++ b/src/frontend/packages/core/src/public-api.ts
@@ -162,6 +162,7 @@ export { RowState, RowsState, getDefaultRowState } from './shared/components/sig
 export { TableCellStatusDirective } from './shared/components/signal-list/table-cell-status.directive';
 export { extractActualListEntity } from './shared/components/signal-list/list-entity.helpers';
 export type { ISimpleListConfig } from './shared/components/signal-list/simple-list-config.types';
+export * from './shared/components/signal-list/range-filter';
 
 // Utility Components
 export { MultilineTitleComponent } from './shared/components/multiline-title/multiline-title.component';

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { rangeMatches, SignalListRangeValue } from './range-filter';
+import { rangeIsComplete, rangeMatches, SignalListRangeValue } from './range-filter';
 
 const d = (op: SignalListRangeValue['op'], a: string, b?: string, inclusiveA?: boolean, inclusiveB?: boolean): SignalListRangeValue =>
   ({ op, a, ...(b !== undefined ? { b } : {}), ...(inclusiveA !== undefined ? { inclusiveA } : {}), ...(inclusiveB !== undefined ? { inclusiveB } : {}) });
@@ -87,5 +87,30 @@ describe('rangeMatches — number domain (memory-style consumer)', () => {
   it('missing or non-numeric row values never match an active range', () => {
     expect(rangeMatches(undefined, d('gte', '0'), 'number')).toBe(false);
     expect(rangeMatches('n/a', d('gte', '0'), 'number')).toBe(false);
+  });
+});
+
+describe('rangeIsComplete', () => {
+  it('a null range is not complete', () => {
+    expect(rangeIsComplete(null, 'date')).toBe(false);
+  });
+
+  it('a single-op range with a parsing primary bound is complete', () => {
+    expect(rangeIsComplete(d('gte', '2026-05-01'), 'date')).toBe(true);
+    expect(rangeIsComplete(d('lt', '512'), 'number')).toBe(true);
+  });
+
+  it('a "between" range with only the primary bound typed is not complete', () => {
+    expect(rangeIsComplete(d('between', '2026-05-01'), 'date')).toBe(false);
+  });
+
+  it('a "between" range with both bounds parsing is complete', () => {
+    expect(rangeIsComplete(d('between', '2026-05-01', '2026-06-01'), 'date')).toBe(true);
+    expect(rangeIsComplete(d('between', '128', '512'), 'number')).toBe(true);
+  });
+
+  it('an unparsable primary bound is not complete', () => {
+    expect(rangeIsComplete(d('gte', 'not-a-date'), 'date')).toBe(false);
+    expect(rangeIsComplete(d('gte', ''), 'date')).toBe(false);
   });
 });

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
@@ -54,6 +54,18 @@ describe('rangeMatches — date domain (day-granular, local time)', () => {
     expect(rangeMatches(may15noon, d('between', '2026-05-01'), 'date')).toBe(true);
     expect(rangeMatches(may15noon, d('lt', 'not-a-date'), 'date')).toBe(true);
   });
+
+  it('day windows honor DST transitions (spring-forward)', () => {
+    // US spring-forward 2026-03-08: lte 2026-03-08 must NOT include 2026-03-09T00:30 local
+    const springForwardProbe = new Date(2026, 2, 9, 0, 30).toISOString();
+    expect(rangeMatches(springForwardProbe, d('lte', '2026-03-08'), 'date')).toBe(false);
+  });
+
+  it('day windows honor DST transitions (fall-back)', () => {
+    // US fall-back 2026-11-01: lte 2026-11-01 MUST include 2026-11-01T23:30 local
+    const fallBackProbe = new Date(2026, 10, 1, 23, 30).toISOString();
+    expect(rangeMatches(fallBackProbe, d('lte', '2026-11-01'), 'date')).toBe(true);
+  });
 });
 
 describe('rangeMatches — number domain (memory-style consumer)', () => {
@@ -61,6 +73,9 @@ describe('rangeMatches — number domain (memory-style consumer)', () => {
     expect(rangeMatches(512, d('gte', '512'), 'number')).toBe(true);
     expect(rangeMatches(511, d('gte', '512'), 'number')).toBe(false);
     expect(rangeMatches(512, d('lt', '512'), 'number')).toBe(false);
+    expect(rangeMatches(512, d('lte', '512'), 'number')).toBe(true);
+    expect(rangeMatches(512, d('gt', '512'), 'number')).toBe(false);
+    expect(rangeMatches(1024, d('gt', '512'), 'number')).toBe(true);
     expect(rangeMatches(256, d('between', '128', '512'), 'number')).toBe(true);
     expect(rangeMatches(512, d('between', '128', '512', true, false), 'number')).toBe(false);
   });

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { rangeMatches, SignalListRangeValue } from './range-filter';
+
+const d = (op: SignalListRangeValue['op'], a: string, b?: string, inclusiveA?: boolean, inclusiveB?: boolean): SignalListRangeValue =>
+  ({ op, a, ...(b !== undefined ? { b } : {}), ...(inclusiveA !== undefined ? { inclusiveA } : {}), ...(inclusiveB !== undefined ? { inclusiveB } : {}) });
+
+describe('rangeMatches — date domain (day-granular, local time)', () => {
+  const may15noon = '2026-05-15T12:00:00Z';
+
+  it('null range matches everything, including missing values', () => {
+    expect(rangeMatches(may15noon, null, 'date')).toBe(true);
+    expect(rangeMatches(undefined, null, 'date')).toBe(true);
+  });
+
+  it('missing value never matches an active range', () => {
+    expect(rangeMatches(undefined, d('gte', '2026-01-01'), 'date')).toBe(false);
+    expect(rangeMatches(null, d('lt', '2099-01-01'), 'date')).toBe(false);
+    expect(rangeMatches('', d('lt', '2099-01-01'), 'date')).toBe(false);
+  });
+
+  it('lt excludes the named day itself', () => {
+    expect(rangeMatches(may15noon, d('lt', '2026-05-15'), 'date')).toBe(false);
+    expect(rangeMatches(may15noon, d('lt', '2026-05-16'), 'date')).toBe(true);
+  });
+
+  it('lte includes through the end of the named day', () => {
+    expect(rangeMatches(may15noon, d('lte', '2026-05-15'), 'date')).toBe(true);
+    expect(rangeMatches(may15noon, d('lte', '2026-05-14'), 'date')).toBe(false);
+  });
+
+  it('gt excludes the named day itself', () => {
+    expect(rangeMatches(may15noon, d('gt', '2026-05-15'), 'date')).toBe(false);
+    expect(rangeMatches(may15noon, d('gt', '2026-05-14'), 'date')).toBe(true);
+  });
+
+  it('gte includes from the start of the named day', () => {
+    expect(rangeMatches(may15noon, d('gte', '2026-05-15'), 'date')).toBe(true);
+    expect(rangeMatches(may15noon, d('gte', '2026-05-16'), 'date')).toBe(false);
+  });
+
+  it('between defaults to inclusive on both ends', () => {
+    expect(rangeMatches(may15noon, d('between', '2026-05-15', '2026-05-15'), 'date')).toBe(true);
+    expect(rangeMatches(may15noon, d('between', '2026-05-01', '2026-05-14'), 'date')).toBe(false);
+  });
+
+  it('between honors exclusive ends', () => {
+    expect(rangeMatches(may15noon, d('between', '2026-05-15', '2026-05-31', false, true), 'date')).toBe(false);
+    expect(rangeMatches(may15noon, d('between', '2026-05-01', '2026-05-15', true, false), 'date')).toBe(false);
+    expect(rangeMatches(may15noon, d('between', '2026-05-01', '2026-05-15', true, true), 'date')).toBe(true);
+  });
+
+  it('half-typed or invalid bounds are inert (match everything)', () => {
+    expect(rangeMatches(may15noon, d('gte', ''), 'date')).toBe(true);
+    expect(rangeMatches(may15noon, d('between', '2026-05-01'), 'date')).toBe(true);
+    expect(rangeMatches(may15noon, d('lt', 'not-a-date'), 'date')).toBe(true);
+  });
+});
+
+describe('rangeMatches — number domain (memory-style consumer)', () => {
+  it('compares plain numbers with no day windowing', () => {
+    expect(rangeMatches(512, d('gte', '512'), 'number')).toBe(true);
+    expect(rangeMatches(511, d('gte', '512'), 'number')).toBe(false);
+    expect(rangeMatches(512, d('lt', '512'), 'number')).toBe(false);
+    expect(rangeMatches(256, d('between', '128', '512'), 'number')).toBe(true);
+    expect(rangeMatches(512, d('between', '128', '512', true, false), 'number')).toBe(false);
+  });
+
+  it('accepts numeric strings as row values', () => {
+    expect(rangeMatches('512', d('gte', '512'), 'number')).toBe(true);
+  });
+
+  it('missing or non-numeric row values never match an active range', () => {
+    expect(rangeMatches(undefined, d('gte', '0'), 'number')).toBe(false);
+    expect(rangeMatches('n/a', d('gte', '0'), 'number')).toBe(false);
+  });
+});

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
@@ -1,0 +1,68 @@
+// Range-comparison filter model for signal-list toolbars (#5770 Part 2).
+// Deliberately domain-general: `valueType` picks the comparison domain so
+// date columns (last refreshed) and numeric columns (memory, instances)
+// share one mechanism — adding a numeric consumer must touch no framework
+// code. Date bounds are DAY-GRANULAR in local time: a date input names a
+// calendar day, so "lte 2026-05-15" reaches through that day's end and
+// "gte 2026-05-15" starts at its beginning.
+
+export type SignalListRangeOperator = 'lt' | 'lte' | 'gt' | 'gte' | 'between';
+export type SignalListRangeValueType = 'date' | 'number';
+
+export interface SignalListRangeValue {
+  readonly op: SignalListRangeOperator;
+  readonly a: string;
+  readonly b?: string;
+  readonly inclusiveA?: boolean;
+  readonly inclusiveB?: boolean;
+}
+
+// [startOfDay, endOfDay] for a YYYY-MM-DD input, in ms; null when unparsable.
+function dayWindow(bound: string): [number, number] | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(bound);
+  if (!m) return null;
+  const start = new Date(+m[1], +m[2] - 1, +m[3]).getTime();
+  if (Number.isNaN(start)) return null;
+  return [start, start + 86_400_000 - 1];
+}
+
+function numWindow(bound: string): [number, number] | null {
+  if (bound.trim() === '') return null;
+  const n = Number(bound);
+  return Number.isNaN(n) ? null : [n, n];
+}
+
+export function rangeMatches(
+  raw: string | number | null | undefined,
+  range: SignalListRangeValue | null,
+  valueType: SignalListRangeValueType,
+): boolean {
+  if (range === null) return true;
+
+  const window = valueType === 'date' ? dayWindow : numWindow;
+  const wa = window(range.a);
+  const wb = range.b !== undefined ? window(range.b) : null;
+  // Half-typed or unparsable bounds: the filter is inert, never blanking
+  // the list under the user's cursor mid-edit.
+  if (wa === null || (range.op === 'between' && wb === null)) return true;
+
+  // Active range + unknown row value: comparisons against unknown are
+  // false (SQL-NULL posture) — a "—" row matches no constraint.
+  if (raw === null || raw === undefined || raw === '') return false;
+  const v = valueType === 'date'
+    ? Date.parse(String(raw))
+    : (typeof raw === 'number' ? raw : Number(raw));
+  if (Number.isNaN(v)) return false;
+
+  switch (range.op) {
+    case 'lt': return v < wa[0];
+    case 'lte': return v <= wa[1];
+    case 'gt': return v > wa[1];
+    case 'gte': return v >= wa[0];
+    case 'between': {
+      const loOk = (range.inclusiveA ?? true) ? v >= wa[0] : v > wa[1];
+      const hiOk = (range.inclusiveB ?? true) ? v <= wb![1] : v < wb![0];
+      return loOk && hiOk;
+    }
+  }
+}

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
@@ -18,12 +18,14 @@ export interface SignalListRangeValue {
 }
 
 // [startOfDay, endOfDay] for a YYYY-MM-DD input, in ms; null when unparsable.
+// End bound computed as start-of-next-day - 1ms to honor DST transitions.
 function dayWindow(bound: string): [number, number] | null {
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(bound);
   if (!m) return null;
   const start = new Date(+m[1], +m[2] - 1, +m[3]).getTime();
   if (Number.isNaN(start)) return null;
-  return [start, start + 86_400_000 - 1];
+  const end = new Date(+m[1], +m[2] - 1, +m[3] + 1).getTime() - 1;
+  return [start, end];
 }
 
 function numWindow(bound: string): [number, number] | null {

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
@@ -34,6 +34,26 @@ function numWindow(bound: string): [number, number] | null {
   return Number.isNaN(n) ? null : [n, n];
 }
 
+// True iff `range` names a fully-typed constraint: a non-null range whose
+// primary bound parses in the given domain, and — for `between` — whose
+// upper bound parses too. A half-typed range (e.g. `{ op: 'between', a: '' }`
+// right after picking "between" but before typing a date) is inert for
+// filtering purposes (see rangeMatches's half-typed-bounds note above) but
+// is NOT the canonical "no constraint" state — updateRange stores it as-is
+// so the popup keeps the user's op choice across keystrokes. Callers that
+// need to know whether a range is actually constraining the list (the
+// Clear button, hasActiveFilter) should check this instead of `!== null`.
+export function rangeIsComplete(
+  range: SignalListRangeValue | null,
+  valueType: SignalListRangeValueType,
+): boolean {
+  if (range === null) return false;
+  const window = valueType === 'date' ? dayWindow : numWindow;
+  if (window(range.a) === null) return false;
+  if (range.op === 'between' && window(range.b ?? '') === null) return false;
+  return true;
+}
+
 export function rangeMatches(
   raw: string | number | null | undefined,
   range: SignalListRangeValue | null,

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -74,6 +74,64 @@
             </div>
           }
         </div>
+      } @else if (activeRange(); as fr) {
+        <div class="relative" data-test="range-filter-wrap" (keydown.escape)="multiPopupOpen.set(false)">
+          <button
+            type="button"
+            data-test="range-filter-toggle"
+            (click)="multiPopupOpen.set(!multiPopupOpen())"
+            class="px-3 py-1 text-sm border border-content-border rounded bg-content-bg text-content-text min-w-44 text-left">
+            {{ rangeSummary(fr) }}
+            <span class="material-icons text-base leading-4 align-middle float-right">arrow_drop_down</span>
+          </button>
+          @if (multiPopupOpen()) {
+            <!-- Overlays the input slot like the checklist popup — same approved
+                 product design; don't "fix" it. -->
+            <div class="absolute left-0 top-0 z-30 min-w-56 border border-content-border rounded bg-content-bg shadow-lg p-2 flex flex-col gap-1.5">
+              <select
+                data-test="range-op"
+                class="text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
+                [value]="fr.selected()?.op ?? 'gte'"
+                (change)="updateRange(fr, { op: $any($event.target).value })">
+                <option value="lt">before</option>
+                <option value="lte">on or before</option>
+                <option value="gt">after</option>
+                <option value="gte">on or after</option>
+                <option value="between">between</option>
+              </select>
+              <input
+                data-test="range-a"
+                [type]="fr.valueType === 'date' ? 'date' : 'number'"
+                class="text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
+                [value]="fr.selected()?.a ?? ''"
+                (change)="updateRange(fr, { a: $any($event.target).value })" />
+              @if ((fr.selected()?.op ?? 'gte') === 'between') {
+                <input
+                  data-test="range-b"
+                  [type]="fr.valueType === 'date' ? 'date' : 'number'"
+                  class="text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
+                  [value]="fr.selected()?.b ?? ''"
+                  (change)="updateRange(fr, { b: $any($event.target).value })" />
+                <label class="flex items-center gap-2 px-1 text-xs text-content-text cursor-pointer">
+                  <input type="checkbox" data-test="range-incl-a"
+                    [checked]="fr.selected()?.inclusiveA ?? true"
+                    (change)="updateRange(fr, { inclusiveA: $any($event.target).checked })" />
+                  include start
+                </label>
+                <label class="flex items-center gap-2 px-1 text-xs text-content-text cursor-pointer">
+                  <input type="checkbox" data-test="range-incl-b"
+                    [checked]="fr.selected()?.inclusiveB ?? true"
+                    (change)="updateRange(fr, { inclusiveB: $any($event.target).checked })" />
+                  include end
+                </label>
+              }
+              <button
+                type="button"
+                (click)="multiPopupOpen.set(false)"
+                class="w-full text-xs text-content-muted border-t border-content-border pt-1">Close</button>
+            </div>
+          }
+        </div>
       } @else {
         <input
           type="text"

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -1754,4 +1754,59 @@ describe('SignalListComponent range filter (filterRanges)', () => {
     fixture.componentInstance.selectedRange.set({ op: 'between', a: '2026-05-01', b: '2026-06-01' });
     expect(component.rangeSummary(fr)).toBe('2026-05-01 – 2026-06-01');
   });
+
+  // Reproduces the real UI sequence: the "between" <select> and the two
+  // <input> bounds each fire their own (change) event, so op and a/b land
+  // in SEPARATE updateRange() calls — never merged in one patch like the
+  // collapse test above. An op-only patch must survive so the template's
+  // between-branch gate (`selected()?.op === 'between'`) can ever see the
+  // op and render the second input + inclusive checkboxes.
+  describe('updateRange sequence: pick "between" before typing any bound', () => {
+    it('(a) op-only patch to "between" with empty bounds stores a non-null selection with op "between"', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { op: 'between' });
+      expect(fixture.componentInstance.selectedRange()).toEqual({ op: 'between', a: '' });
+      expect(component.hasActiveFilter()).toBe(false);
+    });
+
+    it('(b) then typing the first bound keeps op "between" (not reset to gte)', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { op: 'between' });
+      component.updateRange(fr, { a: '2026-05-01' });
+      expect(fixture.componentInstance.selectedRange()).toEqual({ op: 'between', a: '2026-05-01' });
+      expect(component.hasActiveFilter()).toBe(false);
+    });
+
+    it('(c) then typing the second bound completes the range and activates the filter', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { op: 'between' });
+      component.updateRange(fr, { a: '2026-05-01' });
+      component.updateRange(fr, { b: '2026-06-01' });
+      expect(fixture.componentInstance.selectedRange()).toEqual({ op: 'between', a: '2026-05-01', b: '2026-06-01' });
+      expect(component.hasActiveFilter()).toBe(true);
+    });
+
+    it('(d) clearing both bounds one at a time collapses back to null', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { op: 'between' });
+      component.updateRange(fr, { a: '2026-05-01' });
+      component.updateRange(fr, { b: '2026-06-01' });
+      component.updateRange(fr, { a: '' });
+      expect(fixture.componentInstance.selectedRange()).toEqual({ op: 'between', a: '', b: '2026-06-01' });
+      component.updateRange(fr, { b: '' });
+      expect(fixture.componentInstance.selectedRange()).toBe(null);
+    });
+  });
 });

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -4,6 +4,7 @@ import { Component, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { SignalListComponent } from './signal-list.component';
 import type { SignalListConfig, SignalListDropdown, SignalListDropdownOption, SignalListMultiFilter, SignalListRowState } from './signal-list.component';
+import type { SignalListRangeValue } from './range-filter';
 import { SignalListCellTemplateDirective } from './signal-list-cell-template.directive';
 
 // SignalListComponent now applies [routerLink] to the card / table row when a
@@ -1653,5 +1654,104 @@ describe('SignalListComponent checklist-popup filter (filterMultis)', () => {
     expect(component.multiPopupOpen()).toBe(true);
     component.onFilterFieldChange('name');
     expect(component.multiPopupOpen()).toBe(false);
+  });
+});
+
+// Range-comparison filter input (config.filterRanges / SignalListRangeFilter).
+// Mirrors the checklist-popup fixture above; lastRefreshedAt is the first
+// consumer of this control.
+@Component({
+  standalone: true,
+  imports: [SignalListComponent],
+  template: `<app-signal-list [config]="config" />`
+})
+class RangeFilterHost {
+  items = signal([
+    { name: 'one', lastRefreshedAt: '2026-05-01' },
+    { name: 'two', lastRefreshedAt: '2026-06-01' },
+  ]);
+  pageIndex = signal(0);
+  pageSize = signal(10);
+  filterField = signal('lastRefreshedAt');
+  selectedRange = signal<SignalListRangeValue | null>(null);
+  config: SignalListConfig<{ name: string; lastRefreshedAt: string }> = {
+    pagedItems: this.items.asReadonly(),
+    totalFilteredResults: signal(2).asReadonly(),
+    totalPages: signal(1).asReadonly(),
+    pageIndex: this.pageIndex,
+    pageSize: this.pageSize,
+    isAnyLoading: signal(false).asReadonly(),
+    errorsByCnsi: signal(new Map<string, unknown>()).asReadonly(),
+    columns: [
+      { header: 'Name', key: 'name', render: r => r.name },
+      { header: 'Last Refreshed', key: 'lastRefreshedAt', render: r => r.lastRefreshedAt },
+    ],
+    getRowKey: r => r.name,
+    nameFilter: signal(''),
+    filterColumns: ['name', 'lastRefreshedAt'],
+    filterField: this.filterField,
+    filterRanges: [{
+      field: 'lastRefreshedAt',
+      valueType: 'date',
+      selected: this.selectedRange,
+    }],
+  };
+}
+
+describe('SignalListComponent range filter (filterRanges)', () => {
+  function componentWith(fixture: ReturnType<typeof TestBed.createComponent<RangeFilterHost>>) {
+    return fixture.debugElement.children[0].componentInstance as SignalListComponent<{ name: string; lastRefreshedAt: string }>;
+  }
+
+  it('activeRange resolves when filterField names a range field, activeMulti stays undefined', () => {
+    const fixture = TestBed.createComponent(RangeFilterHost);
+    fixture.detectChanges();
+    const component = componentWith(fixture);
+    expect(component.activeRange()?.field).toBe('lastRefreshedAt');
+    expect(component.activeMulti()).toBeUndefined();
+  });
+
+  it('updateRange collapses an empty primary bound to null (no constraint)', () => {
+    const fixture = TestBed.createComponent(RangeFilterHost);
+    fixture.detectChanges();
+    const component = componentWith(fixture);
+    const fr = component.activeRange()!;
+    component.updateRange(fr, { op: 'gte', a: '2026-05-01' });
+    expect(fixture.componentInstance.selectedRange()).toEqual({ op: 'gte', a: '2026-05-01' });
+    component.updateRange(fr, { a: '' });
+    expect(fixture.componentInstance.selectedRange()).toBe(null);
+  });
+
+  it('updateRange resets to page 0', () => {
+    const fixture = TestBed.createComponent(RangeFilterHost);
+    fixture.componentInstance.pageIndex.set(3);
+    fixture.detectChanges();
+    const component = componentWith(fixture);
+    component.updateRange(component.activeRange()!, { op: 'gte', a: '2026-05-01' });
+    expect(fixture.componentInstance.pageIndex()).toBe(0);
+  });
+
+  it('hasActiveFilter sees a non-null range selection and Clear resets it', () => {
+    const fixture = TestBed.createComponent(RangeFilterHost);
+    fixture.detectChanges();
+    const component = componentWith(fixture);
+    fixture.componentInstance.selectedRange.set({ op: 'lt', a: '2026-01-01' });
+    expect(component.hasActiveFilter()).toBe(true);
+    fixture.componentInstance.selectedRange.set(null);
+    expect(component.hasActiveFilter()).toBe(false);
+  });
+
+  it('rangeSummary renders Any / single-bound / between forms', () => {
+    const fixture = TestBed.createComponent(RangeFilterHost);
+    fixture.detectChanges();
+    const component = componentWith(fixture);
+    const fr = component.activeRange()!;
+    expect(component.rangeSummary(fr)).toBe('Any');
+
+    fixture.componentInstance.selectedRange.set({ op: 'gte', a: '2026-05-01' });
+    expect(component.rangeSummary(fr)).toBe('≥ 2026-05-01');
+
+    fixture.componentInstance.selectedRange.set({ op: 'between', a: '2026-05-01', b: '2026-06-01' });
+    expect(component.rangeSummary(fr)).toBe('2026-05-01 – 2026-06-01');
   });
 });

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -475,10 +475,10 @@ export interface SignalListConfig<T> {
   // Filter fields whose input is a checklist popup rather than the plain
   // text box — see SignalListMultiFilter. An array (not a single slot)
   // because more than one filterColumns entry can want this treatment:
-  // stack is the first checklist consumer, status is the second, and a
-  // date-range input is a separate filter-field kind slated for a later
-  // PR (not modeled by this array). Only the entry whose `field` matches
-  // the current filterField() renders.
+  // stack is the first checklist consumer, status is the second, and
+  // range/comparison inputs are modeled by the separate `filterRanges`
+  // array below. Only the entry whose `field` matches the current
+  // filterField() renders.
   readonly filterMultis?: readonly SignalListMultiFilter[];
   // Filter fields whose input is a range-comparison popup (date or number
   // bounds) rather than the plain text box or checklist — see

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 
 import { UsageGaugeComponent } from '../usage-gauge/usage-gauge.component';
 import { SignalListCellTemplateDirective } from './signal-list-cell-template.directive';
+import { SignalListRangeValue, SignalListRangeValueType } from './range-filter';
 
 export type SignalListPillColor = 'success' | 'warning' | 'danger' | 'neutral';
 
@@ -299,6 +300,25 @@ export interface SignalListMultiFilter {
   readonly selected: WritableSignal<string[] | null>;
 }
 
+// Binding for a filter field whose input is a range-comparison popup
+// (date or number bounds) instead of the free-text box or the checklist —
+// see SignalListMultiFilter above for the sibling mechanism this parallels.
+// `field` names the filterColumns entry this control activates for, same
+// contract as SignalListMultiFilter.field: the active entry is whichever
+// filterRanges element's `field` equals filterField(), so the two popup
+// kinds share the component's single `multiPopupOpen` state — filterField()
+// can only name one column at a time, so at most one of activeMulti() /
+// activeRange() is ever defined.
+// `selected === null` means "no constraint" — the range comparator in
+// range-filter.ts treats it the same way.
+export interface SignalListRangeFilter {
+  readonly field: string;
+  readonly valueType: SignalListRangeValueType;
+  readonly selected: WritableSignal<SignalListRangeValue | null>;
+  // Display suffix appended to numeric bounds in the summary/popup, e.g. 'MB'.
+  readonly unit?: string;
+}
+
 export type SignalListViewMode = 'table' | 'card';
 
 /**
@@ -460,6 +480,11 @@ export interface SignalListConfig<T> {
   // PR (not modeled by this array). Only the entry whose `field` matches
   // the current filterField() renders.
   readonly filterMultis?: readonly SignalListMultiFilter[];
+  // Filter fields whose input is a range-comparison popup (date or number
+  // bounds) rather than the plain text box or checklist — see
+  // SignalListRangeFilter. lastRefreshedAt is the first consumer. Only the
+  // entry whose `field` matches the current filterField() renders.
+  readonly filterRanges?: readonly SignalListRangeFilter[];
 }
 
 @Component({
@@ -1178,6 +1203,36 @@ export class SignalListComponent<T> implements AfterViewInit {
     return this.config.filterMultis?.find(m => m.field === field);
   }
 
+  // The filterRanges entry whose field matches the active filterField().
+  // Same single-active-field contract as activeMulti — the two popups
+  // can never be live simultaneously, so they share multiPopupOpen.
+  activeRange(): SignalListRangeFilter | undefined {
+    const field = this.config.filterField?.();
+    return this.config.filterRanges?.find(r => r.field === field);
+  }
+
+  rangeSummary(fr: SignalListRangeFilter): string {
+    const sel = fr.selected();
+    if (sel === null) return 'Any';
+    const unit = fr.unit ? ` ${fr.unit}` : '';
+    const sym: Record<string, string> = { lt: '<', lte: '≤', gt: '>', gte: '≥' };
+    if (sel.op === 'between') return `${sel.a || '…'}${unit} – ${sel.b || '…'}${unit}`;
+    return `${sym[sel.op]} ${sel.a || '…'}${unit}`;
+  }
+
+  // Merges a partial edit into the current range. An empty primary bound
+  // (and, for between, an empty upper bound too) collapses to null so
+  // `selected === null` stays the one canonical "no constraint" state —
+  // the same contract toggleMultiOption keeps for checklists — and a
+  // half-cleared input never leaves a phantom active filter behind.
+  updateRange(fr: SignalListRangeFilter, patch: Partial<SignalListRangeValue>): void {
+    const curr = fr.selected() ?? { op: 'gte' as const, a: '' };
+    const next: SignalListRangeValue = { ...curr, ...patch };
+    const empty = next.a === '' && (next.op !== 'between' || !next.b);
+    fr.selected.set(empty ? null : next);
+    this.config.pageIndex.set(0);
+  }
+
   // Button label for the checklist popup: "All (n)" when every option is
   // implicitly or explicitly selected, the bare value for a single pick,
   // "x of y selected" for a partial pick, and a "showing all" note when
@@ -1200,7 +1255,7 @@ export class SignalListComponent<T> implements AfterViewInit {
   onDocumentClickForMultiPopup(event: Event): void {
     if (!this.multiPopupOpen()) return;
     const target = event.target as HTMLElement | null;
-    if (target && !target.closest('[data-test="multi-filter-wrap"]')) {
+    if (target && !target.closest('[data-test="multi-filter-wrap"], [data-test="range-filter-wrap"]')) {
       this.multiPopupOpen.set(false);
     }
   }
@@ -1305,6 +1360,9 @@ export class SignalListComponent<T> implements AfterViewInit {
     // null/[]/partial states individually.
     for (const fm of this.config.filterMultis ?? []) {
       if (fm.selected() != null) return true;
+    }
+    for (const fr of this.config.filterRanges ?? []) {
+      if (fr.selected() != null) return true;
     }
     if (this.config.nameFilter && this.config.nameFilter().length > 0) return true;
     return false;

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 
 import { UsageGaugeComponent } from '../usage-gauge/usage-gauge.component';
 import { SignalListCellTemplateDirective } from './signal-list-cell-template.directive';
-import { SignalListRangeValue, SignalListRangeValueType } from './range-filter';
+import { rangeIsComplete, SignalListRangeValue, SignalListRangeValueType } from './range-filter';
 
 export type SignalListPillColor = 'success' | 'warning' | 'danger' | 'neutral';
 
@@ -1220,16 +1220,22 @@ export class SignalListComponent<T> implements AfterViewInit {
     return `${sym[sel.op]} ${sel.a || '…'}${unit}`;
   }
 
-  // Merges a partial edit into the current range. An empty primary bound
-  // (and, for between, an empty upper bound too) collapses to null so
-  // `selected === null` stays the one canonical "no constraint" state —
-  // the same contract toggleMultiOption keeps for checklists — and a
-  // half-cleared input never leaves a phantom active filter behind.
+  // Merges a partial edit into the current range. Only collapses to null
+  // when the edit touched a BOUND ('a' or 'b') and every bound is now
+  // empty — an op-only change (e.g. picking "between" before typing any
+  // date) must never collapse, or the template's between-branch gate
+  // (`selected()?.op === 'between'`) would never see the op and the
+  // second input/checkboxes could never render. Half-typed non-empty
+  // ranges are stored as-is; hasActiveFilter() and the row predicate both
+  // treat an incomplete bound as inert rather than as "no constraint", so
+  // a stray non-null selected() here can't blank the list or the Clear
+  // button under the user's cursor mid-edit.
   updateRange(fr: SignalListRangeFilter, patch: Partial<SignalListRangeValue>): void {
     const curr = fr.selected() ?? { op: 'gte' as const, a: '' };
     const next: SignalListRangeValue = { ...curr, ...patch };
-    const empty = next.a === '' && (next.op !== 'between' || !next.b);
-    fr.selected.set(empty ? null : next);
+    const touchedBound = 'a' in patch || 'b' in patch;
+    const allBoundsEmpty = next.a === '' && !next.b;
+    fr.selected.set(touchedBound && allBoundsEmpty ? null : next);
     this.config.pageIndex.set(0);
   }
 
@@ -1361,8 +1367,12 @@ export class SignalListComponent<T> implements AfterViewInit {
     for (const fm of this.config.filterMultis ?? []) {
       if (fm.selected() != null) return true;
     }
+    // updateRange stores a half-typed range (e.g. op picked, no date yet)
+    // as non-null so the popup keeps the user's choice across keystrokes —
+    // so `!= null` alone would flag Clear active on an inert filter.
+    // rangeIsComplete gates on the bound(s) actually parsing.
     for (const fr of this.config.filterRanges ?? []) {
-      if (fr.selected() != null) return true;
+      if (rangeIsComplete(fr.selected(), fr.valueType)) return true;
     }
     if (this.config.nameFilter && this.config.nameFilter().length > 0) return true;
     return false;

--- a/src/jetstream/plugins/cloudfoundry/native_apps_detail.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_detail.go
@@ -398,8 +398,12 @@ func (c *CloudFoundrySpecification) composeAppSummaryEntry(reqCtx context.Contex
 	// Single-app path: OrgName is not stitched here (the org join is a
 	// batch optimisation that pays off on list responses). Detail-page
 	// consumers resolve org via the dedicated /pp/v1/cf/org/{cnsi}/{org}
-	// fetch anyway, so the empty value is the right default.
-	return composeStAppSummary(app, cnsiGUID, process, nil, "", []StAppRoute{})
+	// fetch anyway, so the empty value is the right default. Droplets
+	// mirror the same call-cheap tradeoff as routes: pass an empty (non-
+	// nil) map so a never-staged app reads as legitimately absent rather
+	// than a spurious fetch failure — this single-app path doesn't fan
+	// out to /v3/droplets.
+	return composeStAppSummary(app, cnsiGUID, process, nil, "", []StAppRoute{}, map[string]string{})
 }
 
 // composeAppDetails returns the full StAppDetail envelope for the

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
@@ -16,9 +16,10 @@ import (
 // doesn't sort natively — requests on these trigger the fetch-all-sort-in-
 // memory-paginate fallback path in getNativeAppsSummary.
 var derivedSortFields = map[string]bool{
-	"memory":    true,
-	"diskQuota": true,
-	"instances": true,
+	"memory":          true,
+	"diskQuota":       true,
+	"instances":       true,
+	"lastRefreshedAt": true,
 }
 
 // isDerivedSortField returns true when the Stratos-shape order_by value
@@ -694,10 +695,19 @@ func fetchAllAppsWithFilters(ctx context.Context, cfClient capi.Client, filters 
 }
 
 // sortStAppsByDerivedField sorts composed StApps in place on a process-
-// derived field. Rows with a nil value for the field (composition failure
-// on that row) sort to the end regardless of direction — unavailable data
-// isn't ranked ahead of known data, either as largest or smallest.
+// derived field. Rows with a nil/absent value for the field (composition
+// failure on that row, or an app that's never been staged) sort to the end
+// regardless of direction — unavailable data isn't ranked ahead of known
+// data, either as largest/latest or smallest/earliest.
+//
+// lastRefreshedAt is string-valued (RFC3339, sorts lexicographically =
+// chronologically) so it gets its own comparator rather than being boxed
+// into the numeric one below.
 func sortStAppsByDerivedField(apps []StApp, field string, desc bool) {
+	if field == "lastRefreshedAt" {
+		sortStAppsByDerivedStringField(apps, field, desc)
+		return
+	}
 	sort.SliceStable(apps, func(i, j int) bool {
 		vi, iPresent := derivedSortValue(apps[i], field)
 		vj, jPresent := derivedSortValue(apps[j], field)
@@ -739,4 +749,44 @@ func derivedSortValue(app StApp, field string) (int, bool) {
 		return app.Instances, true
 	}
 	return 0, false
+}
+
+// sortStAppsByDerivedStringField sorts composed StApps in place on a
+// string-valued derived field, applying the same nils-sort-last posture as
+// sortStAppsByDerivedField's numeric path.
+func sortStAppsByDerivedStringField(apps []StApp, field string, desc bool) {
+	sort.SliceStable(apps, func(i, j int) bool {
+		vi, iPresent := derivedSortStringValue(apps[i], field)
+		vj, jPresent := derivedSortStringValue(apps[j], field)
+
+		// Absent values always sort last
+		if !iPresent && jPresent {
+			return false
+		}
+		if iPresent && !jPresent {
+			return true
+		}
+		if !iPresent && !jPresent {
+			return false
+		}
+		if desc {
+			return vi > vj
+		}
+		return vi < vj
+	})
+}
+
+// derivedSortStringValue returns the string value of a string-valued
+// derived sort field on a StApp, plus a present flag. LastRefreshedAt is
+// empty for apps that have never had a droplet staged, which is treated as
+// absent (not a valid, empty-string sort key).
+func derivedSortStringValue(app StApp, field string) (string, bool) {
+	switch field {
+	case "lastRefreshedAt":
+		if app.LastRefreshedAt == "" {
+			return "", false
+		}
+		return app.LastRefreshedAt, true
+	}
+	return "", false
 }

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/fivetwenty-io/capi/v3/pkg/capi"
 	"github.com/labstack/echo/v4"
@@ -269,6 +270,56 @@ func fetchRoutesForApps(ctx echo.Context, cfClient capi.Client, appGUIDs []strin
 	return out, nil
 }
 
+var dropletDerivedFields = []string{"lastRefreshedAt"}
+
+// fetchDropletsForApps returns, per app guid, the created_at of that app's
+// newest STAGED droplet, RFC3339-formatted. Newest-by-created_at rather
+// than "current droplet": rollbacks and droplet copies can repoint the
+// current droplet at an old row, but can't change which row is newest.
+// Apps that never staged have no entry — legit absence, not a failure.
+func fetchDropletsForApps(ctx echo.Context, cfClient capi.Client, appGUIDs []string) (map[string]string, error) {
+	if len(appGUIDs) == 0 {
+		return map[string]string{}, nil
+	}
+	newest := make(map[string]time.Time, len(appGUIDs))
+	// Chunked — see native_guid_chunks.go / #5579.
+	cerr := forEachGuidChunk("app_guids", appGUIDs, func(chunk []string) error {
+		for page := 1; ; page++ {
+			params := capi.NewQueryParams().WithPerPage(fullPagePerRequest)
+			params.Page = page
+			params.Filters["app_guids"] = chunk
+			params.Filters["states"] = []string{"STAGED"}
+			raw, err := cfClient.Droplets().List(ctx.Request().Context(), params)
+			if err != nil {
+				return err
+			}
+			for _, d := range raw.Resources {
+				if d.Relationships == nil || d.Relationships.App == nil {
+					continue
+				}
+				appGUID := relationshipGUID(*d.Relationships.App)
+				if appGUID == "" {
+					continue
+				}
+				if cur, ok := newest[appGUID]; !ok || d.CreatedAt.After(cur) {
+					newest[appGUID] = d.CreatedAt
+				}
+			}
+			if raw.Pagination.Next == nil || page >= raw.Pagination.TotalPages {
+				return nil
+			}
+		}
+	})
+	if cerr != nil {
+		return nil, cerr
+	}
+	out := make(map[string]string, len(newest))
+	for g, ts := range newest {
+		out[g] = ts.Format(time.RFC3339)
+	}
+	return out, nil
+}
+
 // composeStAppSummary builds a summary-tier StApp from its source app, its
 // web Process (may be nil), its Space (may be nil for unresolved), and its
 // route bucket (nil signals routes-fetch failure; an empty slice signals a
@@ -279,7 +330,11 @@ func fetchRoutesForApps(ctx echo.Context, cfClient capi.Client, appGUIDs []strin
 // the orgs-by-guid fetch failed or the org wasn't returned. Stitched at
 // the caller from a batched fetchOrgsByGUIDs so the per-app composition
 // remains pure (no per-row CAPI fanout).
-func composeStAppSummary(app capi.App, cnsiGUID string, process *capi.Process, space *capi.Space, orgName string, routes []StAppRoute) StApp {
+// droplets maps app guid → newest-STAGED-droplet created_at (RFC3339); nil
+// signals the droplets fetch failed (surfaces "lastRefreshedAt" in
+// _meta.unavailable), a non-nil map with a missing key means the app
+// simply never staged (field stays absent, not a failure).
+func composeStAppSummary(app capi.App, cnsiGUID string, process *capi.Process, space *capi.Space, orgName string, routes []StAppRoute, droplets map[string]string) StApp {
 	s := toStApp(app, cnsiGUID)
 
 	var unavailable []string
@@ -321,6 +376,15 @@ func composeStAppSummary(app capi.App, cnsiGUID string, process *capi.Process, s
 		unavailable = append(unavailable, routesDerivedFields...)
 	}
 
+	if droplets != nil {
+		if ts, ok := droplets[app.GUID]; ok {
+			s.LastRefreshedAt = ts
+		}
+		// missing key = never staged: field stays absent, NOT unavailable.
+	} else {
+		unavailable = append(unavailable, dropletDerivedFields...)
+	}
+
 	if len(unavailable) > 0 {
 		s.Meta = &StratosMeta{Unavailable: unavailable}
 	}
@@ -332,7 +396,7 @@ func composeStAppSummary(app capi.App, cnsiGUID string, process *capi.Process, s
 // envelope's _meta stays absent) when no errors occurred. Supports
 // additively stacking errors — each failed sub-fetch gets its own envelope
 // error with its own Affected + AffectedGuids lists.
-func envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr error, affectedGUIDs []string) *StratosMeta {
+func envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr, dropletsErr error, affectedGUIDs []string) *StratosMeta {
 	var errors []StratosError
 	if procErr != nil {
 		errors = append(errors, StratosError{
@@ -361,6 +425,16 @@ func envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr error, affect
 			Title:         "Routes fetch failed",
 			Detail:        routesErr.Error(),
 			Affected:      append([]string(nil), routesDerivedFields...),
+			AffectedGuids: append([]string(nil), affectedGUIDs...),
+		})
+	}
+	if dropletsErr != nil {
+		errors = append(errors, StratosError{
+			Scope:         "envelope",
+			Code:          "DROPLETS_FETCH_FAILED",
+			Title:         "Droplets fetch failed",
+			Detail:        dropletsErr.Error(),
+			Affected:      append([]string(nil), dropletDerivedFields...),
 			AffectedGuids: append([]string(nil), affectedGUIDs...),
 		})
 	}
@@ -410,6 +484,7 @@ func (c *CloudFoundrySpecification) getNativeAppsSummary(ctx echo.Context, cfCli
 	processes, procErr := fetchWebProcessesForApps(ctx, cfClient, appGUIDs)
 	spaces, spaceErr := fetchSpacesByGUIDs(ctx, cfClient, spaceGUIDs)
 	routesByApp, routesErr := fetchRoutesForApps(ctx, cfClient, appGUIDs)
+	dropletsByApp, dropletsErr := fetchDropletsForApps(ctx, cfClient, appGUIDs)
 
 	// Orgs-by-guid for the OrgName stitch. Derive the unique org guids
 	// from the spaces we just fetched — every app's org is reachable
@@ -461,13 +536,17 @@ func (c *CloudFoundrySpecification) getNativeAppsSummary(ctx echo.Context, cfCli
 				rts = []StAppRoute{}
 			}
 		}
-		resources = append(resources, composeStAppSummary(r, cnsiGUID, p, s, orgName, rts))
+		var drops map[string]string
+		if dropletsErr == nil {
+			drops = dropletsByApp
+		}
+		resources = append(resources, composeStAppSummary(r, cnsiGUID, p, s, orgName, rts, drops))
 	}
 
 	response := StratosPagedResponse[StApp]{
 		Resources:  resources,
 		Pagination: BuildPaginationMeta(ctx, page, perPage, raw.Pagination.TotalResults),
-		Meta:       envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr, appGUIDs),
+		Meta:       envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr, dropletsErr, appGUIDs),
 	}
 
 	return ctx.JSON(http.StatusOK, response)
@@ -513,6 +592,7 @@ func (c *CloudFoundrySpecification) getNativeAppsSummaryDerivedSort(
 	processes, procErr := fetchWebProcessesForApps(ctx, cfClient, appGUIDs)
 	spaces, spaceErr := fetchSpacesByGUIDs(ctx, cfClient, spaceGUIDs)
 	routesByApp, routesErr := fetchRoutesForApps(ctx, cfClient, appGUIDs)
+	dropletsByApp, dropletsErr := fetchDropletsForApps(ctx, cfClient, appGUIDs)
 
 	// Orgs-by-guid stitch (mirrors getNativeAppsSummary above).
 	orgs := map[string]capi.Organization{}
@@ -558,7 +638,11 @@ func (c *CloudFoundrySpecification) getNativeAppsSummaryDerivedSort(
 				rts = []StAppRoute{}
 			}
 		}
-		composed = append(composed, composeStAppSummary(r, cnsiGUID, p, s, orgName, rts))
+		var drops map[string]string
+		if dropletsErr == nil {
+			drops = dropletsByApp
+		}
+		composed = append(composed, composeStAppSummary(r, cnsiGUID, p, s, orgName, rts, drops))
 	}
 
 	sortStAppsByDerivedField(composed, sortField, desc)
@@ -577,7 +661,7 @@ func (c *CloudFoundrySpecification) getNativeAppsSummaryDerivedSort(
 	response := StratosPagedResponse[StApp]{
 		Resources:  pageSlice,
 		Pagination: BuildPaginationMeta(ctx, requestedPage, requestedPerPage, totalResults),
-		Meta:       envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr, appGUIDs),
+		Meta:       envelopeMetaForCompositionErrors(procErr, spaceErr, routesErr, dropletsErr, appGUIDs),
 	}
 
 	return ctx.JSON(http.StatusOK, response)

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary.go
@@ -12,9 +12,10 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// derivedSortFields are StApp fields sourced from /v3/processes that CAPI
-// doesn't sort natively — requests on these trigger the fetch-all-sort-in-
-// memory-paginate fallback path in getNativeAppsSummary.
+// derivedSortFields are StApp fields sourced from /v3/processes (memory,
+// diskQuota, instances) or /v3/droplets (lastRefreshedAt) that CAPI doesn't
+// sort natively — requests on these trigger the fetch-all-sort-in-memory-
+// paginate fallback path in getNativeAppsSummary.
 var derivedSortFields = map[string]bool{
 	"memory":          true,
 	"diskQuota":       true,
@@ -23,9 +24,9 @@ var derivedSortFields = map[string]bool{
 }
 
 // isDerivedSortField returns true when the Stratos-shape order_by value
-// refers to a process-derived field (memory / diskQuota / instances).
-// Accepts both "field" and "-field" forms; returns the bare field name and
-// the descending flag.
+// refers to a process-derived field (memory / diskQuota / instances) or
+// droplet-derived field (lastRefreshedAt). Accepts both "field" and "-field"
+// forms; returns the bare field name and the descending flag.
 func isDerivedSortField(orderBy string) (bool, string, bool) {
 	if orderBy == "" {
 		return false, "", false

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
@@ -163,6 +163,11 @@ func TestGetNativeAppsSummary_ReturnsStratosPagedEnvelope(t *testing.T) {
 				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
 				"resources":  []map[string]interface{}{},
 			})
+		case "/v3/droplets":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -423,6 +428,11 @@ func TestGetNativeAppsSummary_PopulatesMemoryDiskInstancesFromProcesses(t *testi
 					},
 				},
 			})
+		case "/v3/droplets":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -657,6 +667,11 @@ func TestGetNativeAppsSummary_DerivedSortFetchesAllAndPaginatesInMemory(t *testi
 				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
 				"resources":  []map[string]interface{}{},
 			})
+		case "/v3/droplets":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -736,6 +751,12 @@ func TestGetNativeAppsSummary_SpacesFetchFailureSurfacesOrgGuidTristate(t *testi
 				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
 				"resources":  []map[string]interface{}{},
 			})
+		case "/v3/droplets":
+			// Droplets succeeds so the test isolates the spaces failure
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -807,6 +828,13 @@ func TestGetNativeAppsSummary_BothCompositionFetchesFailMultiError(t *testing.T)
 			http.Error(w, `{"errors":[{"title":"Unavailable"}]}`, http.StatusServiceUnavailable)
 		case "/v3/routes":
 			http.Error(w, `{"errors":[{"title":"Unavailable"}]}`, http.StatusServiceUnavailable)
+		case "/v3/droplets":
+			// Droplets succeeds so the test isolates to exactly the three
+			// intentional failures (processes/spaces/routes).
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
 		default:
 			http.NotFound(w, r)
 		}
@@ -887,6 +915,12 @@ func TestGetNativeAppsSummary_ProcessesFetchFailureSurfacesTristate(t *testing.T
 			})
 		case "/v3/routes":
 			// Routes succeeds so the test isolates the processes failure
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/droplets":
+			// Droplets succeeds so the test isolates the processes failure
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
 				"resources":  []map[string]interface{}{},
@@ -1156,4 +1190,179 @@ func TestGetNativeApps_ReturnCountsHonorsSpaceGuidsFilter(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, 3, resp.TotalResults)
 	assert.Contains(t, capturedQuery, "space_guids=space-X")
+}
+
+// --- Task 1 (#5770 part 2): last-refreshed droplet enrichment ---
+
+func TestGetNativeAppsSummary_LastRefreshedFromNewestStagedDroplet(t *testing.T) {
+	var dropletQuery url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			w.Write([]byte(`{"links":{}}`))
+		case "/v3/apps":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 2, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					{
+						"guid": "app-1", "name": "App One", "state": "STARTED",
+						"relationships": map[string]interface{}{
+							"space": map[string]interface{}{"data": map[string]interface{}{"guid": "space-1"}},
+						},
+						"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z",
+					},
+					{
+						"guid": "app-2", "name": "App Two", "state": "STOPPED",
+						"relationships": map[string]interface{}{
+							"space": map[string]interface{}{"data": map[string]interface{}{"guid": "space-1"}},
+						},
+						"created_at": "2024-01-03T00:00:00Z", "updated_at": "2024-01-04T00:00:00Z",
+					},
+				},
+			})
+		case "/v3/processes":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/spaces":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/routes":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/droplets":
+			dropletQuery = r.URL.Query()
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 2, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					{"guid": "d-old", "state": "STAGED", "created_at": "2026-05-01T00:00:00Z",
+						"relationships": map[string]interface{}{"app": map[string]interface{}{"data": map[string]interface{}{"guid": "app-1"}}}},
+					{"guid": "d-new", "state": "STAGED", "created_at": "2026-07-15T12:00:00Z",
+						"relationships": map[string]interface{}{"app": map[string]interface{}{"data": map[string]interface{}{"guid": "app-1"}}}},
+				},
+			})
+			// app-2 gets NO droplet rows (never staged).
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/apps/test-cnsi?return=summary", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("test-cnsi")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "test-cnsi", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getNativeApps(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp StratosPagedResponse[StApp]
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Resources, 2)
+	assert.Equal(t, "2026-07-15T12:00:00Z", resp.Resources[0].LastRefreshedAt, "newest STAGED droplet wins")
+	assert.Equal(t, "", resp.Resources[1].LastRefreshedAt, "never-staged app has no value")
+	if resp.Resources[1].Meta != nil {
+		assert.NotContains(t, resp.Resources[1].Meta.Unavailable, "lastRefreshedAt",
+			"legit absence is not a fetch failure")
+	}
+	require.NotNil(t, dropletQuery)
+	assert.Equal(t, "STAGED", dropletQuery.Get("states"), "only successful stagings count")
+	assert.Contains(t, dropletQuery.Get("app_guids"), "app-1")
+	assert.Nil(t, resp.Meta, "no envelope error on clean fetch")
+}
+
+func TestGetNativeAppsSummary_DropletsFetchFailureSurfacesTristate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			w.Write([]byte(`{"links":{}}`))
+		case "/v3/apps":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 1, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					{
+						"guid": "app-1", "name": "App One", "state": "STARTED",
+						"relationships": map[string]interface{}{
+							"space": map[string]interface{}{"data": map[string]interface{}{"guid": "space-1"}},
+						},
+						"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z",
+					},
+				},
+			})
+		case "/v3/processes":
+			// Processes succeeds so the test isolates the droplets failure
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/spaces":
+			// Spaces succeeds so the test isolates the droplets failure
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/routes":
+			// Routes succeeds so the test isolates the droplets failure
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/droplets":
+			w.WriteHeader(http.StatusBadGateway)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/apps/test-cnsi?return=summary", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("test-cnsi")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "test-cnsi", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getNativeApps(ctx))
+	// HTTP 200 — the payload is valid, it describes partial failure
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp StratosPagedResponse[StApp]
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Resources, 1)
+
+	require.NotNil(t, resp.Meta)
+	found := false
+	for _, e := range resp.Meta.Errors {
+		if e.Code == "DROPLETS_FETCH_FAILED" {
+			found = true
+		}
+	}
+	assert.True(t, found, "envelope carries the droplets error")
+	require.NotNil(t, resp.Resources[0].Meta)
+	assert.Contains(t, resp.Resources[0].Meta.Unavailable, "lastRefreshedAt")
 }

--- a/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_apps_summary_test.go
@@ -565,6 +565,25 @@ func TestSortStAppsByDerivedField_Instances(t *testing.T) {
 	assert.Equal(t, []int{1, 3, 5}, []int{apps[0].Instances, apps[1].Instances, apps[2].Instances})
 }
 
+func TestSortStAppsByDerivedField_LastRefreshed(t *testing.T) {
+	apps := []StApp{
+		{GUID: "b", LastRefreshedAt: "2026-07-01T00:00:00Z"},
+		{GUID: "never"}, // absent → end, both directions
+		{GUID: "a", LastRefreshedAt: "2026-05-01T00:00:00Z"},
+	}
+	sortStAppsByDerivedField(apps, "lastRefreshedAt", false)
+	assert.Equal(t, []string{"a", "b", "never"}, []string{apps[0].GUID, apps[1].GUID, apps[2].GUID})
+	sortStAppsByDerivedField(apps, "lastRefreshedAt", true)
+	assert.Equal(t, []string{"b", "a", "never"}, []string{apps[0].GUID, apps[1].GUID, apps[2].GUID})
+}
+
+func TestIsDerivedSortField_LastRefreshed(t *testing.T) {
+	derived, field, desc := isDerivedSortField("-lastRefreshedAt")
+	assert.True(t, derived)
+	assert.Equal(t, "lastRefreshedAt", field)
+	assert.True(t, desc)
+}
+
 func TestGetNativeAppsSummary_DerivedSortFetchesAllAndPaginatesInMemory(t *testing.T) {
 	// Serve 5 apps across 2 CAPI pages; /v3/processes supplies distinct memory
 	// per app so memory sort produces a predictable global order.

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -662,6 +662,10 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 	// is intentionally minimal (the summary path carries the full
 	// _meta.unavailable / _meta.errors envelope).
 	routesByApp, _ := fetchRoutesForApps(ctx, cfClient, appGUIDs)
+	// Droplets are fetched lazily-non-fatal too — same posture as routes
+	// above. On error, dropletsByApp is nil and every row's lookup below
+	// simply misses, leaving LastRefreshedAt at its zero value.
+	dropletsByApp, _ := fetchDropletsForApps(ctx, cfClient, appGUIDs)
 	// Orgs-by-guid: derives the unique org guids from the spaces we
 	// already fetched and stitches OrgName per row. Mirrors the
 	// getNativeAppsSummary path so frontend can render the CF/Org/Space
@@ -699,6 +703,9 @@ func (c *CloudFoundrySpecification) getNativeApps(ctx echo.Context) error {
 		}
 		if rts, ok := routesByApp[r.GUID]; ok {
 			s.Routes = rts
+		}
+		if ts, ok := dropletsByApp[r.GUID]; ok {
+			s.LastRefreshedAt = ts
 		}
 		apps = append(apps, s)
 	}

--- a/src/jetstream/plugins/cloudfoundry/native_handlers_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers_test.go
@@ -256,6 +256,165 @@ func TestGetNativeApps(t *testing.T) {
 	assert.Equal(t, "space-1", resp.Resources[0].SpaceGUID)
 }
 
+// TestGetNativeApps_DefaultPathIncludesLastRefreshedAt covers the app-wall
+// path the frontend actually drains — /pp/v1/cf/apps/{cnsi} with NO
+// ?return= param. This handler does its own inline enrichment (not
+// composeStAppSummary), so LastRefreshedAt needs its own stamp here
+// (#5770 part 2 default-path gap).
+func TestGetNativeApps_DefaultPathIncludesLastRefreshedAt(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			w.Write([]byte(`{"links":{}}`))
+		case "/v3/apps":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 2, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					{
+						"guid": "app-1", "name": "App One", "state": "STARTED",
+						"relationships": map[string]interface{}{
+							"space": map[string]interface{}{"data": map[string]interface{}{"guid": "space-1"}},
+						},
+						"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z",
+					},
+					{
+						"guid": "app-2", "name": "App Two", "state": "STOPPED",
+						"relationships": map[string]interface{}{
+							"space": map[string]interface{}{"data": map[string]interface{}{"guid": "space-1"}},
+						},
+						"created_at": "2024-01-03T00:00:00Z", "updated_at": "2024-01-04T00:00:00Z",
+					},
+				},
+			})
+		case "/v3/processes":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/spaces":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/routes":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/droplets":
+			// app-1 has a STAGED droplet; app-2 never staged.
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 1, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					{"guid": "d-1", "state": "STAGED", "created_at": "2026-07-15T12:00:00Z",
+						"relationships": map[string]interface{}{"app": map[string]interface{}{"data": map[string]interface{}{"guid": "app-1"}}}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/apps/test-cnsi", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("test-cnsi")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "test-cnsi", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getNativeApps(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp StratosPagedResponse[StApp]
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Resources, 2)
+	assert.Equal(t, "2026-07-15T12:00:00Z", resp.Resources[0].LastRefreshedAt, "app-1 stamped from its STAGED droplet")
+	assert.Equal(t, "", resp.Resources[1].LastRefreshedAt, "app-2 never staged: field absent")
+}
+
+// TestGetNativeApps_DefaultPathDropletsFetchFailureIsNonFatal confirms the
+// default (no ?return=) path's lazily-non-fatal posture: a droplets-fetch
+// outage does not error the response, it just leaves LastRefreshedAt
+// unset on every row (this path carries no _meta.unavailable/_meta.errors
+// tristate signalling — that's reserved for the summary path).
+func TestGetNativeApps_DefaultPathDropletsFetchFailureIsNonFatal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3":
+			w.Write([]byte(`{"links":{}}`))
+		case "/v3/apps":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 1, "total_pages": 1},
+				"resources": []map[string]interface{}{
+					{
+						"guid": "app-1", "name": "App One", "state": "STARTED",
+						"relationships": map[string]interface{}{
+							"space": map[string]interface{}{"data": map[string]interface{}{"guid": "space-1"}},
+						},
+						"created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z",
+					},
+				},
+			})
+		case "/v3/processes":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/spaces":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/routes":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"pagination": map[string]interface{}{"total_results": 0, "total_pages": 0},
+				"resources":  []map[string]interface{}{},
+			})
+		case "/v3/droplets":
+			w.WriteHeader(http.StatusBadGateway)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/pp/v1/cf/apps/test-cnsi", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("cnsiGuid")
+	ctx.SetParamValues("test-cnsi")
+
+	plugin := &CloudFoundrySpecification{
+		testProxy: &mockNativeCFProxy{
+			userID:      "user-1",
+			cnsiRecord:  api.CNSIRecord{GUID: "test-cnsi", APIEndpoint: mustParseURL(ts.URL)},
+			tokenRecord: api.TokenRecord{AuthToken: "test-token"},
+		},
+	}
+
+	require.NoError(t, plugin.getNativeApps(ctx))
+	assert.Equal(t, http.StatusOK, rec.Code, "droplets outage must not fail the response")
+
+	var resp StratosPagedResponse[StApp]
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Resources, 1)
+	assert.Equal(t, "app-1", resp.Resources[0].GUID)
+	assert.Equal(t, "", resp.Resources[0].LastRefreshedAt, "row just lacks the field, no error surfaced")
+	assert.Nil(t, resp.Meta, "default path carries no envelope error tristate")
+}
+
 func TestGetNativeApps_PerPagePassthrough(t *testing.T) {
 	// ?per_page=N&page=M without ?return= should issue a SINGLE bounded
 	// /v3/apps call (no internal multi-page drain) and return a

--- a/src/jetstream/plugins/cloudfoundry/native_types.go
+++ b/src/jetstream/plugins/cloudfoundry/native_types.go
@@ -71,7 +71,12 @@ type StApp struct {
 	Routes    []StAppRoute `json:"routes"`
 	CreatedAt string       `json:"createdAt"`
 	UpdatedAt string       `json:"updatedAt"`
-	Meta      *StratosMeta `json:"_meta,omitempty"`
+	// Newest STAGED droplet's created_at (RFC3339) — the app's "last
+	// refreshed" instant (#5770): a droplet row is only born when staging
+	// completes, so this covers push and restage, counts only successes,
+	// and works for docker apps. Absent when the app never staged.
+	LastRefreshedAt string       `json:"lastRefreshedAt,omitempty"`
+	Meta            *StratosMeta `json:"_meta,omitempty"`
 }
 
 // StAppRoute is the inline-collection shape carried on StApp.Routes.


### PR DESCRIPTION
Part 2 of #5770 (Part 1 was #5773): application lists get a Last Refreshed column and a date-range filter.

Closes #5770

## What "last refreshed" means

The newest STAGED droplet's `created_at`. A droplet row is only born when staging completes, so this covers both push and restage, counts only successes (a failed push doesn't move the date), and works for docker apps. Newest-by-created_at rather than "current droplet" — a rollback can repoint the current droplet at an old row, but it can't change which row is newest. Apps that never staged successfully render an em dash and match no active range filter. cloudfoundry/cloud_controller_ng#5347 asks CAPI which field should be canonical for this; if that answer differs, the source is one function to change.

## Backend

Jetstream's apps aggregation gains one more guid-chunked fan-out, `fetchDropletsForApps` (`/v3/droplets?app_guids=…&states=STAGED`), cloned from the existing routes fetch. On the `return=summary` paths it carries the same tristate `_meta` failure signalling as the other sub-fetches (per-row `unavailable` plus a `DROPLETS_FETCH_FAILED` envelope error when the fetch fails; a never-staged app is a plain absence, not a failure). On the default listing path it is lazily-non-fatal like its neighbours. `order_by=lastRefreshedAt` is served by the in-memory derived-sort fallback, with absent values sorting last in both directions.

## Range filter

The filter mechanism is deliberately domain-general: the comparator (`rangeMatches`), the completeness check, and the popup live in the signal-list framework with `valueType: 'date' | 'number'`, and both domains are unit-tested — a future numeric consumer (memory, instances) wires a config entry and touches no framework code. Operators: before, on-or-before, after, on-or-after, and between with independently inclusive/exclusive ends. Date bounds are day-granular in local time — a date input names a calendar day, and the day window is computed from calendar rollover rather than a fixed 24h offset, so DST transition days keep their real length. A half-typed range (operator picked, bounds not complete yet) is kept so the popup remembers the choice, but it is inert: it filters nothing and does not light the Clear button. Filter state is a root-singleton signal shared by the application wall, the CF tab, and the space tab.

A possible later evolution discussed during review: composable and/or filter expressions rather than a fixed operator set. Not built here; the current operator model covers the refresh-policy use case that motivated the issue.

## Verification

Unit-tested on both sides (droplet merge incl. never-staged and fetch-failure cases; comparator across both domains incl. DST-transition dates; popup interaction sequences; predicate and wiring specs on all three lists). Live-verified against a six-endpoint dev setup with exact row counts for on-or-after, between, and exclusive-boundary cases, and the served timestamp checked against `cf curl /v3/droplets` ground truth. Full check gate green at the tip.
