### PR TITLE
build: gate release branches in CI

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'release/**'
     # tools/stb has its own gate (stb_tests.yml); skip the backend suite
     # for stb-only changes.
     paths-ignore:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - develop
       - main
+      - 'release/**'
   pull_request:
     branches:
       - develop
       - main
+      - 'release/**'
   workflow_dispatch:  # on-demand: Actions tab "Run workflow" or `gh workflow run codeql.yml --ref develop`
   schedule:
     - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC — catches advisories on idle branches

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'release/**'
     # tools/stb has its own gate (stb_tests.yml); skip the frontend suite
     # for stb-only changes.
     paths-ignore:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,10 +13,12 @@ on:
       - main
       - develop
       - 'angular**'
+      - 'release/**'
   push:
     branches:
       - develop
       - main
+      - 'release/**'
 
 # One live run per ref: a push to a PR branch (or develop/main) cancels the
 # in-flight run for the same ref, so overlapping runs never contend for

--- a/.github/workflows/stb_tests.yml
+++ b/.github/workflows/stb_tests.yml
@@ -16,10 +16,12 @@ on:
       - main
       - develop
       - 'angular**'
+      - 'release/**'
   push:
     branches:
       - develop
       - main
+      - 'release/**'
     paths:
       - 'tools/stb/**'
 

--- a/changelog.d/0011-release-branch-ci.md
+++ b/changelog.d/0011-release-branch-ci.md
@@ -1,0 +1,4 @@
+[BugFixes]
+- Pull requests targeting a `release/*` branch now run the full test suite.
+  The workflow triggers listed `main`, `develop` and `angular**` only, so a
+  release line got no checks at all — pushes to it are gated too.


### PR DESCRIPTION
`release/5.4.x` currently gets no CI. #5852 merged with EasyCLA as its only check — zero workflow runs were created for its head sha, against three (`Pull Request Tests`, `CodeQL`, `STB Tests`) for the equivalent PR on develop.

The cause is trigger branch filters, not anything about the branch. `pr.yml`, `stb_tests.yml` and `codeql.yml` list `main`, `develop` and `angular**` on `pull_request`; `release/5.4.x` matches none, so nothing fires. `pr.yml` is the one carrying Docs Lint, Lint Check, Frontend Tests, Backend Tests, Build Check, Booklets and E2E Impact, so that single filter accounts for nearly every missing check. The `push` triggers have the same gap, leaving the release line ungated after a merge too.

Adds `release/**` to both trigger kinds across the five workflows that gate code.

This PR gates itself, which is the useful proof: `release/5.4.x` does not carry the change yet, and `Pull Request Tests`, `CodeQL` and `STB Tests` are all running here. A `pull_request` trigger is evaluated against the workflow files in the merge ref, so the new filter takes effect on the PR that introduces it.

Deployment and publishing workflows (`release.yml`, `docker.yml`, `ci-image.yml`, `website-deploy.yml`, `container-push-base-images-develop.yaml`) are deliberately untouched.

The same fix for develop is in #5854.