### PR TITLE
Stop the CSP route test tripping over its own nonce

### DIFF
--- a/changelog.d/0001-csp-test-nonce-collision.md
+++ b/changelog.d/0001-csp-test-nonce-collision.md
@@ -1,0 +1,6 @@
+[Maintainability]
+- Fixed a rare false failure in the jetstream CSP route test. Its sentinel for
+  the raw static file was `RAW`, which is spellable in the base32 alphabet the
+  nonce generator draws from, so roughly one run in a thousand found it inside
+  a nonce and reported that the static handler had won when the document had in
+  fact been served and nonced correctly.

--- a/src/jetstream/csp_test.go
+++ b/src/jetstream/csp_test.go
@@ -414,8 +414,12 @@ func TestServeIndexHTMLOverridesTheStaticCacheMiddleware(t *testing.T) {
 // GET "/*". Echo must prefer the explicit route or the document goes out raw
 // and unnonced, with nothing else failing to show it.
 func TestExplicitRootRouteBeatsTheStaticHandler(t *testing.T) {
+	// Lowercase on purpose: the nonce is rand.Text(), whose base32 alphabet is
+	// uppercase letters and digits, so an uppercase sentinel can turn up inside
+	// a nonce by chance and fail a run that served the right document.
+	const staticBody = "raw-static-file"
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("RAW"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(staticBody), 0o600); err != nil {
 		t.Fatalf("write index.html: %v", err)
 	}
 	p := &portalProxy{indexHTMLTemplate: `<app-root></app-root>`}
@@ -427,7 +431,7 @@ func TestExplicitRootRouteBeatsTheStaticHandler(t *testing.T) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 
-	if strings.Contains(rec.Body.String(), "RAW") {
+	if strings.Contains(rec.Body.String(), staticBody) {
 		t.Errorf("static handler won: %q", rec.Body.String())
 	}
 	if !strings.Contains(rec.Body.String(), "ngCspNonce=") {


### PR DESCRIPTION
`TestExplicitRootRouteBeatsTheStaticHandler` wrote `RAW` into the static
index.html and failed if the response contained it. The nonce comes from
`rand.Text()`, whose base32 alphabet is uppercase letters and digits — `RAW`
is spellable in it, so roughly one run in a thousand finds the sentinel inside
a nonce and reports "static handler won" on a response that was in fact the
correct nonced document.

It failed exactly that way on a local gate run:

```
csp_test.go:431: static handler won: "<app-root ngCspNonce="QFQFBUOK7MIM4MNE7DX2GDFRAW"></app-root>"
```

The sentinel is now lowercase, which the alphabet cannot produce. Confirmed
the test still catches the real regression by pointing the explicit route
somewhere else and watching both assertions fail; 50 consecutive runs pass
with the route registered.
