### PR TITLE
fix(editor): restore completions lost to monaco 0.56 registry gap

### DIFF
--- a/changelog.d/0004-monaco-suggest.md
+++ b/changelog.d/0004-monaco-suggest.md
@@ -1,0 +1,6 @@
+[BugFixes]
+- Completions and go-to-definition returned to the editor: monaco
+  0.56's per-feature registry omits the suggest controller and the
+  go-to commands (upstream's full build imports them directly), so the
+  curated subset lost Ctrl+Space and F12. Found by live-driving the
+  deployed editor; the contribs are now imported directly.

--- a/src/frontend/packages/core/src/monaco-features.ts
+++ b/src/frontend/packages/core/src/monaco-features.ts
@@ -49,6 +49,15 @@ import 'monaco-editor/features/readOnlyMessage/register.js';
 import 'monaco-editor/features/smartSelect/register.js';
 import 'monaco-editor/features/snippet/register.js';
 import 'monaco-editor/features/suggest/register.js';
+// monaco 0.56's feature registry omits the suggest CONTROLLER and the
+// go-to commands: features/suggest/register.js (and register.all.js)
+// import only suggestInlineCompletions, and features/gotoSymbol only the
+// mouse link path — upstream's editor.main.js imports both directly, so
+// only registry-composed builds lose completions and F12. Verified live:
+// without these, editor.action.triggerSuggest does not exist. Import the
+// contribs directly until upstream fixes the registry.
+import 'monaco-editor/editor/contrib/suggest/browser/suggestController.js';
+import 'monaco-editor/editor/contrib/gotoSymbol/browser/goToCommands.js';
 import 'monaco-editor/features/toggleTabFocusMode/register.js';
 import 'monaco-editor/features/unicodeHighlighter/register.js';
 import 'monaco-editor/features/unusualLineTerminators/register.js';


### PR DESCRIPTION
Follow-up to #5827, found by live-driving the deployed editor on a real foundation.

**The gap**: monaco 0.56's per-feature registry is incomplete. `features/suggest/register.js` — and even `features/register.all.js` — import only `suggestInlineCompletions.js`, not the suggest **controller**; `features/gotoSymbol/register.js` imports only the mouse-link path, not `goToCommands.js`. Upstream's own `editor.main.js` imports both contribs directly, which is why full builds never notice. Any build composed from the feature registry (like our curated subset) silently ships without Ctrl+Space completions and the go-to actions.

**The fix**: import `editor/contrib/suggest/browser/suggestController.js` and `editor/contrib/gotoSymbol/browser/goToCommands.js` directly, with a comment explaining why, until the upstream registry is fixed.

**Verification**: deployed to the fw lab console and driven with real keystrokes — before: `editor.action.triggerSuggest` did not exist; after: suggest action, `editor.contrib.suggestController` contribution, and the visible suggest widget all present. The json worker validation, tokenization, find widget, auto-close, and Trusted Types policy were all verified working in the same session. The goToCommands half could not be functionally observed there (no surface with a definition provider on that foundation) and rides along on the same upstream reasoning.

Worth noting for later: this class of gap is invisible to unit tests (the mocks short-circuit the loader) and to the build (the code ships, unregistered) — it only shows up under a real keyboard, which is an argument for keeping the e2e monaco smoke in the loop after monaco upgrades.