### PR TITLE
perf page accuracy, nav debug gate, SQLite persistence docs

### DIFF
--- a/docs/deploy/cloud-foundry/cloud-foundry.md
+++ b/docs/deploy/cloud-foundry/cloud-foundry.md
@@ -15,7 +15,7 @@ In this case, the front-end web application static resources are served by the A
 
 By default, a non-persistent SQLite database is used - by automatically registering the cloud foundry endpoint and connecting to it on login, all data stored in the database can be treated as ephemeral, since it will be re-created next time a user logs in. Cloud Foundry Session Affinity is used to ensure that when scaling up the Console Application to multiple instances, the user is also directed to the instance which will know about them and their endpoints (since each Application instance will have its own local SQLite store).
 
-Alternatively, Stratos can be configured [with a persistent Cloud Foundry database service](db-migration.md), which enables features requiring persistence such as user favorites.
+Alternatively, Stratos can be configured [with a persistent Cloud Foundry database service](db-migration.md), which enables features requiring persistence such as user favorites. Deployments that deliberately stay on SQLite can still make its data recoverable across pushes — see [Persisting the SQLite database](sqlite-persistence.md).
 
 ## Deployment Steps
 

--- a/docs/deploy/cloud-foundry/sqlite-persistence.md
+++ b/docs/deploy/cloud-foundry/sqlite-persistence.md
@@ -1,0 +1,131 @@
+---
+id: sqlite-persistence
+title: Persisting the SQLite database
+sidebar_label: SQLite persistence
+---
+
+When Stratos is pushed to Cloud Foundry without a bound database service it
+falls back to an embedded SQLite database on the container's ephemeral disk.
+Every push, restart, or crash recreates the container and wipes that database:
+registered endpoints reappear through auto-registration, but user tokens,
+favorites, and settings are lost.
+
+[Binding a Postgres or MySQL service](db-migration.md) is the recommended fix.
+When that is not an option, the SQLite database itself can be made recoverable.
+Two approaches are described here — both depend on one hard precondition.
+
+## Precondition: a stable encryption key
+
+Tokens are encrypted at rest with the key configured through
+`ENCRYPTION_KEY` (or the key volume/file settings). If the key is regenerated
+on each deployment, any recovered database decrypts to nothing useful. Set the
+key once as a persisted application environment variable
+(`cf set-env console ENCRYPTION_KEY <64-hex-chars>`) and keep the deployment
+manifest from overwriting it. The key and the data must persist together.
+
+## Approach 1: continuous replication with Litestream
+
+[Litestream](https://litestream.io) tails the SQLite WAL and streams it to
+external storage (S3-compatible object stores, SFTP hosts, and others). Run
+jetstream under Litestream's process supervision and the database survives
+container churn with at most a second or so of data loss:
+
+1. Include the `litestream` Linux binary and a `litestream.yml` in the
+   application package, alongside the `jetstream` binary:
+
+   ```yaml
+   dbs:
+     - path: /home/vcap/app/console-database.db
+       replicas:
+         - type: sftp                      # or s3, abs, gcs …
+           host: replica-host:22
+           user: replica-user
+           key-path: /home/vcap/app/replica_key
+           path: /replica-dir/console-database
+   ```
+
+2. Replace the application start command with a wrapper script:
+
+   ```bash
+   #!/bin/bash
+   set -e
+   cd /home/vcap/app
+   if [ ! -f console-database.db ]; then
+     ./litestream restore -config litestream.yml -if-replica-exists \
+       /home/vcap/app/console-database.db || true
+   fi
+   exec ./litestream replicate -config litestream.yml -exec ./jetstream
+   ```
+
+   A fresh container restores the last replicated state before jetstream
+   opens the database; `-exec` then keeps replication running for the life of
+   the process and exits when jetstream exits.
+
+Notes:
+
+- The container needs network egress to the replica target. Cloud Foundry
+  application security groups typically exclude private ranges, so a scoped
+  ASG (single destination host and port) may be required.
+- Litestream switches the database to WAL journal mode. Jetstream's pure-Go
+  SQLite driver supports WAL databases, but Litestream and jetstream then
+  coordinate through SQLite's cross-process locking — validate the pairing in
+  a non-production environment before relying on it.
+- Replica credentials (SSH key or object-store keys) travel inside the
+  application package; scope them to the replica target only.
+
+## Approach 2: snapshot into a user-provided service
+
+The Cloud Controller's own database can act as the persistent store: a
+user-provided service instance holds a snapshot of the SQLite file, and the
+application restores from it at boot. Whoever pushes Stratos already has the
+credentials to update the service instance, so the save step is part of the
+push ritual rather than something the application must be trusted to do.
+
+Save (operator, before or after a push):
+
+```bash
+cf ssh console -c 'cat /home/vcap/app/console-database.db' | base64 > db.b64
+cf uups console-db-snapshot -p "{\"db\": \"$(cat db.b64)\"}"
+cf bind-service console console-db-snapshot
+```
+
+Restore (start wrapper, before launching jetstream): read the snapshot from
+the service binding, decode it, and write `console-database.db` if the file
+does not exist.
+
+The environment-variable route caps out quickly — Cloud Foundry limits an
+app's total environment (including `VCAP_SERVICES`) to roughly 130KB, and
+even a small Stratos database exceeds that once base64-encoded. The
+`file-based-vcap-services` application feature exists for exactly this: with
+it enabled, the platform writes service bindings to a file and sets
+`VCAP_SERVICES_FILE_PATH` instead of injecting the JSON into the environment,
+lifting the size ceiling (a 250KB credential blob round-trips through the
+Cloud Controller intact):
+
+```bash
+cf curl v3/apps/$(cf app console --guid)/features/file-based-vcap-services \
+  -X PATCH -d '{"enabled": true}'
+```
+
+Caveats:
+
+- Jetstream reads `VCAP_SERVICES` from the environment for bound-database
+  detection and user-provided-service configuration lookup. With the
+  file-based feature enabled those variables are no longer set, so both
+  code paths quietly fall back to SQLite — acceptable when SQLite is the
+  point, but incompatible with a bound database service on the same app
+  (support requires go-cfenv ≥ 1.23, which reads the file path).
+- Snapshots capture a moment in time; anything written after the last save
+  is lost. Pair with Approach 1 when crash-loss matters.
+
+## Choosing
+
+| | Litestream | Service snapshot |
+|---|---|---|
+| Data loss window | ~1s | Since last snapshot |
+| New infrastructure | Replica target (object store / SFTP host) + ASG | None |
+| Operator ritual | None after setup | Save on each push |
+| Moving parts in the container | Litestream supervises jetstream | Start wrapper only |
+
+Both are recovery patterns for deployments that deliberately stay on SQLite —
+a bound database service remains the recommendation for production.

--- a/docs/theming-architecture.md
+++ b/docs/theming-architecture.md
@@ -383,6 +383,12 @@ interface CompanyConfig {
     copyright?: string;      // Copyright text
     additionalInfo?: string; // Extra footer text
   };
+  debug?: {
+    // Render the side-nav "Show all menu items" checkbox, which reveals
+    // nav entries hidden by endpoint/persistence rules. A debugging
+    // affordance — off by default.
+    showAllMenuItemsToggle?: boolean;
+  };
   defaults?: {
     themeMode?: 'light' | 'dark' | 'system';
     sidebarOpen?: boolean;

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.html
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.html
@@ -26,11 +26,12 @@
     <!-- Scope note -->
     <app-card>
       <div class="px-4 py-3 text-sm text-content-muted">
-        The milestone numbers reflect this browsing session's initial page load and
-        stay put as you move around the app. The waterfall and byte totals keep
-        accumulating: every fetch since the page loaded is recorded, including lazy
-        route chunks loaded as you navigate, so the timeline grows (and its scale
-        stretches from ms to s) the longer the session runs &mdash; check
+        The milestone numbers and the Requests/Total transfer headline reflect this
+        browsing session's initial page load and stay put as you move around the
+        app; traffic after the load event (idle editor prefetch, API calls, lazy
+        route chunks) is tallied separately as &ldquo;since load&rdquo;. The
+        waterfall keeps accumulating every fetch, so the timeline grows (and its
+        scale stretches from ms to s) the longer the session runs &mdash; check
         &ldquo;Initial load only&rdquo; on the waterfall to compare like with like.
         Recording stops silently after 500 resources. Reload &amp; measure captures
         a fresh warm (cached) load; for a cold load, hard-reload the browser with
@@ -66,11 +67,11 @@
         }
         <span class="flex gap-2 items-baseline">
           <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">Requests</span>
-          <span class="text-sm font-medium">{{ r.requestCount }}</span>
+          <span class="text-sm font-medium" data-test="requests-summary">{{ r.initialRequestCount }}@if (r.sinceLoadRequestCount > 0) { <span class="text-content-muted">(+{{ r.sinceLoadRequestCount }} since load)</span>}</span>
         </span>
         <span class="flex gap-2 items-baseline">
           <span class="text-xs font-semibold uppercase tracking-wider text-content-muted">Total transfer</span>
-          <span class="text-sm font-medium">{{ formatBytes(r.totalTransferBytes) }}</span>
+          <span class="text-sm font-medium" data-test="transfer-summary">{{ formatBytes(r.initialTransferBytes) }}@if (r.sinceLoadTransferBytes > 0) { <span class="text-content-muted">(+{{ formatBytes(r.sinceLoadTransferBytes) }} since load)</span>}</span>
         </span>
       </div>
       <div class="px-4 pb-3 overflow-x-auto">
@@ -78,29 +79,43 @@
           <thead>
             <tr>
               <th class="text-left text-xs font-semibold uppercase tracking-wider text-content-muted px-3 py-1.5 border-b border-content-border">Milestone</th>
-              <th class="text-right text-xs font-semibold uppercase tracking-wider text-content-muted px-3 py-1.5 border-b border-content-border">Time</th>
+              <th class="text-right text-xs font-semibold uppercase tracking-wider text-content-muted px-3 py-1.5 border-b border-content-border">Browser clock</th>
+              <th class="text-right text-xs font-semibold uppercase tracking-wider text-content-muted px-3 py-1.5 border-b border-content-border" title="Time since the document request hit the wire — browser stall, DNS, TCP and TLS subtracted. This is the part Stratos controls.">Stratos clock</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td class="px-3 py-1.5">Response start</td>
               <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ ms(r.responseStartMs) }}</td>
+              <td class="px-3 py-1.5 text-right whitespace-nowrap" data-test="app-clock-response">{{ appMs(r.responseStartMs) }}</td>
             </tr>
+            @if (r.phases; as p) {
+              <tr data-test="doc-phases">
+                <td class="px-3 py-1.5 text-content-muted">&nbsp;&nbsp;of which document fetch</td>
+                <td class="px-3 py-1.5 text-right whitespace-nowrap text-content-muted" colspan="2">
+                  stalled {{ ms(p.stalledMs) }} &middot; DNS {{ ms(p.dnsMs) }} &middot; TCP {{ ms(p.tcpMs) }} &middot; TLS {{ ms(p.tlsMs) }} &middot; server wait {{ ms(p.serverWaitMs) }}
+                </td>
+              </tr>
+            }
             <tr>
               <td class="px-3 py-1.5">DOMContentLoaded</td>
               <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ ms(r.domContentLoadedMs) }}</td>
+              <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ appMs(r.domContentLoadedMs) }}</td>
             </tr>
             <tr>
               <td class="px-3 py-1.5">Load event</td>
               <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ ms(r.loadEventMs) }}</td>
+              <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ appMs(r.loadEventMs) }}</td>
             </tr>
             <tr>
               <td class="px-3 py-1.5">First contentful paint</td>
               <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ ms(r.firstContentfulPaintMs) }}</td>
+              <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ appMs(r.firstContentfulPaintMs) }}</td>
             </tr>
             <tr>
               <td class="px-3 py-1.5">Largest contentful paint@if (r.lcpElement) { <span class="text-content-muted">({{ r.lcpElement }})</span>}</td>
               <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ ms(r.lcpMs) }}</td>
+              <td class="px-3 py-1.5 text-right whitespace-nowrap">{{ appMs(r.lcpMs) }}</td>
             </tr>
           </tbody>
         </table>

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
@@ -18,6 +18,7 @@ const { fixedReport } = vi.hoisted(() => {
     topology: 'cf-pushed',
     requestId: 'req-abc-123',
     protocol: 'h2',
+    requestStartMs: 10,
     responseStartMs: 12,
     domContentLoadedMs: 300,
     loadEventMs: 500,
@@ -26,6 +27,11 @@ const { fixedReport } = vi.hoisted(() => {
     lcpElement: null,
     requestCount: 2,
     totalTransferBytes: 4096,
+    initialRequestCount: 1,
+    initialTransferBytes: 3000,
+    sinceLoadRequestCount: 1,
+    sinceLoadTransferBytes: 1096,
+    phases: { stalledMs: 5, dnsMs: 1, tcpMs: 2, tlsMs: 3, serverWaitMs: 1 },
     resources: [
       { path: '/main.js', startMs: 1, durationMs: 20, transferBytes: 3000, decodedBytes: 9000, protocol: 'h2', cached: false },
       { path: '/styles.css', startMs: 2, durationMs: 5, transferBytes: 1096, decodedBytes: 2000, protocol: 'h2', cached: true },
@@ -109,6 +115,31 @@ describe('DiagnosticPerformancePageComponent', () => {
     button?.click();
     await fixture.whenStable();
     expect(writeText).toHaveBeenCalledWith(reportToMarkdown(fixedReport));
+  });
+
+  it('headlines the initial-load totals with the since-load overflow alongside', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const requests = el.querySelector('[data-test="requests-summary"]')?.textContent ?? '';
+    expect(requests).toContain('1');
+    expect(requests).toContain('+1 since load');
+    const transfer = el.querySelector('[data-test="transfer-summary"]')?.textContent ?? '';
+    expect(transfer).toContain('+');
+    expect(transfer).toContain('since load');
+  });
+
+  it('shows each milestone on the Stratos clock next to the browser clock', () => {
+    const appClock = (fixture.nativeElement as HTMLElement)
+      .querySelector('[data-test="app-clock-response"]')?.textContent ?? '';
+    // responseStartMs 12 − requestStartMs 10
+    expect(appClock).toContain('2 ms');
+  });
+
+  it('breaks the pre-response time into document fetch phases', () => {
+    const phases = (fixture.nativeElement as HTMLElement)
+      .querySelector('[data-test="doc-phases"]')?.textContent ?? '';
+    expect(phases).toContain('stalled 5 ms');
+    expect(phases).toContain('TLS 3 ms');
+    expect(phases).toContain('server wait 1 ms');
   });
 
   it('shows the cold/warm cache verdict for the load', () => {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.ts
@@ -8,6 +8,7 @@ import { formatBytes } from '../diagnostics-data/entity-footprint';
 import {
   LoadReport,
   ResourceRow,
+  appMs,
   buildLoadReport,
   classifyCache,
   reportToJson,
@@ -90,6 +91,12 @@ export class DiagnosticPerformancePageComponent implements OnInit {
 
   ms(value: number | null): string {
     return value === null ? 'n/a' : `${value.toFixed(0)} ms`;
+  }
+
+  /** Milestone with browser/network setup subtracted — Stratos's own time. */
+  appMs(value: number | null): string {
+    const r = this.report();
+    return (r && appMs(value, r.requestStartMs)) ?? '—';
   }
 
   formatBytes(n: number): string {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
@@ -284,6 +284,7 @@ const reportWith = (resources: ResourceRow[]): LoadReport => ({
   topology: 'local/other',
   requestId: null,
   protocol: 'h2',
+  requestStartMs: 10,
   responseStartMs: 12,
   domContentLoadedMs: 300,
   loadEventMs: 500,
@@ -292,6 +293,11 @@ const reportWith = (resources: ResourceRow[]): LoadReport => ({
   lcpElement: null,
   requestCount: resources.length,
   totalTransferBytes: resources.reduce((n, r) => n + r.transferBytes, 0),
+  initialRequestCount: resources.length,
+  initialTransferBytes: resources.reduce((n, r) => n + r.transferBytes, 0),
+  sinceLoadRequestCount: 0,
+  sinceLoadTransferBytes: 0,
+  phases: null,
   resources,
 });
 
@@ -360,6 +366,38 @@ describe('ResourceWaterfallComponent', () => {
     query<HTMLButtonElement>('[data-test="waterfall-group"]')?.click();
     fixture.detectChanges();
     expect(el().textContent).not.toContain('b.js');
+  });
+
+  it('shifts resources and milestones to the Stratos clock when toggled', () => {
+    render({
+      ...reportWith([row({ path: '/a.js', startMs: 250 })]),
+      requestStartMs: 200,
+      domContentLoadedMs: 300,
+      loadEventMs: 500,
+    });
+    const toggle = query<HTMLInputElement>('[data-test="waterfall-clock"]');
+    expect(toggle).toBeTruthy();
+    expect(toggle?.checked).toBe(false);
+
+    toggle?.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.groups()[0].startMs).toBe(50);
+    expect(fixture.componentInstance.milestones().find(m => m.label === 'DCL')?.ms).toBe(100);
+    expect(fixture.componentInstance.milestones().find(m => m.label === 'Load')?.ms).toBe(300);
+  });
+
+  it('keeps the initial-load filter aligned with the shifted clock', () => {
+    render({
+      ...reportWith([row({ path: '/early.js', startMs: 400 }), row({ path: '/late.js', startMs: 501 })]),
+      requestStartMs: 200,
+      loadEventMs: 500,
+    });
+    query<HTMLInputElement>('[data-test="waterfall-clock"]')?.click();
+    query<HTMLInputElement>('[data-test="waterfall-initial-only"]')?.click();
+    fixture.detectChanges();
+    const paths = fixture.componentInstance.visibleResources().map(r => r.path);
+    expect(paths).toContain('/early.js');
+    expect(paths).not.toContain('/late.js');
   });
 
   it('resets to the first page when a new report arrives', async () => {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
@@ -203,6 +203,14 @@ export function rowLabel(path: string): string {
           [checked]="initialOnly()" (change)="initialOnly.set($any($event.target).checked)">
         Initial load only
       </label>
+      <label
+        class="flex items-center gap-1.5 cursor-pointer select-none"
+        title="Start the timeline when the document request hit the wire — browser stall, DNS, TCP and TLS subtracted. This is the part Stratos controls.">
+        <input
+          type="checkbox" data-test="waterfall-clock"
+          [checked]="stratosClock()" (change)="setClock($any($event.target).checked)">
+        Stratos clock
+      </label>
       @if (viewWindow(); as w) {
         <span data-test="waterfall-zoom-range">{{ formatTick(w.startMs) }} &ndash; {{ formatTick(w.endMs) }}</span>
         <button
@@ -334,7 +342,11 @@ export function rowLabel(path: string): string {
       Dashed lines mark page milestones: DCL = DOM content loaded, Load = load event,
       FCP = first contentful paint, LCP = largest contentful paint (hover a label for its time).
       Drag along the top axis to zoom to a time range; drag again to drill deeper,
-      double-click the axis (or Reset zoom) to zoom back out.
+      double-click the axis (or Reset zoom) to zoom back out. The browser clock starts
+      at navigation, so the empty stretch on the left is browser stall + DNS + TCP + TLS
+      before the document request &mdash; switch to the Stratos clock to subtract it.
+      On a warm (cached) load most bars are near-invisible slivers: cache hits complete
+      in ~0 ms and transfer 0 bytes.
     </div>
   `,
 })
@@ -344,12 +356,32 @@ export class ResourceWaterfallComponent {
   /** Hide fetches that started after the load event (lazy route chunks from
    *  post-load navigation) so the scale stays comparable between looks. */
   initialOnly = signal(false);
+
+  /** Stratos clock: shift every time by requestStart so the axis starts when
+   *  the document request hit the wire, hiding browser/network setup the app
+   *  cannot influence (the otherwise-unexplained empty stretch on the left). */
+  stratosClock = signal(false);
+  private clockOffsetMs = computed(() => this.stratosClock() ? this.report().requestStartMs : 0);
+  private shiftedResources = computed(() => {
+    const offset = this.clockOffsetMs();
+    return offset
+      ? this.report().resources.map(r => ({ ...r, startMs: Math.max(0, r.startMs - offset) }))
+      : this.report().resources;
+  });
+  private shiftedLoadEventMs = computed(() => {
+    const loadEventMs = this.report().loadEventMs;
+    return loadEventMs > 0 ? Math.max(0, loadEventMs - this.clockOffsetMs()) : loadEventMs;
+  });
+
   visibleResources = computed(() =>
-    this.initialOnly() ? initialLoadResources(this.report().resources, this.report().loadEventMs) : this.report().resources);
+    this.initialOnly() ? initialLoadResources(this.shiftedResources(), this.shiftedLoadEventMs()) : this.shiftedResources());
 
   groups = computed(() => groupRows(this.visibleResources()));
-  milestones = computed(() => milestoneLines(this.report()));
-  scaleMax = computed(() => waterfallScaleMax(this.report().loadEventMs, this.visibleResources(), this.milestones()));
+  milestones = computed(() => {
+    const offset = this.clockOffsetMs();
+    return milestoneLines(this.report()).map(m => ({ ...m, ms: Math.max(0, m.ms - offset) }));
+  });
+  scaleMax = computed(() => waterfallScaleMax(this.shiftedLoadEventMs(), this.visibleResources(), this.milestones()));
 
   /** Brush zoom: null = full scale. */
   viewWindow = signal<ViewWindow | null>(null);
@@ -447,6 +479,12 @@ export class ResourceWaterfallComponent {
     this.viewWindow.set(null);
     this.brush.set(null);
     this.page.set(0);
+  }
+
+  /** A zoom window taken on one clock is meaningless on the other. */
+  setClock(stratos: boolean): void {
+    this.stratosClock.set(stratos);
+    this.resetZoom();
   }
 
   prevPage(): void {

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
@@ -3,11 +3,13 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyCache,
   collectResources,
+  computePhases,
   detectTopology,
   buildLoadReport,
   observeFcp,
   reportToMarkdown,
   reportToJson,
+  splitByLoad,
   LoadReport,
 } from './load-performance';
 
@@ -26,6 +28,7 @@ const sampleReport = (): LoadReport => ({
   topology: 'cf-pushed',
   requestId: 'abc-123',
   protocol: 'h2',
+  requestStartMs: 10,
   responseStartMs: 12,
   domContentLoadedMs: 300,
   loadEventMs: 500,
@@ -34,6 +37,11 @@ const sampleReport = (): LoadReport => ({
   lcpElement: 'IMG',
   requestCount: 2,
   totalTransferBytes: 4096,
+  initialRequestCount: 2,
+  initialTransferBytes: 4096,
+  sinceLoadRequestCount: 0,
+  sinceLoadTransferBytes: 0,
+  phases: { stalledMs: 5, dnsMs: 1, tcpMs: 2, tlsMs: 3, serverWaitMs: 1 },
   resources: [
     { path: '/main.js', startMs: 1, durationMs: 20, transferBytes: 3000, decodedBytes: 9000, protocol: 'h2', cached: false },
     { path: '/styles.css', startMs: 2, durationMs: 5, transferBytes: 1096, decodedBytes: 2000, protocol: 'h2', cached: false },
@@ -91,6 +99,89 @@ describe('collectResources', () => {
     // transferBytes === 0 counts as cached regardless of decoded size
     expect(rows[0].cached).toBe(true);
   });
+
+  it('flags a 304 revalidation (headers transferred, empty body) as cached', () => {
+    // Real 304s report decodedBodySize 0, so the small-transfer/large-decoded
+    // heuristic misses them; responseStatus is the reliable signal.
+    const rows = collectResources([
+      entry({ transferSize: 300, decodedBodySize: 0, responseStatus: 304 } as Partial<PerformanceResourceTiming>),
+    ]);
+    expect(rows[0].cached).toBe(true);
+  });
+
+  it('does not flag a small 200 with an empty body as cached', () => {
+    const rows = collectResources([
+      entry({ transferSize: 300, decodedBodySize: 0, responseStatus: 200 } as Partial<PerformanceResourceTiming>),
+    ]);
+    expect(rows[0].cached).toBe(false);
+  });
+});
+
+describe('computePhases', () => {
+  const nav = (overrides: Partial<PerformanceNavigationTiming>): PerformanceNavigationTiming => ({
+    fetchStart: 3,
+    domainLookupStart: 594,
+    domainLookupEnd: 594,
+    connectStart: 594,
+    secureConnectionStart: 688,
+    connectEnd: 974,
+    requestStart: 974,
+    responseStart: 1178,
+    ...overrides,
+  } as PerformanceNavigationTiming);
+
+  it('decomposes the pre-response time into phases', () => {
+    expect(computePhases(nav({}))).toEqual({
+      stalledMs: 591,
+      dnsMs: 0,
+      tcpMs: 94,
+      tlsMs: 286,
+      serverWaitMs: 204,
+    });
+  });
+
+  it('reports zero tcp/tls on a reused connection', () => {
+    expect(computePhases(nav({
+      domainLookupStart: 3, domainLookupEnd: 3,
+      connectStart: 3, secureConnectionStart: 0, connectEnd: 3,
+      requestStart: 10, responseStart: 50,
+    }))).toEqual({
+      stalledMs: 0,
+      dnsMs: 0,
+      tcpMs: 0,
+      tlsMs: 0,
+      serverWaitMs: 40,
+    });
+  });
+
+  it('returns null without a navigation entry', () => {
+    expect(computePhases(undefined)).toBeNull();
+  });
+});
+
+describe('splitByLoad', () => {
+  const res = (startMs: number, transferBytes: number) => ({
+    path: '/x.js', startMs, durationMs: 1, transferBytes,
+    decodedBytes: 1, protocol: 'h2', cached: false,
+  });
+
+  it('splits resources at the load event', () => {
+    expect(splitByLoad([res(100, 10), res(499, 20), res(501, 40)], 500)).toEqual({
+      initialRequestCount: 2,
+      initialTransferBytes: 30,
+      sinceLoadRequestCount: 1,
+      sinceLoadTransferBytes: 40,
+    });
+  });
+
+  it('counts everything as initial while the load event has not fired (loadEventMs 0)', () => {
+    expect(splitByLoad([res(100, 10), res(900, 20)], 0)).toEqual({
+      initialRequestCount: 2,
+      initialTransferBytes: 30,
+      sinceLoadRequestCount: 0,
+      sinceLoadTransferBytes: 0,
+    });
+  });
 });
 
 describe('detectTopology', () => {
@@ -119,6 +210,44 @@ describe('detectTopology', () => {
 });
 
 describe('reportToMarkdown', () => {
+  it('reports initial-load totals with the since-load overflow alongside', () => {
+    const r = sampleReport();
+    r.requestCount = 5;
+    r.totalTransferBytes = 9096;
+    r.initialRequestCount = 2;
+    r.initialTransferBytes = 4096;
+    r.sinceLoadRequestCount = 3;
+    r.sinceLoadTransferBytes = 5000;
+    const md = reportToMarkdown(r);
+    expect(md).toContain('| Requests (initial load) | 2 |');
+    expect(md).toContain('| Total transfer (initial load) | 4096 bytes |');
+    expect(md).toContain('| Since load | +3 requests, +5000 bytes |');
+  });
+
+  it('includes the document fetch phases', () => {
+    const md = reportToMarkdown(sampleReport());
+    expect(md).toContain('| Document fetch | stalled 5 ms · DNS 1 ms · TCP 2 ms · TLS 3 ms · server wait 1 ms |');
+  });
+
+  it('shows each milestone on the app clock (browser/network setup subtracted)', () => {
+    const md = reportToMarkdown(sampleReport());
+    expect(md).toContain('| Response start | 12 ms (2 ms from request start) |');
+    expect(md).toContain('| DOMContentLoaded | 300 ms (290 ms from request start) |');
+    expect(md).toContain('| First contentful paint | 250 ms (240 ms from request start) |');
+  });
+
+  it('keeps a null milestone as n/a with no app clock', () => {
+    const r = sampleReport();
+    r.firstContentfulPaintMs = null;
+    expect(reportToMarkdown(r)).toContain('| First contentful paint | n/a |');
+  });
+
+  it('omits the app clock when request start is unknown', () => {
+    const r = sampleReport();
+    r.requestStartMs = 0;
+    expect(reportToMarkdown(r)).toContain('| Response start | 12 ms |');
+  });
+
   it('includes the topology and resource paths', () => {
     const md = reportToMarkdown(sampleReport());
     expect(md).toContain('cf-pushed');

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
@@ -32,26 +32,94 @@ export function classifyCache(resources: ResourceRow[]): CacheVerdict {
   return { kind: cachedFraction >= 0.5 ? 'warm' : 'cold', cachedFraction };
 }
 
+/** Pre-response time of the document request, decomposed from navigation timing. */
+export interface DocPhases {
+  stalledMs: number;
+  dnsMs: number;
+  tcpMs: number;
+  tlsMs: number;
+  serverWaitMs: number;
+}
+
 export interface LoadReport {
   collectedAt: string;
   topology: 'cf-pushed' | 'local/other';
   requestId: string | null;
   protocol: string;
+  /**
+   * When the document request hit the wire — the app-clock zero. Time before
+   * this (browser stall, DNS, TCP, TLS) is environment the app cannot
+   * influence; everything after (server wait, download, bootstrap, paint)
+   * is Stratos's to optimize. 0 when navigation timing is unavailable.
+   */
+  requestStartMs: number;
   responseStartMs: number;
   domContentLoadedMs: number;
   loadEventMs: number;
   firstContentfulPaintMs: number | null;
   lcpMs: number | null;
   lcpElement: string | null;
+  /** All recorded resources — keeps accumulating after load (see splitByLoad). */
   requestCount: number;
   totalTransferBytes: number;
+  initialRequestCount: number;
+  initialTransferBytes: number;
+  sinceLoadRequestCount: number;
+  sinceLoadTransferBytes: number;
+  phases: DocPhases | null;
   resources: ResourceRow[];
 }
 
 /**
+ * Decompose the document request's pre-response time. A large stalled phase
+ * means the browser sat on the request before even resolving DNS (queueing,
+ * cache lookup, proxy/cert checks) — time no server-side change can recover.
+ * On a reused connection DNS/TCP/TLS all collapse to zero.
+ */
+export function computePhases(nav: PerformanceNavigationTiming | undefined): DocPhases | null {
+  if (!nav) { return null; }
+  const tls = nav.secureConnectionStart > 0 ? nav.connectEnd - nav.secureConnectionStart : 0;
+  return {
+    stalledMs: nav.domainLookupStart - nav.fetchStart,
+    dnsMs: nav.domainLookupEnd - nav.domainLookupStart,
+    tcpMs: (nav.secureConnectionStart > 0 ? nav.secureConnectionStart : nav.connectEnd) - nav.connectStart,
+    tlsMs: tls,
+    serverWaitMs: nav.responseStart - nav.requestStart,
+  };
+}
+
+/**
+ * Split resource totals at the load event, so the initial-load cost stays
+ * readable while background traffic (idle prefetch, API polling, lazy route
+ * chunks) accumulates separately. loadEventMs 0 means the load event has not
+ * fired yet — everything recorded so far is initial.
+ */
+export function splitByLoad(resources: ResourceRow[], loadEventMs: number): {
+  initialRequestCount: number;
+  initialTransferBytes: number;
+  sinceLoadRequestCount: number;
+  sinceLoadTransferBytes: number;
+} {
+  const cutoff = loadEventMs || Infinity;
+  let initialRequestCount = 0, initialTransferBytes = 0;
+  let sinceLoadRequestCount = 0, sinceLoadTransferBytes = 0;
+  for (const r of resources) {
+    if (r.startMs <= cutoff) {
+      initialRequestCount++;
+      initialTransferBytes += r.transferBytes;
+    } else {
+      sinceLoadRequestCount++;
+      sinceLoadTransferBytes += r.transferBytes;
+    }
+  }
+  return { initialRequestCount, initialTransferBytes, sinceLoadRequestCount, sinceLoadTransferBytes };
+}
+
+/**
  * Map resource timing entries to rows, sorted by start time.
- * cached: transferSize 0 (memory/disk cache) or a small transfer with a
- * large decoded body (304 revalidation).
+ * cached: transferSize 0 (memory/disk cache), an explicit 304, or a small
+ * transfer with a large decoded body (304 heuristic for browsers without
+ * responseStatus — real 304s report decodedBodySize 0).
  */
 export function collectResources(entries: PerformanceResourceTiming[]): ResourceRow[] {
   return entries
@@ -65,7 +133,9 @@ export function collectResources(entries: PerformanceResourceTiming[]): Resource
         transferBytes,
         decodedBytes,
         protocol: e.nextHopProtocol ?? '',
-        cached: transferBytes === 0 || (transferBytes < 400 && decodedBytes > 0),
+        cached: transferBytes === 0
+          || e.responseStatus === 304
+          || (transferBytes < 400 && decodedBytes > 0),
       };
     })
     .sort((a, b) => a.startMs - b.startMs);
@@ -163,19 +233,23 @@ export async function buildLoadReport(): Promise<LoadReport> {
     fcp ? Promise.resolve(null) : observeFcp(),
   ]);
 
+  const loadEventMs = nav?.loadEventEnd ?? 0;
   return {
     collectedAt: new Date().toISOString(),
     topology,
     requestId,
     protocol: nav?.nextHopProtocol ?? '',
+    requestStartMs: nav?.requestStart ?? 0,
     responseStartMs: nav?.responseStart ?? 0,
     domContentLoadedMs: nav?.domContentLoadedEventEnd ?? 0,
-    loadEventMs: nav?.loadEventEnd ?? 0,
+    loadEventMs,
     firstContentfulPaintMs: fcp ? fcp.startTime : observedFcpMs,
     lcpMs,
     lcpElement,
     requestCount: resources.length,
     totalTransferBytes: resources.reduce((sum, r) => sum + r.transferBytes, 0),
+    ...splitByLoad(resources, loadEventMs),
+    phases: computePhases(nav),
     resources,
   };
 }
@@ -190,6 +264,15 @@ function safeEntries<T extends PerformanceEntry>(type: string): T[] {
 
 const ms = (n: number | null): string => n === null ? 'n/a' : `${n.toFixed(0)} ms`;
 
+/** Milestone on the app clock: time since the request hit the wire. */
+export const appMs = (n: number | null, requestStartMs: number): string | null =>
+  n === null || !requestStartMs ? null : `${Math.max(0, n - requestStartMs).toFixed(0)} ms`;
+
+const withAppClock = (n: number | null, r: LoadReport): string => {
+  const app = appMs(n, r.requestStartMs);
+  return app === null ? ms(n) : `${ms(n)} (${app} from request start)`;
+};
+
 /** GitHub-pasteable markdown: summary table + top-20-by-transfer resources. */
 export function reportToMarkdown(r: LoadReport): string {
   const lines: string[] = [
@@ -200,13 +283,17 @@ export function reportToMarkdown(r: LoadReport): string {
     `| Collected at | ${r.collectedAt} |`,
     `| Topology | ${r.topology}${r.requestId ? ` (request-id ${r.requestId})` : ''} |`,
     `| Protocol | ${r.protocol || 'unknown'} |`,
-    `| Response start | ${ms(r.responseStartMs)} |`,
-    `| DOMContentLoaded | ${ms(r.domContentLoadedMs)} |`,
-    `| Load event | ${ms(r.loadEventMs)} |`,
-    `| First contentful paint | ${ms(r.firstContentfulPaintMs)} |`,
-    `| Largest contentful paint | ${ms(r.lcpMs)}${r.lcpElement ? ` (${r.lcpElement})` : ''} |`,
-    `| Requests | ${r.requestCount} |`,
-    `| Total transfer | ${r.totalTransferBytes} bytes |`,
+    `| Response start | ${withAppClock(r.responseStartMs, r)} |`,
+    ...(r.phases ? [
+      `| Document fetch | stalled ${ms(r.phases.stalledMs)} · DNS ${ms(r.phases.dnsMs)} · TCP ${ms(r.phases.tcpMs)} · TLS ${ms(r.phases.tlsMs)} · server wait ${ms(r.phases.serverWaitMs)} |`,
+    ] : []),
+    `| DOMContentLoaded | ${withAppClock(r.domContentLoadedMs, r)} |`,
+    `| Load event | ${withAppClock(r.loadEventMs, r)} |`,
+    `| First contentful paint | ${withAppClock(r.firstContentfulPaintMs, r)} |`,
+    `| Largest contentful paint | ${withAppClock(r.lcpMs, r)}${r.lcpElement ? ` (${r.lcpElement})` : ''} |`,
+    `| Requests (initial load) | ${r.initialRequestCount} |`,
+    `| Total transfer (initial load) | ${r.initialTransferBytes} bytes |`,
+    `| Since load | +${r.sinceLoadRequestCount} requests, +${r.sinceLoadTransferBytes} bytes |`,
     '',
     '#### Top resources by transfer size',
     '',

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
@@ -34,25 +34,27 @@
     }
 
 
-    <!-- Show All Menu Items Toggle (only in expanded mode) -->
-    <div class="nav-show-all-toggle border-b border-nav-border p-3" [class.hidden]="iconMode">
-      <label class="flex items-center space-x-2 text-nav-text-muted hover:text-nav-text cursor-pointer" for="nav-show-all">
-        <input
-          id="nav-show-all"
-          type="checkbox"
-          class="form-checkbox h-4 w-4 text-accent rounded border-nav-border focus:ring-accent focus:ring-2"
-          [checked]="showAllMenuItems"
-          (change)="toggleShowAllMenuItems($event)"
-          >
-        <span class="text-sm">Show all menu items</span>
-      </label>
-    </div>
+    <!-- Show All Menu Items debug toggle (opt-in via company config, expanded mode only) -->
+    @if (showMenuItemsToggle()) {
+      <div class="nav-show-all-toggle border-b border-nav-border p-3" [class.hidden]="iconMode">
+        <label class="flex items-center space-x-2 text-nav-text-muted hover:text-nav-text cursor-pointer" for="nav-show-all">
+          <input
+            id="nav-show-all"
+            type="checkbox"
+            class="form-checkbox h-4 w-4 text-accent rounded border-nav-border focus:ring-accent focus:ring-2"
+            [checked]="showAllMenuItems"
+            (change)="toggleShowAllMenuItems($event)"
+            >
+          <span class="text-sm">Show all menu items</span>
+        </label>
+      </div>
+    }
 
     <!-- Navigation Items -->
     <ul class="nav-items flex-1 py-2 space-y-1">
       @for (tab of tabs; track tab) {
         <li class="nav-item-container">
-          @if (showAllMenuItems || !tab.hidden || (tab.hidden && (tab.hidden | async) === false)) {
+          @if (revealHiddenItems || !tab.hidden || (tab.hidden && (tab.hidden | async) === false)) {
             <a
               class="nav-item nav-item-link flex items-center pl-0 pr-3 py-3 text-nav-text-muted hover:text-nav-text hover:bg-nav-hover transition-all duration-200 relative group"
               [class.nav-item--active]="isActiveRoute(tab.link)"

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.spec.ts
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.spec.ts
@@ -6,6 +6,7 @@ import { createBasicStoreModule } from '@stratosui/store/testing';
 
 import { CoreTestingModule } from "@test-framework/core-test.modules";
 import { CustomizationService, MDAppModule } from '@stratosui/core';
+import { StratosBrandingService } from '../../../../../theme/stratos-branding.service';
 import { SideNavComponent } from './side-nav.component';
 
 
@@ -41,5 +42,31 @@ describe('SideNavComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('hides the "Show all menu items" debug checkbox by default', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('#nav-show-all')).toBeNull();
+  });
+
+  it('shows the checkbox when the deployment config enables the debug toggle', () => {
+    const branding = TestBed.inject(StratosBrandingService);
+    vi.spyOn(branding, 'getShowAllMenuItemsToggle').mockReturnValue(true);
+    const enabled = TestBed.createComponent(SideNavComponent);
+    enabled.detectChanges();
+    expect((enabled.nativeElement as HTMLElement).querySelector('#nav-show-all')).toBeTruthy();
+  });
+
+  it('ignores a stale saved preference while the debug toggle is disabled', () => {
+    // With the checkbox hidden there is no way to switch it off — hidden nav
+    // items must not leak through a leftover localStorage value.
+    localStorage.setItem('stratos-show-all-menu-items', 'true');
+    try {
+      const f = TestBed.createComponent(SideNavComponent);
+      f.detectChanges();
+      expect(f.componentInstance.revealHiddenItems).toBe(false);
+    } finally {
+      localStorage.removeItem('stratos-show-all-menu-items');
+    }
   });
 });

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.ts
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.ts
@@ -70,6 +70,16 @@ export class SideNavComponent implements OnInit {
   public environment = environment;
   public showAllMenuItems = false;
 
+  /** Debug affordance (c5c1009a85): only rendered when the deployment's
+   *  company config opts in via debug.showAllMenuItemsToggle. */
+  public showMenuItemsToggle = computed(() => this.branding.getShowAllMenuItemsToggle());
+
+  /** Effective reveal flag: a saved preference counts only while the debug
+   *  toggle is available — a hidden checkbox must not leak hidden nav items. */
+  get revealHiddenItems(): boolean {
+    return this.showMenuItemsToggle() && this.showAllMenuItems;
+  }
+
   tooltipDelay = 0;
 
   private readonly SHOW_ALL_MENU_ITEMS_KEY = 'stratos-show-all-menu-items';

--- a/src/frontend/packages/core/src/main.ts
+++ b/src/frontend/packages/core/src/main.ts
@@ -25,9 +25,20 @@ platformBrowserDynamic().bootstrapModule(AppModule).then(() => {
   const prefetch = () => import('./monaco-loader').then((m) => m.loadMonacoEditor()).catch(() => {
     // Best-effort: a failed prefetch just means the editor loads on demand.
   });
-  if ('requestIdleCallback' in window) {
-    requestIdleCallback(prefetch, { timeout: 30000 });
+  const schedule = () => {
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(prefetch, { timeout: 30000 });
+    } else {
+      setTimeout(prefetch, 5000);
+    }
+  };
+  // Bootstrap resolves before the window load event; a fetch started in that
+  // gap delays the load milestone and gets counted as initial-load traffic
+  // (visible on the load-performance diagnostics page). Hold the prefetch
+  // until the document has finished loading.
+  if (document.readyState === 'complete') {
+    schedule();
   } else {
-    setTimeout(prefetch, 5000);
+    window.addEventListener('load', schedule, { once: true });
   }
 });

--- a/src/frontend/packages/theme/README.md
+++ b/src/frontend/packages/theme/README.md
@@ -101,6 +101,9 @@ from these locations in order:
     "copyright": "2026 Acme Corp. All rights reserved.",
     "additionalInfo": "Version 5.0"
   },
+  "debug": {
+    "showAllMenuItemsToggle": false
+  },
   "defaults": {
     "themeMode": "light",
     "sidebarOpen": true,
@@ -168,6 +171,7 @@ from these locations in order:
 | `defaults.pageSizeTable` | number[] | No | Page size options for table view |
 | `defaults.viewMode` | `table`/`cards` | No | Default list view mode |
 | `defaults.sortDirection` | `asc`/`desc` | No | Default sort direction |
+| `debug.showAllMenuItemsToggle` | boolean | No | Debug: render the side-nav "Show all menu items" checkbox that reveals nav entries hidden by endpoint/persistence rules. Off by default |
 
 ## Service API Summary
 

--- a/src/frontend/packages/theme/company-config.interface.ts
+++ b/src/frontend/packages/theme/company-config.interface.ts
@@ -65,6 +65,11 @@ export interface CompanyConfig {
     additionalInfo?: string; // Additional footer information
   };
 
+  // Debug affordances — troubleshooting UI kept out of normal deployments
+  debug?: {
+    showAllMenuItemsToggle?: boolean; // Reveal the side-nav "Show all menu items" checkbox
+  };
+
   // Deployment defaults — overridden by user/page preferences once set
   defaults?: {
     // User preference defaults (Layer 3)

--- a/src/frontend/packages/theme/stratos-branding.service.ts
+++ b/src/frontend/packages/theme/stratos-branding.service.ts
@@ -719,6 +719,11 @@ export class StratosBrandingService {
     return this._config().company.supportEmail;
   }
 
+  /** Debug affordance: whether the side-nav "Show all menu items" checkbox is available. */
+  getShowAllMenuItemsToggle(): boolean {
+    return this._config().debug?.showAllMenuItemsToggle === true;
+  }
+
   // =========================================================================
   // Config Update Methods (from CompanyConfigService)
   // =========================================================================

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -22,6 +22,7 @@ const sidebars = {
           items: [
             'deploy/cloud-foundry/cloud-foundry',
             'deploy/cloud-foundry/db-migration',
+            'deploy/cloud-foundry/sqlite-persistence',
             'deploy/cloud-foundry/cf-troubleshooting'
           ]
         },


### PR DESCRIPTION
Two related strands, combined per review preference.

## Load-performance page: measure what Stratos controls

The diagnostics load-performance page's headline totals accumulated every fetch since navigation, so background traffic inflated them, and nothing explained the pre-response dead zone at the left of the waterfall.

- **Requests / Total transfer** now cover the initial load, with post-load traffic tallied separately as *since load*.
- A **document-fetch phase row** decomposes time before first byte into stalled / DNS / TCP / TLS / server wait — a large stall or TLS cost is browser/network setup no app change can recover.
- Milestones gain a **Stratos clock** column (time since the request hit the wire, browser and connection setup subtracted), and the waterfall gets a matching clock toggle so the timeline can start at request time.
- The **monaco idle prefetch** could fire between Angular bootstrap and the load event, delaying the load milestone and counting the editor payload as initial-load traffic; it now waits for the load event.
- **304 revalidations** report `decodedBodySize` 0 and were classified as uncached; `responseStatus` now classifies them correctly.
- Markdown/JSON exports carry the split, the phases and both clocks.

The measurement APIs used (Navigation/Resource/Paint Timing) are implemented natively across Chromium, Firefox and Safari; per-field gaps (LCP on Safari, `responseStatus` on older browsers) degrade to n/a or the previous heuristic.

## Side-nav 'Show all menu items' checkbox: config-gated

The checkbox is a debugging affordance — it reveals nav entries hidden by endpoint/persistence rules. It now renders only when the deployment's company config opts in via `debug.showAllMenuItemsToggle` (default off), and a stale saved preference is ignored while the toggle is unavailable so hidden items cannot leak with no visible way to switch them off. Documented in the theme README and theming architecture doc.

## Docs: recovery patterns for SQLite deployments

CF pushes without a bound database run on ephemeral SQLite and lose tokens, favorites and settings on every push. New deploy doc covers two recovery patterns for deployments that deliberately stay on SQLite:

- **Continuous replication with Litestream** (restore-on-boot + `replicate -exec`), including the ASG needed for egress and the WAL cross-process caveat with the pure-Go SQLite driver.
- **Snapshot into a user-provided service**, with the `file-based-vcap-services` app feature lifting the ~130KB env cap (a 250KB credential blob verified to round-trip through the Cloud Controller intact) and the go-cfenv >= 1.23 note for combining the feature with bound-database detection.

Both hinge on a stable `ENCRYPTION_KEY` — the key and the data must persist together. A bound database service remains the production recommendation.

All frontend changes were test-driven (new failing specs first) and live-verified on a deployed CF instance; full check gate green.