### PR TITLE
feat(frontend): make the side-nav Sign Out hideable (5.4.x)

### DIFF
--- a/changelog.d/0010-side-nav-logout.md
+++ b/changelog.d/0010-side-nav-logout.md
@@ -1,0 +1,11 @@
+[Features]
+- The Sign Out button in the side navigation can now be hidden with
+  `HIDE_NAV_LOGOUT=true`. It is presentation only — the user menu in the
+  page header keeps its own Sign Out, so the ability to log out is
+  unchanged.
+
+[BugFixes]
+- The side navigation no longer offers Sign Out when there is no session
+  to end. Running with `AUTH_ENDPOINT_TYPE=none` grants the
+  `stratos.noauth` scope, which the page header has always honoured; the
+  side navigation ignored it and showed the button anyway.

--- a/changelog.d/0010-side-nav-logout.md
+++ b/changelog.d/0010-side-nav-logout.md
@@ -1,8 +1,8 @@
 [Features]
 - The Sign Out button in the side navigation can now be hidden with
-  `HIDE_NAV_LOGOUT=true`. It is presentation only — the user menu in the
-  page header keeps its own Sign Out, so the ability to log out is
-  unchanged.
+  `HIDE_NAV_LOGOUT=true`, or `console.ui.hideNavLogout` on the Helm
+  chart. It is presentation only — the user menu in the page header
+  keeps its own Sign Out, so the ability to log out is unchanged.
 
 [BugFixes]
 - The side navigation no longer offers Sign Out when there is no session

--- a/deploy/kubernetes/console/templates/deployment.yaml
+++ b/deploy/kubernetes/console/templates/deployment.yaml
@@ -299,6 +299,8 @@ spec:
         {{- end }}
         - name: UI_LIST_ALLOW_LOAD_MAXED
           value: {{ default "false" .Values.console.ui.listAllowLoadMaxed | quote }}
+        - name: HIDE_NAV_LOGOUT
+          value: {{ default "false" .Values.console.ui.hideNavLogout | quote }}
         {{- end }}
         - name: ANALYSIS_SERVICES_API
           value: "http://{{ .Release.Name }}-analyzers:8090"

--- a/deploy/kubernetes/console/values.yaml
+++ b/deploy/kubernetes/console/values.yaml
@@ -78,6 +78,9 @@ console:
     listMaxSize:
     # If the maximum list size is met give the user the option to fetch all results regardless
     listAllowLoadMaxed: false
+    # Hide the Sign Out button in the side navigation. Presentation only - the
+    # user menu in the page header keeps its own Sign Out
+    hideNavLogout: false
 
   # Use local admin user instead of UAA - set to a password to enable
   localAdminPassword: ~

--- a/docs/deploy/access.md
+++ b/docs/deploy/access.md
@@ -69,3 +69,23 @@ Password: `hscadmin`
 `stratos.admon`
 
 5. The Console is now ready to be used
+
+## Signing out
+
+Stratos offers Sign Out in two places: at the foot of the side navigation, and
+in the user menu in the page header.
+
+The side navigation button can be hidden on its own by setting
+`HIDE_NAV_LOGOUT` to `true`. This is presentation only — the user menu keeps
+its Sign Out, so the ability to log out is unchanged. Use it where the extra
+button is redundant or crowds the navigation.
+
+| Deployment | How to set it |
+|------------|---------------|
+| Cloud Foundry | `cf set-env console HIDE_NAV_LOGOUT true`, then restage |
+| Kubernetes (Helm) | `--set console.ui.hideNavLogout=true` |
+| Docker, single container | `docker run -e HIDE_NAV_LOGOUT=true ...` |
+
+Both buttons disappear when there is no session to end. Running with
+`AUTH_ENDPOINT_TYPE=none` grants the `stratos.noauth` scope, and Stratos hides
+Sign Out everywhere regardless of `HIDE_NAV_LOGOUT`.

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.html
@@ -109,6 +109,7 @@
     }
 
     <!-- Logout Button -->
+    @if ((canLogout$ | async) && !hideNavLogout()) {
     <div class="nav-logout border-t border-nav-border p-3">
       <button
         class="logout-button w-full flex items-center p-2 text-nav-text-muted hover:text-nav-text hover:bg-nav-hover rounded-lg transition-all duration-200"
@@ -124,6 +125,7 @@
         </span>
       </button>
     </div>
+    }
 
     <!-- Navigation Footer -->
     @if (copyright()) {

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.spec.ts
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { RouterTestingModule } from '@angular/router/testing';
 import { createBasicStoreModule } from '@stratosui/store/testing';
@@ -8,6 +8,7 @@ import { CoreTestingModule } from "@test-framework/core-test.modules";
 import { CustomizationService, MDAppModule } from '@stratosui/core';
 import { StratosBrandingService } from '../../../../../theme/stratos-branding.service';
 import { SideNavComponent } from './side-nav.component';
+import { AuthSignalService } from '../../../core/signals/auth-signal.service';
 
 
 describe('SideNavComponent', () => {
@@ -42,6 +43,37 @@ describe('SideNavComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  // HIDE_NAV_LOGOUT is delivered in the session config; the side nav reads it
+  // to drop its own Sign Out button while the header menu keeps logout.
+  describe('hideNavLogout', () => {
+    const build = (config: Record<string, unknown> | undefined) => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [RouterTestingModule, MDAppModule, CoreTestingModule, createBasicStoreModule(), SideNavComponent],
+        providers: [
+          CustomizationService,
+          provideZonelessChangeDetection(),
+          { provide: AuthSignalService, useValue: { sessionData: signal(config ? { config } : null), logout: () => undefined } },
+        ]
+      });
+      const f = TestBed.createComponent(SideNavComponent);
+      f.detectChanges();
+      return f.componentInstance;
+    };
+
+    it('is false when the flag is unset', () => {
+      expect(build({ enableTechPreview: false }).hideNavLogout()).toBe(false);
+    });
+
+    it('is false when there is no session yet', () => {
+      expect(build(undefined).hideNavLogout()).toBe(false);
+    });
+
+    it('is true when HIDE_NAV_LOGOUT is on', () => {
+      expect(build({ hideNavLogout: true }).hideNavLogout()).toBe(true);
+    });
   });
 
   it('hides the "Show all menu items" debug checkbox by default', () => {

--- a/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.ts
+++ b/src/frontend/packages/core/src/features/dashboard/side-nav/side-nav.component.ts
@@ -1,10 +1,12 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { StratosBrandingService } from '../../../../../theme/stratos-branding.service';
 import { AuthSignalService } from '../../../core/signals/auth-signal.service';
+import { CurrentUserPermissionsService } from '../../../core/permissions/current-user-permissions.service';
+import { StratosCurrentUserPermissions } from '../../../core/permissions/stratos-user-permissions.checker';
 import { DashboardDataService } from '../../../core/dashboard-data.service';
 import { CustomizationService, CustomizationsMetadata } from '../../../core/customizations.types';
 import { environment } from '../../../environments/environment';
@@ -42,6 +44,17 @@ export class SideNavComponent implements OnInit {
   private branding = inject(StratosBrandingService);
   private dashboardData = inject(DashboardDataService);
   private authSignals = inject(AuthSignalService);
+  private permissionsService = inject(CurrentUserPermissionsService);
+
+  // Same guard the page header uses: the 'stratos.noauth' scope means there
+  // is no session to end, so offering Sign Out is meaningless.
+  public canLogout$: Observable<boolean> = this.permissionsService
+    .can(StratosCurrentUserPermissions.CAN_NOT_LOGOUT)
+    .pipe(map(noLogout => !noLogout));
+
+  // HIDE_NAV_LOGOUT removes this button only. The header user menu keeps its
+  // own Sign Out, so hiding it here is presentation, not a capability change.
+  public hideNavLogout = computed(() => !!this.authSignals.sessionData()?.config?.hideNavLogout);
 
 
   public customizations: CustomizationsMetadata;

--- a/src/frontend/packages/store/src/types/auth.types.ts
+++ b/src/frontend/packages/store/src/types/auth.types.ts
@@ -48,6 +48,9 @@ export interface SessionDataConfig {
   APIKeysEnabled?: APIKeysEnabled;
   // Default value for Home View - show only favorited endpoints?
   homeViewShowFavoritesOnly?: boolean;
+  // Hide the Sign Out button in the side nav. Cosmetic only — the header
+  // user menu keeps its own logout, gated separately by CAN_NOT_LOGOUT.
+  hideNavLogout?: boolean;
   userEndpointsEnabled?: UserEndpointsEnabled;
 }
 export interface SessionData {

--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -299,6 +299,7 @@ type Info struct {
 		ListAllowLoadMaxed         bool   `json:"listAllowLoadMaxed,omitempty"`
 		APIKeysEnabled             string `json:"APIKeysEnabled"`
 		HomeViewShowFavoritesOnly  bool   `json:"homeViewShowFavoritesOnly"`
+		HideNavLogout              bool   `json:"hideNavLogout"`
 		UserEndpointsEnabled       string `json:"userEndpointsEnabled"`
 		EndpointCardConcurrency    int    `json:"endpointCardConcurrency"`
 		EndpointRequestConcurrency int    `json:"endpointRequestConcurrency"`
@@ -474,6 +475,7 @@ type PortalConfig struct {
 	CanMigrateDatabaseSchema           bool
 	APIKeysEnabled                     api.APIKeysConfigValue       `configName:"API_KEYS_ENABLED"`
 	HomeViewShowFavoritesOnly          bool                         `configName:"HOME_VIEW_SHOW_FAVORITES_ONLY"`
+	HideNavLogout                      bool                         `configName:"HIDE_NAV_LOGOUT"`
 	EndpointCardConcurrency            int                          `configName:"ENDPOINT_CARD_CONCURRENCY"`
 	EndpointRequestConcurrency         int                          `configName:"ENDPOINT_REQUEST_CONCURRENCY"`
 	UserEndpointsEnabled               api.UserEndpointsConfigValue `configName:"USER_ENDPOINTS_ENABLED"`

--- a/src/jetstream/auth_test.go
+++ b/src/jetstream/auth_test.go
@@ -1035,7 +1035,7 @@ func TestVerifySession(t *testing.T) {
 
 		var expectedScopes = `"scopes":["openid","scim.read","cloud_controller.admin","uaa.user","cloud_controller.read","password.write","routing.router_groups.read","cloud_controller.write","doppler.firehose","scim.write"]`
 
-		var expectedBody = `{"status":"ok","error":"","data":{"version":{"proxy_version":"dev","database_version":20161117141922,"build_date":"","git_commit":"","git_branch":""},"user":{"guid":"asd-gjfg-bob","name":"admin","admin":false,` + expectedScopes + `},"endpoints":{"cf":{}},"plugins":null,"config":{"enableTechPreview":false,"APIKeysEnabled":"admin_only","homeViewShowFavoritesOnly":false,"userEndpointsEnabled":"disabled","endpointCardConcurrency":2,"endpointRequestConcurrency":3}}}`
+		var expectedBody = `{"status":"ok","error":"","data":{"version":{"proxy_version":"dev","database_version":20161117141922,"build_date":"","git_commit":"","git_branch":""},"user":{"guid":"asd-gjfg-bob","name":"admin","admin":false,` + expectedScopes + `},"endpoints":{"cf":{}},"plugins":null,"config":{"enableTechPreview":false,"APIKeysEnabled":"admin_only","homeViewShowFavoritesOnly":false,"hideNavLogout":false,"userEndpointsEnabled":"disabled","endpointCardConcurrency":2,"endpointRequestConcurrency":3}}}`
 
 		Convey("Should contain expected body", func() {
 			So(res, ShouldNotBeNil)

--- a/src/jetstream/info.go
+++ b/src/jetstream/info.go
@@ -62,6 +62,7 @@ func (p *portalProxy) getInfo(c echo.Context) (*api.Info, error) {
 	s.Configuration.ListAllowLoadMaxed = p.Config.UIListAllowLoadMaxed
 	s.Configuration.APIKeysEnabled = string(p.Config.APIKeysEnabled)
 	s.Configuration.HomeViewShowFavoritesOnly = p.Config.HomeViewShowFavoritesOnly
+	s.Configuration.HideNavLogout = p.Config.HideNavLogout
 	s.Configuration.UserEndpointsEnabled = string(p.Config.UserEndpointsEnabled)
 	s.Configuration.EndpointCardConcurrency = p.Config.EndpointCardConcurrency
 	s.Configuration.EndpointRequestConcurrency = p.Config.EndpointRequestConcurrency


### PR DESCRIPTION
Backport of #5851 to the 5.4.x line.

`release/5.4.x` is cut from the `v5.4.0` tag, which is the last commit before `chore(deps): migrate jetstream to Echo v5` — so it carries the Echo v4 line that 5.4.1 will ship from.

The three commits cherry-pick with no conflicts; the only difference from the develop versions is context, `getInfo(c echo.Context)` here against `getInfo(c *echo.Context)` there. Added and removed lines are identical.

- `HIDE_NAV_LOGOUT` hides the side navigation's Sign Out button. Presentation only — the page header user menu keeps its own.
- The side nav now honours `CAN_NOT_LOGOUT`, so `AUTH_ENDPOINT_TYPE=none` (which grants `stratos.noauth`) no longer offers a Sign Out with no session to end.
- `console.ui.hideNavLogout` exposes the flag on the Helm chart.
- `docs/deploy/access.md` gains a "Signing out" section.