### PR TITLE
chore(deps): bump monaco-editor to 0.56 on the new layout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "madge": "^8.0.0",
         "mappy-breakpoints": "0.2.4",
         "marked": "16.1.2",
-        "monaco-editor": "^0.52.2",
+        "monaco-editor": "^0.56.0",
         "monaco-yaml": "^5.5.1",
         "ng2-charts": "^10.0.0",
         "normalizr": "3.6.2",
@@ -122,6 +122,9 @@
         "@types/node": "^24.2.1",
       },
     },
+  },
+  "patchedDependencies": {
+    "monaco-worker-manager@2.0.1": "patches/monaco-worker-manager@2.0.1.patch",
   },
   "overrides": {
     "@babel/core": "7.29.7",
@@ -988,6 +991,8 @@
 
     "@types/stacktrace-js": ["@types/stacktrace-js@0.0.33", "", {}, "sha512-aqJ6QM9QThNL4dHBhwl1f9B0oDqiREkYLn9RldghUKsGeFWWGlCsqsRWxbh+hDvvmptMFqc4aIfFIGz9BBu8Qg=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/webpack": ["@types/webpack@5.28.5", "", { "dependencies": { "@types/node": "*", "tapable": "^2.2.0", "webpack": "^5" } }, "sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
@@ -1423,6 +1428,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.8", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -2030,7 +2037,7 @@
 
     "module-lookup-amd": ["module-lookup-amd@9.1.1", "", { "dependencies": { "commander": "^12.1.0", "requirejs": "^2.3.8", "requirejs-config-file": "^4.0.0" }, "bin": { "lookup-amd": "bin/cli.js" } }, "sha512-JzXhQvud8K3yT9l24XTDMXMQ4/LD9a9oXBcbLP0ubdvBpVrGFsybm5+2PDIl0negUYP1l88fCgjQzoMMg247+Q=="],
 
-    "monaco-editor": ["monaco-editor@0.52.2", "", {}, "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="],
+    "monaco-editor": ["monaco-editor@0.56.0", "", { "dependencies": { "dompurify": "3.4.8", "marked": "14.0.0" } }, "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg=="],
 
     "monaco-languageserver-types": ["monaco-languageserver-types@0.4.1", "", { "dependencies": { "monaco-types": "^0.1.0", "vscode-languageserver-protocol": "^3.0.0", "vscode-uri": "^3.0.0" } }, "sha512-uLiYM6K6jPqAa1ni9lRBoj8ZJAErOcegBrfEpurIUUO8cBhlhrGYjWbjhl4OPcxUNoj1JvqSETjwCTyhGgwymQ=="],
 
@@ -3037,6 +3044,8 @@
     "mini-css-extract-plugin/tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "module-lookup-amd/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
 
     "ng-packagr/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 

--- a/changelog.d/0002-monaco-0-56.md
+++ b/changelog.d/0002-monaco-0-56.md
@@ -1,0 +1,7 @@
+[Chores]
+- monaco-editor updated 0.52.2 to 0.56.0 (supersedes the dependabot
+  bump): the new exports map breaks every legacy deep-import path, so
+  the curated feature subset now uses the 0.53+ feature registry, the
+  json/yaml language registers, and the new worker entry points. The
+  one incompatible dependency import (monaco-worker-manager, used by
+  monaco-yaml's worker) is fixed with a one-line dependency patch.

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "madge": "^8.0.0",
     "mappy-breakpoints": "0.2.4",
     "marked": "16.1.2",
-    "monaco-editor": "^0.52.2",
+    "monaco-editor": "^0.56.0",
     "monaco-yaml": "^5.5.1",
     "ng2-charts": "^10.0.0",
     "normalizr": "3.6.2",
@@ -226,5 +226,8 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10"
+  },
+  "patchedDependencies": {
+    "monaco-worker-manager@2.0.1": "patches/monaco-worker-manager@2.0.1.patch"
   }
 }

--- a/patches/monaco-worker-manager@2.0.1.patch
+++ b/patches/monaco-worker-manager@2.0.1.patch
@@ -1,0 +1,10 @@
+diff --git a/worker.js b/worker.js
+index 8fe26e59cc2ddf7342c5d96b066a3a13a4b4a284..ff5045bbb18a29b1baf0027a62346088386acaf7 100644
+--- a/worker.js
++++ b/worker.js
+@@ -1,4 +1,4 @@
+-import { initialize as initializeWorker } from 'monaco-editor/esm/vs/editor/editor.worker.js';
++import { initialize as initializeWorker } from 'monaco-editor/internal/common/initialize.js';
+ /**
+  * Create a web worker proxy.
+  *

--- a/src/frontend/packages/core/src/monaco-editor-esm.d.ts
+++ b/src/frontend/packages/core/src/monaco-editor-esm.d.ts
@@ -1,10 +1,7 @@
-// monaco-editor publishes only a `module` entry (no main/exports), so the
-// loader imports concrete ESM files — which ship no declarations of their
-// own (only editor.api.d.ts). editor.api's surface is exactly the package's
-// public types; every other imported file is a side-effect-only feature or
-// language contribution, covered by the wildcard below (the specific
-// declaration wins where both match).
-declare module 'monaco-editor/esm/vs/editor/editor.api.js' {
-  export * from 'monaco-editor';
-}
-declare module 'monaco-editor/esm/*';
+// monaco-editor 0.53+ resolves subpaths through its exports map and ships
+// per-file declarations for its public entry points (editor.js, the
+// features/*/register.js modules, the language registers). Some internal
+// files a feature list reaches for (e.g. editor/browser/coreCommands.js)
+// have no declaration of their own — this wildcard types those side-effect
+// imports; any specifier with a real .d.ts wins over it.
+declare module 'monaco-editor/*';

--- a/src/frontend/packages/core/src/monaco-features.ts
+++ b/src/frontend/packages/core/src/monaco-features.ts
@@ -7,67 +7,65 @@
  * the loader was measured to split the editor across ~170 micro-chunks,
  * which cost more gzip and requests than the full build it replaced.)
  *
- * The subset replaces monaco's editor.main.js: Stratos edits only json
- * (its language service, below), yaml (tokenizer below; completion/
- * validation/hover come from monaco-yaml) and plaintext (built in), and
- * its three editor surfaces need nowhere near every editor contribution.
- * Each import registers one feature; anything a kept feature needs arrives
+ * The subset replaces monaco's full build: Stratos edits only json (its
+ * language service, below), yaml (tokenizer below; completion/validation/
+ * hover come from monaco-yaml) and plaintext (built in), and its three
+ * editor surfaces need nowhere near every editor feature. Each import
+ * registers one feature; anything a kept feature needs arrives
  * transitively, so leaving one out only ever prunes, never breaks a kept
- * one. Left out relative to editor.all.js/edcore.main.js: inline
- * completions/edits, semantic tokens, rename, color picker, sticky scroll,
+ * one. Left out relative to monaco's features/register.all.js: inline
+ * completions, semantic tokens, rename, color picker, sticky scroll,
  * parameter hints, inlay hints, linked editing, drag-and-drop & rich
  * paste, the ~80 other bundled languages, the css/html/typescript
  * services, and assorted micro-features with no provider or surface in
  * Stratos. (The diff editor widget is not imported here either, but
- * editor.api.js pulls it in via createDiffEditor — dropping it needs an
- * upstream change.) Re-diff this list against monaco's editor.all.js on
- * every monaco upgrade.
+ * editor.js pulls it in via createDiffEditor — dropping it needs an
+ * upstream change.) Re-diff this list against features/register.all.js
+ * on every monaco upgrade.
  */
-import 'monaco-editor/esm/vs/editor/browser/coreCommands.js';
-import 'monaco-editor/esm/vs/editor/browser/widget/codeEditor/codeEditorWidget.js';
-import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/browser/bracketMatching.js';
-import 'monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard.js';
-import 'monaco-editor/esm/vs/editor/contrib/codeAction/browser/codeActionContributions.js';
-import 'monaco-editor/esm/vs/editor/contrib/codelens/browser/codelensController.js';
-import 'monaco-editor/esm/vs/editor/contrib/comment/browser/comment.js';
-import 'monaco-editor/esm/vs/editor/contrib/contextmenu/browser/contextmenu.js';
-import 'monaco-editor/esm/vs/editor/contrib/cursorUndo/browser/cursorUndo.js';
-import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController.js';
-import 'monaco-editor/esm/vs/editor/contrib/folding/browser/folding.js';
-import 'monaco-editor/esm/vs/editor/contrib/format/browser/formatActions.js';
-import 'monaco-editor/esm/vs/editor/contrib/documentSymbols/browser/documentSymbols.js';
-import 'monaco-editor/esm/vs/editor/contrib/gotoSymbol/browser/goToCommands.js';
-import 'monaco-editor/esm/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.js';
-import 'monaco-editor/esm/vs/editor/contrib/gotoError/browser/gotoError.js';
-import 'monaco-editor/esm/vs/editor/contrib/hover/browser/hoverContribution.js';
-import 'monaco-editor/esm/vs/editor/contrib/indentation/browser/indentation.js';
-import 'monaco-editor/esm/vs/editor/contrib/lineSelection/browser/lineSelection.js';
-import 'monaco-editor/esm/vs/editor/contrib/linesOperations/browser/linesOperations.js';
-import 'monaco-editor/esm/vs/editor/contrib/links/browser/links.js';
-import 'monaco-editor/esm/vs/editor/contrib/longLinesHelper/browser/longLinesHelper.js';
-import 'monaco-editor/esm/vs/editor/contrib/multicursor/browser/multicursor.js';
-import 'monaco-editor/esm/vs/editor/contrib/readOnlyMessage/browser/contribution.js';
-import 'monaco-editor/esm/vs/editor/contrib/smartSelect/browser/smartSelect.js';
-import 'monaco-editor/esm/vs/editor/contrib/snippet/browser/snippetController2.js';
-import 'monaco-editor/esm/vs/editor/contrib/suggest/browser/suggestController.js';
-import 'monaco-editor/esm/vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode.js';
-import 'monaco-editor/esm/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.js';
-import 'monaco-editor/esm/vs/editor/contrib/unusualLineTerminators/browser/unusualLineTerminators.js';
-import 'monaco-editor/esm/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.js';
-import 'monaco-editor/esm/vs/editor/contrib/wordOperations/browser/wordOperations.js';
-// Standalone-editor extras (edcore.main): quick access (F1 palette,
-// Ctrl+G, symbol search) and accessibility helpers.
-import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneHelpQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.js';
-import 'monaco-editor/esm/vs/editor/standalone/browser/toggleHighContrast/toggleHighContrast.js';
-// Translated strings and the codicon font styles (suggest/find icons).
-import 'monaco-editor/esm/vs/editor/common/standaloneStrings.js';
-import 'monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles.js';
+import 'monaco-editor/editor/browser/coreCommands.js';
+import 'monaco-editor/features/codeEditor/register.js';
+import 'monaco-editor/features/bracketMatching/register.js';
+import 'monaco-editor/features/clipboard/register.js';
+import 'monaco-editor/features/codeAction/register.js';
+import 'monaco-editor/features/codelens/register.js';
+import 'monaco-editor/features/comment/register.js';
+import 'monaco-editor/features/contextmenu/register.js';
+import 'monaco-editor/features/cursorUndo/register.js';
+import 'monaco-editor/features/find/register.js';
+import 'monaco-editor/features/folding/register.js';
+import 'monaco-editor/features/format/register.js';
+import 'monaco-editor/features/documentSymbols/register.js';
+import 'monaco-editor/features/gotoSymbol/register.js';
+import 'monaco-editor/features/gotoError/register.js';
+import 'monaco-editor/features/hover/register.js';
+import 'monaco-editor/features/indentation/register.js';
+import 'monaco-editor/features/lineSelection/register.js';
+import 'monaco-editor/features/linesOperations/register.js';
+import 'monaco-editor/features/links/register.js';
+import 'monaco-editor/features/longLinesHelper/register.js';
+import 'monaco-editor/features/multicursor/register.js';
+import 'monaco-editor/features/readOnlyMessage/register.js';
+import 'monaco-editor/features/smartSelect/register.js';
+import 'monaco-editor/features/snippet/register.js';
+import 'monaco-editor/features/suggest/register.js';
+import 'monaco-editor/features/toggleTabFocusMode/register.js';
+import 'monaco-editor/features/unicodeHighlighter/register.js';
+import 'monaco-editor/features/unusualLineTerminators/register.js';
+import 'monaco-editor/features/wordHighlighter/register.js';
+import 'monaco-editor/features/wordOperations/register.js';
+// Standalone-editor extras: quick access (F1 palette, Ctrl+G, symbol
+// search) and accessibility helpers.
+import 'monaco-editor/features/iPadShowKeyboard/register.js';
+import 'monaco-editor/features/quickHelp/register.js';
+import 'monaco-editor/features/gotoLine/register.js';
+import 'monaco-editor/features/quickOutline/register.js';
+import 'monaco-editor/features/quickCommand/register.js';
+import 'monaco-editor/features/toggleHighContrast/register.js';
+// The codicon icon styles (suggest/find widget icons).
+import 'monaco-editor/features/codicon/register.js';
 // Languages: the json language service and the yaml tokenizer.
-import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
-import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js';
+import 'monaco-editor/languages/definitions/yaml/register.js';
+export { jsonDefaults } from 'monaco-editor/languages/features/json/register.js';
 
-export * from 'monaco-editor/esm/vs/editor/editor.api.js';
+export * from 'monaco-editor/editor.js';

--- a/src/frontend/packages/core/src/monaco-loader.spec.ts
+++ b/src/frontend/packages/core/src/monaco-loader.spec.ts
@@ -3,18 +3,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { configureJsonDiagnostics, installWorkerURLPolicy } from './monaco-loader';
 
 // Resolves to the window.monaco mock installed by test-setup. The mock
-// carries no language services, so languages.json is absent by default —
+// carries no language services, so jsonDefaults is absent by default —
 // tests that assert forwarding install it and remove it again afterwards.
-declare const monaco: typeof import('monaco-editor');
+declare const monaco: { jsonDefaults?: unknown };
 
 describe('configureJsonDiagnostics', () => {
   afterEach(() => {
-    delete (monaco as any).languages;
+    delete (monaco as any).jsonDefaults;
   });
 
   it('forwards the options to jsonDefaults.setDiagnosticsOptions', async () => {
     const setDiagnosticsOptions = vi.fn();
-    (monaco as any).languages = { json: { jsonDefaults: { setDiagnosticsOptions } } };
+    (monaco as any).jsonDefaults = { setDiagnosticsOptions };
 
     const options = {
       validate: true,

--- a/src/frontend/packages/core/src/monaco-loader.ts
+++ b/src/frontend/packages/core/src/monaco-loader.ts
@@ -12,10 +12,10 @@
  * the import path.
  */
 
-import type { languages } from 'monaco-editor';
+import type { DiagnosticsOptions } from 'monaco-editor/languages/features/json/register.js';
 import type { MonacoYaml, MonacoYamlOptions } from 'monaco-yaml';
 
-type MonacoApi = typeof import('monaco-editor');
+type MonacoApi = typeof import('./monaco-features');
 
 let monacoLoad: Promise<MonacoApi> | null = null;
 let monacoYaml: MonacoYaml | null = null;
@@ -88,11 +88,13 @@ export async function configureYaml(options: MonacoYamlOptions): Promise<void> {
  * language service ships with Monaco itself, so unlike YAML this delegates
  * straight to `jsonDefaults` — process-global, last caller wins.
  */
-export async function configureJsonDiagnostics(options: languages.json.DiagnosticsOptions): Promise<void> {
+export async function configureJsonDiagnostics(options: DiagnosticsOptions): Promise<void> {
   const monaco = await loadMonacoEditor();
   // Optional-chained: a pre-set window.monaco (the unit-test mock) carries no
   // language services — json configuration is a no-op there, like yaml above.
-  (monaco as any)?.languages?.json?.jsonDefaults?.setDiagnosticsOptions(options);
+  // jsonDefaults is re-exported by monaco-features (monaco 0.55+ moved it out
+  // of the languages.json namespace).
+  (monaco as any)?.jsonDefaults?.setDiagnosticsOptions(options);
 }
 
 async function doLoadMonacoEditor(): Promise<MonacoApi> {

--- a/src/frontend/packages/core/src/monaco-workers/editor.worker.ts
+++ b/src/frontend/packages/core/src/monaco-workers/editor.worker.ts
@@ -1,3 +1,3 @@
 // Local wrapper: the Angular builder only bundles workers referenced by a
 // relative new URL(), so each language worker gets a local entry module.
-import 'monaco-editor/esm/vs/editor/editor.worker';
+import 'monaco-editor/editor/editor.worker.js';

--- a/src/frontend/packages/core/src/monaco-workers/json.worker.ts
+++ b/src/frontend/packages/core/src/monaco-workers/json.worker.ts
@@ -1,3 +1,3 @@
 // Local wrapper: the Angular builder only bundles workers referenced by a
 // relative new URL(), so each language worker gets a local entry module.
-import 'monaco-editor/esm/vs/language/json/json.worker';
+import 'monaco-editor/languages/features/json/json.worker.js';

--- a/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
+++ b/src/frontend/packages/core/src/shared/components/monaco-editor/monaco-editor.component.ts
@@ -59,7 +59,7 @@ export class MonacoEditorComponent implements AfterViewInit, OnDestroy, ControlV
 
   private branding = inject(StratosBrandingService);
   private editor: import('monaco-editor').editor.IStandaloneCodeEditor | undefined;
-  private monaco: typeof import('monaco-editor') | undefined;
+  private monaco: Awaited<ReturnType<typeof loadMonacoEditor>> | undefined;
 
   constructor() {
     // Monaco's theme is process-global (monaco.editor.setTheme), so one


### PR DESCRIPTION
Supersedes #5824 (dependabot could only bump the version; the failure is structural).

**Why the dependabot bump failed**: monaco-editor 0.53+ added a package `exports` map (`"./*.js" → "./esm/vs/*.js"`) with no compat entry for the old paths — every legacy `monaco-editor/esm/vs/...` deep import now resolves to a doubled, nonexistent path. Our loader, the worker wrappers, and monaco-yaml's worker glue all used those paths.

**What this PR does** (stacked on #5826 — merge that first):

- Moves the curated subset to the 0.53+ surfaces: `features/*/register.js` for editor features, `languages/features/json/register.js` + `languages/definitions/yaml/register.js` for the two languages, `editor.js` as the API module, and the new self-starting worker entries (`editor/editor.worker.js`, `languages/features/json/json.worker.js`).
- `jsonDefaults` is a module export in 0.55+ (no longer `monaco.languages.json`); the loader re-exports it through `monaco-features` and `configureJsonDiagnostics` consumes it there. The loader spec's mock surface follows.
- Ambient type declarations shrink to one wildcard — the exports map now resolves types natively.
- `monaco-worker-manager` 2.0.1 (monaco-yaml's worker glue, last released before the new layout) imports the legacy `editor.worker.js` path from inside `node_modules`, where no app-side fix can reach — patched with a one-line `bun patch` (see `patches/`) pointing it at `internal/common/initialize.js`, the same entry monaco's own json worker uses with the identical `(ctx, createData)` signature. Worth revisiting when monaco-yaml ships a release for the new layout.

**Size note (honest)**: upstream grew ~90KB gzip in 0.53→0.56 (LSP client scaffolding among others). The measured editor-open payload is 878KB gz — most of the subset's 0.52 saving (785KB) is eaten by upstream growth, though still ahead of what the full 0.56 build would cost.

**Verification**: all four frontend test projects that failed on the dependabot branch pass — 3453 tests / 2 skipped across core, cloud-foundry, kubernetes, git. Production build green under the new bundle budget.