### PR TITLE
Add the named diff to the shape compare card

### DIFF
--- a/changelog.d/0005-5702-named-diff.md
+++ b/changelog.d/0005-5702-named-diff.md
@@ -1,0 +1,11 @@
+[Features]
+- The Foundational Shape page's Compare card gains a named diff: pick two
+  detail snapshots — live sections (CF admin only) or exported detail files —
+  and see exactly which named organizations, spaces, apps, service instances,
+  bindings and role grants appeared, vanished or changed between them,
+  before → after. Entities match by guid so renames read as changes, a level
+  whose drain never ran on a side reads as not measured rather than deleted,
+  and page-capped datasets carry a truncation warning instead of letting the
+  cap read as change. Importing a detail file into the anonymous Compare slot
+  (or vice versa) now points at the right selector instead of failing
+  cryptically.

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff-card.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff-card.component.html
@@ -1,0 +1,102 @@
+<div class="flex flex-col gap-4 px-4 py-1" data-test="detail-diff">
+  <div>
+    <span class="text-sm font-semibold">Named diff</span>
+    <span class="text-xs text-content-muted ml-2">
+      pick two detail snapshots for a named diff &mdash; live sections (CF admin only) or exported detail files.
+      Entities match by guid; before &rarr; after.
+    </span>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-3 text-xs">
+    @for (slot of ['before', 'after']; track slot) {
+      <label class="flex items-center gap-1.5">
+        <span class="text-content-muted">{{ slot }}</span>
+        <select class="rounded border border-content-border bg-content-secondary px-1.5 py-1"
+          [attr.data-test]="'detail-diff-' + slot" [value]="selected(slot === 'before' ? 'before' : 'after')"
+          (change)="selectFrom(slot === 'before' ? 'before' : 'after', $event)">
+          <option value="">&mdash;</option>
+          @for (option of options(); track option.id) {
+            <option [value]="option.id">{{ option.label }}</option>
+          }
+        </select>
+      </label>
+    }
+    <label class="text-content-muted cursor-pointer hover:underline">
+      Import detail export&hellip;
+      <input type="file" accept=".json,application/json" class="hidden" data-test="detail-diff-import"
+        (change)="importFile($event)">
+    </label>
+  </div>
+  @if (importError(); as error) {
+    <span class="text-xs text-danger-shade-600 dark:text-danger-shade-300" data-test="detail-diff-error">{{ error }}</span>
+  }
+
+  @if (diff(); as d) {
+    @for (warning of d.warnings; track warning) {
+      <div class="text-xs text-warning-shade-700 dark:text-warning-shade-300" data-test="detail-diff-warning">
+        {{ warning }}
+      </div>
+    }
+
+    <div class="flex flex-col gap-3" data-test="detail-diff-levels">
+      @for (level of levelVms(); track level.key) {
+        <div class="flex flex-col gap-1">
+          <div>
+            <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">{{ level.title }}</span>
+            @if (level.unmeasuredSide) {
+              <span class="text-xs text-content-muted ml-2">{{ level.unmeasuredSide }}</span>
+            } @else if (level.empty) {
+              <span class="text-xs text-content-muted ml-2">no change &middot; {{ level.unchanged }} unchanged</span>
+            } @else {
+              <span class="text-xs text-content-muted ml-2">{{ level.unchanged }} unchanged</span>
+            }
+          </div>
+          @if (!level.unmeasuredSide && !level.empty) {
+            <table class="text-xs w-auto">
+              <tbody>
+                @for (entry of level.removed; track entry.guid) {
+                  <tr data-test="detail-diff-removed">
+                    <td class="pr-2 py-0.5 text-danger-shade-700 dark:text-danger-shade-300">&minus;</td>
+                    <td class="pr-4 py-0.5">{{ entry.name }}</td>
+                    <td class="py-0.5 text-content-muted">{{ entry.path }}</td>
+                  </tr>
+                }
+                @for (entry of level.added; track entry.guid) {
+                  <tr data-test="detail-diff-added">
+                    <td class="pr-2 py-0.5 text-success-shade-700 dark:text-success-shade-300">+</td>
+                    <td class="pr-4 py-0.5">{{ entry.name }}</td>
+                    <td class="py-0.5 text-content-muted">{{ entry.path }}</td>
+                  </tr>
+                }
+                @for (entry of level.changed; track entry.guid) {
+                  <tr data-test="detail-diff-changed">
+                    <td class="pr-2 py-0.5 text-content-muted">&Delta;</td>
+                    <td class="pr-4 py-0.5">{{ entry.name }}</td>
+                    <td class="py-0.5 text-content-muted">
+                      @if (entry.path) { <span class="mr-2">{{ entry.path }}</span> }
+                      <span class="tabular-nums">{{ changesText(entry.changes) }}</span>
+                    </td>
+                  </tr>
+                }
+                @if (level.more > 0 || level.isOpen) {
+                  <tr>
+                    <td colspan="3" class="py-0.5">
+                      <button type="button" class="text-content-muted hover:underline"
+                        (click)="toggleLevel(level.key)">
+                        @if (level.isOpen) { show fewer } @else { {{ level.more }} more }
+                      </button>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          }
+        </div>
+      }
+    </div>
+  } @else {
+    <div class="text-xs text-content-muted" data-test="detail-diff-prompt">
+      Select two different sides for a named diff.
+    </div>
+  }
+</div>

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff-card.component.spec.ts
@@ -1,0 +1,119 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DetailDiffCardComponent } from './detail-diff-card.component';
+import { DetailExport } from './detail-export';
+import { computeSessionShape } from './session-shape';
+import { ShapeSection } from './shape-section';
+
+const stamp = { fetchedAt: new Date('2026-08-01T10:00:00Z'), stale: false };
+const never = { fetchedAt: null, stale: false };
+
+const makeSection = (guid: string, name: string, over: Partial<ShapeSection> = {}): ShapeSection => ({
+  guid,
+  name,
+  shape: computeSessionShape([], [], []),
+  totals: {
+    orgs: 0, spaces: null, apps: 0, routes: 0,
+    serviceInstances: 0, serviceOfferings: 0, servicePlans: 0, serviceBrokers: 0,
+  },
+  drains: { orgs: stamp, spaces: never, apps: never },
+  loading: false,
+  hasDrains: true,
+  countsLoaded: true,
+  servicesCountsLoaded: true,
+  admin: true,
+  ...over,
+});
+
+const detailExport = (over: Partial<DetailExport> = {}): DetailExport => ({
+  schema_version: 1,
+  mode: 'detail',
+  endpoint: { guid: 'cf-1', name: 'Lab CF' },
+  collected_at: '2026-08-12T10:00:00.000Z',
+  coverage_note: 'note',
+  drains: { orgs: '2026-08-12T10:00:00.000Z', spaces: null, apps: null },
+  totals: {},
+  organizations: [{ guid: 'o1', name: 'payments-prod', status: 'active', quota_guid: '' }],
+  orphans: {},
+  ...over,
+});
+
+const exportFile = (name: string, exported: object): File =>
+  new File([JSON.stringify(exported)], name, { type: 'application/json' });
+
+describe('DetailDiffCardComponent', () => {
+  let fixture: ComponentFixture<DetailDiffCardComponent>;
+  let component: DetailDiffCardComponent;
+
+  const text = (): string => (fixture.nativeElement as HTMLElement).textContent ?? '';
+  const payloads = new Map<string, DetailExport | null>();
+
+  beforeEach(async () => {
+    payloads.clear();
+    await TestBed.configureTestingModule({
+      imports: [DetailDiffCardComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DetailDiffCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('sections', [
+      makeSection('cf-1', 'Lab CF'),
+      makeSection('cf-2', 'AWS CF', { admin: false }),
+      makeSection('cf-3', 'Empty CF', { drains: { orgs: never, spaces: never, apps: never } }),
+    ]);
+    fixture.componentRef.setInput('detailPayload', (section: ShapeSection) => payloads.get(section.guid) ?? null);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('offers only admin sections whose orgs drain ran as live sides', () => {
+    const ids = component.options().map(option => option.id);
+    expect(ids).toEqual(['live:cf-1']);
+  });
+
+  it('accepts an imported detail file as a side and rejects an anonymous one', async () => {
+    await component.importFrom(exportFile('lab-detail.json', detailExport()));
+    expect(component.options().some(option => option.label.includes('Lab CF'))).toBe(true);
+
+    await component.importFrom(exportFile('shape.json', { schema_version: 1, mode: 'anonymous' }));
+    expect(component.importError()).toContain('anonymous');
+  });
+
+  it('diffs two selected sides and names what changed', async () => {
+    await component.importFrom(exportFile('before.json', detailExport()));
+    await component.importFrom(
+      exportFile('after.json', detailExport({
+        collected_at: '2026-08-12T11:00:00.000Z',
+        organizations: [{ guid: 'o2', name: 'new-org', status: 'active', quota_guid: '' }],
+      }))
+    );
+    component.select('before', component.options()[1].id);
+    component.select('after', component.options()[2].id);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(text()).toContain('new-org');
+    expect(text()).toContain('payments-prod');
+  });
+
+  it('uses the live payload for a live side', async () => {
+    payloads.set('cf-1', detailExport({ organizations: [] }));
+    await component.importFrom(exportFile('before.json', detailExport()));
+    component.select('before', component.options()[1].id);
+    component.select('after', 'live:cf-1');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // payments-prod exists only on the imported before side → reads as removed.
+    expect(text()).toContain('payments-prod');
+    expect(component.diff()?.levels.find(level => level.key === 'organizations')?.removed).toHaveLength(1);
+  });
+
+  it('renders nothing but the prompt until two distinct sides are chosen', () => {
+    expect(component.diff()).toBeNull();
+    expect(text()).toContain('named diff');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff-card.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff-card.component.ts
@@ -1,0 +1,167 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+
+import { DetailDiff, diffDetailExports, LevelDiff, parseImportedDetail } from './detail-diff';
+import { DetailExport } from './detail-export';
+import { ShapeSection } from './shape-section';
+
+/** How many rows a diff bucket shows before collapsing behind "n more". */
+const BUCKET_SHOWN = 20;
+
+interface DetailFile {
+  id: string;
+  label: string;
+  exported: DetailExport;
+}
+
+const humanize = (key: string): string => key.replace(/_/g, ' ');
+
+/**
+ * Named diff (GH #5702, the #5703 comparison leg): two detail-export sides —
+ * live admin sections or imported detail files — diffed with names intact.
+ * The find-act-verify loop as a view: collect, act on the foundation, collect
+ * again, and see exactly which named entities appeared, vanished or changed.
+ * Live sides are admin-only, matching the detail export's gate; an imported
+ * file already carries its names, so it needs no gate. Nothing leaves the
+ * browser and nothing here issues CF requests.
+ */
+@Component({
+  selector: 'app-detail-diff-card',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './detail-diff-card.component.html',
+})
+export class DetailDiffCardComponent {
+  readonly sections = input<ShapeSection[]>([]);
+  /** Builds the named payload for a live section (the page owns the registry access). */
+  readonly detailPayload = input.required<(section: ShapeSection) => DetailExport | null>();
+
+  private readonly files = signal<readonly DetailFile[]>([]);
+  private readonly beforeId = signal<string | null>(null);
+  private readonly afterId = signal<string | null>(null);
+  readonly importError = signal<string | null>(null);
+  private readonly expandedLevels = signal<ReadonlySet<string>>(new Set());
+  private fileSeq = 0;
+
+  /** Live sides mirror the detail-export gate: admin, and an orgs drain to diff. */
+  readonly options = computed(() => [
+    ...this.sections()
+      .filter(section => section.admin && section.drains.orgs.fetchedAt !== null)
+      .map(section => ({ id: `live:${section.guid}`, label: `${section.name} (live)` })),
+    ...this.files().map(file => ({ id: file.id, label: `${file.label} (file)` })),
+  ]);
+
+  selected(slot: 'before' | 'after'): string {
+    return (slot === 'before' ? this.beforeId() : this.afterId()) ?? '';
+  }
+
+  select(slot: 'before' | 'after', id: string): void {
+    (slot === 'before' ? this.beforeId : this.afterId).set(id || null);
+  }
+
+  selectFrom(slot: 'before' | 'after', event: Event): void {
+    this.select(slot, (event.target as HTMLSelectElement).value);
+  }
+
+  /** Template hook for the hidden file input; the parse work lives in importFrom. */
+  importFile(event: Event): void {
+    const inputEl = event.target as HTMLInputElement;
+    const file = inputEl.files?.[0];
+    inputEl.value = '';
+    if (file) {
+      void this.importFrom(file);
+    }
+  }
+
+  async importFrom(file: File): Promise<void> {
+    const { exported, error } = parseImportedDetail(await file.text());
+    if (!exported) {
+      this.importError.set(`${file.name}: ${error}`);
+      return;
+    }
+    const id = `file-${++this.fileSeq}`;
+    const label = `${exported.endpoint.name} ${exported.collected_at.slice(0, 10)}`;
+    this.files.set([...this.files(), { id, label, exported }]);
+    this.importError.set(null);
+    // Fill the first free slot so an import is immediately a side.
+    if (!this.beforeId()) {
+      this.beforeId.set(id);
+    } else if (!this.afterId()) {
+      this.afterId.set(id);
+    }
+  }
+
+  private resolve(id: string | null): DetailExport | null {
+    if (!id) {
+      return null;
+    }
+    if (id.startsWith('live:')) {
+      const section = this.sections().find(s => `live:${s.guid}` === id);
+      return section ? this.detailPayload()(section) : null;
+    }
+    return this.files().find(file => file.id === id)?.exported ?? null;
+  }
+
+  readonly diff = computed<DetailDiff | null>(() => {
+    const beforeId = this.beforeId();
+    const afterId = this.afterId();
+    if (!beforeId || !afterId || beforeId === afterId) {
+      return null;
+    }
+    const before = this.resolve(beforeId);
+    const after = this.resolve(afterId);
+    return before && after ? diffDetailExports(before, after) : null;
+  });
+
+  /** Levels worth a block: measured somewhere; buckets capped behind "n more". */
+  readonly levelVms = computed(() => {
+    const diff = this.diff();
+    if (!diff) {
+      return [];
+    }
+    const expanded = this.expandedLevels();
+    return diff.levels
+      .filter(level => level.measured.some(Boolean))
+      .map(level => {
+        const isOpen = expanded.has(level.key);
+        const cap = <T>(rows: T[]): T[] => (isOpen ? rows : rows.slice(0, BUCKET_SHOWN));
+        const total = level.added.length + level.removed.length + level.changed.length;
+        const shown = isOpen ? total : cap(level.added).length + cap(level.removed).length + cap(level.changed).length;
+        return {
+          key: level.key,
+          title: humanize(level.key),
+          unmeasuredSide: this.unmeasuredNote(level, diff),
+          added: cap(level.added),
+          removed: cap(level.removed),
+          changed: cap(level.changed),
+          unchanged: level.unchanged,
+          empty: total === 0,
+          more: total - shown,
+          isOpen,
+        };
+      });
+  });
+
+  /** Names the side a one-sided level was not measured on; null when both ran. */
+  private unmeasuredNote(level: LevelDiff, diff: DetailDiff): string | null {
+    if (level.measured[0] && level.measured[1]) {
+      return null;
+    }
+    const missing = level.measured[0] ? 1 : 0;
+    const side = diff.sides[missing];
+    return `not measured on ${side.name} (${side.collected_at.slice(0, 10)})`;
+  }
+
+  toggleLevel(key: string): void {
+    const next = new Set(this.expandedLevels());
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    this.expandedLevels.set(next);
+  }
+
+  changesText(changes: { field: string; before: string; after: string }[]): string {
+    return changes.map(change => `${change.field}: ${change.before} → ${change.after}`).join(' · ');
+  }
+}

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff.spec.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffDetailExports, parseImportedDetail } from './detail-diff';
+import { DetailExport } from './detail-export';
+import { DetailApp, DetailOrg, DetailSpace } from './detail-shape';
+
+const T = '2026-08-12T10:00:00.000Z';
+const T2 = '2026-08-12T11:00:00.000Z';
+
+const side = (over: Partial<DetailExport> = {}): DetailExport => ({
+  schema_version: 1,
+  mode: 'detail',
+  endpoint: { guid: 'cf-1', name: 'lab' },
+  collected_at: T,
+  coverage_note: 'note',
+  drains: { orgs: T, spaces: T, apps: T },
+  totals: {},
+  organizations: [],
+  orphans: {},
+  ...over,
+});
+
+const anOrg = (guid: string, name: string, over: Partial<DetailOrg> = {}): DetailOrg => ({
+  guid,
+  name,
+  status: 'active',
+  quota_guid: '',
+  ...over,
+});
+
+const aSpace = (guid: string, name: string, over: Partial<DetailSpace> = {}): DetailSpace => ({
+  guid,
+  name,
+  ...over,
+});
+
+const anApp = (guid: string, name: string, over: Partial<DetailApp> = {}): DetailApp => ({
+  guid,
+  name,
+  state: 'STARTED',
+  instances: 1,
+  routes: [],
+  ...over,
+});
+
+const level = (diff: ReturnType<typeof diffDetailExports>, key: string) => {
+  const found = diff.levels.find(l => l.key === key);
+  expect(found, `level ${key}`).toBeDefined();
+  return found as NonNullable<typeof found>;
+};
+
+describe('diffDetailExports', () => {
+  it('records both sides and their collection times', () => {
+    const diff = diffDetailExports(side(), side({ collected_at: T2 }));
+    expect(diff.sides).toEqual([
+      { name: 'lab', collected_at: T },
+      { name: 'lab', collected_at: T2 },
+    ]);
+  });
+
+  it('reports orgs added and removed by guid, with names', () => {
+    const before = side({ organizations: [anOrg('o1', 'kept'), anOrg('o2', 'zz-deltest-cascade')] });
+    const after = side({ organizations: [anOrg('o1', 'kept'), anOrg('o3', 'payments-prod')] });
+    const orgs = level(diffDetailExports(before, after), 'organizations');
+    expect(orgs.added).toEqual([{ guid: 'o3', name: 'payments-prod' }]);
+    expect(orgs.removed).toEqual([{ guid: 'o2', name: 'zz-deltest-cascade' }]);
+    expect(orgs.unchanged).toBe(1);
+  });
+
+  it('reports a rename and field changes on the same guid', () => {
+    const before = side({ organizations: [anOrg('o1', 'old-name', { status: 'active', quota_guid: 'q1' })] });
+    const after = side({ organizations: [anOrg('o1', 'new-name', { status: 'suspended', quota_guid: 'q2' })] });
+    const orgs = level(diffDetailExports(before, after), 'organizations');
+    expect(orgs.changed).toEqual([
+      {
+        guid: 'o1',
+        name: 'new-name',
+        changes: [
+          { field: 'name', before: 'old-name', after: 'new-name' },
+          { field: 'status', before: 'active', after: 'suspended' },
+          { field: 'quota', before: 'q1', after: 'q2' },
+        ],
+      },
+    ]);
+    expect(orgs.unchanged).toBe(0);
+  });
+
+  it('marks a level unmeasured when either side never ran its drain, and diffs nothing there', () => {
+    const before = side({
+      drains: { orgs: T, spaces: T, apps: null },
+      organizations: [anOrg('o1', 'org', { spaces: [aSpace('s1', 'space')] })],
+    });
+    const after = side({
+      drains: { orgs: T, spaces: null, apps: null },
+      organizations: [anOrg('o1', 'org')],
+    });
+    const diff = diffDetailExports(before, after);
+    const spaces = level(diff, 'spaces');
+    expect(spaces.measured).toEqual([true, false]);
+    expect(spaces.added).toEqual([]);
+    expect(spaces.removed).toEqual([]);
+    const apps = level(diff, 'apps');
+    expect(apps.measured).toEqual([false, false]);
+  });
+
+  it('carries the parent path on nested entries and reports moves as a parent change', () => {
+    const before = side({
+      organizations: [
+        anOrg('o1', 'org-a', { spaces: [aSpace('s1', 'dev', { apps: [anApp('a1', 'api')] })] }),
+        anOrg('o2', 'org-b', { spaces: [] }),
+      ],
+    });
+    const after = side({
+      organizations: [
+        anOrg('o1', 'org-a', { spaces: [] }),
+        anOrg('o2', 'org-b', { spaces: [aSpace('s1', 'dev', { apps: [anApp('a1', 'api')] })] }),
+      ],
+    });
+    const diff = diffDetailExports(before, after);
+    expect(level(diff, 'spaces').changed).toEqual([
+      { guid: 's1', name: 'dev', path: 'org-b', changes: [{ field: 'parent', before: 'org-a', after: 'org-b' }] },
+    ]);
+    // The app stayed in the same space — the move is the space's, not the app's.
+    expect(level(diff, 'apps').changed).toEqual([]);
+    expect(level(diff, 'apps').unchanged).toBe(1);
+  });
+
+  it('does not cascade a parent rename onto children that did not move', () => {
+    const tree = (orgName: string): DetailOrg[] => [
+      anOrg('o1', orgName, { spaces: [aSpace('s1', 'dev', { apps: [anApp('a1', 'api')] })] }),
+    ];
+    const diff = diffDetailExports(side({ organizations: tree('old-org') }), side({ organizations: tree('new-org') }));
+    expect(level(diff, 'organizations').changed).toHaveLength(1);
+    expect(level(diff, 'spaces').changed).toEqual([]);
+    expect(level(diff, 'spaces').unchanged).toBe(1);
+    expect(level(diff, 'apps').changed).toEqual([]);
+    expect(level(diff, 'apps').unchanged).toBe(1);
+  });
+
+  it('diffs app scalar fields and routes', () => {
+    const wrap = (app: DetailApp): DetailOrg[] => [
+      anOrg('o1', 'org', { spaces: [aSpace('s1', 'space', { apps: [app] })] }),
+    ];
+    const before = side({
+      organizations: wrap(anApp('a1', 'api', { state: 'STOPPED', instances: 1, memory_mb: 256, routes: ['api.old.io'] })),
+    });
+    const after = side({
+      organizations: wrap(anApp('a1', 'api', { state: 'STARTED', instances: 3, memory_mb: 512, routes: ['api.new.io'] })),
+    });
+    const apps = level(diffDetailExports(before, after), 'apps');
+    expect(apps.changed[0].changes).toEqual([
+      { field: 'state', before: 'STOPPED', after: 'STARTED' },
+      { field: 'instances', before: '1', after: '3' },
+      { field: 'memory', before: '256M', after: '512M' },
+      { field: 'routes', before: 'api.old.io', after: 'api.new.io' },
+    ]);
+  });
+
+  it('shows a field the side did not compose as a dash, not a change to nothing', () => {
+    const wrap = (app: DetailApp): DetailOrg[] => [
+      anOrg('o1', 'org', { spaces: [aSpace('s1', 'space', { apps: [app] })] }),
+    ];
+    const before = side({ organizations: wrap(anApp('a1', 'api', {})) });
+    const after = side({ organizations: wrap(anApp('a1', 'api', { memory_mb: 512 })) });
+    const apps = level(diffDetailExports(before, after), 'apps');
+    expect(apps.changed[0].changes).toEqual([{ field: 'memory', before: '—', after: '512M' }]);
+  });
+
+  it('diffs service instances and bindings only when the services drain ran on both sides', () => {
+    const withServices = (drained: boolean, instances: boolean): DetailExport =>
+      side({
+        drains: { orgs: T, spaces: T, apps: T, ...(drained && { services: T }) },
+        organizations: [
+          anOrg('o1', 'org', {
+            spaces: [
+              aSpace('s1', 'space', {
+                ...(drained && {
+                  service_instances: instances
+                    ? [{ guid: 'si1', name: 'db', type: 'managed', plan: 'small', offering: 'postgres' }]
+                    : [],
+                }),
+                ...(drained && {
+                  apps: [
+                    anApp('a1', 'api', {
+                      service_bindings: instances
+                        ? [{ guid: 'b1', type: 'app', service_instance: { guid: 'si1', name: 'db' } }]
+                        : [],
+                    }),
+                  ],
+                }),
+              }),
+            ],
+          }),
+        ],
+      });
+    const diff = diffDetailExports(withServices(true, false), withServices(true, true));
+    const instances = level(diff, 'service_instances');
+    expect(instances.measured).toEqual([true, true]);
+    expect(instances.added).toEqual([{ guid: 'si1', name: 'db', path: 'org / space' }]);
+    const bindings = level(diff, 'service_bindings');
+    expect(bindings.added).toEqual([{ guid: 'b1', name: 'db (app)', path: 'org / space / api' }]);
+
+    const undrained = diffDetailExports(withServices(false, false), withServices(true, true));
+    expect(level(undrained, 'service_instances').measured).toEqual([false, true]);
+    expect(level(undrained, 'service_instances').added).toEqual([]);
+  });
+
+  it('diffs role grants per scope and user', () => {
+    const before = side({
+      drains: { orgs: T, spaces: T, apps: null, roles: T },
+      organizations: [
+        anOrg('o1', 'org', {
+          roles: { alice: ['organization_manager'], bob: ['organization_user'] },
+          spaces: [aSpace('s1', 'space', { roles: { alice: ['space_developer'] } })],
+        }),
+      ],
+    });
+    const after = side({
+      drains: { orgs: T, spaces: T, apps: null, roles: T },
+      organizations: [
+        anOrg('o1', 'org', {
+          roles: {
+            alice: ['organization_manager', 'organization_user'],
+            bob: ['organization_user'],
+            carol: ['organization_user'],
+          },
+          spaces: [aSpace('s1', 'space')],
+        }),
+      ],
+    });
+    const roles = level(diffDetailExports(before, after), 'roles');
+    expect(roles.measured).toEqual([true, true]);
+    expect(roles.added).toEqual([{ guid: 'o1:carol', name: 'carol', path: 'org' }]);
+    expect(roles.removed).toEqual([{ guid: 's1:alice', name: 'alice', path: 'org / space' }]);
+    expect(roles.changed).toEqual([
+      {
+        guid: 'o1:alice',
+        name: 'alice',
+        path: 'org',
+        changes: [
+          { field: 'roles', before: 'organization_manager', after: 'organization_manager, organization_user' },
+        ],
+      },
+    ]);
+    expect(roles.unchanged).toBe(1);
+  });
+
+  it('marks roles unmeasured when the measure never ran', () => {
+    const roles = level(diffDetailExports(side(), side()), 'roles');
+    expect(roles.measured).toEqual([false, false]);
+  });
+
+  it('includes orphaned entries under an (orphaned) path', () => {
+    const before = side();
+    const after = side({ orphans: { spaces: [aSpace('s9', 'stray')] } });
+    const spaces = level(diffDetailExports(before, after), 'spaces');
+    expect(spaces.added).toEqual([{ guid: 's9', name: 'stray', path: '(orphaned)' }]);
+  });
+
+  it('warns when the sides come from different endpoints', () => {
+    const other = side({ endpoint: { guid: 'cf-2', name: 'aws' } });
+    const diff = diffDetailExports(side(), other);
+    expect(diff.warnings.some(w => w.includes('different endpoints'))).toBe(true);
+    expect(diffDetailExports(side(), side()).warnings).toEqual([]);
+  });
+
+  it('warns when a side carries a truncated dataset', () => {
+    const truncated = side({ drains: { orgs: T, spaces: T, apps: T, services: T }, truncated: ['service_instances'] });
+    const diff = diffDetailExports(truncated, side({ drains: { orgs: T, spaces: T, apps: T, services: T } }));
+    expect(diff.warnings.some(w => w.includes('service_instances') && w.includes('lab'))).toBe(true);
+  });
+
+  it('sorts every bucket by path then name', () => {
+    const before = side({ organizations: [] });
+    const after = side({
+      organizations: [anOrg('o2', 'zeta'), anOrg('o1', 'alpha')],
+    });
+    const orgs = level(diffDetailExports(before, after), 'organizations');
+    expect(orgs.added.map(entry => entry.name)).toEqual(['alpha', 'zeta']);
+  });
+});
+
+describe('parseImportedDetail', () => {
+  it('accepts a detail export and defaults optional blocks', () => {
+    const raw = JSON.stringify({ ...side(), orphans: undefined });
+    const { exported, error } = parseImportedDetail(raw);
+    expect(error).toBeUndefined();
+    expect(exported?.orphans).toEqual({});
+  });
+
+  it('rejects non-JSON, non-detail and unversioned files with reasons', () => {
+    expect(parseImportedDetail('nope').error).toBe('not valid JSON');
+    expect(parseImportedDetail('42').error).toBe('not a detail export');
+    expect(parseImportedDetail(JSON.stringify({ schema_version: 2, mode: 'detail' })).error).toContain(
+      'schema_version'
+    );
+    expect(parseImportedDetail(JSON.stringify({ ...side(), mode: 'anonymous' })).error).toContain(
+      'anonymous shape export'
+    );
+    expect(parseImportedDetail(JSON.stringify({ schema_version: 1, mode: 'detail' })).error).toBe(
+      'missing organizations'
+    );
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/detail-diff.ts
@@ -1,0 +1,303 @@
+/**
+ * Named diff of two detail exports (GH #5702, closes #5703's comparison leg):
+ * the find-act-verify exhibit as a pure function. Both sides are schema_version
+ * 1 detail files — a live section's payload or an imported export — matched by
+ * guid at every level, so a rename shows as a change and a delete as a removal.
+ *
+ * The honesty rules carry over from the exports themselves: a level whose
+ * drain never ran on either side is unmeasured there and diffs nothing —
+ * never-loaded ≠ empty — and page-capped datasets warn rather than letting
+ * truncation read as deletion.
+ */
+import { DetailExport } from './detail-export';
+import { DetailApp, DetailSpace, RoleGrants } from './detail-shape';
+
+export interface DiffEntry {
+  guid: string;
+  name: string;
+  /** Parent path ("org / space"); absent on top-level entries. */
+  path?: string;
+}
+
+export interface FieldChange {
+  field: string;
+  before: string;
+  after: string;
+}
+
+export interface ChangedEntry extends DiffEntry {
+  changes: FieldChange[];
+}
+
+export interface LevelDiff {
+  key: string;
+  /** Whether each side's drain ran; buckets are empty unless both did. */
+  measured: [boolean, boolean];
+  added: DiffEntry[];
+  removed: DiffEntry[];
+  changed: ChangedEntry[];
+  unchanged: number;
+}
+
+export interface DetailDiff {
+  sides: { name: string; collected_at: string }[];
+  levels: LevelDiff[];
+  warnings: string[];
+}
+
+/** A value the side did not compose renders as a dash, not as empty. */
+const DASH = '—';
+
+const mb = (value: number | undefined): string | undefined => (value === undefined ? undefined : `${value}M`);
+
+/** One flattened entity: identity plus its comparable fields, already stringified. */
+interface FlatEntity {
+  guid: string;
+  name: string;
+  path?: string;
+  fields: Record<string, string | undefined>;
+}
+
+type FlatLevel = Map<string, FlatEntity>;
+
+interface FlatSide {
+  organizations: FlatLevel;
+  spaces: FlatLevel;
+  apps: FlatLevel;
+  service_instances: FlatLevel;
+  service_bindings: FlatLevel;
+  roles: FlatLevel;
+}
+
+/** Comparable fields per level, in the order changes are reported. */
+const LEVEL_FIELDS: Record<keyof FlatSide, string[]> = {
+  organizations: ['name', 'status', 'quota'],
+  spaces: ['name', 'quota', 'parent'],
+  apps: ['name', 'state', 'instances', 'memory', 'disk', 'stack', 'routes', 'parent'],
+  service_instances: ['name', 'type', 'plan', 'offering', 'parent'],
+  service_bindings: ['type', 'instance', 'parent'],
+  roles: ['roles'],
+};
+
+const flatten = (exported: DetailExport): FlatSide => {
+  const side: FlatSide = {
+    organizations: new Map(),
+    spaces: new Map(),
+    apps: new Map(),
+    service_instances: new Map(),
+    service_bindings: new Map(),
+    roles: new Map(),
+  };
+
+  const addRoles = (scopeGuid: string, path: string, grants: RoleGrants | undefined): void => {
+    for (const [username, roles] of Object.entries(grants ?? {})) {
+      side.roles.set(`${scopeGuid}:${username}`, {
+        guid: `${scopeGuid}:${username}`,
+        name: username,
+        path,
+        fields: { roles: [...roles].sort().join(', ') },
+      });
+    }
+  };
+
+  // `parent` compares by guid so only a real move reports — an ancestor's
+  // rename must not cascade a phantom "parent" change onto every child.
+  const addApp = (app: DetailApp, path: string, parentGuid: string): void => {
+    side.apps.set(app.guid, {
+      guid: app.guid,
+      name: app.name,
+      path,
+      fields: {
+        name: app.name,
+        state: app.state,
+        instances: String(app.instances),
+        memory: mb(app.memory_mb),
+        disk: mb(app.disk_mb),
+        stack: app.stack,
+        routes: [...app.routes].sort().join(', '),
+        parent: parentGuid,
+      },
+    });
+    for (const binding of app.service_bindings ?? []) {
+      const instance = binding.service_instance.name ?? binding.service_instance.guid;
+      side.service_bindings.set(binding.guid, {
+        guid: binding.guid,
+        name: `${instance} (${binding.type})`,
+        path: `${path} / ${app.name}`,
+        fields: { type: binding.type, instance, parent: app.guid },
+      });
+    }
+  };
+
+  const addSpace = (space: DetailSpace, path: string, parentGuid: string): void => {
+    side.spaces.set(space.guid, {
+      guid: space.guid,
+      name: space.name,
+      path,
+      fields: { name: space.name, quota: space.quota_guid, parent: parentGuid },
+    });
+    const spacePath = `${path} / ${space.name}`;
+    for (const app of space.apps ?? []) {
+      addApp(app, spacePath, space.guid);
+    }
+    for (const instance of space.service_instances ?? []) {
+      side.service_instances.set(instance.guid, {
+        guid: instance.guid,
+        name: instance.name,
+        path: spacePath,
+        fields: {
+          name: instance.name,
+          type: instance.type,
+          plan: instance.plan,
+          offering: instance.offering,
+          parent: space.guid,
+        },
+      });
+    }
+    addRoles(space.guid, spacePath, space.roles);
+  };
+
+  for (const org of exported.organizations) {
+    side.organizations.set(org.guid, {
+      guid: org.guid,
+      name: org.name,
+      fields: { name: org.name, status: org.status, quota: org.quota_guid || undefined },
+    });
+    for (const space of org.spaces ?? []) {
+      addSpace(space, org.name, org.guid);
+    }
+    addRoles(org.guid, org.name, org.roles);
+  }
+  for (const space of exported.orphans.spaces ?? []) {
+    addSpace(space, '(orphaned)', '(orphaned)');
+  }
+  for (const app of exported.orphans.apps ?? []) {
+    addApp(app, '(orphaned)', '(orphaned)');
+  }
+  return side;
+};
+
+/** Which drain stamp gates each level; orgs are a precondition of the export itself. */
+const LEVEL_DRAINS: Record<keyof FlatSide, string> = {
+  organizations: 'orgs',
+  spaces: 'spaces',
+  apps: 'apps',
+  service_instances: 'services',
+  service_bindings: 'services',
+  roles: 'roles',
+};
+
+const entryOf = ({ guid, name, path }: FlatEntity): DiffEntry => ({ guid, name, ...(path && { path }) });
+
+const byPathThenName = (a: DiffEntry, b: DiffEntry): number =>
+  (a.path ?? '').localeCompare(b.path ?? '') || a.name.localeCompare(b.name);
+
+const diffLevel = (key: keyof FlatSide, before: FlatSide, after: FlatSide, measured: [boolean, boolean]): LevelDiff => {
+  if (!measured[0] || !measured[1]) {
+    return { key, measured, added: [], removed: [], changed: [], unchanged: 0 };
+  }
+  const added: DiffEntry[] = [];
+  const removed: DiffEntry[] = [];
+  const changed: ChangedEntry[] = [];
+  let unchanged = 0;
+  for (const [guid, entity] of after[key]) {
+    if (!before[key].has(guid)) {
+      added.push(entryOf(entity));
+    }
+  }
+  for (const [guid, entity] of before[key]) {
+    const now = after[key].get(guid);
+    if (!now) {
+      removed.push(entryOf(entity));
+      continue;
+    }
+    const changes: FieldChange[] = [];
+    for (const field of LEVEL_FIELDS[key]) {
+      const was = entity.fields[field];
+      const is = now.fields[field];
+      if (was !== is) {
+        // A parent move compares guids but reads as names.
+        changes.push(
+          field === 'parent'
+            ? { field, before: entity.path ?? DASH, after: now.path ?? DASH }
+            : { field, before: was ?? DASH, after: is ?? DASH }
+        );
+      }
+    }
+    if (changes.length) {
+      changed.push({ ...entryOf(now), changes });
+    } else {
+      unchanged++;
+    }
+  }
+  return {
+    key,
+    measured,
+    added: added.sort(byPathThenName),
+    removed: removed.sort(byPathThenName),
+    changed: changed.sort(byPathThenName),
+    unchanged,
+  };
+};
+
+export const diffDetailExports = (before: DetailExport, after: DetailExport): DetailDiff => {
+  const sides = [before, after];
+  const flat: [FlatSide, FlatSide] = [flatten(before), flatten(after)];
+  const warnings: string[] = [];
+  if (before.endpoint.guid !== after.endpoint.guid) {
+    warnings.push(
+      `Sides come from different endpoints (${before.endpoint.name} vs ${after.endpoint.name}) — ` +
+        'entities match by guid, so everything reads as added or removed.'
+    );
+  }
+  for (const exported of sides) {
+    for (const set of exported.truncated ?? []) {
+      warnings.push(
+        `${set} on ${exported.endpoint.name} (${exported.collected_at.slice(0, 10)}) is a page-capped prefix — ` +
+          'added/removed there may reflect truncation, not change.'
+      );
+    }
+  }
+  return {
+    sides: sides.map(exported => ({ name: exported.endpoint.name, collected_at: exported.collected_at })),
+    levels: (Object.keys(LEVEL_FIELDS) as (keyof FlatSide)[]).map(key =>
+      diffLevel(key, flat[0], flat[1], [
+        Boolean(sides[0].drains[LEVEL_DRAINS[key]]),
+        Boolean(sides[1].drains[LEVEL_DRAINS[key]]),
+      ])
+    ),
+    warnings,
+  };
+};
+
+/** Parse an imported detail-export file (the trust boundary for the file slot); never throws. */
+export const parseImportedDetail = (raw: string): { exported?: DetailExport; error?: string } => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { error: 'not valid JSON' };
+  }
+  const candidate = parsed as Partial<DetailExport> | null;
+  if (!candidate || typeof candidate !== 'object') {
+    return { error: 'not a detail export' };
+  }
+  if (candidate.schema_version !== 1) {
+    return { error: `unsupported schema_version (${String(candidate.schema_version)})` };
+  }
+  if (candidate.mode !== 'detail') {
+    return { error: 'an anonymous shape export — import it as a Compare side instead' };
+  }
+  if (!Array.isArray(candidate.organizations)) {
+    return { error: 'missing organizations' };
+  }
+  const exported = candidate as DetailExport;
+  return {
+    exported: {
+      ...exported,
+      drains: exported.drains ?? {},
+      orphans: exported.orphans ?? {},
+      endpoint: exported.endpoint ?? { guid: '', name: 'imported' },
+    },
+  };
+};

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.html
@@ -309,5 +309,7 @@
   <!-- Promotion verification: diff N shape snapshots (live or imported files) -->
   <app-info-card title="Compare shapes" id="shape-compare-anchor">
     <app-shape-compare-card #compare [sections]="sections()" />
+    <hr class="my-3 border-content-border">
+    <app-detail-diff-card [sections]="sections()" [detailPayload]="detailPayloadFn" />
   </app-info-card>
 </div>

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/foundation-shape-page.component.ts
@@ -19,6 +19,7 @@ import writeXlsxFile from 'write-excel-file/browser';
 
 import { EndpointDataRegistry } from '../../services/endpoint-data/endpoint-data.registry';
 import { EndpointDataService } from '../../services/endpoint-data/endpoint-data.service';
+import { DetailDiffCardComponent } from './detail-diff-card.component';
 import { buildDetailExport, DetailExport } from './detail-export';
 import { buildDetailWorkbook } from './detail-export-xlsx';
 import { computeSessionShape } from './session-shape';
@@ -63,7 +64,14 @@ export const ageLabel = (date: Date | null, now: Date): string => {
   selector: 'app-foundation-shape-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DecimalPipe, InfoCardComponent, ShapeCompareCardComponent, ShapeDistCardComponent, ShapeShareBarComponent],
+  imports: [
+    DecimalPipe,
+    DetailDiffCardComponent,
+    InfoCardComponent,
+    ShapeCompareCardComponent,
+    ShapeDistCardComponent,
+    ShapeShareBarComponent,
+  ],
   templateUrl: './foundation-shape-page.component.html',
 })
 export class FoundationShapePageComponent implements OnDestroy {
@@ -281,6 +289,9 @@ export class FoundationShapePageComponent implements OnDestroy {
   canExportDetail(section: ShapeSection): boolean {
     return section.drains.orgs.fetchedAt !== null;
   }
+
+  /** The named-diff card builds live sides on demand through the page's registry access. */
+  readonly detailPayloadFn = (section: ShapeSection): DetailExport | null => this.detailPayload(section);
 
   // <endpoint>-foundational-shape-<mode>-<date>: the name says which endpoint
   // the file came from and, unambiguously, whether it names resources.

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.spec.ts
@@ -171,6 +171,11 @@ describe('parseImportedExport', () => {
     expect(parseImportedExport('null').error).toBe('not a shape export');
   });
 
+  it('points a detail export at the named-diff selector instead of failing cryptically', () => {
+    const raw = JSON.stringify({ schema_version: 1, mode: 'detail', organizations: [], totals: {} });
+    expect(parseImportedExport(raw).error).toContain('Named diff');
+  });
+
   it('defaults missing top_share and composition so comparison never trips', () => {
     const raw = JSON.stringify({ schema_version: 1, collected_at: 'x', totals: { apps: 1 }, distributions: {} });
     const { exported } = parseImportedExport(raw);

--- a/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/foundation-shape/shape-compare.ts
@@ -164,6 +164,9 @@ export const parseImportedExport = (raw: string): { exported?: AgnosticExport; e
   if (candidate.schema_version !== 1) {
     return { error: `unsupported schema_version (${String(candidate.schema_version)})` };
   }
+  if ((candidate as { mode?: string }).mode === 'detail') {
+    return { error: 'a named detail export — import it in the Named diff selector instead' };
+  }
   if (typeof candidate.totals !== 'object' || typeof candidate.distributions !== 'object') {
     return { error: 'missing totals or distributions blocks' };
   }


### PR DESCRIPTION
Closes #5703. Third increment of the #5702 detail leg (the POC issue itself stays open).

The find-act-verify loop as a view: the Compare shapes card gains a named diff — pick two detail snapshots, live sections (CF admin only, the same gate as the detail export) or exported detail files, and see exactly which named orgs, spaces, apps, service instances, bindings and role grants appeared, vanished or changed between them, before → after.

Behaviour:

- Entities match by guid at every level, so a rename reads as a change and a delete as a removal.
- A parent move compares guids but reads as names, so an org rename does not cascade phantom "moved" rows onto its children (caught during live verification: one org rename flagged all 10 child spaces before this rule).
- A level whose drain never ran on a side reads as "not measured" there, never as deleted — never-loaded ≠ empty, same as the exports themselves.
- Page-capped datasets carry a truncation warning instead of letting the cap read as change; sides from different endpoints warn that everything will read as added/removed.
- Orphaned children stay visible under an `(orphaned)` path.
- Importing a detail file into the anonymous Compare slot (or an anonymous file into the named-diff selector) now points at the right slot instead of failing cryptically.

Verified live against a lab foundation (62 orgs / 604 spaces): live-vs-live shows all-unchanged with the endpoint warning; a mutated export diffed against live showed exactly the planted changes (org added/removed/renamed, app `state STOPPED → STARTED · instances 5 → 1`), light and dark themes both checked. 22 new unit/component tests; full gate green (3655 frontend specs, all backend packages).