### PR TITLE
Relative date bounds for the Last Refreshed range filter

### DIFF
--- a/changelog.d/0053-relative-date-range.md
+++ b/changelog.d/0053-relative-date-range.md
@@ -1,0 +1,2 @@
+[Features]
+- Date range filters accept relative bounds: "older than 90 days" or "older than 30 business days", with a user-declared working week (any weekend convention), an optional weekday-holiday count, and the resolved cutoff date shown so holidays can be checked and absorbed one bump at a time. Applies to the Last Refreshed filter on all application lists.

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { rangeIsComplete, rangeMatches, SignalListRangeValue } from './range-filter';
+import { rangeIsComplete, rangeMatches, resolveRelativeDay, SignalListRangeValue } from './range-filter';
 
 const d = (op: SignalListRangeValue['op'], a: string, b?: string, inclusiveA?: boolean, inclusiveB?: boolean): SignalListRangeValue =>
   ({ op, a, ...(b !== undefined ? { b } : {}), ...(inclusiveA !== undefined ? { inclusiveA } : {}), ...(inclusiveB !== undefined ? { inclusiveB } : {}) });
@@ -87,6 +87,157 @@ describe('rangeMatches — number domain (memory-style consumer)', () => {
   it('missing or non-numeric row values never match an active range', () => {
     expect(rangeMatches(undefined, d('gte', '0'), 'number')).toBe(false);
     expect(rangeMatches('n/a', d('gte', '0'), 'number')).toBe(false);
+  });
+});
+
+// Relative bounds: `a`/`b` hold day counts instead of dates. All weekday
+// numbers use the JS Date.getDay() convention (0=Sun … 6=Sat).
+const MON_FRI = [1, 2, 3, 4, 5];
+
+const rel = (
+  op: SignalListRangeValue['op'],
+  a: string,
+  mode: 'days' | 'businessDays',
+  extra: Partial<SignalListRangeValue> = {},
+): SignalListRangeValue => ({ op, a, mode, ...extra });
+
+// Local-time ISO probe for a moment inside a given calendar day.
+const at = (y: number, m: number, d: number, h = 12) => new Date(y, m - 1, d, h).toISOString();
+
+describe('rangeMatches — relative "days ago" bounds', () => {
+  const nowMon = new Date(2026, 7, 10, 12, 0); // Mon 2026-08-10 local noon
+
+  it('lt N days ago matches only values before the resolved day', () => {
+    // 90 days before Mon 2026-08-10 = Tue 2026-05-12.
+    expect(rangeMatches(at(2026, 5, 11), rel('lt', '90', 'days'), 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 5, 12, 0), rel('lt', '90', 'days'), 'date', nowMon)).toBe(false);
+  });
+
+  it('lte N days ago reaches through the end of the resolved day', () => {
+    expect(rangeMatches(at(2026, 5, 12, 23), rel('lte', '90', 'days'), 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 5, 13, 0), rel('lte', '90', 'days'), 'date', nowMon)).toBe(false);
+  });
+
+  it('gte N days ago includes from the start of the resolved day', () => {
+    // 1 day before Mon 2026-08-10 = Sun 2026-08-09.
+    expect(rangeMatches(at(2026, 8, 9, 0), rel('gte', '1', 'days'), 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 8, 8, 23), rel('gte', '1', 'days'), 'date', nowMon)).toBe(false);
+  });
+
+  it('between relative bounds resolves each count to its own day', () => {
+    // a=90 → 2026-05-12, b=30 → 2026-07-11; inclusive both ends by default.
+    expect(rangeMatches(at(2026, 6, 15), rel('between', '90', 'days', { b: '30' }), 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 5, 11), rel('between', '90', 'days', { b: '30' }), 'date', nowMon)).toBe(false);
+    expect(rangeMatches(at(2026, 7, 12), rel('between', '90', 'days', { b: '30' }), 'date', nowMon)).toBe(false);
+  });
+
+  it('non-positive, fractional, or empty counts are inert', () => {
+    expect(rangeMatches(at(2026, 5, 11), rel('lt', '', 'days'), 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 5, 11), rel('lt', '0', 'days'), 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 5, 11), rel('lt', '-3', 'days'), 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 5, 11), rel('lt', '2.5', 'days'), 'date', nowMon)).toBe(true);
+  });
+
+  it('counts beyond the 10-year cap are inert', () => {
+    expect(rangeMatches(at(2026, 5, 11), rel('lt', '99999', 'days'), 'date', nowMon)).toBe(true);
+  });
+
+  it('missing row values still never match an active relative range', () => {
+    expect(rangeMatches(undefined, rel('lt', '90', 'days'), 'date', nowMon)).toBe(false);
+  });
+});
+
+describe('rangeMatches — relative "business days ago" bounds', () => {
+  const nowMon = new Date(2026, 7, 10, 12, 0); // Mon 2026-08-10
+
+  it('walks over weekends: 1 business day before Monday is Friday', () => {
+    const r = rel('gte', '1', 'businessDays', { workingDays: MON_FRI });
+    expect(rangeMatches(at(2026, 8, 7, 0), r, 'date', nowMon)).toBe(true);   // Fri start
+    expect(rangeMatches(at(2026, 8, 6, 23), r, 'date', nowMon)).toBe(false); // Thu end
+  });
+
+  it('counts only working days: 3 business days before Monday is Wednesday', () => {
+    const r = rel('gte', '3', 'businessDays', { workingDays: MON_FRI });
+    expect(rangeMatches(at(2026, 8, 5, 0), r, 'date', nowMon)).toBe(true);   // Wed
+    expect(rangeMatches(at(2026, 8, 4, 23), r, 'date', nowMon)).toBe(false); // Tue
+  });
+
+  it('holidayCount extends the walk by whole working days', () => {
+    // 1 business day + 1 holiday from Monday: Fri, then Thu.
+    const r = rel('gte', '1', 'businessDays', { workingDays: MON_FRI, holidayCount: 1 });
+    expect(rangeMatches(at(2026, 8, 6, 0), r, 'date', nowMon)).toBe(true);   // Thu
+    expect(rangeMatches(at(2026, 8, 5, 23), r, 'date', nowMon)).toBe(false); // Wed
+  });
+
+  it('respects a Sun–Thu working week', () => {
+    const nowSun = new Date(2026, 7, 9, 12, 0); // Sun 2026-08-09
+    // 1 business day before Sunday, skipping Fri+Sat = Thu 2026-08-06.
+    const r = rel('gte', '1', 'businessDays', { workingDays: [0, 1, 2, 3, 4] });
+    expect(rangeMatches(at(2026, 8, 6, 0), r, 'date', nowSun)).toBe(true);
+    expect(rangeMatches(at(2026, 8, 5, 23), r, 'date', nowSun)).toBe(false);
+  });
+
+  it('an empty working-day set is inert', () => {
+    const r = rel('lt', '5', 'businessDays', { workingDays: [] });
+    expect(rangeMatches(at(2026, 5, 11), r, 'date', nowMon)).toBe(true);
+  });
+});
+
+describe('resolveRelativeDay', () => {
+  const nowMon = new Date(2026, 7, 10, 12, 0); // Mon 2026-08-10
+
+  it('resolves a plain-days count to local midnight N days back', () => {
+    const day = resolveRelativeDay(rel('lt', '90', 'days'), 'a', nowMon);
+    expect(day).toEqual(new Date(2026, 4, 12)); // Tue 2026-05-12
+  });
+
+  it('resolves business days landing on a working day (Monday → Friday)', () => {
+    const day = resolveRelativeDay(rel('lt', '1', 'businessDays', { workingDays: MON_FRI }), 'a', nowMon);
+    expect(day).toEqual(new Date(2026, 7, 7)); // Fri 2026-08-07
+  });
+
+  it('absorbs consecutive holidays one bump at a time', () => {
+    // From Monday: 1bd → Fri; +1 holiday → Thu; +2 → Wed.
+    const mk = (holidayCount: number) =>
+      resolveRelativeDay(rel('lt', '1', 'businessDays', { workingDays: MON_FRI, holidayCount }), 'a', nowMon);
+    expect(mk(1)).toEqual(new Date(2026, 7, 6));
+    expect(mk(2)).toEqual(new Date(2026, 7, 5));
+  });
+
+  it('resolves the b bound for between', () => {
+    const day = resolveRelativeDay(rel('between', '90', 'days', { b: '30' }), 'b', nowMon);
+    expect(day).toEqual(new Date(2026, 6, 11)); // Sat 2026-07-11
+  });
+
+  it('returns null for date mode, invalid counts, and empty working-day sets', () => {
+    expect(resolveRelativeDay({ op: 'lt', a: '2026-05-01' }, 'a', nowMon)).toBeNull();
+    expect(resolveRelativeDay(rel('lt', '', 'days'), 'a', nowMon)).toBeNull();
+    expect(resolveRelativeDay(rel('lt', '0', 'days'), 'a', nowMon)).toBeNull();
+    expect(resolveRelativeDay(rel('lt', '5', 'businessDays', { workingDays: [] }), 'a', nowMon)).toBeNull();
+  });
+});
+
+describe('rangeIsComplete — relative modes', () => {
+  it('a positive integer count is complete in days mode', () => {
+    expect(rangeIsComplete(rel('lt', '90', 'days'), 'date')).toBe(true);
+  });
+
+  it('zero, negative, fractional, or empty counts are incomplete', () => {
+    expect(rangeIsComplete(rel('lt', '0', 'days'), 'date')).toBe(false);
+    expect(rangeIsComplete(rel('lt', '-3', 'days'), 'date')).toBe(false);
+    expect(rangeIsComplete(rel('lt', '2.5', 'days'), 'date')).toBe(false);
+    expect(rangeIsComplete(rel('lt', '', 'days'), 'date')).toBe(false);
+  });
+
+  it('business days additionally require a non-empty working-day set', () => {
+    expect(rangeIsComplete(rel('lt', '5', 'businessDays', { workingDays: MON_FRI }), 'date')).toBe(true);
+    expect(rangeIsComplete(rel('lt', '5', 'businessDays', { workingDays: [] }), 'date')).toBe(false);
+    expect(rangeIsComplete(rel('lt', '5', 'businessDays'), 'date')).toBe(false);
+  });
+
+  it('a relative between needs both counts', () => {
+    expect(rangeIsComplete(rel('between', '90', 'days'), 'date')).toBe(false);
+    expect(rangeIsComplete(rel('between', '90', 'days', { b: '30' }), 'date')).toBe(true);
   });
 });
 

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.spec.ts
@@ -183,6 +183,51 @@ describe('rangeMatches — relative "business days ago" bounds', () => {
   });
 });
 
+describe('between normalization — typing order never matters', () => {
+  const nowMon = new Date(2026, 7, 10, 12, 0);
+  const may15noon = '2026-05-15T12:00:00Z';
+
+  it('relative between accepts smaller-first entry (30 then 90)', () => {
+    const r = rel('between', '30', 'days', { b: '90' });
+    expect(rangeMatches(at(2026, 6, 15), r, 'date', nowMon)).toBe(true);
+    expect(rangeMatches(at(2026, 5, 11), r, 'date', nowMon)).toBe(false);
+    expect(rangeMatches(at(2026, 7, 12), r, 'date', nowMon)).toBe(false);
+  });
+
+  it('date between accepts later-date-first entry', () => {
+    expect(rangeMatches(may15noon, d('between', '2026-06-01', '2026-05-01'), 'date')).toBe(true);
+    expect(rangeMatches('2026-04-30T12:00:00Z', d('between', '2026-06-01', '2026-05-01'), 'date')).toBe(false);
+  });
+
+  it('inclusive flags travel with their bound values when flipped', () => {
+    // a = Jun 1 is the UPPER bound after the flip; exclusiveA still excludes Jun 1.
+    const v = new Date(2026, 5, 1, 12).toISOString();
+    expect(rangeMatches(v, d('between', '2026-06-01', '2026-05-01', false, true), 'date')).toBe(false);
+    expect(rangeMatches(v, d('between', '2026-06-01', '2026-05-01', true, true), 'date')).toBe(true);
+  });
+
+  it('number domain between also normalizes', () => {
+    expect(rangeMatches(256, d('between', '512', '128'), 'number')).toBe(true);
+    expect(rangeMatches(64, d('between', '512', '128'), 'number')).toBe(false);
+  });
+});
+
+describe('workingDays sanitation', () => {
+  const nowMon = new Date(2026, 7, 10, 12, 0);
+
+  it('a set of only out-of-range weekday values is inert, not an endless walk', () => {
+    const r = rel('lt', '5', 'businessDays', { workingDays: [7, 13] });
+    expect(rangeMatches(at(2026, 5, 11), r, 'date', nowMon)).toBe(true);
+    expect(rangeIsComplete(r, 'date')).toBe(false);
+    expect(resolveRelativeDay(r, 'a', nowMon)).toBeNull();
+  });
+
+  it('mixed valid and invalid values keep the valid ones', () => {
+    const r = rel('lt', '1', 'businessDays', { workingDays: [1, 2, 3, 4, 5, 9] });
+    expect(resolveRelativeDay(r, 'a', nowMon)).toEqual(new Date(2026, 7, 7)); // Fri
+  });
+});
+
 describe('resolveRelativeDay', () => {
   const nowMon = new Date(2026, 7, 10, 12, 0); // Mon 2026-08-10
 

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
@@ -56,6 +56,19 @@ function parseCount(bound: string): number | null {
   return n > 0 && n <= 3650 ? n : null;
 }
 
+// The model is public (@stratosui/core), so weekday values are sanitized at
+// use: anything outside getDay()'s 0–6 can never match a real day, and an
+// unsanitized set like ISO-numbered [6, 7] would spin the walk forever.
+function validWorkingDays(days: readonly number[] | undefined): number[] {
+  return (days ?? []).filter(d => Number.isInteger(d) && d >= 0 && d <= 6);
+}
+
+// Resolved-day memo: the range value is immutable (every edit stores a new
+// object) so object identity + bound + calendar day fully key a walk result.
+// Kept because resolution runs per row in list predicates and inside
+// change-detection-hot template bindings.
+const relativeDayCache = new WeakMap<SignalListRangeValue, Map<string, Date | null>>();
+
 // Resolves a relative bound to the local-midnight Date it names, or null
 // when the range is not relative or the bound doesn't parse. Exported so
 // the popup can display the resolved date next to the holiday warning.
@@ -68,12 +81,28 @@ export function resolveRelativeDay(
 ): Date | null {
   const mode = range.mode ?? 'date';
   if (mode === 'date') return null;
+  const key = `${bound}|${now.getFullYear()}-${now.getMonth()}-${now.getDate()}`;
+  const hit = relativeDayCache.get(range);
+  if (hit?.has(key)) return hit.get(key)!;
+  const day = resolveRelativeDayUncached(range, bound, mode, now);
+  const entry = hit ?? new Map<string, Date | null>();
+  if (!hit) relativeDayCache.set(range, entry);
+  entry.set(key, day);
+  return day;
+}
+
+function resolveRelativeDayUncached(
+  range: SignalListRangeValue,
+  bound: 'a' | 'b',
+  mode: SignalListRangeBoundMode,
+  now: Date,
+): Date | null {
   const count = parseCount(bound === 'a' ? range.a : range.b ?? '');
   if (count === null) return null;
   if (mode === 'days') {
     return new Date(now.getFullYear(), now.getMonth(), now.getDate() - count);
   }
-  const working = new Set(range.workingDays ?? []);
+  const working = new Set(validWorkingDays(range.workingDays));
   if (working.size === 0) return null;
   const h = range.holidayCount;
   const holidays = Number.isInteger(h) && (h as number) > 0 ? (h as number) : 0;
@@ -108,6 +137,13 @@ export function rangeIsComplete(
   valueType: SignalListRangeValueType,
 ): boolean {
   if (range === null) return false;
+  // Relative modes: completeness is answerable from the raw fields — don't
+  // run the business-day walk from change-detection-hot callers.
+  if (valueType === 'date' && (range.mode ?? 'date') !== 'date') {
+    if (parseCount(range.a) === null) return false;
+    if (range.op === 'between' && parseCount(range.b ?? '') === null) return false;
+    return range.mode !== 'businessDays' || validWorkingDays(range.workingDays).length > 0;
+  }
   const window = (bound: 'a' | 'b') => boundWindow(range, bound, valueType);
   if (window('a') === null) return false;
   if (range.op === 'between' && window('b') === null) return false;
@@ -160,8 +196,17 @@ export function rangeMatches(
     case 'gt': return v > wa[1];
     case 'gte': return v >= wa[0];
     case 'between': {
-      const loOk = (range.inclusiveA ?? true) ? v >= wa[0] : v > wa[1];
-      const hiOk = (range.inclusiveB ?? true) ? v <= wb![1] : v < wb![0];
+      // Typing order never matters: bounds entered upper-first (natural for
+      // "between 30 and 90 days ago") are flipped here, each inclusive flag
+      // traveling with its bound's value.
+      let [lo, hi] = [wa, wb!];
+      let [incLo, incHi] = [range.inclusiveA ?? true, range.inclusiveB ?? true];
+      if (lo[0] > hi[0]) {
+        [lo, hi] = [hi, lo];
+        [incLo, incHi] = [incHi, incLo];
+      }
+      const loOk = incLo ? v >= lo[0] : v > lo[1];
+      const hiOk = incHi ? v <= hi[1] : v < hi[0];
       return loOk && hiOk;
     }
   }

--- a/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/range-filter.ts
@@ -9,12 +9,25 @@
 export type SignalListRangeOperator = 'lt' | 'lte' | 'gt' | 'gte' | 'between';
 export type SignalListRangeValueType = 'date' | 'number';
 
+// Bound interpretation for date-domain ranges. 'date' (the default when the
+// field is absent) reads `a`/`b` as YYYY-MM-DD; the relative modes read them
+// as day counts walked back from "today", so "older than 90 days" is plain
+// `lt` with a relative bound — no extra operators. 'businessDays' counts
+// only days in `workingDays` (JS getDay() numbers, 0=Sun … 6=Sat), stepping
+// `holidayCount` extra working days to compensate for weekday holidays the
+// user knows about — we deliberately hold no holiday data, the popup shows
+// the resolved date and tells the user to bump the count if it's a holiday.
+export type SignalListRangeBoundMode = 'date' | 'days' | 'businessDays';
+
 export interface SignalListRangeValue {
   readonly op: SignalListRangeOperator;
   readonly a: string;
   readonly b?: string;
   readonly inclusiveA?: boolean;
   readonly inclusiveB?: boolean;
+  readonly mode?: SignalListRangeBoundMode;
+  readonly workingDays?: readonly number[];
+  readonly holidayCount?: number;
 }
 
 // [startOfDay, endOfDay] for a YYYY-MM-DD input, in ms; null when unparsable.
@@ -34,6 +47,53 @@ function numWindow(bound: string): [number, number] | null {
   return Number.isNaN(n) ? null : [n, n];
 }
 
+// Positive integer day count, capped at ~10 years — beyond that a relative
+// staleness bound is meaningless and the business-day walk gets needlessly
+// long. Out-of-range counts read as unparsable (inert / incomplete).
+function parseCount(bound: string): number | null {
+  if (!/^\d+$/.test(bound)) return null;
+  const n = +bound;
+  return n > 0 && n <= 3650 ? n : null;
+}
+
+// Resolves a relative bound to the local-midnight Date it names, or null
+// when the range is not relative or the bound doesn't parse. Exported so
+// the popup can display the resolved date next to the holiday warning.
+// The business-day walk counts only working days, so it lands on a working
+// day by construction — never a weekend, whatever the week shape.
+export function resolveRelativeDay(
+  range: SignalListRangeValue,
+  bound: 'a' | 'b',
+  now: Date = new Date(),
+): Date | null {
+  const mode = range.mode ?? 'date';
+  if (mode === 'date') return null;
+  const count = parseCount(bound === 'a' ? range.a : range.b ?? '');
+  if (count === null) return null;
+  if (mode === 'days') {
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate() - count);
+  }
+  const working = new Set(range.workingDays ?? []);
+  if (working.size === 0) return null;
+  const h = range.holidayCount;
+  const holidays = Number.isInteger(h) && (h as number) > 0 ? (h as number) : 0;
+  let remaining = count + holidays;
+  // setDate rollover keeps this in local time across month/year/DST edges.
+  const cur = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  while (remaining > 0) {
+    cur.setDate(cur.getDate() - 1);
+    if (working.has(cur.getDay())) remaining--;
+  }
+  return cur;
+}
+
+// [startOfDay, endOfDay] window for a resolved local-midnight Date — the
+// relative-mode counterpart of dayWindow's string parse.
+function dayWindowFromDate(day: Date): [number, number] {
+  const end = new Date(day.getFullYear(), day.getMonth(), day.getDate() + 1).getTime() - 1;
+  return [day.getTime(), end];
+}
+
 // True iff `range` names a fully-typed constraint: a non-null range whose
 // primary bound parses in the given domain, and — for `between` — whose
 // upper bound parses too. A half-typed range (e.g. `{ op: 'between', a: '' }`
@@ -48,22 +108,40 @@ export function rangeIsComplete(
   valueType: SignalListRangeValueType,
 ): boolean {
   if (range === null) return false;
-  const window = valueType === 'date' ? dayWindow : numWindow;
-  if (window(range.a) === null) return false;
-  if (range.op === 'between' && window(range.b ?? '') === null) return false;
+  const window = (bound: 'a' | 'b') => boundWindow(range, bound, valueType);
+  if (window('a') === null) return false;
+  if (range.op === 'between' && window('b') === null) return false;
   return true;
+}
+
+// Comparison window for one bound, honoring the range's bound mode: number
+// domain and literal dates parse the bound string; relative date modes
+// resolve the count to a day first. Null = bound not (yet) parsable.
+function boundWindow(
+  range: SignalListRangeValue,
+  bound: 'a' | 'b',
+  valueType: SignalListRangeValueType,
+  now?: Date,
+): [number, number] | null {
+  const raw = bound === 'a' ? range.a : range.b ?? '';
+  if (valueType !== 'date') return numWindow(raw);
+  if ((range.mode ?? 'date') !== 'date') {
+    const day = resolveRelativeDay(range, bound, now);
+    return day === null ? null : dayWindowFromDate(day);
+  }
+  return dayWindow(raw);
 }
 
 export function rangeMatches(
   raw: string | number | null | undefined,
   range: SignalListRangeValue | null,
   valueType: SignalListRangeValueType,
+  now?: Date,
 ): boolean {
   if (range === null) return true;
 
-  const window = valueType === 'date' ? dayWindow : numWindow;
-  const wa = window(range.a);
-  const wb = range.b !== undefined ? window(range.b) : null;
+  const wa = boundWindow(range, 'a', valueType, now);
+  const wb = range.b !== undefined ? boundWindow(range, 'b', valueType, now) : null;
   // Half-typed or unparsable bounds: the filter is inert, never blanking
   // the list under the user's cursor mid-edit.
   if (wa === null || (range.op === 'between' && wb === null)) return true;

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -139,11 +139,15 @@
                 </label>
               }
               @if (fr.selected()?.mode === 'businessDays') {
-                <div class="flex gap-1.5 px-1" data-test="working-days">
+                <!-- Weekend framing: checked = weekend (the smaller, more
+                     natural set); the model still stores the complement as
+                     workingDays, so the walk and specs are untouched. -->
+                <div class="px-1 text-xs text-content-muted">Weekend days</div>
+                <div class="flex gap-1.5 px-1" data-test="weekend-days">
                   @for (wd of weekdayToggles; track wd.value) {
                     <label class="flex flex-col items-center text-[10px] text-content-text cursor-pointer">
                       <input type="checkbox" [attr.data-test]="'wd-' + wd.value"
-                        [checked]="fr.selected()?.workingDays?.includes(wd.value)"
+                        [checked]="!fr.selected()?.workingDays?.includes(wd.value)"
                         (change)="toggleWorkingDay(fr, wd.value)" />
                       {{ wd.label }}
                     </label>
@@ -151,10 +155,10 @@
                 </div>
                 <label class="flex items-center gap-2 px-1 text-xs text-content-text">
                   + weekday holidays
-                  <input type="number" min="0" data-test="range-holidays"
+                  <input type="number" min="0" step="1" data-test="range-holidays"
                     class="w-14 text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
                     [value]="fr.selected()?.holidayCount ?? 0"
-                    (change)="updateRange(fr, { holidayCount: +$any($event.target).value || 0 })" />
+                    (change)="updateRange(fr, { holidayCount: +$any($event.target).value })" />
                 </label>
               }
               @if (isRelativeRange(fr)) {
@@ -165,8 +169,8 @@
                 }
                 @if (fr.selected()?.mode === 'businessDays') {
                   <div data-test="range-holiday-warning" class="px-1 text-xs text-content-muted">
-                    Holidays are not counted — if the resolved date is a
-                    holiday, increase the holiday count by 1 and check again.
+                    If the resolved date is a holiday, increase the holiday
+                    count by 1 and check again.
                   </div>
                 }
               }

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -169,8 +169,18 @@
                 }
                 @if (fr.selected()?.mode === 'businessDays') {
                   <div data-test="range-holiday-warning" class="px-1 text-xs text-content-muted">
-                    If the resolved date is a holiday, increase the holiday
-                    count by 1 and check again.
+                    <!-- Between: the holiday count is part of BOTH bounds'
+                         walks, so bumping it moves both dates — the
+                         per-bound remedies are that bound's own count or
+                         its include checkbox. -->
+                    @if ((fr.selected()?.op ?? 'gte') === 'between') {
+                      If either resolved date is a holiday, adjust that
+                      bound's day count or its include checkbox — the
+                      holiday count shifts both dates.
+                    } @else {
+                      If the resolved date is a holiday, increase the holiday
+                      count by 1 and check again.
+                    }
                   </div>
                 }
               }

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -88,27 +88,40 @@
             <!-- Overlays the input slot like the checklist popup — same approved
                  product design; don't "fix" it. -->
             <div class="absolute left-0 top-0 z-30 min-w-56 border border-content-border rounded bg-content-bg shadow-lg p-2 flex flex-col gap-1.5">
+              @if (fr.valueType === 'date') {
+                <select
+                  data-test="range-mode"
+                  class="text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
+                  [value]="fr.selected()?.mode ?? 'date'"
+                  (change)="updateRange(fr, { mode: $any($event.target).value })">
+                  <option value="date">specific date</option>
+                  <option value="days">days ago</option>
+                  <option value="businessDays">business days ago</option>
+                </select>
+              }
               <select
                 data-test="range-op"
                 class="text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
                 [value]="fr.selected()?.op ?? 'gte'"
                 (change)="updateRange(fr, { op: $any($event.target).value })">
-                <option value="lt">before</option>
-                <option value="lte">on or before</option>
-                <option value="gt">after</option>
-                <option value="gte">on or after</option>
-                <option value="between">between</option>
+                <option value="lt">{{ opLabel(fr, 'lt') }}</option>
+                <option value="lte">{{ opLabel(fr, 'lte') }}</option>
+                <option value="gt">{{ opLabel(fr, 'gt') }}</option>
+                <option value="gte">{{ opLabel(fr, 'gte') }}</option>
+                <option value="between">{{ opLabel(fr, 'between') }}</option>
               </select>
               <input
                 data-test="range-a"
-                [type]="fr.valueType === 'date' ? 'date' : 'number'"
+                [type]="fr.valueType === 'date' && !isRelativeRange(fr) ? 'date' : 'number'"
+                [attr.min]="isRelativeRange(fr) ? 1 : null"
                 class="text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
                 [value]="fr.selected()?.a ?? ''"
                 (change)="updateRange(fr, { a: $any($event.target).value })" />
               @if ((fr.selected()?.op ?? 'gte') === 'between') {
                 <input
                   data-test="range-b"
-                  [type]="fr.valueType === 'date' ? 'date' : 'number'"
+                  [type]="fr.valueType === 'date' && !isRelativeRange(fr) ? 'date' : 'number'"
+                  [attr.min]="isRelativeRange(fr) ? 1 : null"
                   class="text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
                   [value]="fr.selected()?.b ?? ''"
                   (change)="updateRange(fr, { b: $any($event.target).value })" />
@@ -124,6 +137,38 @@
                     (change)="updateRange(fr, { inclusiveB: $any($event.target).checked })" />
                   include end
                 </label>
+              }
+              @if (fr.selected()?.mode === 'businessDays') {
+                <div class="flex gap-1.5 px-1" data-test="working-days">
+                  @for (wd of weekdayToggles; track wd.value) {
+                    <label class="flex flex-col items-center text-[10px] text-content-text cursor-pointer">
+                      <input type="checkbox" [attr.data-test]="'wd-' + wd.value"
+                        [checked]="fr.selected()?.workingDays?.includes(wd.value)"
+                        (change)="toggleWorkingDay(fr, wd.value)" />
+                      {{ wd.label }}
+                    </label>
+                  }
+                </div>
+                <label class="flex items-center gap-2 px-1 text-xs text-content-text">
+                  + weekday holidays
+                  <input type="number" min="0" data-test="range-holidays"
+                    class="w-14 text-sm border border-content-border rounded bg-content-bg text-content-text px-1 py-0.5"
+                    [value]="fr.selected()?.holidayCount ?? 0"
+                    (change)="updateRange(fr, { holidayCount: +$any($event.target).value || 0 })" />
+                </label>
+              }
+              @if (isRelativeRange(fr)) {
+                @if (resolvedDayLabel(fr, 'a'); as dayA) {
+                  <div data-test="range-resolved" class="px-1 text-xs text-content-muted">
+                    → {{ dayA }}@if (resolvedDayLabel(fr, 'b'); as dayB) {&nbsp;– {{ dayB }}}
+                  </div>
+                }
+                @if (fr.selected()?.mode === 'businessDays') {
+                  <div data-test="range-holiday-warning" class="px-1 text-xs text-content-muted">
+                    Holidays are not counted — if the resolved date is a
+                    holiday, increase the holiday count by 1 and check again.
+                  </div>
+                }
               }
               <button
                 type="button"

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -1873,16 +1873,48 @@ describe('SignalListComponent range filter (filterRanges)', () => {
       expect(component.hasActiveFilter()).toBe(true);
     });
 
-    it('toggling every working day off leaves the filter inert, not active', () => {
+    it('the last working day cannot be toggled off — a 7-day weekend is refused', () => {
       const fixture = TestBed.createComponent(RangeFilterHost);
       fixture.detectChanges();
       const component = componentWith(fixture);
       const fr = component.activeRange()!;
       component.updateRange(fr, { mode: 'businessDays' });
       component.updateRange(fr, { a: '30' });
-      for (const day of [1, 2, 3, 4, 5]) component.toggleWorkingDay(fr, day);
-      expect(fixture.componentInstance.selectedRange()?.workingDays).toEqual([]);
-      expect(component.hasActiveFilter()).toBe(false);
+      for (const day of [1, 2, 3, 4]) component.toggleWorkingDay(fr, day);
+      expect(fixture.componentInstance.selectedRange()?.workingDays).toEqual([5]);
+      component.toggleWorkingDay(fr, 5); // refused: would empty the working week
+      expect(fixture.componentInstance.selectedRange()?.workingDays).toEqual([5]);
+      expect(component.hasActiveFilter()).toBe(true);
+    });
+
+    it('clearing the count in a relative range keeps mode, week, and holidays', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { mode: 'businessDays' });
+      component.updateRange(fr, { a: '30' });
+      component.toggleWorkingDay(fr, 5);
+      component.updateRange(fr, { holidayCount: 2 });
+      component.updateRange(fr, { a: '' }); // clear to retype
+      expect(fixture.componentInstance.selectedRange()).toEqual({
+        op: 'gte', a: '', mode: 'businessDays', workingDays: [1, 2, 3, 4], holidayCount: 2,
+      });
+      expect(component.hasActiveFilter()).toBe(false); // inert, but config survives
+    });
+
+    it('holidayCount patches are floored to non-negative integers', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { mode: 'businessDays' });
+      component.updateRange(fr, { holidayCount: 1.5 });
+      expect(fixture.componentInstance.selectedRange()?.holidayCount).toBe(1);
+      component.updateRange(fr, { holidayCount: -2 });
+      expect(fixture.componentInstance.selectedRange()?.holidayCount).toBe(0);
+      component.updateRange(fr, { holidayCount: Number.NaN });
+      expect(fixture.componentInstance.selectedRange()?.holidayCount).toBe(0);
     });
 
     it('rangeSummary renders relative forms', () => {
@@ -1905,22 +1937,29 @@ describe('SignalListComponent range filter (filterRanges)', () => {
     });
 
     it('resolvedDayLabel names the resolved day for a complete relative bound, null otherwise', () => {
-      const fixture = TestBed.createComponent(RangeFilterHost);
-      fixture.detectChanges();
-      const component = componentWith(fixture);
-      const fr = component.activeRange()!;
+      // Frozen clock: the component and the expectation must see the same
+      // "today", or a run straddling local midnight flakes.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 7, 10, 12, 0)); // Mon 2026-08-10
+      try {
+        const fixture = TestBed.createComponent(RangeFilterHost);
+        fixture.detectChanges();
+        const component = componentWith(fixture);
+        const fr = component.activeRange()!;
 
-      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '2026-05-01' });
-      expect(component.resolvedDayLabel(fr, 'a')).toBeNull();
+        fixture.componentInstance.selectedRange.set({ op: 'lt', a: '2026-05-01' });
+        expect(component.resolvedDayLabel(fr, 'a')).toBeNull();
 
-      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '1', mode: 'days' });
-      const today = new Date();
-      const expected = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1)
-        .toLocaleDateString(undefined, { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
-      expect(component.resolvedDayLabel(fr, 'a')).toBe(expected);
+        fixture.componentInstance.selectedRange.set({ op: 'lt', a: '1', mode: 'days' });
+        const expected = new Date(2026, 7, 9)
+          .toLocaleDateString(undefined, { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
+        expect(component.resolvedDayLabel(fr, 'a')).toBe(expected);
 
-      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '', mode: 'days' });
-      expect(component.resolvedDayLabel(fr, 'a')).toBeNull();
+        fixture.componentInstance.selectedRange.set({ op: 'lt', a: '', mode: 'days' });
+        expect(component.resolvedDayLabel(fr, 'a')).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('opLabel wording follows the mode', () => {

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -1962,6 +1962,26 @@ describe('SignalListComponent range filter (filterRanges)', () => {
       }
     });
 
+    it('holiday warning is singular for one bound, plural with per-bound remedies for between', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      (fixture.nativeElement.querySelector('[data-test="range-filter-toggle"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { mode: 'businessDays' });
+      fixture.detectChanges();
+      const warnText = () =>
+        (fixture.nativeElement.querySelector('[data-test="range-holiday-warning"]') as HTMLElement).textContent!.replace(/\s+/g, ' ').trim();
+      expect(warnText()).toContain('the resolved date');
+      expect(warnText()).not.toContain('either');
+
+      component.updateRange(fr, { op: 'between' });
+      fixture.detectChanges();
+      expect(warnText()).toContain('either resolved date');
+      expect(warnText()).toContain('holiday count shifts both dates');
+    });
+
     it('opLabel wording follows the mode', () => {
       const fixture = TestBed.createComponent(RangeFilterHost);
       fixture.detectChanges();

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -1809,4 +1809,129 @@ describe('SignalListComponent range filter (filterRanges)', () => {
       expect(fixture.componentInstance.selectedRange()).toBe(null);
     });
   });
+
+  // Relative bound modes ("older than N days / business days"): the mode
+  // select, count input, working-day toggles, and holiday count each fire
+  // their own change event — same separate-events discipline as the
+  // between sequence above.
+  describe('relative bound modes', () => {
+    it('a mode-only patch stores the mode without collapsing to null', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      component.updateRange(component.activeRange()!, { mode: 'days' });
+      expect(fixture.componentInstance.selectedRange()).toEqual({ op: 'gte', a: '', mode: 'days' });
+      expect(component.hasActiveFilter()).toBe(false);
+    });
+
+    it('switching mode clears the bounds but keeps the op — a date is not a count', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { op: 'lt' });
+      component.updateRange(fr, { a: '2026-05-01' });
+      component.updateRange(fr, { mode: 'days' });
+      expect(fixture.componentInstance.selectedRange()).toEqual({ op: 'lt', a: '', mode: 'days' });
+    });
+
+    it('switching to businessDays seeds a Mon–Fri working week', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      component.updateRange(component.activeRange()!, { mode: 'businessDays' });
+      expect(fixture.componentInstance.selectedRange()?.workingDays).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('toggleWorkingDay flips membership in both directions', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { mode: 'businessDays' });
+      component.toggleWorkingDay(fr, 5); // Friday off
+      expect(fixture.componentInstance.selectedRange()?.workingDays).toEqual([1, 2, 3, 4]);
+      component.toggleWorkingDay(fr, 0); // Sunday on
+      expect(fixture.componentInstance.selectedRange()?.workingDays).toEqual([1, 2, 3, 4, 0]);
+    });
+
+    it('full event sequence: mode, then count, then toggles, then holidays', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { op: 'lt' });
+      component.updateRange(fr, { mode: 'businessDays' });
+      expect(component.hasActiveFilter()).toBe(false); // no count yet
+      component.updateRange(fr, { a: '30' });
+      expect(component.hasActiveFilter()).toBe(true);
+      component.toggleWorkingDay(fr, 5);
+      component.updateRange(fr, { holidayCount: 2 });
+      expect(fixture.componentInstance.selectedRange()).toEqual({
+        op: 'lt', a: '30', mode: 'businessDays', workingDays: [1, 2, 3, 4], holidayCount: 2,
+      });
+      expect(component.hasActiveFilter()).toBe(true);
+    });
+
+    it('toggling every working day off leaves the filter inert, not active', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      component.updateRange(fr, { mode: 'businessDays' });
+      component.updateRange(fr, { a: '30' });
+      for (const day of [1, 2, 3, 4, 5]) component.toggleWorkingDay(fr, day);
+      expect(fixture.componentInstance.selectedRange()?.workingDays).toEqual([]);
+      expect(component.hasActiveFilter()).toBe(false);
+    });
+
+    it('rangeSummary renders relative forms', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+
+      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '90', mode: 'days' });
+      expect(component.rangeSummary(fr)).toBe('older than 90 days');
+
+      fixture.componentInstance.selectedRange.set({ op: 'gte', a: '30', mode: 'businessDays', workingDays: [1, 2, 3, 4, 5] });
+      expect(component.rangeSummary(fr)).toBe('within 30 business days');
+
+      fixture.componentInstance.selectedRange.set({ op: 'gt', a: '7', mode: 'days' });
+      expect(component.rangeSummary(fr)).toBe('newer than 7 days');
+
+      fixture.componentInstance.selectedRange.set({ op: 'between', a: '90', b: '30', mode: 'days' });
+      expect(component.rangeSummary(fr)).toBe('90 – 30 days ago');
+    });
+
+    it('resolvedDayLabel names the resolved day for a complete relative bound, null otherwise', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+
+      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '2026-05-01' });
+      expect(component.resolvedDayLabel(fr, 'a')).toBeNull();
+
+      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '1', mode: 'days' });
+      const today = new Date();
+      const expected = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1)
+        .toLocaleDateString(undefined, { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
+      expect(component.resolvedDayLabel(fr, 'a')).toBe(expected);
+
+      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '', mode: 'days' });
+      expect(component.resolvedDayLabel(fr, 'a')).toBeNull();
+    });
+
+    it('opLabel wording follows the mode', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      const component = componentWith(fixture);
+      const fr = component.activeRange()!;
+      expect(component.opLabel(fr, 'lt')).toBe('before');
+      fixture.componentInstance.selectedRange.set({ op: 'lt', a: '90', mode: 'days' });
+      expect(component.opLabel(fr, 'lt')).toBe('older than');
+      expect(component.opLabel(fr, 'gte')).toBe('within');
+    });
+  });
 });

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 
 import { UsageGaugeComponent } from '../usage-gauge/usage-gauge.component';
 import { SignalListCellTemplateDirective } from './signal-list-cell-template.directive';
-import { rangeIsComplete, SignalListRangeValue, SignalListRangeValueType } from './range-filter';
+import { rangeIsComplete, resolveRelativeDay, SignalListRangeValue, SignalListRangeValueType } from './range-filter';
 
 export type SignalListPillColor = 'success' | 'warning' | 'danger' | 'neutral';
 
@@ -1214,10 +1214,63 @@ export class SignalListComponent<T> implements AfterViewInit {
   rangeSummary(fr: SignalListRangeFilter): string {
     const sel = fr.selected();
     if (sel === null) return 'Any';
+    const mode = fr.valueType === 'date' ? (sel.mode ?? 'date') : 'date';
+    if (mode !== 'date') {
+      const relUnit = mode === 'businessDays' ? 'business days' : 'days';
+      const n = sel.a || '…';
+      switch (sel.op) {
+        case 'lt': return `older than ${n} ${relUnit}`;
+        case 'lte': return `at least ${n} ${relUnit} old`;
+        case 'gt': return `newer than ${n} ${relUnit}`;
+        case 'gte': return `within ${n} ${relUnit}`;
+        case 'between': return `${n} – ${sel.b || '…'} ${relUnit} ago`;
+      }
+    }
     const unit = fr.unit ? ` ${fr.unit}` : '';
     const sym: Record<string, string> = { lt: '<', lte: '≤', gt: '>', gte: '≥' };
     if (sel.op === 'between') return `${sel.a || '…'}${unit} – ${sel.b || '…'}${unit}`;
     return `${sym[sel.op]} ${sel.a || '…'}${unit}`;
+  }
+
+  // Op wording tracks the bound mode: absolute dates read as positions on a
+  // calendar ("before"), relative counts read as ages ("older than").
+  opLabel(fr: SignalListRangeFilter, op: SignalListRangeValue['op']): string {
+    const relative = fr.valueType === 'date' && (fr.selected()?.mode ?? 'date') !== 'date';
+    const labels: Record<SignalListRangeValue['op'], string> = relative
+      ? { lt: 'older than', lte: 'at least', gt: 'newer than', gte: 'within', between: 'between' }
+      : { lt: 'before', lte: 'on or before', gt: 'after', gte: 'on or after', between: 'between' };
+    return labels[op];
+  }
+
+  // The calendar day a relative bound currently resolves to, formatted for
+  // the popup ("Fri, Aug 7, 2026"), or null when the bound is absolute or
+  // not yet parsable. Shown next to the holiday warning so the user can
+  // verify the date and bump the holiday count if it lands on one.
+  resolvedDayLabel(fr: SignalListRangeFilter, bound: 'a' | 'b'): string | null {
+    const sel = fr.selected();
+    if (sel === null || fr.valueType !== 'date') return null;
+    const day = resolveRelativeDay(sel, bound);
+    if (day === null) return null;
+    return day.toLocaleDateString(undefined, { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  isRelativeRange(fr: SignalListRangeFilter): boolean {
+    return fr.valueType === 'date' && (fr.selected()?.mode ?? 'date') !== 'date';
+  }
+
+  // Sun-first so toggle order matches the getDay() numbering the model uses.
+  readonly weekdayToggles = [
+    { value: 0, label: 'Su' }, { value: 1, label: 'Mo' }, { value: 2, label: 'Tu' },
+    { value: 3, label: 'We' }, { value: 4, label: 'Th' }, { value: 5, label: 'Fr' },
+    { value: 6, label: 'Sa' },
+  ];
+
+  // Flips one weekday in the business-day working week. Routed through
+  // updateRange so paging reset and storage rules stay in one place.
+  toggleWorkingDay(fr: SignalListRangeFilter, day: number): void {
+    const curr = fr.selected()?.workingDays ?? [];
+    const workingDays = curr.includes(day) ? curr.filter(d => d !== day) : [...curr, day];
+    this.updateRange(fr, { workingDays });
   }
 
   // Merges a partial edit into the current range. Only collapses to null
@@ -1232,7 +1285,17 @@ export class SignalListComponent<T> implements AfterViewInit {
   // button under the user's cursor mid-edit.
   updateRange(fr: SignalListRangeFilter, patch: Partial<SignalListRangeValue>): void {
     const curr = fr.selected() ?? { op: 'gte' as const, a: '' };
-    const next: SignalListRangeValue = { ...curr, ...patch };
+    let next: SignalListRangeValue = { ...curr, ...patch };
+    // A mode switch clears the bounds — `a`/`b` change meaning between a
+    // date string and a day count, so carrying one across modes would store
+    // garbage. The op and any chosen working week survive; businessDays
+    // seeds Mon–Fri on first entry so the toggles have a sane start.
+    if (patch.mode !== undefined && patch.mode !== (curr.mode ?? 'date')) {
+      next = { ...next, a: '', b: undefined };
+      if (patch.mode === 'businessDays' && next.workingDays === undefined) {
+        next = { ...next, workingDays: [1, 2, 3, 4, 5] };
+      }
+    }
     const touchedBound = 'a' in patch || 'b' in patch;
     const allBoundsEmpty = next.a === '' && !next.b;
     fr.selected.set(touchedBound && allBoundsEmpty ? null : next);

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -1265,11 +1265,15 @@ export class SignalListComponent<T> implements AfterViewInit {
     return this.rangeMode(fr) !== 'date';
   }
 
-  // Sun-first so toggle order matches the getDay() numbering the model uses.
+  // Thursday-first so every real-world weekend reads as a consecutive run:
+  // Thu–Fri (Iran, Afghanistan), Fri–Sat (much of MENA), Sat–Sun (most of
+  // the world), and the single-day conventions all sit in the head of the
+  // row with nothing wrapping (Sun-first split the default Sat+Sun weekend
+  // across the row's two far ends). Values stay getDay() numbers.
   readonly weekdayToggles = [
+    { value: 4, label: 'Th' }, { value: 5, label: 'Fr' }, { value: 6, label: 'Sa' },
     { value: 0, label: 'Su' }, { value: 1, label: 'Mo' }, { value: 2, label: 'Tu' },
-    { value: 3, label: 'We' }, { value: 4, label: 'Th' }, { value: 5, label: 'Fr' },
-    { value: 6, label: 'Sa' },
+    { value: 3, label: 'We' },
   ];
 
   // Flips one weekday in the business-day working week. Routed through

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 
 import { UsageGaugeComponent } from '../usage-gauge/usage-gauge.component';
 import { SignalListCellTemplateDirective } from './signal-list-cell-template.directive';
-import { rangeIsComplete, resolveRelativeDay, SignalListRangeValue, SignalListRangeValueType } from './range-filter';
+import { rangeIsComplete, resolveRelativeDay, SignalListRangeBoundMode, SignalListRangeValue, SignalListRangeValueType } from './range-filter';
 
 export type SignalListPillColor = 'success' | 'warning' | 'danger' | 'neutral';
 
@@ -1211,10 +1211,18 @@ export class SignalListComponent<T> implements AfterViewInit {
     return this.config.filterRanges?.find(r => r.field === field);
   }
 
+  // Single source of truth for a range filter's bound mode: number-domain
+  // filters are always absolute, date-domain ones follow the stored mode.
+  // Every relative-vs-absolute decision (labels, summary, input types)
+  // routes through here.
+  private rangeMode(fr: SignalListRangeFilter): SignalListRangeBoundMode {
+    return fr.valueType === 'date' ? (fr.selected()?.mode ?? 'date') : 'date';
+  }
+
   rangeSummary(fr: SignalListRangeFilter): string {
     const sel = fr.selected();
     if (sel === null) return 'Any';
-    const mode = fr.valueType === 'date' ? (sel.mode ?? 'date') : 'date';
+    const mode = this.rangeMode(fr);
     if (mode !== 'date') {
       const relUnit = mode === 'businessDays' ? 'business days' : 'days';
       const n = sel.a || '…';
@@ -1235,8 +1243,7 @@ export class SignalListComponent<T> implements AfterViewInit {
   // Op wording tracks the bound mode: absolute dates read as positions on a
   // calendar ("before"), relative counts read as ages ("older than").
   opLabel(fr: SignalListRangeFilter, op: SignalListRangeValue['op']): string {
-    const relative = fr.valueType === 'date' && (fr.selected()?.mode ?? 'date') !== 'date';
-    const labels: Record<SignalListRangeValue['op'], string> = relative
+    const labels: Record<SignalListRangeValue['op'], string> = this.isRelativeRange(fr)
       ? { lt: 'older than', lte: 'at least', gt: 'newer than', gte: 'within', between: 'between' }
       : { lt: 'before', lte: 'on or before', gt: 'after', gte: 'on or after', between: 'between' };
     return labels[op];
@@ -1255,7 +1262,7 @@ export class SignalListComponent<T> implements AfterViewInit {
   }
 
   isRelativeRange(fr: SignalListRangeFilter): boolean {
-    return fr.valueType === 'date' && (fr.selected()?.mode ?? 'date') !== 'date';
+    return this.rangeMode(fr) !== 'date';
   }
 
   // Sun-first so toggle order matches the getDay() numbering the model uses.
@@ -1267,8 +1274,11 @@ export class SignalListComponent<T> implements AfterViewInit {
 
   // Flips one weekday in the business-day working week. Routed through
   // updateRange so paging reset and storage rules stay in one place.
+  // Removing the last working day is refused — a 7-day weekend would make
+  // the walk unresolvable while the summary still reads as a constraint.
   toggleWorkingDay(fr: SignalListRangeFilter, day: number): void {
     const curr = fr.selected()?.workingDays ?? [];
+    if (curr.includes(day) && curr.length === 1) return;
     const workingDays = curr.includes(day) ? curr.filter(d => d !== day) : [...curr, day];
     this.updateRange(fr, { workingDays });
   }
@@ -1296,9 +1306,18 @@ export class SignalListComponent<T> implements AfterViewInit {
         next = { ...next, workingDays: [1, 2, 3, 4, 5] };
       }
     }
+    if (patch.holidayCount !== undefined) {
+      const n = Math.floor(Number(patch.holidayCount));
+      next = { ...next, holidayCount: Number.isFinite(n) && n > 0 ? n : 0 };
+    }
     const touchedBound = 'a' in patch || 'b' in patch;
     const allBoundsEmpty = next.a === '' && !next.b;
-    fr.selected.set(touchedBound && allBoundsEmpty ? null : next);
+    // Collapse-to-null is a date-mode rule only: a relative range carries
+    // configuration beyond its bounds (mode, working week, holiday count)
+    // that emptying a count input to retype it must not destroy. An empty
+    // relative range is simply inert; Clear remains the real reset.
+    const collapse = touchedBound && allBoundsEmpty && (next.mode ?? 'date') === 'date';
+    fr.selected.set(collapse ? null : next);
     this.config.pageIndex.set(0);
   }
 


### PR DESCRIPTION
Adds relative bounds to the Last Refreshed range filter on all three
application lists: "older than 90 days", "older than 30 business
days", "within 7 days", and between-ranges of either. Follows up
#5774's range filter; all five existing operators work over relative
bounds — no new operators, no backend changes, and number-domain
range consumers are untouched.

Business days are defined per query by the user: a weekend-day
chooser, the day count, and a count of weekday-falling holidays. The
popup shows the resolved cutoff date so the count can be verified and
corrected against holidays the user knows about. State is
session-only.

## Design rationale

**Relative bounds are a bound *mode*, not new operators.** "Older
than 90 days" is `before` with a bound of "90 days ago". Folding the
relativity into the bound keeps all five operators working unchanged,
gives "newer than" for free, and leaves the comparison machinery
untouched.

**Structured inputs, not phrase parsing.** Free-text phrases would
require natural-language parsing per language. A mode select + count
+ unit is language-neutral in structure; only the labels are English,
consistent with the rest of the UI.

**Business days are declared by the user, not detected.** Which days
are a weekend and which holidays count are organizational policy — no
browser or locale API can answer them (a locale gives the
locale-typical weekend, not the org's, and would give two viewers of
the same list different answers). All calendar inputs are entered in
the filter popup and live only for the session; user-level
configuration storage can pre-fill the same inputs later.

**Weekend framing (checked = weekend).** The weekend is the smaller
set, matches how people describe their week, and inverts the
dangerous state: "nothing checked" means a 7-day working week (valid)
instead of a zero-day week. The model stores the complement (working
days); removing the last working day is refused.

**Thursday-first toggle order.** Sun-first rendering split the
default Sat+Sun weekend across the row's two far ends. Thursday-first
puts every real-world weekend in one consecutive run: Thu–Fri (Iran,
Afghanistan), Fri–Sat (much of MENA), Sat–Sun (most of the world),
and single-day conventions — nothing wraps.

**Holidays: a count, not a calendar.** Holiday data is per-country,
per-region, per-year, and company-observed dates differ from official
ones; datasets are heavy and still wrong for a given org. Instead the
user supplies a count of weekday-falling holidays; the walk steps
that many extra working days. The popup shows the resolved cutoff
date next to a warning — check the date, bump the count if it names a
holiday, and it re-resolves one working day back: a verification loop
instead of a dataset. Holidays landing on non-working days consume
nothing, hence "weekday holidays". For `between` the holiday count
participates in both bounds' walks, so the warning goes plural and
points at the per-bound remedies (that bound's own count or its
include checkbox).

**Between accepts either typing order.** Bounds entered upper-first
("between 30 and 90 days ago" is natural smaller-first) are flipped
internally, each inclusive flag traveling with its bound's value — in
every domain and mode.

**Walk semantics.** The business-day walk counts only working days,
so the resolved date lands on a working day by construction — never a
weekend, whatever the week shape. Day-granular local-time arithmetic
via calendar rollover (DST-safe), consistent with the absolute date
filter. Counts are positive integers capped at 3650 (~10 years).

## Last Refreshed semantics (what this filter operates on)

The column is derived, not a first-class CF timestamp: **Last
Refreshed = the newest STAGED droplet's `created_at`**. Restages
count; failed pushes don't; an app that has never staged successfully
shows "—" and matches no active range. CF exposes no direct "last
refreshed" concept — whether droplet `created_at` is the right proxy
was raised upstream as cloudfoundry/cloud_controller_ng#5347 (no
reply yet; the droplet-based definition stands until guidance says
otherwise).

Invariant worth knowing when reading the column: Last Refreshed can
never precede Created — a droplet is produced by staging an app that
already exists. A row violating that ordering indicates a data
anomaly, not a display quirk.

## Known, accepted limitations

- **Midnight staleness:** a relative cutoff re-resolves whenever the
  filter re-evaluates; a tab left untouched across local midnight can
  be one day stale until any interaction or data refresh. Accepted:
  self-healing, one-day worst case.
- **One calendar per query:** a list spanning CF endpoints in
  different countries gets whichever week the user entered; narrow to
  an endpoint for per-environment precision.
- **Holiday count is approximate by design** — the resolved-date
  display plus the warning is the correction mechanism.

## Verification

- TDD throughout; 153 signal-list specs (40 model + 108 component +
  5 consumer-config additions), 450 green across signal-list and CF
  consumer suites; full `make check gate` exit 0 at the tip.
- Live-verified on a 380-app wall against independently computed
  ground truth from the rendered column: older than 40 days → 144
  (cutoff Mon Jun 29); older than 11 business days Mon–Fri → 156
  (Fri Jul 24); +1 holiday → 152 (Thu Jul 23); same count with a
  Sun–Thu week → 152 (Thu Jul 23); between 30/90 and 90/30 both →
  24. Weekend chooser and warning text verified in the running app.
