### PR TITLE
docs(deploy): require PostgreSQL 14+, drop the 9.4 example

### DIFF
--- a/changelog.d/0002-postgres-supported-versions.md
+++ b/changelog.d/0002-postgres-supported-versions.md
@@ -1,0 +1,5 @@
+[Chores]
+- Documented the supported PostgreSQL versions (14 and later, matching what the
+  upstream `lib/pq` driver tests against) and removed the PostgreSQL 9.4 service
+  plan from the Cloud Foundry database-binding example, which had been telling
+  operators to provision a major that left upstream support in 2020.

--- a/docs/contributing_guide.md
+++ b/docs/contributing_guide.md
@@ -294,6 +294,9 @@ complex selectors, animations).
 Stratos supports PostgreSQL, MySQL/MariaDB, and SQLite. For local development,
 SQLite is the default (zero setup).
 
+PostgreSQL 14 and later is supported — the versions the upstream
+[`lib/pq`](https://github.com/lib/pq) driver tests against.
+
 For MySQL/MariaDB (closer to production) using the repo's `docker-compose.yml`:
 
 ```bash

--- a/docs/deploy/cloud-foundry/db-migration.md
+++ b/docs/deploy/cloud-foundry/db-migration.md
@@ -13,15 +13,21 @@ the steps below to implement.
 
     > **NOTE** Stratos supports postgresql and mysql DBs. Stratos will enumerate the bound service instances to detect the database type - see  [below](#note-on-service-bindings) for more detail.
 
-    Use `cf create-service` to create a service instance for the DB - for example:
+    > **NOTE** For PostgreSQL, use a plan offering **PostgreSQL 14 or later** — the
+    > versions the upstream [`lib/pq`](https://github.com/lib/pq) driver tests
+    > against. Older majors are out of upstream support and are not tested.
+
+    First list what your marketplace offers, since service and plan names differ
+    between foundations:
     ```
-    cf create-service postgresql v9.4 console_db
+    cf marketplace
     ```
-    * In this example, `postgresql` is the service name for the Postgres DB service, `v9.4` is the service plan and `console_db` is the name for the service instance that will be created. 
-    * To view services and service plans:
-      ```
-      cf marketplace
-      ```
+
+    Then use `cf create-service` to create a service instance for the DB - for example:
+    ```
+    cf create-service postgresql <plan> console_db
+    ```
+    * In this example, `postgresql` is the service name for the Postgres DB service, `<plan>` is the service plan you picked from the marketplace and `console_db` is the name for the service instance that will be created.
 
     You can also create an [User-Provided Service Instance](https://docs.cloudfoundry.org/devguide/services/user-provided.html):
     ```bash

--- a/docs/developer-environment.md
+++ b/docs/developer-environment.md
@@ -138,6 +138,9 @@ Stratos connects to external SQL databases. It does not bundle a database server
 | PostgreSQL | `pgsql` | Via container | Recommended |
 | MySQL / MariaDB | `mysql` | Via container | Supported |
 
+PostgreSQL 14 and later is supported — the versions the upstream
+[`lib/pq`](https://github.com/lib/pq) driver tests against.
+
 Any PostgreSQL-compatible (CockroachDB, Aurora, AlloyDB) or MySQL-compatible
 (MariaDB, Aurora MySQL, PlanetScale) service works with existing drivers.
 


### PR DESCRIPTION
The Cloud Foundry database-binding guide told operators to run
`cf create-service postgresql v9.4 console_db`. PostgreSQL 9.4 left upstream
support in February 2020, so the one concrete command in that guide has been
pointing at an unsupported major for years — and on most foundations that plan
no longer exists, so the example fails outright.

The supported range was also declared nowhere in the docs. A reader had no way
to find out which PostgreSQL versions Stratos is expected to work against.

Changes:

- `docs/deploy/cloud-foundry/db-migration.md` — replaces the `v9.4` plan with a
  `<plan>` placeholder, moves `cf marketplace` ahead of the `create-service`
  call (you cannot pick a plan before you have listed them), and adds a note
  requiring PostgreSQL 14 or later.
- `docs/contributing_guide.md` and `docs/developer-environment.md` — state the
  supported range where each already discusses database choice.

14 as the floor comes from the driver: upstream [`lib/pq`](https://github.com/lib/pq)
tests against 14 and later, so those are the versions Stratos' PostgreSQL
support is actually exercised on.

Docs only — no code, no build, no behaviour change.

`deploy/containers/postgres/Dockerfile` still pins `postgres:9.4.9`. It has not
been referenced by anything since 2017 and is deliberately left alone here
rather than mixed into a documentation change.
