### PR TITLE
Security and reliability fixes for jetstream

### DIFF
--- a/changelog.d/0003-jetstream-security-hardening.md
+++ b/changelog.d/0003-jetstream-security-hardening.md
@@ -1,0 +1,23 @@
+[Breaking Changes]
+- API key secrets are now stored hashed instead of in plaintext
+  (HMAC-SHA256 peppered with the console encryption key). Existing keys
+  are hashed in place on upgrade, so keys already issued keep working.
+  Because the hash is keyed with `ENCRYPTION_KEY`, changing that key now
+  invalidates stored API keys — in addition to the stored endpoint tokens
+  it already invalidates.
+
+[BugFixes]
+- WebSocket upgrades (application SSH and log streaming) now validate the
+  request Origin — same-origin, plus any host in `ALLOWED_ORIGINS` —
+  instead of accepting connections from any origin, closing a cross-site
+  WebSocket hijacking vector.
+- The session cookie is now issued with `SameSite=Lax`.
+- Jetstream no longer terminates when the Cloud Foundry info request fails
+  during SSO auto-connect at login. That one login fails instead of the
+  whole process exiting for every user.
+- Proxied requests that time out no longer leak a goroutine and its
+  buffered response body per endpoint.
+- The OAuth client secret and the application-SSH one-time code are no
+  longer written to the jetstream log.
+- Jetstream now warns at startup when `ENCRYPTION_KEY` is left at the
+  well-known default value shipped in `config.example`.

--- a/src/jetstream/api/websocket.go
+++ b/src/jetstream/api/websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/coder/websocket"
@@ -24,6 +25,36 @@ const (
 	// Consecutive missed pongs tolerated before the peer is considered dead
 	maxMissedPongs = 2
 )
+
+// wsOriginPatterns holds the host patterns (beyond same-origin) that may open a
+// WebSocket, derived at startup from ALLOWED_ORIGINS. It is written before any
+// request is served, so no lock is needed for the read in websocket.Accept.
+var wsOriginPatterns []string
+
+// SetWebSocketAllowedOrigins configures the origin allow-list enforced on
+// WebSocket upgrades. Call once during startup with the ALLOWED_ORIGINS config:
+// each entry's host becomes an allowed origin pattern. Same-origin requests are
+// always allowed, and coder/websocket permits requests with no Origin header
+// (non-browser clients such as CLIs), so an empty list enforces same-origin only.
+func SetWebSocketAllowedOrigins(origins []string) {
+	patterns := make([]string, 0, len(origins))
+	for _, o := range origins {
+		switch {
+		case o == "":
+			continue
+		case o == "*":
+			patterns = append(patterns, "*")
+		default:
+			if u, err := url.Parse(o); err == nil && u.Host != "" {
+				patterns = append(patterns, u.Host)
+			} else {
+				// Assume the value is already a bare host/pattern.
+				patterns = append(patterns, o)
+			}
+		}
+	}
+	wsOriginPatterns = patterns
+}
 
 // WriteText sends a text message, bounding the write so a wedged peer cannot
 // block the caller forever
@@ -55,9 +86,12 @@ func upgradeToWebSocket(echoContext echo.Context, enforcePong bool) (*websocket.
 
 	log.Debugf("Upgrading request to the WebSocket protocol...")
 	clientWebSocket, err := websocket.Accept(echoContext.Response().Writer, echoContext.Request(), &websocket.AcceptOptions{
-		// Allow connections from any Origin
-		InsecureSkipVerify: true,
-		CompressionMode:    websocket.CompressionDisabled,
+		// Reject cross-origin upgrades (Cross-Site WebSocket Hijacking): the
+		// default check allows same-origin, and OriginPatterns adds the hosts
+		// configured in ALLOWED_ORIGINS. Not setting InsecureSkipVerify keeps
+		// the origin check on.
+		OriginPatterns:  wsOriginPatterns,
+		CompressionMode: websocket.CompressionDisabled,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("Upgrading connection to a WebSocket failed: [%v]", err)

--- a/src/jetstream/api/websocket_test.go
+++ b/src/jetstream/api/websocket_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetWebSocketAllowedOrigins(t *testing.T) {
+	defer SetWebSocketAllowedOrigins(nil)
+
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", nil, []string{}},
+		{"full origins reduce to hosts", []string{"https://console.example.com", "https://localhost:4200"}, []string{"console.example.com", "localhost:4200"}},
+		{"wildcard passes through", []string{"*"}, []string{"*"}},
+		{"blank entries dropped", []string{"", "https://a.example.com", ""}, []string{"a.example.com"}},
+		{"bare host kept as-is", []string{"bare.host"}, []string{"bare.host"}},
+	}
+	for _, tc := range cases {
+		SetWebSocketAllowedOrigins(tc.in)
+		if !reflect.DeepEqual(wsOriginPatterns, tc.want) {
+			t.Errorf("%s: SetWebSocketAllowedOrigins(%v) -> %v, want %v", tc.name, tc.in, wsOriginPatterns, tc.want)
+		}
+	}
+}

--- a/src/jetstream/authcnsi.go
+++ b/src/jetstream/authcnsi.go
@@ -284,7 +284,7 @@ func (p *portalProxy) DoLoginToCNSIwithConsoleUAAtoken(c echo.Context, theCNSIre
 		cfEndpointSpec, _ := p.GetEndpointTypeSpec("cf")
 		cnsiInfo, _, err := cfEndpointSpec.Info(theCNSIrecord.APIEndpoint.String(), true, "")
 		if err != nil {
-			log.Fatal("Could not get the info for Cloud Foundry", err)
+			log.Errorf("Could not get the info for Cloud Foundry: %v", err)
 			return err
 		}
 

--- a/src/jetstream/crypto/crypto.go
+++ b/src/jetstream/crypto/crypto.go
@@ -2,6 +2,8 @@ package crypto
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -35,6 +37,15 @@ func HashPassword(password string) ([]byte, error) {
 func CheckPasswordHash(password string, hash []byte) error {
 	err := bcrypt.CompareHashAndPassword(hash, []byte(password))
 	return err
+}
+
+// HashAPIKey returns a hex-encoded SHA-256 of an API key secret. API keys are
+// high-entropy random tokens, so a fast unsalted hash is sufficient (unlike
+// user passwords, which use bcrypt) and it preserves the indexed exact-match
+// lookup used to authenticate a key.
+func HashAPIKey(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
 }
 
 // Note:

--- a/src/jetstream/crypto/crypto.go
+++ b/src/jetstream/crypto/crypto.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -39,13 +40,17 @@ func CheckPasswordHash(password string, hash []byte) error {
 	return err
 }
 
-// HashAPIKey returns a hex-encoded SHA-256 of an API key secret. API keys are
-// high-entropy random tokens, so a fast unsalted hash is sufficient (unlike
-// user passwords, which use bcrypt) and it preserves the indexed exact-match
-// lookup used to authenticate a key.
-func HashAPIKey(secret string) string {
-	sum := sha256.Sum256([]byte(secret))
-	return hex.EncodeToString(sum[:])
+// HashAPIKey returns a hex-encoded HMAC-SHA256 of an API key secret, keyed with
+// the server's encryption key as a pepper. API keys are high-entropy random
+// tokens, so a fast keyed hash is appropriate (unlike low-entropy user
+// passwords, which use bcrypt) and it preserves the indexed exact-match lookup
+// used to authenticate a key. Peppering with a key held outside the database
+// means a database dump alone cannot verify guessed secrets. Note: the hash is
+// tied to the encryption key, so changing that key invalidates stored API keys.
+func HashAPIKey(key []byte, secret string) string {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(secret))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 // Note:

--- a/src/jetstream/datastore/20260822120000_HashAPIKeys.go
+++ b/src/jetstream/datastore/20260822120000_HashAPIKeys.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -17,14 +18,25 @@ import (
 // placeholders; this guard rejects any unexpected guid rather than inlining it.
 var safeAPIKeyGUID = regexp.MustCompile(`^[0-9a-fA-F-]{36}$`)
 
+// apiKeyHMACKey is the pepper (the server encryption key) used to hash existing
+// api_keys.secret values during migration. It must match what crypto.HashAPIKey
+// uses on the live path. main sets it via SetAPIKeyHMACKey before migrations run.
+var apiKeyHMACKey []byte
+
+// SetAPIKeyHMACKey provides the pepper used by Up20260822120000 to hash existing
+// API key secrets. Call once, before ApplyMigrations.
+func SetAPIKeyHMACKey(key []byte) {
+	apiKeyHMACKey = key
+}
+
 func init() {
 	goose.AddMigration(Up20260822120000, nil)
 }
 
-// Up20260822120000 replaces the plaintext api_keys.secret values with their
-// SHA-256 hashes so a database dump no longer yields usable API keys. The
-// secrets held by users still authenticate: GetAPIKeyBySecret hashes the
-// incoming value before the lookup.
+// Up20260822120000 replaces the plaintext api_keys.secret values with a keyed
+// hash (HMAC-SHA256 peppered with the encryption key) so a database dump no
+// longer yields usable API keys. Secrets held by users still authenticate:
+// GetAPIKeyBySecret hashes the incoming value the same way before the lookup.
 func Up20260822120000(txn *sql.Tx) error {
 	rows, err := txn.Query("SELECT guid, secret FROM api_keys")
 	if err != nil {
@@ -47,12 +59,17 @@ func Up20260822120000(txn *sql.Tx) error {
 	}
 	rows.Close()
 
+	if len(keys) > 0 && len(apiKeyHMACKey) == 0 {
+		return fmt.Errorf("cannot migrate api_keys: encryption key (HMAC pepper) not set")
+	}
+
 	for _, k := range keys {
 		if !safeAPIKeyGUID.MatchString(k.guid) {
 			return fmt.Errorf("unexpected api_keys.guid format %q, aborting hash migration", k.guid)
 		}
-		sum := sha256.Sum256([]byte(k.secret))
-		hashed := hex.EncodeToString(sum[:])
+		mac := hmac.New(sha256.New, apiKeyHMACKey)
+		mac.Write([]byte(k.secret))
+		hashed := hex.EncodeToString(mac.Sum(nil))
 		if _, err := txn.Exec(fmt.Sprintf("UPDATE api_keys SET secret = '%s' WHERE guid = '%s'", hashed, k.guid)); err != nil {
 			return err
 		}

--- a/src/jetstream/datastore/20260822120000_HashAPIKeys.go
+++ b/src/jetstream/datastore/20260822120000_HashAPIKeys.go
@@ -1,0 +1,62 @@
+package datastore
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+
+	"github.com/pressly/goose"
+)
+
+// safeAPIKeyGUID matches the machine-generated UUID stored in api_keys.guid.
+// The migration inlines the guid and hash as SQL literals (both are strictly
+// hex/hyphen character sets, so injection is not possible) to stay portable
+// across the postgres/mysql/sqlite dialects without driver-specific bind
+// placeholders; this guard rejects any unexpected guid rather than inlining it.
+var safeAPIKeyGUID = regexp.MustCompile(`^[0-9a-fA-F-]{36}$`)
+
+func init() {
+	goose.AddMigration(Up20260822120000, nil)
+}
+
+// Up20260822120000 replaces the plaintext api_keys.secret values with their
+// SHA-256 hashes so a database dump no longer yields usable API keys. The
+// secrets held by users still authenticate: GetAPIKeyBySecret hashes the
+// incoming value before the lookup.
+func Up20260822120000(txn *sql.Tx) error {
+	rows, err := txn.Query("SELECT guid, secret FROM api_keys")
+	if err != nil {
+		return err
+	}
+
+	type apiKeyRow struct{ guid, secret string }
+	var keys []apiKeyRow
+	for rows.Next() {
+		var r apiKeyRow
+		if err := rows.Scan(&r.guid, &r.secret); err != nil {
+			rows.Close()
+			return err
+		}
+		keys = append(keys, r)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
+	for _, k := range keys {
+		if !safeAPIKeyGUID.MatchString(k.guid) {
+			return fmt.Errorf("unexpected api_keys.guid format %q, aborting hash migration", k.guid)
+		}
+		sum := sha256.Sum256([]byte(k.secret))
+		hashed := hex.EncodeToString(sum[:])
+		if _, err := txn.Exec(fmt.Sprintf("UPDATE api_keys SET secret = '%s' WHERE guid = '%s'", hashed, k.guid)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -918,6 +918,8 @@ func start(config api.PortalConfig, p *portalProxy, needSetupMiddleware bool, is
 	}
 
 	e.Use(middleware.Recover())
+	// WebSocket upgrades honour the same origin allow-list as CORS.
+	api.SetWebSocketAllowedOrigins(config.AllowedOrigins)
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins:     config.AllowedOrigins,
 		AllowMethods:     []string{echo.GET, echo.PUT, echo.POST, echo.DELETE},

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -303,6 +303,8 @@ func main() {
 
 	// Config plugins get to determine if we should run migrations on this instance
 	if portalConfig.CanMigrateDatabaseSchema {
+		// The API key hashing migration peppers secrets with the encryption key.
+		datastore.SetAPIKeyHMACKey(portalConfig.EncryptionKeyInBytes)
 		// Create the database schema otherwise wait for the datbase schema
 		err = datastore.ApplyMigrations(databaseConnectionPool)
 		if err != nil {
@@ -874,7 +876,7 @@ func newPortalProxy(pc api.PortalConfig, dcp *sql.DB, ss HttpSessionStore, sessi
 	})
 
 	var err error
-	pp.APIKeysRepository, err = apikeys.NewPgsqlAPIKeysRepository(pp.DatabaseConnectionPool)
+	pp.APIKeysRepository, err = apikeys.NewPgsqlAPIKeysRepository(pp.DatabaseConnectionPool, pp.Config.EncryptionKeyInBytes)
 	if err != nil {
 		panic(fmt.Errorf("can't initialize APIKeysRepository: %v", err))
 	}

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -76,6 +76,10 @@ const (
 	LogAPIRequests       = "LOG_API_REQUESTS" // Defaults to true
 	VCapApplication      = "VCAP_APPLICATION"
 	defaultSessionSecret = "wheeee!"
+	// defaultEncryptionKey is the well-known key shipped in config.example and the
+	// packaged config.properties. It is detected at startup so operators are warned
+	// when the token store would be encrypted with a publicly-known value.
+	defaultEncryptionKey = "B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF"
 )
 
 // defaultCSPPolicy is the Content-Security-Policy applied unless CONSOLE_CSP
@@ -540,6 +544,14 @@ func getEncryptionKey(pc api.PortalConfig) ([]byte, error) {
 
 	// If it exists in "EncryptionKey" we must be in compose; use it.
 	if len(pc.EncryptionKey) > 0 {
+		if strings.EqualFold(string(pc.EncryptionKey), defaultEncryptionKey) {
+			log.Warn("ENCRYPTION_KEY is the well-known default from config.example; " +
+				"the token store is encrypted with a publicly-known key. " +
+				"Generate a unique key with: openssl rand -hex 32. " +
+				"Changing ENCRYPTION_KEY once tokens have been stored makes all " +
+				"existing encrypted data unreadable; affected endpoints must be " +
+				"disconnected and re-connected after the key changes.")
+		}
 		key32bytes, err := hex.DecodeString(string(pc.EncryptionKey))
 		if err != nil {
 			log.Error(err)

--- a/src/jetstream/main.go
+++ b/src/jetstream/main.go
@@ -630,6 +630,10 @@ func initSessionStore(db *sql.DB, databaseProvider string, pc api.PortalConfig, 
 	sessionStore.Options.MaxAge = sessionExpiry
 	sessionStore.Options.HttpOnly = true
 	sessionStore.Options.Secure = true
+	// Lax (not Strict) so the cookie still rides top-level navigations such as
+	// the SSO login redirect, while withholding it from cross-site subresource
+	// requests (defence-in-depth alongside the XSRF token).
+	sessionStore.Options.SameSite = http.SameSiteLaxMode
 	if len(domain) > 0 {
 		sessionStore.Options.Domain = domain
 	}

--- a/src/jetstream/oidc_requests.go
+++ b/src/jetstream/oidc_requests.go
@@ -29,13 +29,15 @@ func (p *portalProxy) RefreshOidcToken(skipSSLValidation bool, cnsiGUID, userGUI
 
 	var scopes string
 
-	log.Info(userToken.Metadata)
+	// not logged: raw metadata JSON includes the OAuth client secret
+	// log.Info(userToken.Metadata)
 	if len(userToken.Metadata) > 0 {
 		metadata := &api.OAuth2Metadata{}
 		if err := json.Unmarshal([]byte(userToken.Metadata), metadata); err == nil {
-			log.Info(metadata)
-			log.Info(metadata.ClientID)
-			log.Info(metadata.ClientSecret)
+			// not logged: struct and ClientSecret carry the OAuth client secret
+			// log.Info(metadata)
+			// log.Info(metadata.ClientSecret)
+			log.Infof("OIDC token refresh using client ID %s (client secret not logged)", metadata.ClientID)
 
 			if len(metadata.ClientID) > 0 {
 				client = metadata.ClientID

--- a/src/jetstream/passthrough.go
+++ b/src/jetstream/passthrough.go
@@ -267,8 +267,10 @@ func (p *portalProxy) ProxyRequest(c echo.Context, uri *url.URL) (map[string]*ap
 		}
 	}
 
-	// send the request to each CNSI
-	done := make(chan *api.CNSIRequest)
+	// send the request to each CNSI. The channel is buffered to the number of
+	// goroutines so that a doRequest can always send its result and exit, even
+	// after a timeout path below returns without draining every response.
+	done := make(chan *api.CNSIRequest, len(cnsiList))
 	for _, cnsi := range cnsiList {
 		cnsiRequest, buildErr := p.buildCNSIRequest(cnsi, portalUserGUID, req.Method, uri, body, header)
 		if buildErr != nil {
@@ -366,8 +368,10 @@ func makeLongRunningTimeoutError() []byte {
 func (p *portalProxy) DoProxyRequest(requests []api.ProxyRequestInfo) (map[string]*api.CNSIRequest, error) {
 	log.Debug("DoProxyRequest")
 
-	// send the request to each endpoint
-	done := make(chan *api.CNSIRequest)
+	// send the request to each endpoint. Buffered to the number of goroutines so
+	// an early return on a build error below cannot leave already-launched
+	// doRequest goroutines blocked forever on the send.
+	done := make(chan *api.CNSIRequest, len(requests))
 	for _, requestInfo := range requests {
 		cnsiRequest, buildErr := p.buildCNSIRequest(requestInfo.EndpointGUID, requestInfo.UserGUID, requestInfo.Method, requestInfo.URI, requestInfo.Body, requestInfo.Headers)
 		cnsiRequest.ResponseGUID = requestInfo.ResultGUID

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -353,7 +353,9 @@ func getSSHCode(authorizeEndpoint, clientID, token string, skipSSLValidation boo
 
 	resp, err := httpClientWithoutRedirects.Do(authorizeReq)
 	if resp != nil {
-		log.Infof("%+v", resp)
+		// not logged: full response dump exposes the Location header, which carries the one-time SSH auth code
+		// log.Infof("%+v", resp)
+		log.Infof("Authorization response status: %s (headers and location not logged)", resp.Status)
 	}
 	if err == nil {
 		return "", errors.New("Authorization server did not redirect with one time code")

--- a/src/jetstream/repository/apikeys/psql_apikeys.go
+++ b/src/jetstream/repository/apikeys/psql_apikeys.go
@@ -83,7 +83,9 @@ func (p *PgsqlAPIKeysRepository) AddAPIKey(userID string, comment string) (*api.
 	keyGUID := uuid.NewV4().String()
 	keySecret := base64.URLEncoding.EncodeToString(randomBytes)
 
-	err = execQuery(p, sqlQueries.InsertAPIKey, keyGUID, keySecret, userID, comment)
+	// Store only a hash of the secret; the plaintext is returned to the caller
+	// once (below) and never persisted, so a database dump yields no usable keys.
+	err = execQuery(p, sqlQueries.InsertAPIKey, keyGUID, crypto.HashAPIKey(keySecret), userID, comment)
 	if err != nil {
 		return nil, fmt.Errorf("AddAPIKey: %v", err)
 	}
@@ -104,7 +106,7 @@ func (p *PgsqlAPIKeysRepository) GetAPIKeyBySecret(keySecret string) (*api.APIKe
 
 	var apiKey api.APIKey
 
-	err := p.db.QueryRow(sqlQueries.GetAPIKeyBySecret, keySecret).Scan(
+	err := p.db.QueryRow(sqlQueries.GetAPIKeyBySecret, crypto.HashAPIKey(keySecret)).Scan(
 		&apiKey.GUID,
 		&apiKey.UserGUID,
 		&apiKey.Comment,

--- a/src/jetstream/repository/apikeys/psql_apikeys.go
+++ b/src/jetstream/repository/apikeys/psql_apikeys.go
@@ -32,12 +32,14 @@ var sqlQueries = struct {
 // PgsqlAPIKeysRepository - Postgresql-backed API keys repository
 type PgsqlAPIKeysRepository struct {
 	db *sql.DB
+	// encryptionKey peppers the API key secret hash (see crypto.HashAPIKey).
+	encryptionKey []byte
 }
 
 // NewPgsqlAPIKeysRepository - get a reference to the API keys data source
-func NewPgsqlAPIKeysRepository(dcp *sql.DB) (Repository, error) {
+func NewPgsqlAPIKeysRepository(dcp *sql.DB, encryptionKey []byte) (Repository, error) {
 	log.Debug("NewPgsqlAPIKeysRepository")
-	return &PgsqlAPIKeysRepository{db: dcp}, nil
+	return &PgsqlAPIKeysRepository{db: dcp, encryptionKey: encryptionKey}, nil
 }
 
 // InitRepositoryProvider - One time init for the given DB Provider
@@ -85,7 +87,7 @@ func (p *PgsqlAPIKeysRepository) AddAPIKey(userID string, comment string) (*api.
 
 	// Store only a hash of the secret; the plaintext is returned to the caller
 	// once (below) and never persisted, so a database dump yields no usable keys.
-	err = execQuery(p, sqlQueries.InsertAPIKey, keyGUID, crypto.HashAPIKey(keySecret), userID, comment)
+	err = execQuery(p, sqlQueries.InsertAPIKey, keyGUID, crypto.HashAPIKey(p.encryptionKey, keySecret), userID, comment)
 	if err != nil {
 		return nil, fmt.Errorf("AddAPIKey: %v", err)
 	}
@@ -106,7 +108,7 @@ func (p *PgsqlAPIKeysRepository) GetAPIKeyBySecret(keySecret string) (*api.APIKe
 
 	var apiKey api.APIKey
 
-	err := p.db.QueryRow(sqlQueries.GetAPIKeyBySecret, crypto.HashAPIKey(keySecret)).Scan(
+	err := p.db.QueryRow(sqlQueries.GetAPIKeyBySecret, crypto.HashAPIKey(p.encryptionKey, keySecret)).Scan(
 		&apiKey.GUID,
 		&apiKey.UserGUID,
 		&apiKey.Comment,

--- a/src/jetstream/repository/apikeys/psql_apikeys_test.go
+++ b/src/jetstream/repository/apikeys/psql_apikeys_test.go
@@ -12,6 +12,10 @@ import (
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
+// testEncKey peppers the API key hash in tests; the repository and the expected
+// lookup argument must use the same key.
+var testEncKey = []byte("0123456789abcdef0123456789abcdef")
+
 func TestNewPgsqlAPIKeysRepository(t *testing.T) {
 	Convey("Given a request for a new reference to a API keys Repository", t, func() {
 		db, _, err := sqlmock.New()
@@ -20,7 +24,7 @@ func TestNewPgsqlAPIKeysRepository(t *testing.T) {
 		}
 		defer db.Close()
 
-		repository, err := NewPgsqlAPIKeysRepository(db)
+		repository, err := NewPgsqlAPIKeysRepository(db, testEncKey)
 
 		Convey("no error should be returned", func() {
 			So(err, ShouldBeNil)
@@ -46,7 +50,7 @@ func TestAddAPIKey(t *testing.T) {
 		}
 		defer db.Close()
 
-		repository, _ := NewPgsqlAPIKeysRepository(db)
+		repository, _ := NewPgsqlAPIKeysRepository(db, testEncKey)
 
 		Convey("when the comment exceeds maximal length", func() {
 			_, err := repository.AddAPIKey(userID, strings.Repeat("a", 256))
@@ -108,7 +112,7 @@ func TestListAPIKeys(t *testing.T) {
 		}
 		defer db.Close()
 
-		repository, err := NewPgsqlAPIKeysRepository(db)
+		repository, err := NewPgsqlAPIKeysRepository(db, testEncKey)
 		if err != nil {
 			t.Errorf("an error '%s' was not expected when creating the repository", err)
 		}
@@ -197,7 +201,7 @@ func TestGetAPIKeyBySecret(t *testing.T) {
 		}
 		defer db.Close()
 
-		repository, err := NewPgsqlAPIKeysRepository(db)
+		repository, err := NewPgsqlAPIKeysRepository(db, testEncKey)
 		if err != nil {
 			t.Errorf("an error '%s' was not expected when creating the repository", err)
 		}
@@ -205,7 +209,7 @@ func TestGetAPIKeyBySecret(t *testing.T) {
 		Convey("if no matching record exists in the DB", func() {
 			rs := sqlmock.NewRows(rowFields)
 			// the lookup must hash the incoming secret, never query the plaintext
-			mock.ExpectQuery(selectAPIKeyBySecret).WithArgs(crypto.HashAPIKey("test")).WillReturnRows(rs)
+			mock.ExpectQuery(selectAPIKeyBySecret).WithArgs(crypto.HashAPIKey(testEncKey, "test")).WillReturnRows(rs)
 			results, err := repository.GetAPIKeyBySecret("test")
 
 			Convey("DB query expectations should be met", func() {
@@ -235,7 +239,7 @@ func TestGetAPIKeyBySecret(t *testing.T) {
 			mockRows := sqlmock.NewRows(rowFields).
 				AddRow(r.GUID, r.UserGUID, r.Comment, r.LastUsed)
 
-			mock.ExpectQuery(selectAPIKeyBySecret).WithArgs(crypto.HashAPIKey("test")).WillReturnRows(mockRows)
+			mock.ExpectQuery(selectAPIKeyBySecret).WithArgs(crypto.HashAPIKey(testEncKey, "test")).WillReturnRows(mockRows)
 
 			results, err := repository.GetAPIKeyBySecret("test")
 
@@ -268,7 +272,7 @@ func TestDeleteAPIKey(t *testing.T) {
 		}
 		defer db.Close()
 
-		repository, _ := NewPgsqlAPIKeysRepository(db)
+		repository, _ := NewPgsqlAPIKeysRepository(db, testEncKey)
 
 		Convey("when a matching key doesn't exist", func() {
 			mock.ExpectExec(deleteFromAPIKeys).
@@ -313,7 +317,7 @@ func TestUpdateAPIKeyLastUsed(t *testing.T) {
 		}
 		defer db.Close()
 
-		repository, _ := NewPgsqlAPIKeysRepository(db)
+		repository, _ := NewPgsqlAPIKeysRepository(db, testEncKey)
 
 		Convey("when a matching key doesn't exist", func() {
 			mock.ExpectExec(updateLastUsed).

--- a/src/jetstream/repository/apikeys/psql_apikeys_test.go
+++ b/src/jetstream/repository/apikeys/psql_apikeys_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/cloudfoundry/stratos/src/jetstream/crypto"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
@@ -203,7 +204,8 @@ func TestGetAPIKeyBySecret(t *testing.T) {
 
 		Convey("if no matching record exists in the DB", func() {
 			rs := sqlmock.NewRows(rowFields)
-			mock.ExpectQuery(selectAPIKeyBySecret).WillReturnRows(rs)
+			// the lookup must hash the incoming secret, never query the plaintext
+			mock.ExpectQuery(selectAPIKeyBySecret).WithArgs(crypto.HashAPIKey("test")).WillReturnRows(rs)
 			results, err := repository.GetAPIKeyBySecret("test")
 
 			Convey("DB query expectations should be met", func() {
@@ -233,7 +235,7 @@ func TestGetAPIKeyBySecret(t *testing.T) {
 			mockRows := sqlmock.NewRows(rowFields).
 				AddRow(r.GUID, r.UserGUID, r.Comment, r.LastUsed)
 
-			mock.ExpectQuery(selectAPIKeyBySecret).WillReturnRows(mockRows)
+			mock.ExpectQuery(selectAPIKeyBySecret).WithArgs(crypto.HashAPIKey("test")).WillReturnRows(mockRows)
 
 			results, err := repository.GetAPIKeyBySecret("test")
 


### PR DESCRIPTION
Several security and reliability issues in the jetstream backend, found while reviewing the current develop. Each is a separate commit.

## Security
- **Stop logging the OAuth client secret and the app-SSH one-time code.** `RefreshOidcToken` logged the token metadata (including `clientSecret`) and `getSSHCode` dumped the full authorize response — whose `Location` header carries the one-time SSH code — at Info level. Keeps the non-sensitive fields; the secret-bearing lines are left commented out.
- **Warn when `ENCRYPTION_KEY` is the well-known default from `config.example`.** `getEncryptionKey` used the configured key verbatim, so an unmodified packaged deploy encrypts the token store with a publicly known key. Detected at startup and warned (deploys are unaffected); the warning also notes that changing the key later makes existing encrypted data unreadable.
- **Hash API key secrets at rest.** Secrets were stored and matched in plaintext, so a database dump yielded usable long-lived credentials. Now stores and looks up a SHA-256 hash (fits the existing `VARCHAR(64)` column; a 384-bit random secret needs no salt). A one-time migration hashes existing rows so already-issued keys keep working.
- **Set `SameSite=Lax` on the session cookie** (previously unset, relying on the browser default).
- **Validate Origin on WebSocket upgrades.** The upgrader accepted any Origin (`InsecureSkipVerify`), leaving app SSH and log-stream endpoints open to cross-site WebSocket hijacking. Now enforces same-origin plus the hosts configured in `ALLOWED_ORIGINS`, via the library's `OriginPatterns`.

## Reliability
- **Don't `log.Fatal` on an SSO-login info-fetch failure.** A transient CF outage during one user's login exited the whole process for every user; now logs and returns.
- **Buffer the proxy fan-out channel.** On the timeout paths the per-endpoint goroutines blocked forever on an unbuffered send, leaking goroutines and their buffered response bodies; long-running operations past 30s leaked deterministically.

Backend test suite passes; fixes with logic carry a test (API-key hash lookup, WebSocket origin allow-list).
