### PR TITLE
fix(editor): attach monaco's static widget CSS

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -119,7 +119,12 @@
               "src/frontend/packages/theme/styles/main.scss",
               "src/frontend/packages/theme/theme-transitions.scss",
               "src/frontend/packages/core/src/styles.scss",
-              "node_modules/xterm/css/xterm.css"
+              "node_modules/xterm/css/xterm.css",
+              {
+                "input": "src/frontend/packages/core/src/monaco-styles.css",
+                "inject": false,
+                "bundleName": "monaco"
+              }
             ],
             "stylePreprocessorOptions": {
               "includePaths": [

--- a/changelog.d/0004-monaco-suggest.md
+++ b/changelog.d/0004-monaco-suggest.md
@@ -1,0 +1,6 @@
+[BugFixes]
+- Completions and go-to-definition returned to the editor: monaco
+  0.56's per-feature registry omits the suggest controller and the
+  go-to commands (upstream's full build imports them directly), so the
+  curated subset lost Ctrl+Space and F12. Found by live-driving the
+  deployed editor; the contribs are now imported directly.

--- a/changelog.d/0005-monaco-static-css.md
+++ b/changelog.d/0005-monaco-static-css.md
@@ -1,0 +1,9 @@
+[BugFixes]
+- Monaco's static widget styles finally reach the page: the builder
+  bundles the CSS monaco imports from JS into chunk .css files, but
+  nothing attaches those for a plain dynamic import() — since the ESM
+  switch the editor has rendered on runtime-injected styles and
+  browser defaults (visible with monaco 0.56 as a naked IME textarea
+  inside the editor and a chromeless find widget). The subset's CSS is
+  now built as a stable non-injected "monaco" styles bundle that the
+  loader links when the editor loads.

--- a/src/frontend/packages/core/src/monaco-features.ts
+++ b/src/frontend/packages/core/src/monaco-features.ts
@@ -49,6 +49,15 @@ import 'monaco-editor/features/readOnlyMessage/register.js';
 import 'monaco-editor/features/smartSelect/register.js';
 import 'monaco-editor/features/snippet/register.js';
 import 'monaco-editor/features/suggest/register.js';
+// monaco 0.56's feature registry omits the suggest CONTROLLER and the
+// go-to commands: features/suggest/register.js (and register.all.js)
+// import only suggestInlineCompletions, and features/gotoSymbol only the
+// mouse link path — upstream's editor.main.js imports both directly, so
+// only registry-composed builds lose completions and F12. Verified live:
+// without these, editor.action.triggerSuggest does not exist. Import the
+// contribs directly until upstream fixes the registry.
+import 'monaco-editor/editor/contrib/suggest/browser/suggestController.js';
+import 'monaco-editor/editor/contrib/gotoSymbol/browser/goToCommands.js';
 import 'monaco-editor/features/toggleTabFocusMode/register.js';
 import 'monaco-editor/features/unicodeHighlighter/register.js';
 import 'monaco-editor/features/unusualLineTerminators/register.js';

--- a/src/frontend/packages/core/src/monaco-loader.ts
+++ b/src/frontend/packages/core/src/monaco-loader.ts
@@ -97,10 +97,33 @@ export async function configureJsonDiagnostics(options: DiagnosticsOptions): Pro
   (monaco as any)?.jsonDefaults?.setDiagnosticsOptions(options);
 }
 
+/**
+ * Attaches Monaco's static widget stylesheet. The builder bundles the CSS
+ * that monaco imports from JS into per-chunk .css files, but nothing loads
+ * those for a plain dynamic import() — monaco then renders on its
+ * runtime-injected styles and browser defaults only (naked ime-text-area,
+ * chromeless find widget). monaco-styles.css is built as a non-injected
+ * styles bundle named "monaco" (angular.json), so its URL is stable and
+ * same-origin — covered by style-src-elem 'self', no nonce needed.
+ */
+function attachMonacoStylesheet(): void {
+  if (document.querySelector('link[data-monaco-styles]')) {
+    return;
+  }
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  // Resolve against the app base, not the current (deep) route URL.
+  link.href = new URL('monaco.css', document.baseURI).toString();
+  link.setAttribute('data-monaco-styles', '');
+  document.head.appendChild(link);
+}
+
 async function doLoadMonacoEditor(): Promise<MonacoApi> {
   if ((window as any).monaco) {
     return (window as any).monaco;
   }
+
+  attachMonacoStylesheet();
 
   // The builder rewrites each relative `new Worker(new URL(...))` into a
   // hashed lazy chunk of its own; bare package specifiers are not resolved

--- a/src/frontend/packages/core/src/monaco-styles.css
+++ b/src/frontend/packages/core/src/monaco-styles.css
@@ -1,0 +1,118 @@
+/*
+ * Static stylesheet aggregate for the curated Monaco subset
+ * (monaco-features.ts). The application builder bundles the CSS that
+ * monaco imports from JS into per-chunk .css files, but nothing attaches
+ * those to the page for a plain dynamic import() — so monaco widgets
+ * rendered on runtime-injected styles and browser defaults only (the
+ * naked ime-text-area was the visible symptom). This file is built as a
+ * non-injected styles bundle (angular.json bundleName "monaco") and
+ * linked by monaco-loader.ts when the editor loads.
+ *
+ * Relative paths because monaco-editor's exports map rewrites every
+ * package subpath to *.js, which blocks css specifiers.
+ *
+ * GENERATED from the monaco-features.ts import graph — regenerate on
+ * every monaco upgrade or feature-list change:
+ *   bun x esbuild src/frontend/packages/core/src/monaco-features.ts \
+ *     --bundle --format=esm --outdir=/tmp/esb --metafile=/tmp/meta.json \
+ *     --loader:.ttf=file
+ *   then list the .css inputs of the metafile here.
+ */
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/actionbar/actionbar.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/aria/aria.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/button/button.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon-modifiers.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/contextview/contextview.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/countBadge/countBadge.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/dnd/dnd.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/dropdown/dropdown.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/findinput/findInput.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/hover/hoverWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/iconLabel/iconlabel.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/inputbox/inputBox.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/keybindingLabel/keybindingLabel.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/list/list.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/mouseCursor/mouseCursor.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/progressbar/progressbar.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/sash/sash.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/scrollbar/media/scrollbars.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/selectBox/selectBox.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/selectBox/selectBoxCustom.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/severityIcon/media/severityIcon.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/splitview/splitview.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/table/table.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/toggle/toggle.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/toolbar/toolbar.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/base/browser/ui/tree/media/tree.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/controller/editContext/native/nativeEditContext.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/gpu/css/media/decorationCssRuleExtractor.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/blockDecorations/blockDecorations.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/decorations/decorations.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/glyphMargin/glyphMargin.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/gpuMark/gpuMark.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/indentGuides/indentGuides.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/lineNumbers/lineNumbers.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/linesDecorations/linesDecorations.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/margin/margin.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/marginDecorations/marginDecorations.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/minimap/minimap.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/overlayWidgets/overlayWidgets.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/rulers/rulers.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/scrollDecoration/scrollDecoration.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/selections/selections.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/viewCursors/viewCursors.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/viewLines/viewLines.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/viewParts/whitespace/whitespace.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/widget/codeEditor/editor.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/widget/diffEditor/components/accessibleDiffViewer.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/widget/diffEditor/style.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/widget/markdownRenderer/browser/renderedMarkdown.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/browser/widget/multiDiffEditor/style.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/anchorSelect/browser/anchorSelect.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/bracketMatching/browser/bracketMatching.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/codeAction/browser/lightBulbWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/codelens/browser/codelensWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/colorPicker/browser/colorPicker.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/dnd/browser/dnd.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/dropOrPasteInto/browser/postEditWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/find/browser/findOptionsWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/find/browser/findWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/floatingMenu/browser/floatingMenu.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/folding/browser/folding.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/gotoError/browser/media/gotoErrorWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/gotoSymbol/browser/peek/referencesWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/hover/browser/hover.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/inlineCompletions/browser/hintsWidget/inlineCompletionsHintsWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/view.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/inlineProgress/browser/inlineProgressWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/linkedEditing/browser/linkedEditing.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/links/browser/links.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/message/browser/messageController.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/middleScroll/browser/middleScroll.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/parameterHints/browser/parameterHints.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/peekView/browser/media/peekViewWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/placeholderText/browser/placeholderText.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/rename/browser/renameWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/snippet/browser/snippetSession.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/stickyScroll/browser/stickyScroll.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/suggest/browser/media/suggest.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/symbolIcons/browser/symbolIcons.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/unicodeHighlighter/browser/bannerController.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/wordHighlighter/browser/highlightDecorations.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/contrib/zoneWidget/browser/zoneWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/standalone/browser/inspectTokens/inspectTokens.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/standalone/browser/quickInput/standaloneQuickInput.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/editor/standalone/browser/standalone-tokens.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/platform/actionWidget/browser/actionWidget.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/platform/actions/browser/menuEntryActionViewItem.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/platform/hover/browser/hover.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/platform/opener/browser/link.css';
+@import '../../../../../node_modules/monaco-editor/esm/vs/platform/quickinput/browser/media/quickInput.css';


### PR DESCRIPTION
Stacked on #5829 (branched from it — merge that first). Found while answering "what is that extra window?" on a deployed editor.

**The defect** — older than the recent monaco work: the application builder bundles the CSS that monaco imports from JS into per-chunk `.css` files, but nothing attaches those for a plain dynamic `import()`. Confirmed empirically: no built JS and no index.html reference the chunk css names, and the shipped v5.2.0 zip carries the same orphaned css chunks — so since the ESM switch (#5561) every deployed editor has rendered on monaco's runtime-injected styles plus browser defaults. monaco 0.52 masked the worst of it by positioning its input textarea from JS; 0.56's `ime-text-area` relies on the stylesheet, so an unstyled white textarea with a browser resize grip floated into view inside the editor, and the find widget renders with no chrome (transparent background, live-confirmed).

**The fix**:
- `monaco-styles.css` — generated aggregate of the 98 css files in the curated subset's import graph (via the esbuild metafile; regeneration command in the header; relative paths because monaco's exports map rewrites every package subpath to `*.js`, blocking css specifiers).
- Built as a non-injected styles bundle named `monaco` (angular.json) — emitted as a stable, unhashed `monaco.css`, so nothing pays for it at first paint.
- `monaco-loader` links it (idempotent, resolved against `document.baseURI`) when the editor loads. Same-origin, so `style-src-elem 'self'` covers it — no nonce required.

**Live-verified on a deployed foundation**: `monaco.css` attached with 1138 rules; the IME textarea computes `position:absolute`, transparent, `resize:none`, `z-index:-10` (the phantom window is gone); the find widget has its themed chrome back.

Maintenance note: regenerate `monaco-styles.css` whenever the feature list or the monaco version changes — the command is in the file header.