### PR TITLE
chore(changelog): drop fragments published in 5.4.0

### DIFF
--- a/changelog.d/0001-mask-env-var-secrets.md
+++ b/changelog.d/0001-mask-env-var-secrets.md
@@ -1,9 +1,0 @@
-[Features]
-- The application Variables tab now masks secret-looking values —
-  keys matching pass/secret/token/private/key/cred, URLs with
-  embedded credentials, and PEM private-key blocks under any
-  variable name — in both the variables list and the All
-  Variables block. Values appear only on explicit request: a per-row
-  Show/Hide toggle in the list, a Show secrets toggle on the block.
-  The same value heuristics the Service Keys page already uses; hosts and
-  ports in connection URLs stay readable.

--- a/changelog.d/0002-waterfall-document-row.md
+++ b/changelog.d/0002-waterfall-document-row.md
@@ -1,8 +1,0 @@
-[Features]
-- The diagnostics resource waterfall now draws the document request itself
-  as its first row, segmented by phase (stall, DNS, TCP, TLS, server wait,
-  download). Previously the document was invisible — it is a navigation
-  entry, not a resource entry — so on a high-latency connection the chart
-  showed an unexplained void until the HTML arrived. Under the Stratos
-  clock the row collapses to just server wait + download, the part the
-  app can influence.

--- a/changelog.d/0003-jetstream-security-hardening.md
+++ b/changelog.d/0003-jetstream-security-hardening.md
@@ -1,26 +1,4 @@
-[Breaking Changes]
-- API key secrets are now stored hashed instead of in plaintext
-  (HMAC-SHA256 peppered with the console encryption key). Existing keys
-  are hashed in place on upgrade, so keys already issued keep working.
-  Because the hash is keyed with `ENCRYPTION_KEY`, changing that key now
-  invalidates stored API keys — in addition to the stored endpoint tokens
-  it already invalidates.
-
 [BugFixes]
-- WebSocket upgrades (application SSH and log streaming) now validate the
-  request Origin — same-origin, plus any host in `ALLOWED_ORIGINS` —
-  instead of accepting connections from any origin, closing a cross-site
-  WebSocket hijacking vector.
-- The session cookie is now issued with `SameSite=Lax`.
-- Jetstream no longer terminates when the Cloud Foundry info request fails
-  during SSO auto-connect at login. That one login fails instead of the
-  whole process exiting for every user.
-- Proxied requests that time out no longer leak a goroutine and its
-  buffered response body per endpoint.
-- The OAuth client secret and the application-SSH one-time code are no
-  longer written to the jetstream log.
-- Jetstream now warns at startup when `ENCRYPTION_KEY` is left at the
-  well-known default value shipped in `config.example`.
 - The UAA token endpoint is now checked at the point the request is made,
   rather than trusted from wherever it was built. It must be an absolute
   http(s) URL with a plain host and path — no user info, query or

--- a/changelog.d/0004-login-double-redirect.md
+++ b/changelog.d/0004-login-double-redirect.md
@@ -1,6 +1,0 @@
-[BugFixes]
-- Signing in no longer flashes the Home page, blanks the console, and
-  reloads it. The login click handler and the existing-session check both
-  triggered the post-login redirect; the two navigations cancelled each
-  other and the loser fell back to a full page reload. The redirect now
-  runs once.


### PR DESCRIPTION
v5.4.0 was tagged on this line and its post-release sweep never ran, so `changelog.d` still holds the four fragments it published. As things stand the next release off develop would repeat v5.4.0's Breaking Change about API key hashing, both its features and six of its bug fixes, verbatim.

Same cleanup #5855 did on the 5.4 line, where the identical four were still sitting when `release/5.4.x` was cut.

Each was checked against the published v5.4.0 notes before removal rather than going by filename:

| Fragment | Probe found in v5.4.0's notes |
|---|---|
| `0001-mask-env-var-secrets.md` | "The application Variables tab now masks secret-looking" |
| `0002-waterfall-document-row.md` | "The diagnostics resource waterfall now draws the docume" |
| `0003-jetstream-security-hardening.md` | "API key secrets are now stored hashed instead of in pla" |
| `0004-login-double-redirect.md` | "Signing in no longer flashes the Home page, blanks the" |

**0003 is trimmed, not deleted.** It is the one fragment that changed after the tag — 93f3f982ad appended the UAA token endpoint check to it, and that bullet has never appeared in a release. Deleting the file wholesale would have dropped an unshipped security fix from the next release notes. Only the already-published content is removed; the UAA bullet stays and now carries the file on its own.

Fragments 0005 through 0011 are untouched. They were published in the `5.4.1-dev.N` prereleases, and `changelog.d/README.md` is explicit that prerelease fragments accumulate until the official release — so they belong in the next one.

After this, `release-notes.sh assemble` on develop opens with the side-nav Sign Out feature and the UAA fix, and contains no v5.4.0 content.