### PR TITLE
signal-list: per-filter Clear button in filter popups

### DIFF
--- a/changelog.d/0054-filter-clear-button.md
+++ b/changelog.d/0054-filter-clear-button.md
@@ -1,0 +1,2 @@
+[Features]
+- The stack checklist and date-range filter popups gain a Clear button that resets just that filter back to All/Any — other filters, the name text, and the sort are untouched. The toolbar's clear-all button still resets everything at once.

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.html
@@ -67,10 +67,18 @@
               @if (fm.selected() !== null && fm.selected()!.length === 0) {
                 <div class="mt-1 px-1 text-xs text-warning-shade-600 dark:text-warning-shade-300">Nothing selected — showing all</div>
               }
-              <button
-                type="button"
-                (click)="multiPopupOpen.set(false)"
-                class="mt-1 w-full text-xs text-content-muted border-t border-content-border pt-1">Close</button>
+              <div class="mt-1 flex border-t border-content-border pt-1">
+                <button
+                  type="button"
+                  data-test="multi-filter-clear"
+                  [disabled]="fm.selected() === null"
+                  (click)="clearPopupFilter(fm)"
+                  class="flex-1 text-xs text-content-muted disabled:opacity-40">Clear</button>
+                <button
+                  type="button"
+                  (click)="multiPopupOpen.set(false)"
+                  class="flex-1 text-xs text-content-muted">Close</button>
+              </div>
             </div>
           }
         </div>
@@ -184,10 +192,18 @@
                   </div>
                 }
               }
-              <button
-                type="button"
-                (click)="multiPopupOpen.set(false)"
-                class="w-full text-xs text-content-muted border-t border-content-border pt-1">Close</button>
+              <div class="flex border-t border-content-border pt-1">
+                <button
+                  type="button"
+                  data-test="range-filter-clear"
+                  [disabled]="fr.selected() === null"
+                  (click)="clearPopupFilter(fr)"
+                  class="flex-1 text-xs text-content-muted disabled:opacity-40">Clear</button>
+                <button
+                  type="button"
+                  (click)="multiPopupOpen.set(false)"
+                  class="flex-1 text-xs text-content-muted">Close</button>
+              </div>
             </div>
           }
         </div>

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.spec.ts
@@ -1655,6 +1655,42 @@ describe('SignalListComponent checklist-popup filter (filterMultis)', () => {
     component.onFilterFieldChange('name');
     expect(component.multiPopupOpen()).toBe(false);
   });
+
+  describe('popup Clear button', () => {
+    function openPopup(fixture: ReturnType<typeof TestBed.createComponent<MultiFilterHost>>): HTMLButtonElement {
+      (fixture.nativeElement.querySelector('[data-test="multi-filter-toggle"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      return fixture.nativeElement.querySelector('[data-test="multi-filter-clear"]') as HTMLButtonElement;
+    }
+
+    it('is disabled while the filter is already inactive (null selection)', () => {
+      const fixture = TestBed.createComponent(MultiFilterHost);
+      fixture.detectChanges();
+      expect(openPopup(fixture).disabled).toBe(true);
+    });
+
+    it('resets the selection to null, pages back to 0, and leaves the popup open', () => {
+      const fixture = TestBed.createComponent(MultiFilterHost);
+      fixture.componentInstance.selectedStacks.set(['cflinuxfs4']);
+      fixture.componentInstance.pageIndex.set(3);
+      fixture.detectChanges();
+      const clear = openPopup(fixture);
+      expect(clear.disabled).toBe(false);
+
+      clear.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.selectedStacks()).toBe(null);
+      expect(fixture.componentInstance.pageIndex()).toBe(0);
+      const component = componentWith(fixture);
+      expect(component.multiPopupOpen()).toBe(true);
+      // Visible feedback: the popup stays up while the toggle summary and
+      // the button's own disabled state flip to the neutral form
+      expect(fixture.nativeElement.querySelector('[data-test="multi-filter-clear"]')).not.toBeNull();
+      expect((fixture.nativeElement.querySelector('[data-test="multi-filter-clear"]') as HTMLButtonElement).disabled).toBe(true);
+      expect(component.multiSummary(component.activeMulti()!)).toBe('All (3)');
+    });
+  });
 });
 
 // Range-comparison filter input (config.filterRanges / SignalListRangeFilter).
@@ -1991,6 +2027,42 @@ describe('SignalListComponent range filter (filterRanges)', () => {
       fixture.componentInstance.selectedRange.set({ op: 'lt', a: '90', mode: 'days' });
       expect(component.opLabel(fr, 'lt')).toBe('older than');
       expect(component.opLabel(fr, 'gte')).toBe('within');
+    });
+  });
+
+  describe('popup Clear button', () => {
+    function openPopup(fixture: ReturnType<typeof TestBed.createComponent<RangeFilterHost>>): HTMLButtonElement {
+      (fixture.nativeElement.querySelector('[data-test="range-filter-toggle"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      return fixture.nativeElement.querySelector('[data-test="range-filter-clear"]') as HTMLButtonElement;
+    }
+
+    it('is disabled while the filter is already inactive (null selection)', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      fixture.detectChanges();
+      expect(openPopup(fixture).disabled).toBe(true);
+    });
+
+    it('discards a configured relative range, pages back to 0, and leaves the popup open reading Any', () => {
+      const fixture = TestBed.createComponent(RangeFilterHost);
+      // A relative range with configuration beyond its bounds — exactly the
+      // state updateRange's implicit collapse refuses to destroy; the
+      // explicit Clear is allowed to.
+      fixture.componentInstance.selectedRange.set({ op: 'lte', a: '5', mode: 'businessDays', workingDays: [1, 2, 3, 4], holidayCount: 2 });
+      fixture.componentInstance.pageIndex.set(2);
+      fixture.detectChanges();
+      const clear = openPopup(fixture);
+      expect(clear.disabled).toBe(false);
+
+      clear.click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.selectedRange()).toBe(null);
+      expect(fixture.componentInstance.pageIndex()).toBe(0);
+      const component = componentWith(fixture);
+      expect(component.multiPopupOpen()).toBe(true);
+      expect((fixture.nativeElement.querySelector('[data-test="range-filter-clear"]') as HTMLButtonElement).disabled).toBe(true);
+      expect(component.rangeSummary(component.activeRange()!)).toBe('Any');
     });
   });
 });

--- a/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
+++ b/src/frontend/packages/core/src/shared/components/signal-list/signal-list.component.ts
@@ -1276,6 +1276,16 @@ export class SignalListComponent<T> implements AfterViewInit {
     { value: 3, label: 'We' },
   ];
 
+  // Clear button in the checklist/range popups: resets THIS filter to its
+  // neutral state and leaves the popup open, so the toggle summary flipping
+  // to All/Any is the visible feedback. For a relative range this is the
+  // one deliberate gesture that discards the stored configuration — the
+  // implicit collapse rules in updateRange stay date-mode-only.
+  clearPopupFilter(f: SignalListMultiFilter | SignalListRangeFilter): void {
+    f.selected.set(null);
+    this.config.pageIndex.set(0);
+  }
+
   // Flips one weekday in the business-day working week. Routed through
   // updateRange so paging reset and storage rules stay in one place.
   // Removing the last working day is refused — a 7-day weekend would make


### PR DESCRIPTION
## What

Adds a per-filter Clear button to the two filter popups (the checklist filter, e.g. Stack, and the range filter, e.g. Last Refreshed) on signal-list toolbars. The footer of each popup is now `Clear | Close`.

Clear resets **only that filter** to its neutral state (All / Any) and pages back to 0. Every other filter keeps constraining — filters compose as a conjunction (each active filter is an independent AND-term in the row predicate), and Clear simply removes its one term. The toolbar's global clear remains the only control that drops everything (and sort) at once.

## Why

Every filter had a self-reset gesture except the range filter: name (delete the text), checklist (re-check everything), dropdowns (the All option). A *relative* date range deliberately keeps its configuration (mode, working week, holiday count) when a bound is emptied — so the only way back to "Any" was the global clear, which wipes name/stack/sort along with it.

The explicit Clear button is the one deliberate gesture allowed to discard that configuration; the implicit collapse rules in `updateRange` stay date-mode-only, so blanking a count mid-edit still preserves the setup.

## Scope signifiers

Two things distinguish this from the global clear without extra labeling: it lives inside the popup that opened from that filter's own button (the same per-column vs. toolbar split as spreadsheet column-filter menus), and it disables itself whenever *this* filter is already inactive — it can be gray while the global clear is lit because other filters remain active.

Clear leaves the popup open: the toggle summary flipping to All/Any and the button graying out are the feedback.

## Verification

- 4 new specs drive the rendered buttons: disabled-when-inactive for both popups, and the full clear sequence (selection nulled, page reset, popup still open, summary flipped) including discarding a fully-configured relative business-days range. Suite: 112/112.
- Live on the Applications list: stack filter (382→206 apps) + "within 3 days" range on top (→6) → Clear in the range popup → back to exactly 206 with the stack filter intact and the global clear still lit for it; the checklist popup's Clear likewise restored 206→382 with all boxes re-checked.
