### PR TITLE
Add the two missing dev-tooling fragments

### DIFF
--- a/changelog.d/0007-dev-server-binding.md
+++ b/changelog.d/0007-dev-server-binding.md
@@ -1,0 +1,5 @@
+[BugFixes]
+- The dev server binds all interfaces explicitly. Without a `--host`,
+  `ng serve` picks its own loopback binding and can come up IPv6-only,
+  which reads as connection refused to anything resolving localhost to
+  127.0.0.1.

--- a/changelog.d/0007-make-help-release-verbs.md
+++ b/changelog.d/0007-make-help-release-verbs.md
@@ -1,0 +1,6 @@
+[Maintainability]
+- `make help` now lists the three release-flow verbs it skipped:
+  `changelog` (dependency-bump audit), `preview` (render the notes as
+  the release page will show them) and `sweep` (remove consumed
+  fragments) — the notes-preview step was undiscoverable exactly when
+  it matters, right before a tag.


### PR DESCRIPTION
The dev-server binding fix (#5815) and the make help release verbs (#5816) merged without changelog fragments; the release-notes audit expects every merged change represented. Fragments only — no code. Completes the v5.2.0 notes.