### PR TITLE
Migrate jetstream websockets from gorilla to coder/websocket

### DIFF
--- a/src/frontend/packages/cf-autoscaler/tsconfig.spec.json
+++ b/src/frontend/packages/cf-autoscaler/tsconfig.spec.json
@@ -5,5 +5,5 @@
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts", "**/*.d.ts", "../../vitest.workspace.setup.ts"]
 }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/build-tab/build-tab.component.html
@@ -278,8 +278,8 @@
                 {{ detail.process?.healthCheckType ?? "-" }}</app-metadata-item
               >
               <app-metadata-item icon="schedule" label="Health Check Timeout">
-                @let healthCheckTimeout = detail.process?.healthCheckTimeoutSeconds;
-                {{ healthCheckTimeout != null ? (healthCheckTimeout | uptime) : "-" }}</app-metadata-item
+                @let healthCheckTimeout = detail.process?.healthCheckTimeoutSeconds ?? null;
+                {{ healthCheckTimeout !== null ? (healthCheckTimeout | uptime) : "-" }}</app-metadata-item
               >
               @if (detail.process?.healthCheckType === "http") {
                 <app-metadata-item icon="http" label="Health Check HTTP Endpoint">{{

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-instance-summary/service-instance-summary.component.spec.ts
@@ -1,4 +1,4 @@
-import { provideZonelessChangeDetection, signal, Signal, WritableSignal } from '@angular/core';
+import { provideZonelessChangeDetection, signal, Signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';

--- a/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-users-roles-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-users-roles-data.service.ts
@@ -12,7 +12,6 @@ import {
   IUserPermissionInOrg,
   IUserPermissionInSpace,
   OrgUserRoleNames,
-  SpaceUserRoleNames,
   createUserRoleInOrg,
   createUserRoleInSpace,
 } from '../../store/types/cf-user.types';

--- a/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.test-deps.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/role-assignment/role-assignment.test-deps.ts
@@ -78,7 +78,6 @@ export function provideRoleAssignmentTestDeps(cfg: RoleAssignmentTestCfg): Provi
  * and role-definition labels established in role-assignment.component.html.
  */
 export class RoleAssignmentDriver {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(private fixture: ComponentFixture<any>) {}
 
   private get el(): HTMLElement {

--- a/src/frontend/packages/cloud-foundry/tsconfig.spec.json
+++ b/src/frontend/packages/cloud-foundry/tsconfig.spec.json
@@ -5,5 +5,5 @@
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts", "**/*.d.ts", "../../vitest.workspace.setup.ts"]
 }

--- a/src/frontend/packages/core/src/core/user-profile.service.spec.ts
+++ b/src/frontend/packages/core/src/core/user-profile.service.spec.ts
@@ -3,7 +3,7 @@ import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { SessionData, UserProfileInfo } from '@stratosui/store';
 import { UserProfileDataService } from '@stratosui/store';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { first } from 'rxjs/operators';
 
 import { AuthSignalService } from './signals/auth-signal.service';

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.html
@@ -17,5 +17,5 @@
     <app-checkbox class="connection-dialog__shared" appInput name="systemShared"
     formControlName="systemShared">Share this endpoint connection</app-checkbox>
   }
-  <button type="submit" class="hidden"></button>
+  <button type="submit" class="hidden" aria-label="Submit"></button>
 </form>

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -44,7 +44,7 @@
         </select>
       }
       @if (activeMulti(); as fm) {
-        <div class="relative" data-test="multi-filter-wrap" (keydown.escape)="multiPopupOpen.set(false)">
+        <div class="relative" data-test="multi-filter-wrap" tabindex="-1" (keydown.escape)="multiPopupOpen.set(false)">
           <button
             type="button"
             data-test="multi-filter-toggle"
@@ -75,7 +75,7 @@
           }
         </div>
       } @else if (activeRange(); as fr) {
-        <div class="relative" data-test="range-filter-wrap" (keydown.escape)="multiPopupOpen.set(false)">
+        <div class="relative" data-test="range-filter-wrap" tabindex="-1" (keydown.escape)="multiPopupOpen.set(false)">
           <button
             type="button"
             data-test="range-filter-toggle"

--- a/src/frontend/packages/core/tsconfig.spec.json
+++ b/src/frontend/packages/core/tsconfig.spec.json
@@ -8,5 +8,5 @@
     ]
   },
   "files": ["src/test-setup.ts", "src/polyfills.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts", "**/*.d.ts", "../../vitest.workspace.setup.ts"]
 }

--- a/src/frontend/packages/extension/tsconfig.spec.json
+++ b/src/frontend/packages/extension/tsconfig.spec.json
@@ -5,5 +5,5 @@
       "types": ["vitest/globals", "node"]
     },
     "files": ["src/test-setup.ts"],
-    "include": ["**/*.spec.ts", "**/*.d.ts"]
+    "include": ["**/*.spec.ts", "**/*.d.ts", "../../vitest.workspace.setup.ts"]
 }

--- a/src/frontend/packages/git/tsconfig.spec.json
+++ b/src/frontend/packages/git/tsconfig.spec.json
@@ -5,5 +5,5 @@
     "types": ["vitest/globals", "node"]
   },
   "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts", "**/*.d.ts", "../../vitest.workspace.setup.ts"]
 }

--- a/src/frontend/packages/kubernetes/tsconfig.spec.json
+++ b/src/frontend/packages/kubernetes/tsconfig.spec.json
@@ -14,6 +14,7 @@
   ],
   "include": [
     "**/*.spec.ts",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "../../vitest.workspace.setup.ts"
   ]
 }

--- a/src/frontend/packages/shared/tsconfig.spec.json
+++ b/src/frontend/packages/shared/tsconfig.spec.json
@@ -12,6 +12,7 @@
   ],
   "include": [
     "**/*.spec.ts",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "../../vitest.workspace.setup.ts"
   ]
 }

--- a/src/frontend/packages/store/tsconfig.spec.json
+++ b/src/frontend/packages/store/tsconfig.spec.json
@@ -7,5 +7,5 @@
     "target": "ES2022"
   },
   "files": ["src/test-setup.ts"],
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts", "**/*.d.ts", "../../vitest.workspace.setup.ts"]
 }

--- a/src/jetstream/api/go.mod
+++ b/src/jetstream/api/go.mod
@@ -3,9 +3,9 @@ module github.com/cloudfoundry/stratos/src/jetstream/api
 go 1.26.3
 
 require (
+	github.com/coder/websocket v1.8.15
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/sessions v1.4.0
-	github.com/gorilla/websocket v1.5.3
 	github.com/govau/cf-common v0.0.7
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/sirupsen/logrus v1.9.3

--- a/src/jetstream/api/go.sum
+++ b/src/jetstream/api/go.sum
@@ -1,5 +1,7 @@
 github.com/cloudfoundry-community/go-cfenv v1.19.0 h1:mRd4iX2A46wsbNW9FeQ1nOYLoXuBfiAk5kO84uaA7uw=
 github.com/cloudfoundry-community/go-cfenv v1.19.0/go.mod h1:LbfbhxtHR0qWDuicL0tagf461PQIBmR3FXidZXDJcuE=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -15,8 +17,6 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/govau/cf-common v0.0.7 h1:uhp1P6XM6GGzu1+A4C7LELLX/9mCmH6W5DpJZC0kWmo=
 github.com/govau/cf-common v0.0.7/go.mod h1:5xL/OfE7wxeyHlXb7iei0rAbdQ/5v6dF18BZknPv7NQ=
 github.com/labstack/echo/v4 v4.13.3 h1:pwhpCPrTl5qry5HRdM5FwdXnhXSLSY+WE+YQSeCaafY=

--- a/src/jetstream/api/websocket.go
+++ b/src/jetstream/api/websocket.go
@@ -1,60 +1,50 @@
 package api
 
 import (
+	"context"
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	// Time allowed to read the next pong message from the peer
-	pongWait = 30 * time.Second
+	// Send ping messages to peer with this period
+	pingPeriod = 27 * time.Second
 
-	// Send ping messages to peer with this period (must be less than pongWait)
-	pingPeriod = (pongWait * 9) / 10
-
-	// Time allowed to write a ping message
-	pingWriteTimeout = 10 * time.Second
+	// Time allowed for a ping to be written and answered with a pong
+	pingWait = 10 * time.Second
 )
-
-// Allow connections from any Origin
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
 
 // Upgrade the HTTP connection to a WebSocket with a Ping ticker
 func UpgradeToWebSocket(echoContext echo.Context) (*websocket.Conn, *time.Ticker, error) {
 
-	// Adapt echo.Context to Gorilla handler
-	responseWriter := echoContext.Response().Writer
-	request := echoContext.Request()
-
-	// We're now ok talking to CF, time to upgrade the request to a WebSocket connection
 	log.Debugf("Upgrading request to the WebSocket protocol...")
-	clientWebSocket, err := upgrader.Upgrade(responseWriter, request, nil)
+	clientWebSocket, err := websocket.Accept(echoContext.Response().Writer, echoContext.Request(), &websocket.AcceptOptions{
+		// Allow connections from any Origin
+		InsecureSkipVerify: true,
+		CompressionMode:    websocket.CompressionDisabled,
+	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("Upgrading connection to a WebSocket failed: [%v]", err)
 	}
 	log.Debugf("Successfully upgraded to a WebSocket connection")
 
-	// HSC-1276 - handle pong messages and reset the read deadline
-	if err := clientWebSocket.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
-		log.Warnf("Unable to set read deadline on the WebSocket connection: %v", err)
-	}
-	clientWebSocket.SetPongHandler(func(string) error {
-		return clientWebSocket.SetReadDeadline(time.Now().Add(pongWait))
-	})
-
-	// HSC-1276 - send regular Pings to prevent the WebSocket being closed on us
+	// HSC-1276 - send regular Pings to prevent the WebSocket being closed on us.
+	// A pong is only observed while a read is pending on the connection, so a
+	// ping timeout is logged rather than treated as a dead peer - some handlers
+	// (e.g. app deploy during the push phase) legitimately go long periods
+	// without a pending read.
 	ticker := time.NewTicker(pingPeriod)
 	go func() {
 		for range ticker.C {
-			if err := clientWebSocket.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(pingWriteTimeout)); err != nil {
-				log.Errorf("Web socket ping error: %+v", err)
+			ctx, cancel := context.WithTimeout(context.Background(), pingWait)
+			err := clientWebSocket.Ping(ctx)
+			cancel()
+			if err != nil {
+				log.Debugf("Web socket ping did not complete: %v", err)
 			}
 		}
 	}()

--- a/src/jetstream/api/websocket.go
+++ b/src/jetstream/api/websocket.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,10 +17,41 @@ const (
 
 	// Time allowed for a ping to be written and answered with a pong
 	pingWait = 10 * time.Second
+
+	// Bound for writing a single outgoing message
+	writeTimeout = 10 * time.Second
+
+	// Consecutive missed pongs tolerated before the peer is considered dead
+	maxMissedPongs = 2
 )
 
-// Upgrade the HTTP connection to a WebSocket with a Ping ticker
-func UpgradeToWebSocket(echoContext echo.Context) (*websocket.Conn, *time.Ticker, error) {
+// WriteText sends a text message, bounding the write so a wedged peer cannot
+// block the caller forever
+func WriteText(conn *websocket.Conn, data []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
+	defer cancel()
+	return conn.Write(ctx, websocket.MessageText, data)
+}
+
+// UpgradeToWebSocket upgrades the HTTP connection to a WebSocket and starts a
+// keepalive ping loop that closes the connection when the peer stops
+// answering, so a handler blocked in Read observes a half-open connection.
+// Pongs are only processed while a read is pending, so this variant is for
+// handlers that keep a standing read on the connection; use
+// UpgradeToWebSocketNoPongCheck otherwise.
+func UpgradeToWebSocket(echoContext echo.Context) (*websocket.Conn, error) {
+	return upgradeToWebSocket(echoContext, true)
+}
+
+// UpgradeToWebSocketNoPongCheck is UpgradeToWebSocket for handlers that go
+// long periods without a pending read (e.g. app deploy during the push
+// phase): missed pongs are expected there and only a failure to write the
+// ping closes the connection.
+func UpgradeToWebSocketNoPongCheck(echoContext echo.Context) (*websocket.Conn, error) {
+	return upgradeToWebSocket(echoContext, false)
+}
+
+func upgradeToWebSocket(echoContext echo.Context, enforcePong bool) (*websocket.Conn, error) {
 
 	log.Debugf("Upgrading request to the WebSocket protocol...")
 	clientWebSocket, err := websocket.Accept(echoContext.Response().Writer, echoContext.Request(), &websocket.AcceptOptions{
@@ -28,26 +60,48 @@ func UpgradeToWebSocket(echoContext echo.Context) (*websocket.Conn, *time.Ticker
 		CompressionMode:    websocket.CompressionDisabled,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("Upgrading connection to a WebSocket failed: [%v]", err)
+		return nil, fmt.Errorf("Upgrading connection to a WebSocket failed: [%v]", err)
 	}
 	log.Debugf("Successfully upgraded to a WebSocket connection")
 
-	// HSC-1276 - send regular Pings to prevent the WebSocket being closed on us.
-	// A pong is only observed while a read is pending on the connection, so a
-	// ping timeout is logged rather than treated as a dead peer - some handlers
-	// (e.g. app deploy during the push phase) legitimately go long periods
-	// without a pending read.
-	ticker := time.NewTicker(pingPeriod)
+	// HSC-1276 - send regular Pings to prevent the WebSocket being closed on
+	// us. The request context ends when the handler returns, terminating the
+	// loop for finished connections.
+	requestContext := echoContext.Request().Context()
 	go func() {
-		for range ticker.C {
-			ctx, cancel := context.WithTimeout(context.Background(), pingWait)
+		ticker := time.NewTicker(pingPeriod)
+		defer ticker.Stop()
+		missedPongs := 0
+		for {
+			select {
+			case <-requestContext.Done():
+				return
+			case <-ticker.C:
+			}
+
+			ctx, cancel := context.WithTimeout(requestContext, pingWait)
 			err := clientWebSocket.Ping(ctx)
 			cancel()
-			if err != nil {
-				log.Debugf("Web socket ping did not complete: %v", err)
+
+			switch {
+			case err == nil:
+				missedPongs = 0
+			case errors.Is(err, context.DeadlineExceeded):
+				// No pong observed - either the peer is gone or no read was
+				// pending to process it
+				missedPongs++
+				if enforcePong && missedPongs > maxMissedPongs {
+					log.Debug("WebSocket peer stopped answering pings - closing the connection")
+					clientWebSocket.CloseNow()
+					return
+				}
+			default:
+				// The ping could not be written - the connection is dead
+				clientWebSocket.CloseNow()
+				return
 			}
 		}
 	}()
 
-	return clientWebSocket, ticker, nil
+	return clientWebSocket, nil
 }

--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/cfapppush v0.0.0-00010101000000-000000000000
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/kubernetes v0.0.0-20250312201517-2a076063346f
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/monocular v0.0.0-00010101000000-000000000000
+	github.com/coder/websocket v1.8.15
 	github.com/domodwyer/mailyak v3.1.1+incompatible
 	github.com/fivetwenty-io/capi/v3 v3.222.4
 	github.com/go-sql-driver/mysql v1.9.2
@@ -42,7 +43,6 @@ require (
 	github.com/gorilla/context v1.1.2
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/govau/cf-common v0.0.7
 	github.com/kat-co/vala v0.0.0-20170210184112-42e1d8b61f12
 	github.com/labstack/echo/v4 v4.13.3
@@ -134,6 +134,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect

--- a/src/jetstream/go.sum
+++ b/src/jetstream/go.sum
@@ -130,6 +130,8 @@ github.com/cloudfoundry/noaa/v2 v2.5.0/go.mod h1:R33q73MnTXa549YPMHupTdQuKL3QqKQ
 github.com/cloudfoundry/sonde-go v0.0.0-20250505082611-517434ece96d h1:zFEOGvCZYR7QrZ94C7r2dqsLNw/BYMr0QYyuwlMAhrY=
 github.com/cloudfoundry/sonde-go v0.0.0-20250505082611-517434ece96d/go.mod h1:n3NQkJyrQPZ/pq+mjECQL7sLjL/U3rmTwyWMwpGxcXQ=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
 github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -92,7 +92,9 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	userGUID := echoContext.Get("user_id").(string)
 
 	log.Debug("UpgradeToWebSocket")
-	clientWebSocket, pingTicker, err := api.UpgradeToWebSocket(echoContext)
+	// No pong check: this handler goes long periods without a pending read
+	// (the push phase), during which pongs are never processed
+	clientWebSocket, err := api.UpgradeToWebSocketNoPongCheck(echoContext)
 	log.Debug("UpgradeToWebSocket done")
 	if err != nil {
 		log.Errorf("Upgrade to websocket failed due to: %+v", err)
@@ -103,7 +105,6 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	clientWebSocket.SetReadLimit(-1)
 	readCtx := echoContext.Request().Context()
 	defer clientWebSocket.CloseNow()
-	defer pingTicker.Stop()
 
 	// We use a simple protocol to get the source to use for cf push and any cf push cli overrides
 
@@ -780,7 +781,7 @@ func (sw *SocketWriter) Write(data []byte) (int, error) {
 
 	message, _ := getMarshalledSocketMessage(string(data), DATA)
 
-	err := sw.clientWebSocket.Write(context.Background(), websocket.MessageText, message)
+	err := api.WriteText(sw.clientWebSocket, message)
 	if err != nil {
 		log.Warnf("Failed to write data to web socket: %s", err)
 		return 0, err
@@ -797,20 +798,19 @@ func sendManifest(manifest Applications, clientWebSocket *websocket.Conn) error 
 	manifestJSON := string(manifestBytes)
 	message, _ := getMarshalledSocketMessage(manifestJSON, MANIFEST)
 
-	clientWebSocket.Write(context.Background(), websocket.MessageText, message)
-	return nil
+	return api.WriteText(clientWebSocket, message)
 }
 
 func sendErrorMessage(clientWebSocket *websocket.Conn, err error, errorType MessageType) {
 	closingMessage, _ := getMarshalledSocketMessage(fmt.Sprintf("Failed due to %s!", err), errorType)
-	if err := clientWebSocket.Write(context.Background(), websocket.MessageText, closingMessage); err != nil {
+	if err := api.WriteText(clientWebSocket, closingMessage); err != nil {
 		log.Warnf("Failed to write error message to web socket: %s", err)
 	}
 }
 
 func sendEvent(clientWebSocket *websocket.Conn, event MessageType) {
 	msg, _ := getMarshalledSocketMessage("", event)
-	if err := clientWebSocket.Write(context.Background(), websocket.MessageText, msg); err != nil {
+	if err := api.WriteText(clientWebSocket, msg); err != nil {
 		log.Warnf("Failed to write message to web socket: %s", err)
 	}
 }
@@ -818,7 +818,7 @@ func sendEvent(clientWebSocket *websocket.Conn, event MessageType) {
 // SendEvent sends a message over the web socket
 func (cfAppPush *CFAppPush) SendEvent(clientWebSocket *websocket.Conn, event MessageType, data string) {
 	msg, _ := getMarshalledSocketMessage(data, event)
-	if err := clientWebSocket.Write(context.Background(), websocket.MessageText, msg); err != nil {
+	if err := api.WriteText(clientWebSocket, msg); err != nil {
 		log.Warnf("Failed to write message to web socket: %s", err)
 	}
 }

--- a/src/jetstream/plugins/cfapppush/deploy.go
+++ b/src/jetstream/plugins/cfapppush/deploy.go
@@ -1,6 +1,7 @@
 package cfapppush
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -13,7 +14,8 @@ import (
 	"time"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
@@ -96,7 +98,11 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 		log.Errorf("Upgrade to websocket failed due to: %+v", err)
 		return err
 	}
-	defer clientWebSocket.Close()
+	// The file/folder upload protocol sends each file as one whole binary
+	// message, so no read limit can be safely applied to this socket
+	clientWebSocket.SetReadLimit(-1)
+	readCtx := echoContext.Request().Context()
+	defer clientWebSocket.CloseNow()
 	defer pingTicker.Stop()
 
 	// We use a simple protocol to get the source to use for cf push and any cf push cli overrides
@@ -110,7 +116,7 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	log.Debug("Waiting for source information from client")
 
 	msg := SocketMessage{}
-	if err := clientWebSocket.ReadJSON(&msg); err != nil {
+	if err := wsjson.Read(readCtx, clientWebSocket, &msg); err != nil {
 		log.Errorf("Error reading JSON: %v+", err)
 		return err
 	}
@@ -134,7 +140,7 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	case SOURCE_GITSCM:
 		stratosProject, appDir, err = cfAppPush.getGitSCMSource(clientWebSocket, tempDir, msg, userGUID)
 	case SOURCE_FOLDER:
-		stratosProject, appDir, err = getFolderSource(clientWebSocket, tempDir, msg)
+		stratosProject, appDir, err = getFolderSource(readCtx, clientWebSocket, tempDir, msg)
 	case SOURCE_GITURL:
 		stratosProject, appDir, err = getGitURLSource(clientWebSocket, tempDir, msg)
 	case SOURCE_DOCKER_IMG:
@@ -158,7 +164,7 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 	log.Debug("Waiting for app overrides from client")
 
 	msgOverrides := SocketMessage{}
-	if err := clientWebSocket.ReadJSON(&msgOverrides); err != nil {
+	if err := wsjson.Read(readCtx, clientWebSocket, &msgOverrides); err != nil {
 		log.Errorf("Error reading JSON: %v+", err)
 		return err
 	}
@@ -260,11 +266,11 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 
 	log.Debug("Waiting for close acknowledgement from the client")
 
-	wait := 30 * time.Second
-	clientWebSocket.SetReadDeadline(time.Now().Add(wait))
+	ackCtx, ackCancel := context.WithTimeout(readCtx, 30*time.Second)
+	defer ackCancel()
 
 	// Wait for the client to acknowledge the close - timeout ?
-	if err := clientWebSocket.ReadJSON(&msg); err != nil {
+	if err := wsjson.Read(ackCtx, clientWebSocket, &msg); err != nil {
 		log.Errorf("Error reading JSON: %v+", err)
 		return nil
 	}
@@ -275,8 +281,8 @@ func (cfAppPush *CFAppPush) deploy(echoContext echo.Context) error {
 		log.Debug("Got close acknowledgement from the client")
 	}
 
-	// Close the web socket - should we wait for ack from client?
-	clientWebSocket.Close()
+	// Close the web socket
+	clientWebSocket.Close(websocket.StatusNormalClosure, "")
 
 	return nil
 }
@@ -292,7 +298,7 @@ func safeUploadJoin(base, name string) (string, error) {
 	return filepath.Join(base, name), nil
 }
 
-func getFolderSource(clientWebSocket *websocket.Conn, tempDir string, msg SocketMessage) (StratosProject, string, error) {
+func getFolderSource(readCtx context.Context, clientWebSocket *websocket.Conn, tempDir string, msg SocketMessage) (StratosProject, string, error) {
 	// The msg data is JSON for the Folder info
 	info := FolderSourceInfo{
 		WaitAfterUpload: false,
@@ -323,7 +329,7 @@ func getFolderSource(clientWebSocket *websocket.Conn, tempDir string, msg Socket
 
 		// We should get a SOURCE_FILE message next
 		msg := SocketMessage{}
-		if err := clientWebSocket.ReadJSON(&msg); err != nil {
+		if err := wsjson.Read(readCtx, clientWebSocket, &msg); err != nil {
 			log.Errorf("Error reading JSON: %v+", err)
 			return StratosProject{}, tempDir, err
 		}
@@ -336,13 +342,13 @@ func getFolderSource(clientWebSocket *websocket.Conn, tempDir string, msg Socket
 		log.Debugf("Transferring file: %s", msg.Message)
 
 		// Now expecting a binary message
-		messageType, p, err := clientWebSocket.ReadMessage()
+		messageType, p, err := clientWebSocket.Read(readCtx)
 
 		if err != nil {
 			return StratosProject{}, tempDir, err
 		}
 
-		if messageType != websocket.BinaryMessage {
+		if messageType != websocket.MessageBinary {
 			return StratosProject{}, tempDir, errors.New("expecting binary file data")
 		}
 
@@ -401,7 +407,7 @@ func getFolderSource(clientWebSocket *websocket.Conn, tempDir string, msg Socket
 	// The client (v2) can request only source upload and for deploy to wait until it sends a message
 	if info.WaitAfterUpload {
 		msg := SocketMessage{}
-		if err := clientWebSocket.ReadJSON(&msg); err != nil {
+		if err := wsjson.Read(readCtx, clientWebSocket, &msg); err != nil {
 			log.Errorf("Error reading JSON: %v+", err)
 			return StratosProject{}, tempDir, err
 		}
@@ -774,7 +780,7 @@ func (sw *SocketWriter) Write(data []byte) (int, error) {
 
 	message, _ := getMarshalledSocketMessage(string(data), DATA)
 
-	err := sw.clientWebSocket.WriteMessage(websocket.TextMessage, message)
+	err := sw.clientWebSocket.Write(context.Background(), websocket.MessageText, message)
 	if err != nil {
 		log.Warnf("Failed to write data to web socket: %s", err)
 		return 0, err
@@ -791,20 +797,20 @@ func sendManifest(manifest Applications, clientWebSocket *websocket.Conn) error 
 	manifestJSON := string(manifestBytes)
 	message, _ := getMarshalledSocketMessage(manifestJSON, MANIFEST)
 
-	clientWebSocket.WriteMessage(websocket.TextMessage, message)
+	clientWebSocket.Write(context.Background(), websocket.MessageText, message)
 	return nil
 }
 
 func sendErrorMessage(clientWebSocket *websocket.Conn, err error, errorType MessageType) {
 	closingMessage, _ := getMarshalledSocketMessage(fmt.Sprintf("Failed due to %s!", err), errorType)
-	if err := clientWebSocket.WriteMessage(websocket.TextMessage, closingMessage); err != nil {
+	if err := clientWebSocket.Write(context.Background(), websocket.MessageText, closingMessage); err != nil {
 		log.Warnf("Failed to write error message to web socket: %s", err)
 	}
 }
 
 func sendEvent(clientWebSocket *websocket.Conn, event MessageType) {
 	msg, _ := getMarshalledSocketMessage("", event)
-	if err := clientWebSocket.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := clientWebSocket.Write(context.Background(), websocket.MessageText, msg); err != nil {
 		log.Warnf("Failed to write message to web socket: %s", err)
 	}
 }
@@ -812,7 +818,7 @@ func sendEvent(clientWebSocket *websocket.Conn, event MessageType) {
 // SendEvent sends a message over the web socket
 func (cfAppPush *CFAppPush) SendEvent(clientWebSocket *websocket.Conn, event MessageType, data string) {
 	msg, _ := getMarshalledSocketMessage(data, event)
-	if err := clientWebSocket.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := clientWebSocket.Write(context.Background(), websocket.MessageText, msg); err != nil {
 		log.Warnf("Failed to write message to web socket: %s", err)
 	}
 }

--- a/src/jetstream/plugins/cfapppush/go.mod
+++ b/src/jetstream/plugins/cfapppush/go.mod
@@ -14,7 +14,6 @@ require (
 	code.cloudfoundry.org/cli/v8 v8.18.2
 	code.cloudfoundry.org/clock v1.64.0
 	github.com/cloudfoundry/stratos/src/jetstream/api v0.0.0-00010101000000-000000000000
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/sirupsen/logrus v1.9.4
 	golang.org/x/crypto v0.53.0 // indirect
@@ -26,7 +25,10 @@ require (
 
 require github.com/kr/text v0.2.0 // indirect
 
-require github.com/mholt/archives v0.1.5
+require (
+	github.com/coder/websocket v1.8.15
+	github.com/mholt/archives v0.1.5
+)
 
 require (
 	code.cloudfoundry.org/bytefmt v0.67.0 // indirect

--- a/src/jetstream/plugins/cfapppush/go.sum
+++ b/src/jetstream/plugins/cfapppush/go.sum
@@ -85,6 +85,8 @@ github.com/cloudfoundry/bosh-cli v6.4.1+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ5
 github.com/cloudfoundry/bosh-utils v0.0.385 h1:rOgL4fKxeLNUAYoHSfycRro29ns9bhsEyBJ8DQ5W4Rc=
 github.com/cloudfoundry/bosh-utils v0.0.385/go.mod h1:vYjxd5zpxGjBKC+8voohfdXZkVk0UMOOvlMlZfxyOLM=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cppforlife/go-patch v0.2.0 h1:Y14MnCQjDlbw7WXT4k+u6DPAA9XnygN4BfrSpI/19RU=
 github.com/cppforlife/go-patch v0.2.0/go.mod h1:67a7aIi94FHDZdoeGSJRRFDp66l9MhaAG1yGxpUoFD8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -187,8 +189,6 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/govau/cf-common v0.0.7 h1:uhp1P6XM6GGzu1+A4C7LELLX/9mCmH6W5DpJZC0kWmo=
 github.com/govau/cf-common v0.0.7/go.mod h1:5xL/OfE7wxeyHlXb7iei0rAbdQ/5v6dF18BZknPv7NQ=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=

--- a/src/jetstream/plugins/cfapppush/pushapp.go
+++ b/src/jetstream/plugins/cfapppush/pushapp.go
@@ -22,7 +22,7 @@ import (
 	"code.cloudfoundry.org/cli/v8/util/manifestparser"
 	"code.cloudfoundry.org/cli/v8/util/progressbar"
 	"code.cloudfoundry.org/cli/v8/util/ui"
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 
 	"code.cloudfoundry.org/cli/v8/cf/flags"
 

--- a/src/jetstream/plugins/cfapppush/types.go
+++ b/src/jetstream/plugins/cfapppush/types.go
@@ -1,9 +1,7 @@
 package cfapppush
 
 import (
-	"net/http"
-
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 )
 
 type ManifestResponse struct {
@@ -18,13 +16,6 @@ type SocketMessage struct {
 
 type SocketWriter struct {
 	clientWebSocket *websocket.Conn
-}
-
-// Allow connections from any Origin
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
 }
 
 type StratosProject struct {

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -1,6 +1,7 @@
 package cfappssh
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -12,7 +13,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
@@ -20,7 +21,6 @@ import (
 
 // See: https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html
 
-// WebScoket code based on: https://github.com/gorilla/websocket/blob/master/examples/command/main.go
 
 const (
 	// Time allowed to write a message to the peer.
@@ -132,8 +132,10 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = ws.Close() }()
+	defer ws.CloseNow()
 	defer pingTicker.Stop()
+
+	readCtx := c.Request().Context()
 
 	modes := ssh.TerminalModes{
 		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
@@ -168,7 +170,7 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 
 	// Read the input from the web socket and pipe it to the SSH client
 	for {
-		_, r, err := ws.ReadMessage()
+		_, r, err := ws.Read(readCtx)
 		if err != nil {
 			log.Error("Error reading message from web socket")
 			log.Warnf("%+v", err)
@@ -252,15 +254,17 @@ func pumpStdout(ws *websocket.Conn, r io.Reader, done chan struct{}) {
 			if err != io.EOF {
 				log.Errorf("App SSH encountered an error reading from stdout; %v", err)
 			}
-			_ = ws.Close()
+			_ = ws.CloseNow()
 			break
 		}
 
-		_ = ws.SetWriteDeadline(time.Now().Add(writeWait))
+		ctx, cancel := context.WithTimeout(context.Background(), writeWait)
 		bytes := fmt.Sprintf("% x\n", buffer[:len])
-		if err := ws.WriteMessage(websocket.TextMessage, []byte(bytes)); err != nil {
+		err = ws.Write(ctx, websocket.MessageText, []byte(bytes))
+		cancel()
+		if err != nil {
 			log.Error("App SSH Failed to write nessage")
-			_ = ws.Close()
+			_ = ws.CloseNow()
 			break
 		}
 	}

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -1,7 +1,6 @@
 package cfappssh
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -23,9 +22,6 @@ import (
 
 
 const (
-	// Time allowed to write a message to the peer.
-	writeWait = 10 * time.Second
-
 	md5FingerprintLength          = 47 // inclusive of space between bytes
 	base64Sha256FingerprintLength = 43
 )
@@ -128,12 +124,15 @@ func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 	defer func() { _ = connection.Close() }()
 
 	// Upgrade the web socket
-	ws, pingTicker, err := api.UpgradeToWebSocket(c)
+	ws, err := api.UpgradeToWebSocket(c)
 	if err != nil {
 		return err
 	}
 	defer ws.CloseNow()
-	defer pingTicker.Stop()
+
+	// A pasted block of text arrives as a single KeyCode message of unbounded
+	// size, so no read limit can be safely applied to this socket
+	ws.SetReadLimit(-1)
 
 	readCtx := c.Request().Context()
 
@@ -258,11 +257,8 @@ func pumpStdout(ws *websocket.Conn, r io.Reader, done chan struct{}) {
 			break
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), writeWait)
 		bytes := fmt.Sprintf("% x\n", buffer[:len])
-		err = ws.Write(ctx, websocket.MessageText, []byte(bytes))
-		cancel()
-		if err != nil {
+		if err := api.WriteText(ws, []byte(bytes)); err != nil {
 			log.Error("App SSH Failed to write nessage")
 			_ = ws.CloseNow()
 			break

--- a/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
+++ b/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cloudfoundry/noaa/v2/consumer"
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 )
@@ -41,15 +41,19 @@ func (c *CloudFoundrySpecification) commonStreamHandler(echoContext echo.Context
 	if err != nil {
 		return err
 	}
-	defer func() { _ = clientWebSocket.Close() }()
+	defer clientWebSocket.CloseNow()
 	defer pingTicker.Stop()
+
+	// Discard incoming messages, effectively making our WebSocket read-only;
+	// the returned context is cancelled when the client disconnects
+	readCtx := clientWebSocket.CloseRead(echoContext.Request().Context())
 
 	if err := bespokeStreamHandler(echoContext, ac, clientWebSocket); err != nil {
 		return err
 	}
 
 	// This blocks until the WebSocket is closed
-	drainClientMessages(clientWebSocket)
+	<-readCtx.Done()
 	return nil
 }
 
@@ -218,17 +222,6 @@ func drainFirehoseEvents(eventChan <-chan *events.Envelope, callback func(msg *e
 	}
 }
 
-// Drain and discard incoming messages from the WebSocket client, effectively making our WebSocket read-only
-func drainClientMessages(clientWebSocket *websocket.Conn) {
-	for {
-		_, _, err := clientWebSocket.ReadMessage()
-		if err != nil {
-			// We get here when the client (browser) disconnects
-			break
-		}
-	}
-}
-
 func appStreamHandler(echoContext echo.Context, ac *AuthorizedConsumer, clientWebSocket *websocket.Conn) error {
 	// Get the CNSI and app IDs from route parameters
 	cnsiGUID := echoContext.Param("cnsiGuid")
@@ -241,7 +234,7 @@ func appStreamHandler(echoContext echo.Context, ac *AuthorizedConsumer, clientWe
 		if jsonMsg, err := json.Marshal(msg); err != nil {
 			log.Errorf("Received unparsable message from Doppler %v, %v", jsonMsg, err)
 		} else {
-			err := clientWebSocket.WriteMessage(websocket.TextMessage, jsonMsg)
+			err := clientWebSocket.Write(context.Background(), websocket.MessageText, jsonMsg)
 			if err != nil {
 				log.Errorf("Error writing data to WebSocket, %v", err)
 			}
@@ -289,7 +282,7 @@ func firehoseStreamHandler(echoContext echo.Context, ac *AuthorizedConsumer, cli
 		if jsonMsg, err := json.Marshal(msg); err != nil {
 			log.Errorf("Received unparsable message from Doppler %v, %v", jsonMsg, err)
 		} else {
-			err := clientWebSocket.WriteMessage(websocket.TextMessage, jsonMsg)
+			err := clientWebSocket.Write(context.Background(), websocket.MessageText, jsonMsg)
 			if err != nil {
 				log.Errorf("Error writing data to WebSocket, %v", err)
 			}

--- a/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
+++ b/src/jetstream/plugins/cloudfoundry/cf_websocket_streams.go
@@ -37,16 +37,27 @@ func (c *CloudFoundrySpecification) commonStreamHandler(echoContext echo.Context
 	}
 	defer func() { _ = ac.consumer.Close() }()
 
-	clientWebSocket, pingTicker, err := api.UpgradeToWebSocket(echoContext)
+	clientWebSocket, err := api.UpgradeToWebSocket(echoContext)
 	if err != nil {
 		return err
 	}
 	defer clientWebSocket.CloseNow()
-	defer pingTicker.Stop()
 
-	// Discard incoming messages, effectively making our WebSocket read-only;
-	// the returned context is cancelled when the client disconnects
-	readCtx := clientWebSocket.CloseRead(echoContext.Request().Context())
+	// Drain and discard incoming messages from the WebSocket client,
+	// effectively making our WebSocket read-only; the standing read also
+	// processes the keepalive pongs. The context ends when the client
+	// disconnects.
+	readCtx, stopReading := context.WithCancel(echoContext.Request().Context())
+	defer stopReading()
+	go func() {
+		defer stopReading()
+		for {
+			if _, _, err := clientWebSocket.Read(readCtx); err != nil {
+				// We get here when the client (browser) disconnects
+				return
+			}
+		}
+	}()
 
 	if err := bespokeStreamHandler(echoContext, ac, clientWebSocket); err != nil {
 		return err
@@ -234,7 +245,7 @@ func appStreamHandler(echoContext echo.Context, ac *AuthorizedConsumer, clientWe
 		if jsonMsg, err := json.Marshal(msg); err != nil {
 			log.Errorf("Received unparsable message from Doppler %v, %v", jsonMsg, err)
 		} else {
-			err := clientWebSocket.Write(context.Background(), websocket.MessageText, jsonMsg)
+			err := api.WriteText(clientWebSocket, jsonMsg)
 			if err != nil {
 				log.Errorf("Error writing data to WebSocket, %v", err)
 			}
@@ -282,7 +293,7 @@ func firehoseStreamHandler(echoContext echo.Context, ac *AuthorizedConsumer, cli
 		if jsonMsg, err := json.Marshal(msg); err != nil {
 			log.Errorf("Received unparsable message from Doppler %v, %v", jsonMsg, err)
 		} else {
-			err := clientWebSocket.Write(context.Background(), websocket.MessageText, jsonMsg)
+			err := api.WriteText(clientWebSocket, jsonMsg)
 			if err != nil {
 				log.Errorf("Error writing data to WebSocket, %v", err)
 			}

--- a/src/jetstream/plugins/kubernetes/auth/go.mod
+++ b/src/jetstream/plugins/kubernetes/auth/go.mod
@@ -32,13 +32,13 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudfoundry-community/go-cfenv v1.19.0 // indirect
+	github.com/coder/websocket v1.8.15 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/sessions v1.4.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/govau/cf-common v0.0.7 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/src/jetstream/plugins/kubernetes/auth/go.sum
+++ b/src/jetstream/plugins/kubernetes/auth/go.sum
@@ -12,6 +12,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudfoundry-community/go-cfenv v1.19.0 h1:mRd4iX2A46wsbNW9FeQ1nOYLoXuBfiAk5kO84uaA7uw=
 github.com/cloudfoundry-community/go-cfenv v1.19.0/go.mod h1:LbfbhxtHR0qWDuicL0tagf461PQIBmR3FXidZXDJcuE=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -34,8 +36,6 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/govau/cf-common v0.0.7 h1:uhp1P6XM6GGzu1+A4C7LELLX/9mCmH6W5DpJZC0kWmo=
 github.com/govau/cf-common v0.0.7/go.mod h1:5xL/OfE7wxeyHlXb7iei0rAbdQ/5v6dF18BZknPv7NQ=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/src/jetstream/plugins/kubernetes/get_release.go
+++ b/src/jetstream/plugins/kubernetes/get_release.go
@@ -101,12 +101,11 @@ func (c *KubernetesSpecification) GetReleaseStatus(ec echo.Context) error {
 	}
 
 	// Upgrade to a web socket
-	ws, pingTicker, err := api.UpgradeToWebSocket(ec)
+	ws, err := api.UpgradeToWebSocket(ec)
 	if err != nil {
 		return err
 	}
 	defer ws.CloseNow()
-	defer pingTicker.Stop()
 
 	// ws is the websocket ready for use
 
@@ -204,36 +203,30 @@ func (c *KubernetesSpecification) GetReleaseStatus(ec echo.Context) error {
 }
 
 func readLoop(c *websocket.Conn, stopchan chan<- bool, pausechan chan<- bool) {
+	defer close(stopchan)
 	for {
-
 		messageType, data, err := c.Read(context.Background())
 		if err != nil {
 			c.CloseNow()
-			close(stopchan)
-			break
+			return
 		}
 
-		switch messageType {
-		case websocket.MessageText:
-			message := ResourceMessage{}
-			err = json.Unmarshal(data, &message)
-			if err != nil {
-				log.Warnf("Failed to parse content of helm resource websocket message: %+v", err)
-				break
-			}
-
-			switch message.MessageType {
-			case PauseTrue:
-				pausechan <- true
-				break
-			case PauseFalse:
-				pausechan <- false
-				break
-			}
-		default:
+		if messageType != websocket.MessageText {
 			c.CloseNow()
-			close(stopchan)
-			break
+			return
+		}
+
+		message := ResourceMessage{}
+		if err := json.Unmarshal(data, &message); err != nil {
+			log.Warnf("Failed to parse content of helm resource websocket message: %+v", err)
+			continue
+		}
+
+		switch message.MessageType {
+		case PauseTrue:
+			pausechan <- true
+		case PauseFalse:
+			pausechan <- false
 		}
 	}
 }
@@ -248,7 +241,7 @@ func sendResource(ws *websocket.Conn, kind string, data interface{}) error {
 		}
 
 		if txt, err = json.Marshal(resp); err == nil {
-			if err = ws.Write(context.Background(), websocket.MessageText, txt); err == nil {
+			if err = api.WriteText(ws, txt); err == nil {
 				return nil
 			}
 		}

--- a/src/jetstream/plugins/kubernetes/get_release.go
+++ b/src/jetstream/plugins/kubernetes/get_release.go
@@ -1,12 +1,12 @@
 package kubernetes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 
@@ -105,7 +105,7 @@ func (c *KubernetesSpecification) GetReleaseStatus(ec echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer ws.Close()
+	defer ws.CloseNow()
 	defer pingTicker.Stop()
 
 	// ws is the websocket ready for use
@@ -172,7 +172,7 @@ func (c *KubernetesSpecification) GetReleaseStatus(ec echo.Context) error {
 			paused = pause
 			break
 		case <-stopchan:
-			ws.Close()
+			ws.Close(websocket.StatusNormalClosure, "")
 			return nil
 		case <-time.After(sleep):
 			break
@@ -206,21 +206,15 @@ func (c *KubernetesSpecification) GetReleaseStatus(ec echo.Context) error {
 func readLoop(c *websocket.Conn, stopchan chan<- bool, pausechan chan<- bool) {
 	for {
 
-		messageType, r, err := c.NextReader()
+		messageType, data, err := c.Read(context.Background())
 		if err != nil {
-			c.Close()
+			c.CloseNow()
 			close(stopchan)
 			break
 		}
 
 		switch messageType {
-		case websocket.TextMessage:
-			data, err := ioutil.ReadAll(r)
-			if err != nil {
-				log.Warnf("Failed to read content of helm resource websocket message: %+v", err)
-				break
-			}
-
+		case websocket.MessageText:
 			message := ResourceMessage{}
 			err = json.Unmarshal(data, &message)
 			if err != nil {
@@ -237,7 +231,7 @@ func readLoop(c *websocket.Conn, stopchan chan<- bool, pausechan chan<- bool) {
 				break
 			}
 		default:
-			c.Close()
+			c.CloseNow()
 			close(stopchan)
 			break
 		}
@@ -254,7 +248,7 @@ func sendResource(ws *websocket.Conn, kind string, data interface{}) error {
 		}
 
 		if txt, err = json.Marshal(resp); err == nil {
-			if ws.WriteMessage(websocket.TextMessage, txt); err == nil {
+			if err = ws.Write(context.Background(), websocket.MessageText, txt); err == nil {
 				return nil
 			}
 		}

--- a/src/jetstream/plugins/kubernetes/go.mod
+++ b/src/jetstream/plugins/kubernetes/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/cloudfoundry/stratos/src/jetstream/api v0.0.0-20250312201517-2a076063346f
 	github.com/cloudfoundry/stratos/src/jetstream/plugins/kubernetes/auth v0.0.0-20250312201517-2a076063346f
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/coder/websocket v1.8.15
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.9.3

--- a/src/jetstream/plugins/kubernetes/go.sum
+++ b/src/jetstream/plugins/kubernetes/go.sum
@@ -44,6 +44,8 @@ github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnT
 github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/cloudfoundry-community/go-cfenv v1.19.0 h1:mRd4iX2A46wsbNW9FeQ1nOYLoXuBfiAk5kO84uaA7uw=
 github.com/cloudfoundry-community/go-cfenv v1.19.0/go.mod h1:LbfbhxtHR0qWDuicL0tagf461PQIBmR3FXidZXDJcuE=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
 github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -142,8 +144,6 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/govau/cf-common v0.0.7 h1:uhp1P6XM6GGzu1+A4C7LELLX/9mCmH6W5DpJZC0kWmo=

--- a/src/jetstream/plugins/kubernetes/helm_client.go
+++ b/src/jetstream/plugins/kubernetes/helm_client.go
@@ -78,7 +78,7 @@ func (c *KubernetesSpecification) GetHelmConfiguration(endpointGUID, userID, nam
 	rcg := newJetStreamRCGetter([]byte(kubeconfigcontents), hc.Folder, namespace)
 
 	var nopLogger = func(a string, b ...interface{}) {
-		log.Debugf(a, b)
+		log.Debugf(a, b...)
 	}
 
 	var actionConfig action.Configuration

--- a/src/jetstream/plugins/kubernetes/install_release.go
+++ b/src/jetstream/plugins/kubernetes/install_release.go
@@ -110,7 +110,7 @@ func (c *KubernetesSpecification) InstallRelease(ec echo.Context) error {
 
 	release, err := install.Run(chart, userSuppliedValues)
 	if err != nil {
-		return api.NewJetstreamUserErrorf(fmt.Sprintf("Error installing: %+v", err))
+		return api.NewJetstreamUserErrorf("Error installing: %+v", err)
 	}
 
 	return ec.JSON(200, release)

--- a/src/jetstream/plugins/kubernetes/kube_dashboard.go
+++ b/src/jetstream/plugins/kubernetes/kube_dashboard.go
@@ -85,7 +85,7 @@ func (k *KubernetesSpecification) kubeDashboardCreateServiceAccount(c echo.Conte
 
 	err := dashboard.CreateServiceAccount(p, endpointGUID, userGUID)
 	if err != nil {
-		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), err.Error())
+		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), "%s", err.Error())
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
@@ -101,7 +101,7 @@ func (k *KubernetesSpecification) kubeDashboardDeleteServiceAccount(c echo.Conte
 
 	err := dashboard.DeleteServiceAccount(p, endpointGUID, userGUID)
 	if err != nil {
-		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), err.Error())
+		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), "%s", err.Error())
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
@@ -117,7 +117,7 @@ func (k *KubernetesSpecification) kubeDashboardInstallDashboard(c echo.Context) 
 
 	err := dashboard.InstallDashboard(p, endpointGUID, userGUID)
 	if err != nil {
-		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), err.Error())
+		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), "%s", err.Error())
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
@@ -133,7 +133,7 @@ func (k *KubernetesSpecification) kubeDashboardDeleteDashboard(c echo.Context) e
 
 	err := dashboard.DeleteDashboard(p, endpointGUID, userGUID)
 	if err != nil {
-		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), err.Error())
+		return api.NewHTTPShadowError(http.StatusInternalServerError, err.Error(), "%s", err.Error())
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")

--- a/src/jetstream/plugins/kubernetes/terminal/helpers.go
+++ b/src/jetstream/plugins/kubernetes/terminal/helpers.go
@@ -256,7 +256,7 @@ func sendProgressMessage(ws *websocket.Conn, progressMsg string) {
 	// Send a message to say that we are creating the pod
 	msg := fmt.Sprintf("\033]2;%s\007", progressMsg)
 	bytes := fmt.Sprintf("% x\n", []byte(msg))
-	if err := ws.Write(context.Background(), websocket.MessageText, []byte(bytes)); err != nil {
+	if err := api.WriteText(ws, []byte(bytes)); err != nil {
 		log.Error("Could not send message to client to indicate terminal is starting")
 	}
 }

--- a/src/jetstream/plugins/kubernetes/terminal/helpers.go
+++ b/src/jetstream/plugins/kubernetes/terminal/helpers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
 	"github.com/cloudfoundry/stratos/src/jetstream/plugins/kubernetes/auth"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -256,7 +256,7 @@ func sendProgressMessage(ws *websocket.Conn, progressMsg string) {
 	// Send a message to say that we are creating the pod
 	msg := fmt.Sprintf("\033]2;%s\007", progressMsg)
 	bytes := fmt.Sprintf("% x\n", []byte(msg))
-	if err := ws.WriteMessage(websocket.TextMessage, []byte(bytes)); err != nil {
+	if err := ws.Write(context.Background(), websocket.MessageText, []byte(bytes)); err != nil {
 		log.Error("Could not send message to client to indicate terminal is starting")
 	}
 }

--- a/src/jetstream/plugins/kubernetes/terminal/start.go
+++ b/src/jetstream/plugins/kubernetes/terminal/start.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
@@ -34,12 +33,6 @@ type terminalSize struct {
 	Width  uint16
 	Height uint16
 }
-
-const (
-	// Time allowed to write a message to the peer.
-	writeWait = 10 * time.Second
-
-)
 
 // Start handles web-socket request to launch a Kubernetes Terminal
 func (k *KubeTerminal) Start(c echo.Context) error {
@@ -70,12 +63,15 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 	log.Debugf("Kubernetes Version: %s", version)
 
 	// Upgrade the web socket for the incoming request
-	ws, pingTicker, err := api.UpgradeToWebSocket(c)
+	ws, err := api.UpgradeToWebSocket(c)
 	if err != nil {
 		return err
 	}
 	defer ws.CloseNow()
-	defer pingTicker.Stop()
+
+	// A pasted block of text arrives as a single KeyCode message of unbounded
+	// size, so no read limit can be safely applied to this socket
+	ws.SetReadLimit(-1)
 
 	readCtx := c.Request().Context()
 
@@ -168,7 +164,7 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 			slice := make([]byte, 1)
 			slice[0] = 0
 			slice = append(slice, []byte(res.Key)...)
-			wsConn.Write(readCtx, websocket.MessageText, slice)
+			api.WriteText(wsConn, slice)
 		} else {
 			size := terminalSize{
 				Width:  uint16(res.Cols),
@@ -177,7 +173,7 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 			j, _ := json.Marshal(size)
 			resizeStream := []byte{4}
 			slice := append(resizeStream, j...)
-			wsConn.Write(readCtx, websocket.MessageText, slice)
+			api.WriteText(wsConn, slice)
 		}
 	}
 }
@@ -190,11 +186,13 @@ func pumpStdout(ws *websocket.Conn, source *websocket.Conn) {
 			ws.CloseNow()
 			break
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), writeWait)
+		if len(r) == 0 {
+			// Exec stream messages carry a leading channel byte; tolerate
+			// empty keepalive frames
+			continue
+		}
 		bytes := fmt.Sprintf("% x\n", r[1:])
-		err = ws.Write(ctx, websocket.MessageText, []byte(bytes))
-		cancel()
-		if err != nil {
+		if err := api.WriteText(ws, []byte(bytes)); err != nil {
 			log.Errorf("Kubernetes Terminal failed to write message: %+v", err)
 			ws.CloseNow()
 			break

--- a/src/jetstream/plugins/kubernetes/terminal/start.go
+++ b/src/jetstream/plugins/kubernetes/terminal/start.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -17,15 +18,10 @@ import (
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 )
 
 // TTY Resize, see: https://gitlab.cncf.ci/kubernetes/kubernetes/commit/3b21a9901bcd48bb452d3bf1a0cddc90dae142c4#9691a2f9b9c30711f0397221db0b9ac55ab0e2d1
-
-// Allow connections from any Origin
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
 
 // KeyCode - JSON object that is passed from the front-end to notify of a key press or a term resize
 type KeyCode struct {
@@ -43,14 +39,6 @@ const (
 	// Time allowed to write a message to the peer.
 	writeWait = 10 * time.Second
 
-	// Time allowed to read the next pong message from the peer.
-	pongWait = 60 * time.Second
-
-	// Send pings to peer with this period. Must be less than pongWait.
-	pingPeriod = (pongWait * 9) / 10
-
-	// Time to wait before force close on connection.
-	closeGracePeriod = 10 * time.Second
 )
 
 // Start handles web-socket request to launch a Kubernetes Terminal
@@ -86,8 +74,10 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	defer ws.Close()
+	defer ws.CloseNow()
 	defer pingTicker.Stop()
+
+	readCtx := c.Request().Context()
 
 	// At this point we aer using web sockets, so we can not return errors to the client as the connection
 	// has been upgraded to a web socket
@@ -125,22 +115,27 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 		}
 	}
 
-	dialer := &websocket.Dialer{
-		TLSClientConfig: tlsConfig,
-	}
-
 	if strings.HasPrefix(target, "https://") {
 		target = "wss://" + target[8:]
 	} else {
 		target = "ws://" + target[7:]
 	}
 
-	header := &http.Header{}
+	header := http.Header{}
 	header.Add("Authorization", fmt.Sprintf("Bearer %s", string(k.Token)))
-	wsConn, _, err := dialer.Dial(target, *header)
+	wsConn, _, err := websocket.Dial(readCtx, target, &websocket.DialOptions{
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{TLSClientConfig: tlsConfig},
+		},
+		HTTPHeader:      header,
+		CompressionMode: websocket.CompressionDisabled,
+	})
 
 	if err == nil {
-		defer wsConn.Close()
+		defer wsConn.CloseNow()
+		// Terminal output from the API server can arrive in arbitrarily large
+		// messages - this is a trusted upstream, so no read limit
+		wsConn.SetReadLimit(-1)
 	}
 
 	if err != nil {
@@ -150,35 +145,18 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 		return nil
 	}
 
-	stdoutDone := make(chan bool)
-	go pumpStdout(ws, wsConn, stdoutDone)
-	go ping(ws, stdoutDone)
-
-	// If the downstream connection is closed, close the other web socket as well
-	ws.SetCloseHandler(func(code int, text string) error {
-		wsConn.Close()
-		// Cleanup
-		k.cleanupPodAndSecret(podData)
-		podData = nil
-		return nil
-	})
-
-	// Wait a while when reading - can take some time for the container to launch
-	ws.SetReadDeadline(time.Now().Add(pongWait))
-	ws.SetPongHandler(func(string) error { ws.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+	go pumpStdout(ws, wsConn)
 
 	// Read the input from the web socket and pipe it to the SSH client
 	for {
-		_, r, err := ws.ReadMessage()
+		_, r, err := ws.Read(readCtx)
 		if err != nil {
-			// Error reading - so clean up
+			// Error reading (including the client closing the web socket) - so clean up
 			k.cleanupPodAndSecret(podData)
 			podData = nil
 
-			ws.SetWriteDeadline(time.Now().Add(writeWait))
-			ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-			time.Sleep(closeGracePeriod)
-			ws.Close()
+			wsConn.CloseNow()
+			ws.Close(websocket.StatusNormalClosure, "")
 
 			// No point returning an error - we've already upgraded to web sockets, so we can't use the HTTP response now
 			return nil
@@ -190,7 +168,7 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 			slice := make([]byte, 1)
 			slice[0] = 0
 			slice = append(slice, []byte(res.Key)...)
-			wsConn.WriteMessage(websocket.TextMessage, slice)
+			wsConn.Write(readCtx, websocket.MessageText, slice)
 		} else {
 			size := terminalSize{
 				Width:  uint16(res.Cols),
@@ -199,41 +177,27 @@ func (k *KubeTerminal) Start(c echo.Context) error {
 			j, _ := json.Marshal(size)
 			resizeStream := []byte{4}
 			slice := append(resizeStream, j...)
-			wsConn.WriteMessage(websocket.TextMessage, slice)
+			wsConn.Write(readCtx, websocket.MessageText, slice)
 		}
 	}
 }
 
-func pumpStdout(ws *websocket.Conn, source *websocket.Conn, done chan bool) {
+func pumpStdout(ws *websocket.Conn, source *websocket.Conn) {
 	for {
-		_, r, err := source.ReadMessage()
+		_, r, err := source.Read(context.Background())
 		if err != nil {
-			// Close
-			ws.Close()
-			done <- true
+			// Close - unblocks the client read loop so it cleans up the pod
+			ws.CloseNow()
 			break
 		}
-		ws.SetWriteDeadline(time.Now().Add(writeWait))
+		ctx, cancel := context.WithTimeout(context.Background(), writeWait)
 		bytes := fmt.Sprintf("% x\n", r[1:])
-		if err := ws.WriteMessage(websocket.TextMessage, []byte(bytes)); err != nil {
+		err = ws.Write(ctx, websocket.MessageText, []byte(bytes))
+		cancel()
+		if err != nil {
 			log.Errorf("Kubernetes Terminal failed to write message: %+v", err)
-			ws.Close()
+			ws.CloseNow()
 			break
-		}
-	}
-}
-
-func ping(ws *websocket.Conn, done chan bool) {
-	ticker := time.NewTicker(pingPeriod)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			if err := ws.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(writeWait)); err != nil {
-				log.Errorf("Web socket ping error: %+v", err)
-			}
-		case <-done:
-			return
 		}
 	}
 }

--- a/src/jetstream/plugins/monocular/cache.go
+++ b/src/jetstream/plugins/monocular/cache.go
@@ -299,14 +299,14 @@ func extractArchiveFiles(archivePath, chartName, downloadFolder string, filename
 
 	f, err := os.Open(archivePath)
 	if err != nil {
-		log.Error("Helm: Archive extract file: Could not open file %s - %+v", archivePath, err)
+		log.Errorf("Helm: Archive extract file: Could not open file %s - %+v", archivePath, err)
 		return err
 	}
 	defer f.Close()
 
 	gzf, err := gzip.NewReader(f)
 	if err != nil {
-		log.Error("Helm: Archive extract file: Could not open zip file %s - %+v", archivePath, err)
+		log.Errorf("Helm: Archive extract file: Could not open zip file %s - %+v", archivePath, err)
 		return err
 	}
 
@@ -318,7 +318,7 @@ func extractArchiveFiles(archivePath, chartName, downloadFolder string, filename
 		}
 
 		if err != nil {
-			log.Error("Helm: Archive extract file: Could not process archive file %s - %+v", archivePath, err)
+			log.Errorf("Helm: Archive extract file: Could not process archive file %s - %+v", archivePath, err)
 			return err
 		}
 

--- a/src/jetstream/plugins/monocular/go.mod
+++ b/src/jetstream/plugins/monocular/go.mod
@@ -16,11 +16,11 @@ require (
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/cloudfoundry-community/go-cfenv v1.19.0 // indirect
+	github.com/coder/websocket v1.8.15 // indirect
 	github.com/go-sql-driver/mysql v1.9.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/sessions v1.4.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/govau/cf-common v0.0.7 // indirect
 	github.com/kat-co/vala v0.0.0-20170210184112-42e1d8b61f12 // indirect
 	github.com/kr/pretty v0.3.1 // indirect

--- a/src/jetstream/plugins/monocular/go.sum
+++ b/src/jetstream/plugins/monocular/go.sum
@@ -4,6 +4,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cloudfoundry-community/go-cfenv v1.19.0 h1:mRd4iX2A46wsbNW9FeQ1nOYLoXuBfiAk5kO84uaA7uw=
 github.com/cloudfoundry-community/go-cfenv v1.19.0/go.mod h1:LbfbhxtHR0qWDuicL0tagf461PQIBmR3FXidZXDJcuE=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,8 +23,6 @@ github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kX
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
-github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/govau/cf-common v0.0.7 h1:uhp1P6XM6GGzu1+A4C7LELLX/9mCmH6W5DpJZC0kWmo=
 github.com/govau/cf-common v0.0.7/go.mod h1:5xL/OfE7wxeyHlXb7iei0rAbdQ/5v6dF18BZknPv7NQ=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/src/jetstream/plugins/monocular/sync.go
+++ b/src/jetstream/plugins/monocular/sync.go
@@ -84,7 +84,7 @@ func (m *Monocular) deleteChartStoreForEndpoint(id string) {
 
 	// Delete files from the cache
 	if err := m.deleteCacheForEndpoint(id); err != nil {
-		log.Warnf("Unable to delete Helm Chart Cache for endpoint %s - %+v", err)
+		log.Warnf("Unable to delete Helm Chart Cache for endpoint %s - %+v", id, err)
 	}
 }
 
@@ -103,7 +103,7 @@ func (m *Monocular) processSyncRequests() {
 		metadata.Busy = false
 		err := m.syncHelmRepository(job.Endpoint.GUID, job.Endpoint.Name, chartIndexURL)
 		if err != nil {
-			log.Warn("Helm Repository sync repository failed for repository %s - %v", job.Endpoint.GUID, err)
+			log.Warnf("Helm Repository sync repository failed for repository %s - %v", job.Endpoint.GUID, err)
 			metadata.Status = "Sync Failed"
 		}
 


### PR DESCRIPTION
## What

Migrates jetstream's direct websocket usage from `gorilla/websocket` to `coder/websocket` v1.8.15, covering the whole streaming surface: CF app log/firehose streams, app SSH, app deploy, the Kubernetes terminal, and the helm release status watcher.

Why: our gorilla dependency is pinned to an orphaned pseudo-version with no upstream release able to absorb it — background and evaluation in #5736. As predicted there, gorilla remains an *indirect* dependency via noaa until the log-cache work retires it; the win is moving our own streaming code onto a maintained API.

Four commits, reviewable independently:

1. **the migration** — mechanical conversion of 10 usage sites across 8 files, plus module tidies
2. **go vet cleanup** — pre-existing printf-family misuse in the kubernetes and monocular plugins that failed `go test ./...` vet in both modules (one of them a garbled log line: missing argument printed `%!+v(MISSING)`)
3. **eslint baseline** — pre-existing frontend warnings 8 → 0, plus the vitest workspace setup file added to spec tsconfigs to silence a per-gate build nag
4. **hardening** — issues found reviewing the migration; the notable ones below

## Behaviour notes

- **Read limits**: coder's 32KiB default is kept where client messages are small (log streams, helm status) as free hardening over gorilla's unlimited reads. It is disabled where a single legitimate message can be large: deploy (each uploaded file is one binary message) and the SSH/kube terminals (a paste arrives as one KeyCode message).
- **Keepalive**: the shared ping loop now also detects dead peers — on ping write failure everywhere, and additionally after ~3 missed pongs for handlers that keep a standing read. Deploy uses a no-pong-check variant: during a push it has no pending read, so pongs are never processed and missed pongs are expected. The keepalive goroutine terminates with the request context (the previous ticker-based goroutine outlived its connection).
- **Kube terminal cleanup**: pod/secret deletion now rides the read-error path rather than gorilla's `SetCloseHandler`.
- Two panic-shaped defects in rewritten functions are fixed: a double `close(stopchan)` in the helm status readLoop when a client sends a non-text frame, and an unchecked `r[1:]` on empty exec-stream messages in the terminal stdout pump.
- All server→client text writes go through a shared bounded write helper; deploy's output writer was previously unbounded and could wedge on a half-open connection.

## Verification

Live against a real CF (v2-disabled foundation) and a local k3d cluster, driving the actual UI:

- app deploy from archive: upload, staging log stream, running instance, clean close handshake — twice (once per build)
- app SSH: interactive shell, command round-trip
- app log stream: real-time router lines while generating traffic
- Kubernetes terminal: pod creation, bidirectional shell, pod+secret cleanup on disconnect
- helm release view: live pods/graph/resources over the status socket

Edge triggers exercised directly against the sockets:

- binary frame at a live helm status socket → clean close, no panic, server keeps serving
- stray text frame mid log-stream → stream keeps flowing (matches old drain behaviour)
- single 40KiB KeyCode frame at a live kube terminal → accepted, echoed back

Full check gate green (backend suites, vitest, lint); `go vet ./...` clean across all seven modules.

Closes #5736
