### PR TITLE
Fix full page reload after login

### DIFF
--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.spec.ts
@@ -231,6 +231,21 @@ describe('LoginPageComponent', () => {
     const sanitize = (s: string) => (component as any).sanitizeSsoMessage(s);
     expect(sanitize('a'.repeat(500)).length).toBe(256);
   });
+
+  // The click handler and the existing-session auto-redirect can both observe
+  // "logged in + valid" for the same login and call handleSuccessfulLogin. Only
+  // the first may navigate; a second navigation races the first, gets cancelled
+  // to false, and hard-reloads the page (the post-login blank + repaint).
+  it('navigates once when handleSuccessfulLogin is triggered twice', async () => {
+    const navSpy = vi.spyOn((component as any).router, 'navigate').mockResolvedValue(true);
+    const auth = { redirect: undefined } as any;
+
+    await (component as any).handleSuccessfulLogin(auth);
+    await (component as any).handleSuccessfulLogin(auth);
+
+    expect(navSpy).toHaveBeenCalledTimes(1);
+    expect(navSpy).toHaveBeenCalledWith(['/home'], { queryParams: {} });
+  });
 });
 
 describe('LoginPageComponent — error banner branding', () => {

--- a/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
+++ b/src/frontend/packages/core/src/features/login/login-page/login-page.component.ts
@@ -181,6 +181,14 @@ export class LoginPageComponent implements OnInit {
   private readonly MAX_REDIRECT_ATTEMPTS = 2;
   private readonly REDIRECT_COUNTER_KEY = 'stratos_login_redirect_attempts';
 
+  // Guards handleSuccessfulLogin against being run twice for the same login: the
+  // click handler and the existing-session auto-redirect can both observe the
+  // "logged in + valid" state in one tick and each navigate to /home. Two
+  // concurrent navigations make the router cancel one (resolving false), which
+  // drops into the window.location.href fallback — a full page reload seen as a
+  // blank + repaint after login.
+  private redirectInFlight = false;
+
   private get redirectAttempts(): number {
     return parseInt(sessionStorage.getItem(this.REDIRECT_COUNTER_KEY) || '0', 10);
   }
@@ -368,10 +376,19 @@ export class LoginPageComponent implements OnInit {
   }
 
   private async handleSuccessfulLogin(auth: AuthState): Promise<null> {
+    // Run the post-login redirect once: a duplicate call (click handler +
+    // existing-session auto-redirect firing on the same state) would race a
+    // second navigation, get cancelled to false, and hard-reload the page.
+    if (this.redirectInFlight) {
+      return null;
+    }
+    this.redirectInFlight = true;
+
     this.redirectAttempts++;
 
     // Prevent infinite redirect loop
     if (!this.underRedirectCap) {
+      this.redirectInFlight = false;
       return null;
     }
 


### PR DESCRIPTION
After a successful login the console rendered `/home`, blanked the whole app, and re-rendered — a visible full page reload on every sign-in.

## Cause
`handleSuccessfulLogin` ran twice for the same login: the click handler and the `ngOnInit` existing-session auto-redirect both fire when auth becomes "logged in + valid", so two concurrent `router.navigate(['/home'])` calls collide. With `onSameUrlNavigation: 'reload'` the router cancels one, which resolves `false` and drops into the `window.location.href` fallback — a full document reload. A HAR of the login confirmed a single script-initiated `document` `GET /home` (an in-app router navigation issues no document request).

## Fix
Guard `handleSuccessfulLogin` so the redirect runs once. With one navigation nothing is cancelled, `navResult` is `true`, the fallback never fires, and `/home` renders a single time. The `window.location.href` fallback still covers a genuine navigation failure.

Includes a regression test asserting a single `router.navigate` when both triggers fire.
