### PR TITLE
perf(editor): curate the monaco subset, prefetch when idle

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -144,6 +144,13 @@
               "outputHashing": "all",
               "sourceMap": false,
               "extractLicenses": true,
+              "budgets": [
+                {
+                  "type": "anyScript",
+                  "maximumWarning": "2.5mb",
+                  "maximumError": "3mb"
+                }
+              ],
               "fileReplacements": [
                 {
                   "replace": "src/frontend/packages/core/src/environments/environment.ts",

--- a/changelog.d/0001-monaco-subset.md
+++ b/changelog.d/0001-monaco-subset.md
@@ -1,0 +1,9 @@
+[Maintainability]
+- The Monaco editor now ships as a curated feature-and-language subset
+  (core editor, json language service, yaml tokenizer) instead of the
+  full build with ~80 bundled languages: the editor-open payload drops
+  from 868KB to 785KB gzipped and the built frontend loses 800KB of
+  never-used language modules. The subset also prefetches once the
+  browser goes idle after bootstrap, so the first editor surface opens
+  without paying the chunk fetch at click time. A bundle budget now
+  fails the build if the chunk regresses toward the full build.

--- a/src/frontend/packages/core/src/main.ts
+++ b/src/frontend/packages/core/src/main.ts
@@ -16,5 +16,18 @@ if (environment.production) {
 performance.setResourceTimingBufferSize?.(500);
 
 // Monaco is loaded on demand by MonacoEditorComponent (all consumers are
-// post-login) — keeping its ~1MB payload off the bootstrap critical path.
-platformBrowserDynamic().bootstrapModule(AppModule);
+// post-login) — keeping its payload off the bootstrap critical path. Once
+// the app is up and the browser is idle, prefetch it so the first editor
+// surface opens without paying the chunk fetch at click time. Sessions
+// that never open an editor spend the bandwidth idly; sessions that do
+// get an instant editor — the trade is deliberate.
+platformBrowserDynamic().bootstrapModule(AppModule).then(() => {
+  const prefetch = () => import('./monaco-loader').then((m) => m.loadMonacoEditor()).catch(() => {
+    // Best-effort: a failed prefetch just means the editor loads on demand.
+  });
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(prefetch, { timeout: 30000 });
+  } else {
+    setTimeout(prefetch, 5000);
+  }
+});

--- a/src/frontend/packages/core/src/monaco-editor-esm.d.ts
+++ b/src/frontend/packages/core/src/monaco-editor-esm.d.ts
@@ -1,7 +1,10 @@
 // monaco-editor publishes only a `module` entry (no main/exports), so the
-// loader imports the concrete ESM file — which ships no declaration of its
-// own (only editor.api.d.ts). Its API surface is exactly the package's
-// public types.
-declare module 'monaco-editor/esm/vs/editor/editor.main.js' {
+// loader imports concrete ESM files — which ship no declarations of their
+// own (only editor.api.d.ts). editor.api's surface is exactly the package's
+// public types; every other imported file is a side-effect-only feature or
+// language contribution, covered by the wildcard below (the specific
+// declaration wins where both match).
+declare module 'monaco-editor/esm/vs/editor/editor.api.js' {
   export * from 'monaco-editor';
 }
+declare module 'monaco-editor/esm/*';

--- a/src/frontend/packages/core/src/monaco-features.ts
+++ b/src/frontend/packages/core/src/monaco-features.ts
@@ -1,0 +1,73 @@
+/**
+ * Curated Monaco feature subset.
+ *
+ * This module exists to be the single dynamic-import target of
+ * monaco-loader.ts: every feature is a *static* import here so the whole
+ * subset lands in one lazy chunk. (Importing each feature dynamically from
+ * the loader was measured to split the editor across ~170 micro-chunks,
+ * which cost more gzip and requests than the full build it replaced.)
+ *
+ * The subset replaces monaco's editor.main.js: Stratos edits only json
+ * (its language service, below), yaml (tokenizer below; completion/
+ * validation/hover come from monaco-yaml) and plaintext (built in), and
+ * its three editor surfaces need nowhere near every editor contribution.
+ * Each import registers one feature; anything a kept feature needs arrives
+ * transitively, so leaving one out only ever prunes, never breaks a kept
+ * one. Left out relative to editor.all.js/edcore.main.js: inline
+ * completions/edits, semantic tokens, rename, color picker, sticky scroll,
+ * parameter hints, inlay hints, linked editing, drag-and-drop & rich
+ * paste, the ~80 other bundled languages, the css/html/typescript
+ * services, and assorted micro-features with no provider or surface in
+ * Stratos. (The diff editor widget is not imported here either, but
+ * editor.api.js pulls it in via createDiffEditor — dropping it needs an
+ * upstream change.) Re-diff this list against monaco's editor.all.js on
+ * every monaco upgrade.
+ */
+import 'monaco-editor/esm/vs/editor/browser/coreCommands.js';
+import 'monaco-editor/esm/vs/editor/browser/widget/codeEditor/codeEditorWidget.js';
+import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/browser/bracketMatching.js';
+import 'monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js';
+import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionContributions.js';
+import 'monaco-editor/esm/vs/editor/contrib/codelens/browser/codelensController.js';
+import 'monaco-editor/esm/vs/editor/contrib/comment/browser/comment.js';
+import 'monaco-editor/esm/vs/editor/contrib/contextmenu/browser/contextmenu.js';
+import 'monaco-editor/esm/vs/editor/contrib/cursorUndo/browser/cursorUndo.js';
+import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController.js';
+import 'monaco-editor/esm/vs/editor/contrib/folding/browser/folding.js';
+import 'monaco-editor/esm/vs/editor/contrib/format/browser/formatActions.js';
+import 'monaco-editor/esm/vs/editor/contrib/documentSymbols/browser/documentSymbols.js';
+import 'monaco-editor/esm/vs/editor/contrib/gotoSymbol/browser/goToCommands.js';
+import 'monaco-editor/esm/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.js';
+import 'monaco-editor/esm/vs/editor/contrib/gotoError/browser/gotoError.js';
+import 'monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution.js';
+import 'monaco-editor/esm/vs/editor/contrib/indentation/browser/indentation.js';
+import 'monaco-editor/esm/vs/editor/contrib/lineSelection/browser/lineSelection.js';
+import 'monaco-editor/esm/vs/editor/contrib/linesOperations/browser/linesOperations.js';
+import 'monaco-editor/esm/vs/editor/contrib/links/browser/links.js';
+import 'monaco-editor/esm/vs/editor/contrib/longLinesHelper/browser/longLinesHelper.js';
+import 'monaco-editor/esm/vs/editor/contrib/multicursor/browser/multicursor.js';
+import 'monaco-editor/esm/vs/editor/contrib/readOnlyMessage/browser/contribution.js';
+import 'monaco-editor/esm/vs/editor/contrib/smartSelect/browser/smartSelect.js';
+import 'monaco-editor/esm/vs/editor/contrib/snippet/browser/snippetController2.js';
+import 'monaco-editor/esm/vs/editor/contrib/suggest/browser/suggestController.js';
+import 'monaco-editor/esm/vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode.js';
+import 'monaco-editor/esm/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.js';
+import 'monaco-editor/esm/vs/editor/contrib/unusualLineTerminators/browser/unusualLineTerminators.js';
+import 'monaco-editor/esm/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.js';
+import 'monaco-editor/esm/vs/editor/contrib/wordOperations/browser/wordOperations.js';
+// Standalone-editor extras (edcore.main): quick access (F1 palette,
+// Ctrl+G, symbol search) and accessibility helpers.
+import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneHelpQuickAccess.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/toggleHighContrast/toggleHighContrast.js';
+// Translated strings and the codicon font styles (suggest/find icons).
+import 'monaco-editor/esm/vs/editor/common/standaloneStrings.js';
+import 'monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles.js';
+// Languages: the json language service and the yaml tokenizer.
+import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
+
+export * from 'monaco-editor/esm/vs/editor/editor.api.js';

--- a/src/frontend/packages/core/src/monaco-loader.ts
+++ b/src/frontend/packages/core/src/monaco-loader.ts
@@ -6,15 +6,18 @@
  * bundled by the builder from `new Worker(new URL(...))` references —
  * replacing the AMD loader and the copied vs/ asset tree (#5561).
  *
- * Consumers keep using the `monaco` global: the legacy surface predates the
- * ESM import and every call site reads `window.monaco` after awaiting
- * loadMonacoEditor().
+ * loadMonacoEditor() resolves to the monaco API instance and app code uses
+ * that. `window.monaco` is still published as a legacy surface: the e2e
+ * smoke test reads it and the unit-test mocks pre-set it to short-circuit
+ * the import path.
  */
 
 import type { languages } from 'monaco-editor';
 import type { MonacoYaml, MonacoYamlOptions } from 'monaco-yaml';
 
-let monacoLoad: Promise<void> | null = null;
+type MonacoApi = typeof import('monaco-editor');
+
+let monacoLoad: Promise<MonacoApi> | null = null;
 let monacoYaml: MonacoYaml | null = null;
 
 /**
@@ -57,7 +60,7 @@ export function installWorkerURLPolicy(): void {
   });
 }
 
-export function loadMonacoEditor(): Promise<void> {
+export function loadMonacoEditor(): Promise<MonacoApi> {
   if (!monacoLoad) {
     monacoLoad = doLoadMonacoEditor();
     // Allow a retry after a failed load (e.g. transient network error)
@@ -86,15 +89,15 @@ export async function configureYaml(options: MonacoYamlOptions): Promise<void> {
  * straight to `jsonDefaults` — process-global, last caller wins.
  */
 export async function configureJsonDiagnostics(options: languages.json.DiagnosticsOptions): Promise<void> {
-  await loadMonacoEditor();
+  const monaco = await loadMonacoEditor();
   // Optional-chained: a pre-set window.monaco (the unit-test mock) carries no
   // language services — json configuration is a no-op there, like yaml above.
-  (window as any).monaco?.languages?.json?.jsonDefaults?.setDiagnosticsOptions(options);
+  (monaco as any)?.languages?.json?.jsonDefaults?.setDiagnosticsOptions(options);
 }
 
-async function doLoadMonacoEditor(): Promise<void> {
+async function doLoadMonacoEditor(): Promise<MonacoApi> {
   if ((window as any).monaco) {
-    return;
+    return (window as any).monaco;
   }
 
   // The builder rewrites each relative `new Worker(new URL(...))` into a
@@ -119,18 +122,20 @@ async function doLoadMonacoEditor(): Promise<void> {
     },
   };
 
-  // Explicit file specifier: monaco-editor publishes only a `module` field
-  // (no main/exports), which vitest's vite resolver rejects as a bare
-  // 'monaco-editor' import while esbuild accepts it — the concrete path
-  // resolves identically in both (typed by monaco-editor-esm.d.ts).
+  // monaco-features re-exports editor.api after statically importing the
+  // curated feature/language subset (see its header for what is in and out,
+  // and why it must be one dynamic-import target rather than per-feature
+  // dynamic imports). monaco-yaml rides the same await so a failure of
+  // either leaves the loader retryable as one unit.
   const [monaco, { configureMonacoYaml }] = await Promise.all([
-    import('monaco-editor/esm/vs/editor/editor.main.js'),
+    import('./monaco-features'),
     import('monaco-yaml'),
   ]);
 
-  // Baseline YAML support (highlighting, indentation-aware completion);
+  // Baseline YAML support (indentation-aware completion, hover);
   // schema-driven validation is layered on per-editor via configureYaml().
   monacoYaml = configureMonacoYaml(monaco, { hover: true, completion: true, validate: true });
 
   (window as any).monaco = monaco;
+  return monaco;
 }

--- a/src/frontend/packages/core/src/shared/components/monaco-editor/README.md
+++ b/src/frontend/packages/core/src/shared/components/monaco-editor/README.md
@@ -6,7 +6,7 @@ A standalone Angular component that wraps Monaco Editor behind an ngx-monaco-edi
 
 - ✅ Standalone component (no module required)
 - ✅ Full ngModel two-way binding support via ControlValueAccessor
-- ✅ TypeScript type safety with @types/monaco-editor
+- ✅ TypeScript type safety (typed by the monaco-editor package itself)
 - ✅ Automatic layout handling with ResizeObserver
 - ✅ Automatic app-theme synchronization (opt out by pinning `options.theme`)
 - ✅ YAML language support (via monaco-yaml)
@@ -36,17 +36,17 @@ import { MonacoEditorComponent, MonacoEditorOptions, MonacoEditorModel } from '@
   `
 })
 export class ExampleComponent {
-  code = 'console.log("Hello World");';
+  code = '{ "hello": "world" }';
 
   editorOptions: MonacoEditorOptions = {
     theme: 'vs-dark',
-    language: 'javascript',
+    language: 'json',
     automaticLayout: true,
     minimap: { enabled: true }
   };
 
   model: MonacoEditorModel = {
-    language: 'javascript'
+    language: 'json'
   };
 
   onEditorInit(editor: MonacoEditorComponent) {
@@ -60,6 +60,7 @@ export class ExampleComponent {
 ```typescript
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { configureYaml } from '../../../monaco-loader';
 import { MonacoEditorComponent, MonacoEditorOptions, MonacoEditorModel } from '@stratos/core';
 
 @Component({
@@ -268,13 +269,17 @@ this.editor.layout();
 
 ## Language Support
 
-### Built-in Languages
-Monaco includes built-in support for:
-- JavaScript/TypeScript
-- HTML/CSS
-- JSON
-- Markdown
-- And many more...
+### Shipped Languages
+The lazy chunk is a tree-shaken subset (`edcore.main` plus explicit
+contributions in `monaco-loader.ts`) carrying only the languages Stratos
+edits:
+- JSON (full language service: validation, completion, schemas)
+- YAML (tokenizer from monaco-editor; everything else from monaco-yaml)
+- Plaintext (built in)
+
+Any other `language` id falls back to plaintext rendering. To ship another
+language, add its contribution import to the loader (and a worker wrapper
+in `monaco-workers/` if it has a language service).
 
 ### YAML Support
 YAML support is provided via `monaco-yaml`, registered once by the ESM

--- a/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
+++ b/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
@@ -15,8 +15,6 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { StratosBrandingService } from '../../../../../theme/stratos-branding.service';
 import { loadMonacoEditor } from '../../../monaco-loader';
 
-declare const monaco: typeof import('monaco-editor');
-
 export interface MonacoEditorModel {
   language?: string;
   uri?: string;
@@ -61,6 +59,7 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
 
   private branding = inject(StratosBrandingService);
   private editor: import('monaco-editor').editor.IStandaloneCodeEditor | undefined;
+  private monaco: typeof import('monaco-editor') | undefined;
 
   constructor() {
     // Monaco's theme is process-global (monaco.editor.setTheme), so one
@@ -68,10 +67,10 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
     // Callers that pin options.theme opt out of the sync.
     effect(() => {
       const dark = this.branding.isDarkMode();
-      if (!this.editor || this.options.theme || typeof monaco === 'undefined') {
+      if (!this.editor || this.options.theme || !this.monaco) {
         return;
       }
-      monaco.editor.setTheme(dark ? 'vs-dark' : 'vs');
+      this.monaco.editor.setTheme(dark ? 'vs-dark' : 'vs');
     });
   }
   private value = '';
@@ -84,7 +83,7 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
   async ngAfterViewInit(): Promise<void> {
     try {
       // Monaco is loaded on demand (not at bootstrap); idempotent across editors
-      await loadMonacoEditor();
+      this.monaco = await loadMonacoEditor();
     } catch (error) {
       console.error('Failed to load Monaco Editor:', error);
       return;
@@ -101,8 +100,9 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
   }
 
   private initMonaco(): void {
-    if (typeof monaco === 'undefined') {
-      console.error('Monaco editor is not loaded. Ensure monaco-editor is loaded globally.');
+    const monaco = this.monaco;
+    if (!monaco) {
+      console.error('Monaco editor is not loaded. loadMonacoEditor() resolved without an instance.');
       return;
     }
 
@@ -238,12 +238,9 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
   }
 
   public setLanguage(language: string): void {
-    if (typeof monaco === 'undefined') {
-      return;
-    }
     const model = this.editor?.getModel();
-    if (model) {
-      monaco.editor.setModelLanguage(model, language);
+    if (this.monaco && model) {
+      this.monaco.editor.setModelLanguage(model, language);
     }
   }
 }


### PR DESCRIPTION
Reduces the Monaco editor footprint and its first-open latency.

**What changed**

- `monaco-loader.ts` no longer imports `editor.main.js` (the full build: every editor contribution plus ~80 bundled languages and the css/html/typescript language services). It dynamic-imports a new `monaco-features.ts`, which statically assembles a curated subset: the editor core, the features our three editor surfaces use (find, suggest, hover, folding, format, code actions, quick access, accessibility helpers, …), the json language service, and the yaml tokenizer (everything else yaml comes from monaco-yaml).
- The subset must stay a single dynamic-import target: importing each feature dynamically from the loader was measured to shatter the editor into ~170 micro-chunks that cost *more* gzip (871KB vs 868KB) and far more requests than the full build it replaced. One target keeps it to one well-compressed chunk.
- The loader now resolves the monaco API instance and the wrapper component consumes that instead of the `monaco` global. `window.monaco` is still published — the e2e smoke test and the unit-test mocks are its remaining consumers.
- `main.ts` prefetches the editor via `requestIdleCallback` once bootstrap completes, so the first editor surface opens without paying the chunk fetch at click time. Sessions that never open an editor spend that bandwidth idly — deliberate trade, noted in the comment.
- A production `anyScript` budget (warn 2.5MB / error 3MB) guards the chunk: the curated chunk is 2.31MB; a regression to the full build would fail the build. The budget was verified to actually fail (tightened to 2MB → build error naming the chunk).

**Measured** (transitive chunk closure loaded on first editor open, production build)

| | before (editor.main) | after |
|---|---|---|
| editor-open payload | 3.38MB raw / 868KB gz / 4 chunks | 3.07MB raw / **785KB gz** / 3 chunks |
| total dist JS | 9.88MB / 151 files | 9.08MB / 68 files |

The diff editor widget is still carried because `editor.api.js` pulls it in via `createDiffEditor`; dropping it needs an upstream change.

**Verification**: monaco/loader/csp specs 14/14; full core + cloud-foundry + kubernetes vitest projects 3423 passed / 2 skipped; production build green with the budget in place.