### PR TITLE
chore(changelog): fragments for the delete dialog and dev WebSocket fixes

### DIFF
--- a/changelog.d/0003-delete-dialog-org-space.md
+++ b/changelog.d/0003-delete-dialog-org-space.md
@@ -1,0 +1,6 @@
+[BugFixes]
+- The application delete confirmation now names the org and space when the
+  wizard is opened by URL or after a refresh. It resolved all four names
+  together, so a page load where the app and endpoint had arrived but the org
+  and space had not showed `org "?" / space "?"` — losing the disambiguation
+  the dialog exists to provide. Each name is now resolved on its own.

--- a/changelog.d/0004-dev-stack-websocket-origin.md
+++ b/changelog.d/0004-dev-stack-websocket-origin.md
@@ -1,0 +1,7 @@
+[BugFixes]
+- `make dev backend` now allow-lists the `ng serve` origin, so WebSocket
+  features work in the development stack. jetstream rejects cross-origin
+  upgrades unless the origin is in `ALLOWED_ORIGINS`, and the dev target set
+  none — which broke `cf push`, application log streams and SSH with
+  `request Origin ... is not authorized for Host ...`. A packaged console
+  serves the UI from jetstream itself, so only development was affected.


### PR DESCRIPTION
Pre-tag audit for 5.5.1. Four commits have landed since `v5.5.0`; two of them
arrived in #5860 with no changelog fragment, so they would have been absent
from the release notes:

- `4c7fcb6478` — the application delete confirmation naming org and space on a
  cold load.
- `403c098882` — the dev-stack `ALLOWED_ORIGINS` default, without which `cf
  push`, log streams and SSH fail under `ng serve`.

Both are written up as `[BugFixes]`, following `0011-release-branch-ci.md`,
which filed a `build:` change the same way.

The remaining two commits (`2d5ef8fa14`, `1c7fd76159`) are already covered by
`0001-yaml-v4.md`, so `release-notes.sh deps` has nothing left to draft — its
two bumps are the ones that fragment describes.

`./build/release-notes.sh assemble` validates and now yields Bug Fixes ×2,
Maintainability ×1, Chores ×2 for 5.5.1.
