### PR TITLE
build: gate release branches in CI

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'release/**'
     # tools/stb has its own gate (stb_tests.yml); skip the backend suite
     # for stb-only changes.
     paths-ignore:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - develop
       - main
+      - 'release/**'
   pull_request:
     branches:
       - develop
       - main
+      - 'release/**'
   workflow_dispatch:  # on-demand: Actions tab "Run workflow" or `gh workflow run codeql.yml --ref develop`
   schedule:
     - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC — catches advisories on idle branches

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'release/**'
     # tools/stb has its own gate (stb_tests.yml); skip the frontend suite
     # for stb-only changes.
     paths-ignore:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,10 +13,12 @@ on:
       - main
       - develop
       - 'angular**'
+      - 'release/**'
   push:
     branches:
       - develop
       - main
+      - 'release/**'
 
 # One live run per ref: a push to a PR branch (or develop/main) cancels the
 # in-flight run for the same ref, so overlapping runs never contend for

--- a/.github/workflows/stb_tests.yml
+++ b/.github/workflows/stb_tests.yml
@@ -16,10 +16,12 @@ on:
       - main
       - develop
       - 'angular**'
+      - 'release/**'
   push:
     branches:
       - develop
       - main
+      - 'release/**'
     paths:
       - 'tools/stb/**'
 

--- a/changelog.d/0011-release-branch-ci.md
+++ b/changelog.d/0011-release-branch-ci.md
@@ -1,0 +1,4 @@
+[BugFixes]
+- Pull requests targeting a `release/*` branch now run the full test suite.
+  The workflow triggers listed `main`, `develop` and `angular**` only, so a
+  release line got no checks at all — pushes to it are gated too.


### PR DESCRIPTION
Companion to #5853, which applies the same change to `release/5.4.x`.

`pr.yml`, `stb_tests.yml` and `codeql.yml` list `main`, `develop` and `angular**` on `pull_request`, so a PR targeting a `release/*` branch gets no checks at all — #5852 merged into `release/5.4.x` with EasyCLA as its only status, and no workflow run was created for its head sha. The `push` triggers have the same gap, so the release line is ungated after a merge too.

Adds `release/**` to both trigger kinds across the five workflows that gate code. Carrying it on develop means the next release line cut from here is gated from the moment it exists, rather than needing this fix applied again.

Deployment and publishing workflows (`release.yml`, `docker.yml`, `ci-image.yml`, `website-deploy.yml`, `container-push-base-images-develop.yaml`) are deliberately untouched.