### PR TITLE
fix(release): refuse a backend artifact older than the release

### DIFF
--- a/build/release-cf.sh
+++ b/build/release-cf.sh
@@ -53,8 +53,22 @@ fi
 # composes in one pass. korifi keeps requiring its own static build below.
 CF_ARCH="${CF_ARCH:-amd64}"
 jetstream_bin="${BIN_DIR}/jetstream"
+took_fallback=false
 if [[ ! -f "${jetstream_bin}" && "${MODE}" == "cf" && -f "${BIN_DIR}/jetstream-linux-${CF_ARCH}" ]]; then
   jetstream_bin="${BIN_DIR}/jetstream-linux-${CF_ARCH}"
+  took_fallback=true
+fi
+
+# The cross-compiled artifact is whatever the last `make build backend` left
+# behind, which may predate the version being packaged now — and the zip would
+# still carry this release's name. That shipped a v5.1.0 backend inside a
+# 5.2.0-dev.1 package once. The version is linked in via ldflags, so the
+# binary itself can be asked.
+if [[ "${took_fallback}" == true ]] && ! grep -aqF "${VERSION}" "${jetstream_bin}"; then
+  error "Backend artifact predates this release — it does not carry ${VERSION}"
+  error "  Using: ${jetstream_bin}"
+  error "  Run: make build backend  (refreshes every platform artifact)"
+  fail=1
 fi
 
 if [[ ! -f "${jetstream_bin}" ]]; then

--- a/changelog.d/0002-release-cf-stale-artifact.md
+++ b/changelog.d/0002-release-cf-stale-artifact.md
@@ -1,0 +1,7 @@
+[Maintainability]
+- `make release cf` now refuses to package a fallback backend artifact that
+  does not carry the version being released. The cf fallback takes whatever
+  cross-compiled binary the last backend build left in dist/bin, which can
+  predate the release being cut — that once shipped a v5.1.0 backend inside
+  a package labelled 5.2.0-dev.1. The version is linked into the binary via
+  ldflags, so the script now asks the artifact itself before packaging it.


### PR DESCRIPTION
When `dist/bin/jetstream` is absent, cf packaging falls back to the cross-compiled `dist/bin/jetstream-linux-<arch>` left by the last `make build backend`. That artifact can predate the version being packaged while the zip carries the new release's name — caught live when a package labelled 5.2.0-dev.1 deployed a backend reporting v5.1.0.

The version is linked into the binary via ldflags, so the script now greps the fallback artifact for the version being packaged and fails with a rebuild hint when it is missing. Builds that provide `dist/bin/jetstream` directly are unaffected, and CI never takes the fallback (`make build` immediately precedes packaging there).

Verified by reverse test: a stale artifact trips the guard and fails the run; an artifact carrying the version passes it (the run proceeds to the pre-existing ELF check). `bash -n` clean. Shell-only change — no gate-covered code touched.