### PR TITLE
Draw the document request as the waterfall's first row

### DIFF
--- a/changelog.d/0002-waterfall-document-row.md
+++ b/changelog.d/0002-waterfall-document-row.md
@@ -1,0 +1,8 @@
+[Features]
+- The diagnostics resource waterfall now draws the document request itself
+  as its first row, segmented by phase (stall, DNS, TCP, TLS, server wait,
+  download). Previously the document was invisible — it is a navigation
+  entry, not a resource entry — so on a high-latency connection the chart
+  showed an unexplained void until the HTML arrived. Under the Stratos
+  clock the row collapses to just server wait + download, the part the
+  app can influence.

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/diagnostic-performance-page.component.spec.ts
@@ -32,6 +32,7 @@ const { fixedReport } = vi.hoisted(() => {
     sinceLoadRequestCount: 1,
     sinceLoadTransferBytes: 1096,
     phases: { stalledMs: 5, dnsMs: 1, tcpMs: 2, tlsMs: 3, serverWaitMs: 1 },
+    document: null,
     resources: [
       { path: '/main.js', startMs: 1, durationMs: 20, transferBytes: 3000, decodedBytes: 9000, protocol: 'h2', cached: false },
       { path: '/styles.css', startMs: 2, durationMs: 5, transferBytes: 1096, decodedBytes: 2000, protocol: 'h2', cached: true },

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.spec.ts
@@ -2,9 +2,10 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
-import { LoadReport, ResourceRow } from '../diagnostics-data/load-performance';
+import { DocumentRow, LoadReport, ResourceRow } from '../diagnostics-data/load-performance';
 import {
   ResourceWaterfallComponent,
+  shiftDocumentRow,
   WATERFALL_GROUP_GAP_MS,
   WATERFALL_ROW_CAP,
   axisTicks,
@@ -298,7 +299,43 @@ const reportWith = (resources: ResourceRow[]): LoadReport => ({
   sinceLoadRequestCount: 0,
   sinceLoadTransferBytes: 0,
   phases: null,
+  document: null,
   resources,
+});
+
+const doc = (over: Partial<DocumentRow> = {}): DocumentRow => ({
+  path: '/',
+  startMs: 0,
+  endMs: 860,
+  transferBytes: 5000,
+  segments: [
+    { label: 'stalled', startMs: 0, durationMs: 320 },
+    { label: 'TLS', startMs: 320, durationMs: 224 },
+    { label: 'server wait', startMs: 544, durationMs: 212 },
+    { label: 'download', startMs: 756, durationMs: 104 },
+  ],
+  ...over,
+});
+
+describe('shiftDocumentRow', () => {
+  it('drops segments that end before the offset and clips one that straddles it', () => {
+    const shifted = shiftDocumentRow(doc(), 400)!;
+    expect(shifted.startMs).toBe(0);
+    expect(shifted.endMs).toBe(460);
+    expect(shifted.segments).toEqual([
+      { label: 'TLS', startMs: 0, durationMs: 144 },
+      { label: 'server wait', startMs: 144, durationMs: 212 },
+      { label: 'download', startMs: 356, durationMs: 104 },
+    ]);
+  });
+
+  it('returns the row unchanged at zero offset', () => {
+    expect(shiftDocumentRow(doc(), 0)).toEqual(doc());
+  });
+
+  it('passes null through', () => {
+    expect(shiftDocumentRow(null, 100)).toBeNull();
+  });
 });
 
 /** One resource per group: starts spaced past the gap so nothing clusters. */
@@ -322,6 +359,24 @@ describe('ResourceWaterfallComponent', () => {
       providers: [provideZonelessChangeDetection()],
     }).compileComponents();
     fixture = TestBed.createComponent(ResourceWaterfallComponent);
+  });
+
+  it('renders the document request as a pinned segmented row', () => {
+    render({ ...reportWith(spacedResources(2)), document: doc() });
+    const documentEl = query('[data-test="waterfall-document"]');
+    expect(documentEl).not.toBeNull();
+    expect(documentEl!.textContent).toContain('document');
+    expect(documentEl!.querySelectorAll('[data-test="waterfall-document-segment"]').length).toBe(4);
+  });
+
+  it('omits the document row when the report has none', () => {
+    render(reportWith(spacedResources(2)));
+    expect(query('[data-test="waterfall-document"]')).toBeNull();
+  });
+
+  it('extends the scale to cover a document outliving every resource', () => {
+    render({ ...reportWith([row({ startMs: 0, durationMs: 10 })]), loadEventMs: 100, document: doc({ endMs: 2000 }) });
+    expect(fixture.componentInstance.scaleMax()).toBeGreaterThanOrEqual(2000);
   });
 
   it('summarises resources and groups in the banner', () => {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, effect, input, signal } from '@angular/core';
 
 import { formatBytes } from '../diagnostics-data/entity-footprint';
-import { LoadReport, ResourceRow } from '../diagnostics-data/load-performance';
+import { DocSegment, DocumentRow, LoadReport, ResourceRow } from '../diagnostics-data/load-performance';
 
 /** Group lines per waterfall page. */
 export const WATERFALL_ROW_CAP = 40;
@@ -113,6 +113,26 @@ export function groupRows(resources: ResourceRow[], gapMs: number = WATERFALL_GR
     }
   }
   return groups;
+}
+
+/** Clock-shift a document row: segments wholly before the offset vanish, a
+ *  straddling one is clipped, the rest slide left. Under the Stratos clock
+ *  this collapses the row to server wait + download — the app-influenced part. */
+export function shiftDocumentRow(d: DocumentRow | null, offsetMs: number): DocumentRow | null {
+  if (!d || !offsetMs) { return d; }
+  const segments = d.segments
+    .map(s => {
+      const start = Math.max(0, s.startMs - offsetMs);
+      const end = Math.max(0, s.startMs + s.durationMs - offsetMs);
+      return { ...s, startMs: start, durationMs: end - start };
+    })
+    .filter(s => s.durationMs > 0);
+  return {
+    ...d,
+    startMs: Math.max(0, d.startMs - offsetMs),
+    endMs: Math.max(0, d.endMs - offsetMs),
+    segments,
+  };
 }
 
 /** Resources that started before the load event; everything when the load
@@ -281,6 +301,28 @@ export function rowLabel(path: string): string {
         </div>
       </div>
 
+      <!-- Row 0: the document request itself, segmented by phase. It is not a
+           resource-timing entry, so without this row a slow connection draws
+           an unexplained void until the HTML arrives. -->
+      @if (windowDocument(); as d) {
+        <div
+          class="flex h-5 items-stretch hover:bg-content-secondary transition-colors"
+          data-test="waterfall-document" [title]="documentTitle(d)">
+          <div class="w-56 shrink-0 pr-2 text-xs leading-5 text-content-muted truncate">document · {{ rowLabel(d.path) }}</div>
+          <div class="relative flex-1 min-w-0">
+            @for (s of d.segments; track s.label; let first = $first; let last = $last) {
+              <div
+                data-test="waterfall-document-segment"
+                class="absolute top-1/2 -translate-y-1/2 h-2.5 bg-[#2a78d6] dark:bg-[#3987e5] min-w-[1px]"
+                [class.rounded-l]="first" [class.rounded-r]="last"
+                [style.opacity]="segmentOpacity(s.label)"
+                [style.left.%]="pct(s.startMs)"
+                [style.width.%]="spanPct(s.startMs, s.durationMs)"></div>
+            }
+          </div>
+        </div>
+      }
+
       <!-- One line per group: single-member groups render as plain resource
            rows; multi-member groups render a summary line that expands. -->
       @for (g of pagedGroups(); track g.key) {
@@ -343,8 +385,9 @@ export function rowLabel(path: string): string {
       FCP = first contentful paint, LCP = largest contentful paint (hover a label for its time).
       Drag along the top axis to zoom to a time range; drag again to drill deeper,
       double-click the axis (or Reset zoom) to zoom back out. The browser clock starts
-      at navigation, so the empty stretch on the left is browser stall + DNS + TCP + TLS
-      before the document request &mdash; switch to the Stratos clock to subtract it.
+      at navigation; the document row's leading segments show the browser stall + DNS +
+      TCP + TLS spent before the request hit the wire (hover the row for each phase's
+      time) &mdash; switch to the Stratos clock to subtract them.
       On a warm (cached) load most bars are near-invisible slivers: cache hits complete
       in ~0 ms and transfer 0 bytes.
     </div>
@@ -381,7 +424,25 @@ export class ResourceWaterfallComponent {
     const offset = this.clockOffsetMs();
     return milestoneLines(this.report()).map(m => ({ ...m, ms: Math.max(0, m.ms - offset) }));
   });
-  scaleMax = computed(() => waterfallScaleMax(this.shiftedLoadEventMs(), this.visibleResources(), this.milestones()));
+
+  /** The document request, clock-shifted; always part of the initial load so
+   *  the initial-only filter never hides it. */
+  private shiftedDocument = computed(() => shiftDocumentRow(this.report().document, this.clockOffsetMs()));
+  /** The document row when it intersects the current view window. */
+  windowDocument = computed(() => {
+    const d = this.shiftedDocument();
+    if (!d) { return null; }
+    const v = this.view();
+    return d.endMs >= v.startMs && d.startMs <= v.endMs ? d : null;
+  });
+
+  scaleMax = computed(() => {
+    const d = this.shiftedDocument();
+    const spans = d
+      ? [...this.visibleResources(), { startMs: d.startMs, durationMs: d.endMs - d.startMs }]
+      : this.visibleResources();
+    return waterfallScaleMax(this.shiftedLoadEventMs(), spans, this.milestones());
+  });
 
   /** Brush zoom: null = full scale. */
   viewWindow = signal<ViewWindow | null>(null);
@@ -503,6 +564,27 @@ export class ResourceWaterfallComponent {
       next.add(key);
     }
     this.expanded.set(next);
+  }
+
+  /** Phase-graded opacity: setup phases faint, app-influenced phases solid. */
+  segmentOpacity(label: DocSegment['label']): number {
+    switch (label) {
+      case 'stalled': return 0.3;
+      case 'DNS': return 0.42;
+      case 'TCP': return 0.55;
+      case 'TLS': return 0.68;
+      case 'server wait': return 0.85;
+      default: return 1;
+    }
+  }
+
+  documentTitle(d: DocumentRow): string {
+    return [
+      `${d.path} (document)`,
+      ...d.segments.map(s => `${s.label}: ${s.durationMs.toFixed(0)} ms`),
+      `total to last byte: ${(d.endMs - d.startMs).toFixed(0)} ms`,
+      `transfer: ${formatBytes(d.transferBytes)}`,
+    ].join('\n');
   }
 
   barTitle(r: ResourceRow): string {

--- a/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostic-performance-page/resource-waterfall.component.ts
@@ -569,6 +569,7 @@ export class ResourceWaterfallComponent {
   /** Phase-graded opacity: setup phases faint, app-influenced phases solid. */
   segmentOpacity(label: DocSegment['label']): number {
     switch (label) {
+      case 'redirect': return 0.25;
       case 'stalled': return 0.3;
       case 'DNS': return 0.42;
       case 'TCP': return 0.55;

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
@@ -206,6 +206,12 @@ describe('documentRow', () => {
     ]);
   });
 
+  it('labels a document-level redirect instead of leaving a leading void', () => {
+    const d = documentRow(nav({ redirectStart: 1, redirectEnd: 200, fetchStart: 200, domainLookupStart: 325 }))!;
+    expect(d.segments[0]).toEqual({ label: 'redirect', startMs: 1, durationMs: 199 });
+    expect(d.segments[1]).toEqual({ label: 'stalled', startMs: 200, durationMs: 125 });
+  });
+
   it('returns null without a navigation entry', () => {
     expect(documentRow(undefined)).toBeNull();
   });

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.spec.ts
@@ -5,6 +5,7 @@ import {
   collectResources,
   computePhases,
   detectTopology,
+  documentRow,
   buildLoadReport,
   observeFcp,
   reportToMarkdown,
@@ -42,6 +43,7 @@ const sampleReport = (): LoadReport => ({
   sinceLoadRequestCount: 0,
   sinceLoadTransferBytes: 0,
   phases: { stalledMs: 5, dnsMs: 1, tcpMs: 2, tlsMs: 3, serverWaitMs: 1 },
+  document: null,
   resources: [
     { path: '/main.js', startMs: 1, durationMs: 20, transferBytes: 3000, decodedBytes: 9000, protocol: 'h2', cached: false },
     { path: '/styles.css', startMs: 2, durationMs: 5, transferBytes: 1096, decodedBytes: 2000, protocol: 'h2', cached: false },
@@ -156,6 +158,56 @@ describe('computePhases', () => {
 
   it('returns null without a navigation entry', () => {
     expect(computePhases(undefined)).toBeNull();
+  });
+});
+
+describe('documentRow', () => {
+  const nav = (overrides: Partial<PerformanceNavigationTiming>): PerformanceNavigationTiming => ({
+    name: 'http://localhost/',
+    startTime: 0,
+    fetchStart: 5,
+    domainLookupStart: 325,
+    domainLookupEnd: 786,
+    connectStart: 786,
+    secureConnectionStart: 883,
+    connectEnd: 1107,
+    requestStart: 1107,
+    responseStart: 1319,
+    responseEnd: 1400,
+    transferSize: 5000,
+    ...overrides,
+  } as PerformanceNavigationTiming);
+
+  it('builds a phase-segmented row spanning navigation start to response end', () => {
+    const d = documentRow(nav({}))!;
+    expect(d.path).toBe('/');
+    expect(d.startMs).toBe(0);
+    expect(d.endMs).toBe(1400);
+    expect(d.transferBytes).toBe(5000);
+    expect(d.segments).toEqual([
+      { label: 'stalled', startMs: 5, durationMs: 320 },
+      { label: 'DNS', startMs: 325, durationMs: 461 },
+      { label: 'TCP', startMs: 786, durationMs: 97 },
+      { label: 'TLS', startMs: 883, durationMs: 224 },
+      { label: 'server wait', startMs: 1107, durationMs: 212 },
+      { label: 'download', startMs: 1319, durationMs: 81 },
+    ]);
+  });
+
+  it('omits zero-length phases (reused connection: no DNS/TCP/TLS)', () => {
+    const d = documentRow(nav({
+      fetchStart: 3, domainLookupStart: 3, domainLookupEnd: 3,
+      connectStart: 3, secureConnectionStart: 0, connectEnd: 3,
+      requestStart: 10, responseStart: 50, responseEnd: 60,
+    }))!;
+    expect(d.segments).toEqual([
+      { label: 'server wait', startMs: 10, durationMs: 40 },
+      { label: 'download', startMs: 50, durationMs: 10 },
+    ]);
+  });
+
+  it('returns null without a navigation entry', () => {
+    expect(documentRow(undefined)).toBeNull();
   });
 });
 

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
@@ -43,7 +43,7 @@ export interface DocPhases {
 
 /** One phase of the document request, drawn as a segment of the waterfall's document row. */
 export interface DocSegment {
-  label: 'stalled' | 'DNS' | 'TCP' | 'TLS' | 'server wait' | 'download';
+  label: 'redirect' | 'stalled' | 'DNS' | 'TCP' | 'TLS' | 'server wait' | 'download';
   startMs: number;
   durationMs: number;
 }
@@ -97,10 +97,17 @@ export interface LoadReport {
  * per non-empty phase, from navigation start to the document's last byte.
  * Zero-length phases (reused connection: no DNS/TCP/TLS) are omitted.
  */
-export function documentRow(nav: PerformanceNavigationTiming | undefined): DocumentRow | null {
-  if (!nav) { return null; }
+/**
+ * The single source of the document request's phase boundaries — both the
+ * phase row (computePhases) and the waterfall's document row (documentRow)
+ * read from this table so they can never diverge. TLS-less and
+ * redirect-less loads produce zero-length spans for those labels.
+ */
+function navSpans(nav: PerformanceNavigationTiming): [DocSegment['label'], number, number][] {
   const tlsStart = nav.secureConnectionStart;
-  const spans: [DocSegment['label'], number, number][] = [
+  const redirected = nav.redirectStart > 0;
+  return [
+    ['redirect', redirected ? nav.redirectStart : 0, redirected ? nav.redirectEnd : 0],
     ['stalled', nav.fetchStart, nav.domainLookupStart],
     ['DNS', nav.domainLookupStart, nav.domainLookupEnd],
     ['TCP', nav.connectStart, tlsStart > 0 ? tlsStart : nav.connectEnd],
@@ -108,12 +115,16 @@ export function documentRow(nav: PerformanceNavigationTiming | undefined): Docum
     ['server wait', nav.requestStart, nav.responseStart],
     ['download', nav.responseStart, nav.responseEnd],
   ];
+}
+
+export function documentRow(nav: PerformanceNavigationTiming | undefined): DocumentRow | null {
+  if (!nav) { return null; }
   return {
     path: new URL(nav.name, location.href).pathname,
     startMs: nav.startTime,
     endMs: nav.responseEnd,
     transferBytes: nav.transferSize ?? 0,
-    segments: spans
+    segments: navSpans(nav)
       .filter(([, start, end]) => end - start > 0)
       .map(([label, start, end]) => ({ label, startMs: start, durationMs: end - start })),
   };
@@ -127,13 +138,17 @@ export function documentRow(nav: PerformanceNavigationTiming | undefined): Docum
  */
 export function computePhases(nav: PerformanceNavigationTiming | undefined): DocPhases | null {
   if (!nav) { return null; }
-  const tls = nav.secureConnectionStart > 0 ? nav.connectEnd - nav.secureConnectionStart : 0;
+  const spans = navSpans(nav);
+  const dur = (label: DocSegment['label']): number => {
+    const [, start, end] = spans.find(([l]) => l === label)!;
+    return end - start;
+  };
   return {
-    stalledMs: nav.domainLookupStart - nav.fetchStart,
-    dnsMs: nav.domainLookupEnd - nav.domainLookupStart,
-    tcpMs: (nav.secureConnectionStart > 0 ? nav.secureConnectionStart : nav.connectEnd) - nav.connectStart,
-    tlsMs: tls,
-    serverWaitMs: nav.responseStart - nav.requestStart,
+    stalledMs: dur('stalled'),
+    dnsMs: dur('DNS'),
+    tcpMs: dur('TCP'),
+    tlsMs: dur('TLS'),
+    serverWaitMs: dur('server wait'),
   };
 }
 

--- a/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
+++ b/src/frontend/packages/core/src/features/about/diagnostics-data/load-performance.ts
@@ -41,6 +41,27 @@ export interface DocPhases {
   serverWaitMs: number;
 }
 
+/** One phase of the document request, drawn as a segment of the waterfall's document row. */
+export interface DocSegment {
+  label: 'stalled' | 'DNS' | 'TCP' | 'TLS' | 'server wait' | 'download';
+  startMs: number;
+  durationMs: number;
+}
+
+/**
+ * The document (navigation) request itself. It never appears in the
+ * resource-timing buffer, so without this row the waterfall draws nothing
+ * until the HTML arrives — on a high-latency path that reads as "no activity"
+ * even though the browser was busy connecting the whole time.
+ */
+export interface DocumentRow {
+  path: string;
+  startMs: number;
+  endMs: number;
+  transferBytes: number;
+  segments: DocSegment[];
+}
+
 export interface LoadReport {
   collectedAt: string;
   topology: 'cf-pushed' | 'local/other';
@@ -67,7 +88,35 @@ export interface LoadReport {
   sinceLoadRequestCount: number;
   sinceLoadTransferBytes: number;
   phases: DocPhases | null;
+  document: DocumentRow | null;
   resources: ResourceRow[];
+}
+
+/**
+ * Build the waterfall's document row from the navigation entry: one segment
+ * per non-empty phase, from navigation start to the document's last byte.
+ * Zero-length phases (reused connection: no DNS/TCP/TLS) are omitted.
+ */
+export function documentRow(nav: PerformanceNavigationTiming | undefined): DocumentRow | null {
+  if (!nav) { return null; }
+  const tlsStart = nav.secureConnectionStart;
+  const spans: [DocSegment['label'], number, number][] = [
+    ['stalled', nav.fetchStart, nav.domainLookupStart],
+    ['DNS', nav.domainLookupStart, nav.domainLookupEnd],
+    ['TCP', nav.connectStart, tlsStart > 0 ? tlsStart : nav.connectEnd],
+    ['TLS', tlsStart > 0 ? tlsStart : 0, tlsStart > 0 ? nav.connectEnd : 0],
+    ['server wait', nav.requestStart, nav.responseStart],
+    ['download', nav.responseStart, nav.responseEnd],
+  ];
+  return {
+    path: new URL(nav.name, location.href).pathname,
+    startMs: nav.startTime,
+    endMs: nav.responseEnd,
+    transferBytes: nav.transferSize ?? 0,
+    segments: spans
+      .filter(([, start, end]) => end - start > 0)
+      .map(([label, start, end]) => ({ label, startMs: start, durationMs: end - start })),
+  };
 }
 
 /**
@@ -250,6 +299,7 @@ export async function buildLoadReport(): Promise<LoadReport> {
     totalTransferBytes: resources.reduce((sum, r) => sum + r.transferBytes, 0),
     ...splitByLoad(resources, loadEventMs),
     phases: computePhases(nav),
+    document: documentRow(nav),
     resources,
   };
 }


### PR DESCRIPTION
## Summary

The diagnostics resource waterfall never drew the document request itself: it is a navigation timing entry, not a resource entry, so the chart's first visible row was whatever loaded after the HTML arrived. On a high-latency connection that left an unexplained void covering the first second-plus of the page load.

This adds the document request as row 0 of the waterfall, segmented by phase:

- redirect, stalled, DNS, TCP, TLS, server wait, download
- Under the Stratos clock the row collapses to server wait + download — the part the app can actually influence
- The phase spans are computed once in a shared table (`load-performance.ts`) used by both the phase summary row and the waterfall, so the two can't disagree

## Testing

- Unit specs for the new span table and the row-0 rendering (core suite green)
- Full `make check gate` green
- Verified live on a deployed console over a ~100ms RTT link, where the document row now accounts for the previously blank lead-in
