### PR TITLE
chore(changelog): fragment for login reload fix

### DIFF
--- a/changelog.d/0004-login-double-redirect.md
+++ b/changelog.d/0004-login-double-redirect.md
@@ -1,0 +1,6 @@
+[BugFixes]
+- Signing in no longer flashes the Home page, blanks the console, and
+  reloads it. The login click handler and the existing-session check both
+  triggered the post-login redirect; the two navigations cancelled each
+  other and the loser fell back to a full page reload. The redirect now
+  runs once.


### PR DESCRIPTION
PR #5837 (the post-login double-redirect reload fix) merged without a changelog fragment. This adds the missing BugFixes entry so the fix appears in the next release's notes.

No code changes.