### PR TITLE
Foundational shape: spreadsheet form of the detail export

### DIFF
--- a/changelog.d/0004-5702-detail-export-xlsx.md
+++ b/changelog.d/0004-5702-detail-export-xlsx.md
@@ -1,0 +1,8 @@
+[Features]
+- The named detail export on the Foundational Shape page now has a spreadsheet
+  form alongside the JSON: one workbook with the tree flattened to a sheet per
+  entity type (overview with drain stamps and totals, organizations, spaces,
+  apps, service instances, service bindings, role grants). It passes the same
+  CF-admin-only confirmation as the JSON form, a never-run drain's sheet is
+  absent rather than empty, and orphaned children stay visible with an
+  `(orphaned)` marker in their parent columns.

--- a/changelog.d/0004-shape-roles-measure-truncation.md
+++ b/changelog.d/0004-shape-roles-measure-truncation.md
@@ -1,0 +1,6 @@
+[Bug Fixes]
+- Fixed the Foundational Shape "Users & roles" measure silently keeping only
+  the first 50 users on foundations with more than 50 — the same server-paged
+  truncation the summary tiles had. The measure now drains every page of the
+  users endpoint, so the detail export's role grants cover the whole
+  foundation, and its stated cost reads "1 request per 500 users".

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-export-xlsx.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-export-xlsx.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDetailExport, DETAIL_COVERAGE_NOTE, DetailExportInput } from './detail-export';
+import { buildDetailWorkbook } from './detail-export-xlsx';
+import { ShapeSheet } from './shape-export-xlsx';
+import { app, binding, org, serviceInstance, space, user } from './testing/entity-builders';
+
+const fetched = new Date('2026-08-10T10:00:00Z');
+
+const baseInput = (overrides: Partial<DetailExportInput> = {}): DetailExportInput => ({
+  endpoint: { guid: 'cf-1', name: 'My Cloud Foundry' },
+  entities: {
+    orgs: [org('o1')],
+    spaces: [space('s1', 'o1')],
+    apps: [
+      app('a1', {
+        spaceGuid: 's1',
+        orgGuid: 'o1',
+        memory: 256,
+        diskQuota: 1024,
+        stackName: 'cflinuxfs4',
+        routes: [
+          { guid: 'r1', url: 'a1.example.com' },
+          { guid: 'r2', url: 'a1.internal' },
+        ],
+      }),
+    ],
+    serviceInstances: [serviceInstance('si1', 's1', { servicePlan: { guid: 'p1', name: 'small', serviceOffering: { guid: 'off1', name: 'postgres' } } })],
+    bindings: [binding('b1', 'a1', 'si1')],
+    users: [
+      user('alice', {
+        orgRoles: [{ orgGuid: 'o1', roles: ['organization_manager'] }],
+        spaceRoles: [{ spaceGuid: 's1', orgGuid: 'o1', roles: ['space_developer'] }],
+      }),
+    ],
+  },
+  sessionTotals: {
+    orgs: 1, spaces: 1, apps: 1, routes: 2,
+    serviceInstances: 1, serviceOfferings: 4, servicePlans: 5, serviceBrokers: 1,
+  },
+  drains: { counts: true, servicesCounts: true, orgs: true, spaces: true, apps: true },
+  drainStamps: { orgs: fetched, spaces: fetched, apps: fetched, services: fetched },
+  collectedAt: new Date('2026-08-10T11:00:00Z'),
+  rolesFetchedAt: fetched,
+  ...overrides,
+});
+
+const workbook = (overrides: Partial<DetailExportInput> = {}): ShapeSheet[] =>
+  buildDetailWorkbook(buildDetailExport(baseInput(overrides)));
+
+const sheet = (sheets: ShapeSheet[], name: string): ShapeSheet => {
+  const found = sheets.find(s => s.name === name);
+  expect(found, `sheet ${name}`).toBeDefined();
+  return found as ShapeSheet;
+};
+
+describe('buildDetailWorkbook', () => {
+  it('emits one sheet per named data type, Overview first', () => {
+    expect(workbook().map(s => s.name)).toEqual([
+      'Overview', 'Organizations', 'Spaces', 'Apps', 'Service instances', 'Service bindings', 'Roles',
+    ]);
+  });
+
+  it('Overview carries the endpoint identity, metadata block, drain stamps and totals', () => {
+    const rows = sheet(workbook(), 'Overview').rows;
+    expect(rows).toContainEqual(['Endpoint', 'My Cloud Foundry']);
+    expect(rows).toContainEqual(['Endpoint GUID', 'cf-1']);
+    expect(rows).toContainEqual(['Collected at', '2026-08-10T11:00:00.000Z']);
+    expect(rows).toContainEqual(['Coverage note', DETAIL_COVERAGE_NOTE]);
+    expect(rows).toContainEqual(['orgs', '2026-08-10T10:00:00.000Z']);
+    expect(rows).toContainEqual(['roles', '2026-08-10T10:00:00.000Z']);
+    expect(rows).toContainEqual(['entity', 'count']);
+    expect(rows).toContainEqual(['organizations', 1]);
+  });
+
+  it('Overview marks a never-run drain as never, and omits the truncated row when nothing is capped', () => {
+    const rows = sheet(workbook({ drainStamps: { orgs: fetched, spaces: fetched, apps: null, services: fetched } }), 'Overview').rows;
+    expect(rows).toContainEqual(['apps', 'never']);
+    expect(rows.some(r => r[0] === 'Truncated datasets')).toBe(false);
+  });
+
+  it('Overview names the page-capped datasets when there are any', () => {
+    const rows = sheet(workbook({
+      entities: { orgs: [org('o1')], spaces: [space('s1', 'o1')], serviceInstances: [serviceInstance('si1', 's1')] },
+      sessionTotals: {
+        orgs: 1, spaces: 1, apps: 1, routes: 2,
+        serviceInstances: 3, serviceOfferings: 4, servicePlans: 5, serviceBrokers: 1,
+      },
+    }), 'Overview').rows;
+    expect(rows).toContainEqual(['Truncated datasets', 'service_instances']);
+  });
+
+  it('Organizations rows carry identity and the always-emit quota link', () => {
+    const rows = sheet(workbook(), 'Organizations').rows;
+    expect(rows[0]).toEqual(['guid', 'name', 'status', 'quota_guid', 'spaces_count', 'apps_count']);
+    expect(rows).toContainEqual(['o1', 'org-o1', 'active', '', '', '']);
+  });
+
+  it('Spaces rows name their org; an orphaned space is kept and marked', () => {
+    const rows = sheet(workbook({
+      entities: { orgs: [org('o1')], spaces: [space('s1', 'o1'), space('s-lost', 'o-gone')] },
+    }), 'Spaces').rows;
+    expect(rows[0]).toEqual(['org', 'org_guid', 'guid', 'name', 'quota_guid']);
+    expect(rows).toContainEqual(['org-o1', 'o1', 's1', 'space-s1', '']);
+    expect(rows).toContainEqual(['(orphaned)', '', 's-lost', 'space-s-lost', '']);
+  });
+
+  it('Apps rows keep numbers as numbers and join routes; an orphaned app is kept and marked', () => {
+    const rows = sheet(workbook({
+      entities: {
+        orgs: [org('o1')],
+        spaces: [space('s1', 'o1')],
+        apps: [
+          app('a1', {
+            spaceGuid: 's1', memory: 256, diskQuota: 1024, stackName: 'cflinuxfs4',
+            routes: [{ guid: 'r1', url: 'a1.example.com' }, { guid: 'r2', url: 'a1.internal' }],
+          }),
+          app('a-lost', { spaceGuid: 's-gone' }),
+        ],
+      },
+    }), 'Apps').rows;
+    expect(rows[0]).toEqual([
+      'org', 'space', 'guid', 'name', 'state', 'instances',
+      'stack', 'memory_mb', 'disk_mb', 'routes', 'last_refreshed_at', 'unavailable',
+    ]);
+    expect(rows).toContainEqual([
+      'org-o1', 'space-s1', 'a1', 'app-a1', 'STARTED', 1,
+      'cflinuxfs4', 256, 1024, 'a1.example.com, a1.internal', '', '',
+    ]);
+    expect(rows).toContainEqual([
+      '(orphaned)', '(orphaned)', 'a-lost', 'app-a-lost', 'STARTED', 1, '', '', '', '', '', '',
+    ]);
+  });
+
+  it('Service instances and bindings flatten with their plan, offering and target names', () => {
+    const sheets = workbook();
+    expect(sheet(sheets, 'Service instances').rows).toContainEqual([
+      'org-o1', 'space-s1', 'si1', 'si-si1', 'managed', 'small', 'postgres',
+    ]);
+    expect(sheet(sheets, 'Service bindings').rows).toContainEqual([
+      'org-o1', 'space-s1', 'app-a1', 'b1', 'app', '', 'si-si1', 'si1',
+    ]);
+  });
+
+  it('Roles flattens both scopes to one row per user and scope', () => {
+    const rows = sheet(workbook(), 'Roles').rows;
+    expect(rows[0]).toEqual(['scope', 'org', 'space', 'username', 'roles']);
+    expect(rows).toContainEqual(['organization', 'org-o1', '', 'alice', 'organization_manager']);
+    expect(rows).toContainEqual(['space', 'org-o1', 'space-s1', 'alice', 'space_developer']);
+  });
+
+  it('never-run drains collapse the workbook to Overview and Organizations alone', () => {
+    const sheets = workbook({
+      entities: { orgs: [org('o1')] },
+      drainStamps: { orgs: fetched, spaces: null, apps: null, services: null },
+      rolesFetchedAt: undefined,
+    });
+    expect(sheets.map(s => s.name)).toEqual(['Overview', 'Organizations']);
+  });
+
+  it('a drain that ran and found nothing produces no sheet either', () => {
+    const sheets = workbook({
+      entities: { orgs: [org('o1')], spaces: [] },
+    });
+    expect(sheets.map(s => s.name)).not.toContain('Spaces');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-export-xlsx.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-export-xlsx.ts
@@ -1,0 +1,131 @@
+/**
+ * Spreadsheet form of the named detail export (GH #5702): one workbook, one
+ * sheet per entity type, flattened from the same DetailExport the JSON
+ * download emits. The JSON stays the schema_version 1 contract; the workbook
+ * is a rendering of it, so anything absent from the JSON (never-run drain)
+ * is absent here too, and a sheet with no data rows is not written at all.
+ *
+ * Orphans — children whose parent is missing from a drain that ran — keep
+ * the honesty rule from detail-shape.ts: they land in the same sheet as
+ * their siblings with `(orphaned)` in the parent columns, visible rather
+ * than dropped.
+ */
+import { DetailExport } from './detail-export';
+import { DetailApp, DetailSpace } from './detail-shape';
+import { ShapeSheet } from './shape-export-xlsx';
+
+const ORPHANED = '(orphaned)';
+
+type Cell = string | number;
+
+/** Optional schema fields render as an empty cell, never as "undefined". */
+const cell = (value: Cell | undefined): Cell => value ?? '';
+
+/** Every space with its org's name; orphaned spaces carry the marker. */
+const spaceRows = (exported: DetailExport): { org: string; orgGuid: string; space: DetailSpace }[] => [
+  ...exported.organizations.flatMap(o =>
+    (o.spaces ?? []).map(space => ({ org: o.name, orgGuid: o.guid, space }))),
+  ...(exported.orphans.spaces ?? []).map(space => ({ org: ORPHANED, orgGuid: '', space })),
+];
+
+/** Every app with its org and space names; orphaned apps carry the marker in both. */
+const appRows = (exported: DetailExport): { org: string; space: string; app: DetailApp }[] => [
+  ...spaceRows(exported).flatMap(({ org, space }) =>
+    (space.apps ?? []).map(app => ({ org, space: space.name, app }))),
+  ...(exported.orphans.apps ?? []).map(app => ({ org: ORPHANED, space: ORPHANED, app })),
+];
+
+const overviewSheet = (exported: DetailExport): ShapeSheet => ({
+  name: 'Overview',
+  rows: [
+    ['Endpoint', exported.endpoint.name],
+    ['Endpoint GUID', exported.endpoint.guid],
+    ['Collected at', exported.collected_at],
+    ['Schema version', exported.schema_version],
+    ['Coverage note', exported.coverage_note],
+    ...(exported.truncated ? [['Truncated datasets', exported.truncated.join(', ')] as Cell[]] : []),
+    [],
+    ['drain', 'last run'],
+    ...Object.entries(exported.drains).map(([name, stamp]): Cell[] => [name, stamp ?? 'never']),
+    [],
+    ['entity', 'count'],
+    ...Object.entries(exported.totals),
+  ],
+});
+
+const organizationsSheet = (exported: DetailExport): ShapeSheet => ({
+  name: 'Organizations',
+  rows: [
+    ['guid', 'name', 'status', 'quota_guid', 'spaces_count', 'apps_count'],
+    ...exported.organizations.map((o): Cell[] =>
+      [o.guid, o.name, o.status, o.quota_guid, cell(o.spaces_count), cell(o.apps_count)]),
+  ],
+});
+
+const spacesSheet = (exported: DetailExport): ShapeSheet => ({
+  name: 'Spaces',
+  rows: [
+    ['org', 'org_guid', 'guid', 'name', 'quota_guid'],
+    ...spaceRows(exported).map(({ org, orgGuid, space }): Cell[] =>
+      [org, orgGuid, space.guid, space.name, cell(space.quota_guid)]),
+  ],
+});
+
+const appsSheet = (exported: DetailExport): ShapeSheet => ({
+  name: 'Apps',
+  rows: [
+    ['org', 'space', 'guid', 'name', 'state', 'instances',
+      'stack', 'memory_mb', 'disk_mb', 'routes', 'last_refreshed_at', 'unavailable'],
+    ...appRows(exported).map(({ org, space, app }): Cell[] => [
+      org, space, app.guid, app.name, app.state, app.instances,
+      cell(app.stack), cell(app.memory_mb), cell(app.disk_mb),
+      app.routes.join(', '), cell(app.last_refreshed_at), (app.unavailable ?? []).join(', '),
+    ]),
+  ],
+});
+
+const serviceInstancesSheet = (exported: DetailExport): ShapeSheet => ({
+  name: 'Service instances',
+  rows: [
+    ['org', 'space', 'guid', 'name', 'type', 'plan', 'offering'],
+    ...spaceRows(exported).flatMap(({ org, space }) =>
+      (space.service_instances ?? []).map((si): Cell[] =>
+        [org, space.name, si.guid, si.name, si.type, cell(si.plan), cell(si.offering)])),
+  ],
+});
+
+const serviceBindingsSheet = (exported: DetailExport): ShapeSheet => ({
+  name: 'Service bindings',
+  rows: [
+    ['org', 'space', 'app', 'guid', 'type', 'name', 'service_instance', 'service_instance_guid'],
+    ...appRows(exported).flatMap(({ org, space, app }) =>
+      (app.service_bindings ?? []).map((b): Cell[] => [
+        org, space, app.name, b.guid, b.type, cell(b.name),
+        cell(b.service_instance.name), b.service_instance.guid,
+      ])),
+  ],
+});
+
+const rolesSheet = (exported: DetailExport): ShapeSheet => ({
+  name: 'Roles',
+  rows: [
+    ['scope', 'org', 'space', 'username', 'roles'],
+    ...exported.organizations.flatMap(o =>
+      Object.entries(o.roles ?? {}).map(([username, roles]): Cell[] =>
+        ['organization', o.name, '', username, roles.join(', ')])),
+    ...spaceRows(exported).flatMap(({ org, space }) =>
+      Object.entries(space.roles ?? {}).map(([username, roles]): Cell[] =>
+        ['space', org, space.name, username, roles.join(', ')])),
+  ],
+});
+
+/** Overview always (it carries the coverage note and drain stamps); every other sheet only when it has data rows. */
+export const buildDetailWorkbook = (exported: DetailExport): ShapeSheet[] => [
+  overviewSheet(exported),
+  organizationsSheet(exported),
+  spacesSheet(exported),
+  appsSheet(exported),
+  serviceInstancesSheet(exported),
+  serviceBindingsSheet(exported),
+  rolesSheet(exported),
+].filter(sheet => sheet.name === 'Overview' || sheet.rows.length > 1);

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
@@ -289,6 +289,12 @@
               (click)="downloadDetailJson(section)">
               Download detail JSON
             </button>
+            <button data-test="export-detail-xlsx" type="button"
+              class="px-2.5 py-1 text-xs font-medium rounded border border-warning-shade-300 text-warning-shade-700 dark:border-warning-shade-700 dark:text-warning-shade-300 hover:bg-content-secondary transition-colors disabled:opacity-50"
+              [disabled]="!canExportDetail(section)"
+              (click)="downloadDetailXlsx(section)">
+              Download detail spreadsheet
+            </button>
             @if (!canExportDetail(section)) {
               <span class="text-xs text-content-muted">needs the orgs drain first</span>
             }

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.spec.ts
@@ -9,6 +9,10 @@ import { FoundationShapePageComponent } from './foundation-shape-page.component'
 import { MeasuredEcosystem, MeasuredRoles, MeasuredTotals, ShapeMeasureService } from './shape-measure.service';
 import { app, binding, org, serviceInstance, space, user } from './testing/entity-builders';
 
+// jsdom cannot exercise the real workbook writer; the mock records the sheets it was handed.
+const writeXlsxMock = vi.hoisted(() => vi.fn(() => ({ toFile: vi.fn(() => Promise.resolve()) })));
+vi.mock('write-excel-file/browser', () => ({ default: writeXlsxMock }));
+
 const cfEndpoint = { guid: 'cf-1', name: 'My Cloud Foundry', cnsi_type: 'cf' } as EndpointModel;
 const adminCfEndpoint = {
   guid: 'cf-1',
@@ -309,12 +313,12 @@ describe('FoundationShapePageComponent', () => {
   });
 
   describe('detail (named) export', () => {
-    const clickDetailExport = async () => {
+    const clickDetailExport = async (button = 'export-detail-json') => {
       endpoints.set([adminCfEndpoint]);
       fixture.detectChanges();
       await fixture.whenStable();
       (fixture.nativeElement as HTMLElement)
-        .querySelector<HTMLButtonElement>('[data-test="export-detail-json"]')
+        .querySelector<HTMLButtonElement>(`[data-test="${button}"]`)
         .click();
       await fixture.whenStable();
     };
@@ -325,6 +329,7 @@ describe('FoundationShapePageComponent', () => {
       // call history would otherwise carry over from the previous test.
       vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test').mockClear();
       vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined).mockClear();
+      writeXlsxMock.mockClear();
     });
 
     it('stays hidden from a non-admin connection, alongside the anonymous export', () => {
@@ -371,6 +376,20 @@ describe('FoundationShapePageComponent', () => {
       await clickDetailExport();
       expect(confirmed.config).not.toBeNull();
       expect(URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('the spreadsheet form passes the same confirmation gate, then writes the flattened workbook', async () => {
+      await clickDetailExport('export-detail-xlsx');
+      expect(confirmed.config?.title).toBe('Export named foundation data');
+      const sheets = writeXlsxMock.mock.calls[0][0] as { sheet: string; data: unknown[][] }[];
+      expect(sheets.map(s => s.sheet)).toEqual(['Overview', 'Organizations', 'Spaces', 'Apps']);
+    });
+
+    it('declining the spreadsheet confirmation writes nothing', async () => {
+      confirmed.accept = false;
+      await clickDetailExport('export-detail-xlsx');
+      expect(confirmed.config).not.toBeNull();
+      expect(writeXlsxMock).not.toHaveBeenCalled();
     });
 
     it('mentions role grants in the confirmation only once they are measured', async () => {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
@@ -20,6 +20,7 @@ import writeXlsxFile from 'write-excel-file/browser';
 import { EndpointDataRegistry } from '../../services/endpoint-data/endpoint-data.registry';
 import { EndpointDataService } from '../../services/endpoint-data/endpoint-data.service';
 import { buildDetailExport, DetailExport } from './detail-export';
+import { buildDetailWorkbook } from './detail-export-xlsx';
 import { computeSessionShape } from './session-shape';
 import { ShapeCompareCardComponent } from './shape-compare-card.component';
 import { ShapeDistCardComponent } from './shape-dist-card.component';
@@ -308,9 +309,10 @@ export class FoundationShapePageComponent implements OnDestroy {
   /**
    * Named export: the double-check the #5702 maintainer comment asks for.
    * The dialog says what leaves the browser, because the file cannot be
-   * un-shared once it has.
+   * un-shared once it has. One gate for both file forms — the spreadsheet
+   * names exactly what the JSON names.
    */
-  downloadDetailJson(section: ShapeSection): void {
+  private confirmDetailExport(section: ShapeSection, download: (payload: DetailExport) => void): void {
     const payload = this.detailPayload(section);
     if (!payload) {
       return;
@@ -329,8 +331,21 @@ export class FoundationShapePageComponent implements OnDestroy {
         'Download named data',
         true
       ),
-      () => this.downloadFile(this.exportFileName(section, 'detail', 'json'), JSON.stringify(payload, null, 2))
+      () => download(payload)
     );
+  }
+
+  downloadDetailJson(section: ShapeSection): void {
+    this.confirmDetailExport(section, payload =>
+      this.downloadFile(this.exportFileName(section, 'detail', 'json'), JSON.stringify(payload, null, 2))
+    );
+  }
+
+  downloadDetailXlsx(section: ShapeSection): void {
+    this.confirmDetailExport(section, payload => {
+      const sheets = buildDetailWorkbook(payload).map(({ name, rows }) => ({ sheet: name, data: rows }));
+      void writeXlsxFile(sheets).toFile(this.exportFileName(section, 'detail', 'xlsx'));
+    });
   }
 
   downloadXlsx(section: ShapeSection): void {

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-measure.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-measure.service.spec.ts
@@ -96,14 +96,16 @@ describe('ShapeMeasureService', () => {
   });
 
   describe('measureRoles', () => {
-    it('takes the whole users-and-roles join in one request', () => {
-      expect(service.rolesCost()).toBe('1 request');
+    const pageUrl = (page: number) => `/pp/v1/cf/users/cf-1?per_page=500&page=${page}`;
+
+    it('takes the whole users-and-roles join in one drained request', () => {
+      expect(service.rolesCost()).toBe('1 request per 500 users');
       service.measureRoles('cf-1');
       expect(service.inFlight().has('cf-1:roles')).toBe(true);
 
-      httpMock.expectOne('/pp/v1/cf/users/cf-1').flush({
+      httpMock.expectOne(pageUrl(1)).flush({
         resources: [{ guid: 'u1', username: 'alice', cnsiGuid: 'cf-1', orgRoles: [{ orgGuid: 'o1', roles: ['org_manager'] }], spaceRoles: [] }],
-        totalResults: 1,
+        pagination: { totalResults: 1, totalPages: 1 },
       });
       httpMock.verify();
 
@@ -113,16 +115,31 @@ describe('ShapeMeasureService', () => {
       expect(service.inFlight().has('cf-1:roles')).toBe(false);
     });
 
+    it('drains every page — a >500-user foundation keeps its later-page users', () => {
+      service.measureRoles('cf-1');
+      httpMock.expectOne(pageUrl(1)).flush({
+        resources: [{ guid: 'u1', username: 'alice', cnsiGuid: 'cf-1', orgRoles: [], spaceRoles: [] }],
+        pagination: { totalResults: 501, totalPages: 2 },
+      });
+      httpMock.expectOne(pageUrl(2)).flush({
+        resources: [{ guid: 'u2', username: 'fw-lab-norm-07', cnsiGuid: 'cf-1', orgRoles: [], spaceRoles: [{ orgGuid: 'o1', spaceGuid: 's1', roles: ['developer'] }] }],
+        pagination: { totalResults: 501, totalPages: 2 },
+      });
+      httpMock.verify();
+
+      expect(service.roles().get('cf-1')?.users.map(u => u.username)).toEqual(['alice', 'fw-lab-norm-07']);
+    });
+
     it('records nothing when the fetch fails, so failure never reads as "no grants"', () => {
       service.measureRoles('cf-1');
-      httpMock.expectOne('/pp/v1/cf/users/cf-1').flush('nope', { status: 403, statusText: 'Forbidden' });
+      httpMock.expectOne(pageUrl(1)).flush('nope', { status: 403, statusText: 'Forbidden' });
       expect(service.roles().get('cf-1')).toBeUndefined();
       expect(service.inFlight().has('cf-1:roles')).toBe(false);
     });
 
     it('distinguishes a foundation with no users from a failure', () => {
       service.measureRoles('cf-1');
-      httpMock.expectOne('/pp/v1/cf/users/cf-1').flush({ resources: [], totalResults: 0 });
+      httpMock.expectOne(pageUrl(1)).flush({ resources: [], pagination: { totalResults: 0, totalPages: 1 } });
       expect(service.roles().get('cf-1')?.users).toEqual([]);
     });
   });

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-measure.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-measure.service.ts
@@ -3,7 +3,8 @@ import { inject, Injectable, signal } from '@angular/core';
 import { forkJoin, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { StBuildpacksResponse, StStacksResponse, StUser, StUsersResponse } from '../../services/endpoint-data/stratos-types';
+import { drainCfPages } from '../../services/endpoint-data/drain-pages';
+import { StBuildpacksResponse, StStacksResponse, StUser } from '../../services/endpoint-data/stratos-types';
 
 /**
  * Measure-on-demand blocks for the foundation shape page (GH #5702): the
@@ -43,9 +44,11 @@ export interface MeasuredEcosystem {
 }
 
 /**
- * Users with their org and space role grants — the whole join arrives in the
- * one `/pp/v1/cf/users/{cnsi}` envelope, so this block costs a single request
- * however large the foundation is. It feeds the detail export's per-org and
+ * Users with their org and space role grants — each `/pp/v1/cf/users/{cnsi}`
+ * page carries the whole join for its users, drained across every page (the
+ * endpoint is server-paged at 500; a bare GET keeps only the V3-default
+ * first 50 and silently drops every later user — the same truncation #5805
+ * fixed for the summary tiles). It feeds the detail export's per-org and
  * per-space `roles`; the anonymous export never carries it.
  */
 export interface MeasuredRoles {
@@ -76,7 +79,7 @@ export class ShapeMeasureService {
   }
 
   rolesCost(): string {
-    return '1 request';
+    return '1 request per 500 users';
   }
 
   measureTotals(guid: string): void {
@@ -128,13 +131,12 @@ export class ShapeMeasureService {
     if (!this.begin(key)) {
       return;
     }
-    this.http
-      .get<StUsersResponse>(`/pp/v1/cf/users/${guid}`)
+    drainCfPages<StUser>(this.http, `/pp/v1/cf/users/${guid}`)
       .pipe(catchError(() => of(null)))
-      .subscribe(response => {
-        if (response) {
+      .subscribe(drained => {
+        if (drained) {
           this._roles.update(all =>
-            new Map(all).set(guid, { users: response.resources ?? [], fetchedAt: new Date() })
+            new Map(all).set(guid, { users: drained.resources, fetchedAt: new Date() })
           );
         }
         this.end(key);


### PR DESCRIPTION
Second increment of #5702: the named detail export gains a spreadsheet form, and live verification of it surfaced (and this PR fixes) a page-cap truncation in the roles measure.

## Spreadsheet form of the detail export

`buildDetailWorkbook` flattens the `DetailExport` tree into one workbook, one sheet per entity type:

| Sheet | Content |
|---|---|
| Overview (always) | endpoint identity, collected-at, coverage note, truncated datasets, drain → last-run stamps, entity totals |
| Organizations | guid, name, status, quota link, counts |
| Spaces | org + guid/name/quota link |
| Apps | org, space, state, instances, stack, memory/disk, routes, unavailable fields |
| Service instances | org, space, type, plan, offering |
| Service bindings | org, space, app, binding, target instance |
| Roles | scope, org, space, username, grants |

The workbook is a rendering of the schema_version 1 JSON contract, following the same honesty rules as the anonymous spreadsheet (#5703): a never-run drain's sheet is absent rather than empty, and orphaned children stay in their sheet with an `(orphaned)` marker in the parent columns instead of being dropped.

Both detail forms now share one confirmation gate — the spreadsheet names exactly what the JSON names, so it takes the same dialog spelling out what leaves the browser.

## Roles measure: drain every page

`measureRoles` issued a bare GET against the server-paged users endpoint, keeping only the V3-default first 50 users — the same silent truncation #5805 fixed for the summary tiles. On a 315-user foundation the export's role grants were missing every user past page one. The measure now reuses `drainCfPages`, and its stated cost reads "1 request per 500 users".

## Verification

- Full gate (lint + 3632 unit tests + production build) green; 14 new tests across the series, including a two-page drain spec the old single-GET code fails.
- Live-verified against a 62-org / 604-space / 315-user foundation: sheet layout and positional empty cells, orphan handling, confirm/decline paths, and the Roles sheet carrying the full grant list (1525 rows, previously 54) with per-space counts matching the foundation's known role holders.

Part of #5702 (PR 3 will follow: named diff + compare-card selector).
