### PR TITLE
fix(dashboard): stop persisting viewport state over the measurement

### DIFF
--- a/changelog.d/0005-dashboard-mobile-layout-persisted.md
+++ b/changelog.d/0005-dashboard-mobile-layout-persisted.md
@@ -1,0 +1,8 @@
+[BugFixes]
+- The console no longer loads in the mobile layout on a desktop window (or the
+  desktop layout on a narrow one). `isMobile` and `isMobileNavOpen` are measured
+  from the viewport, but they were being written to the stored user preferences
+  and then restored over the live measurement when preferences loaded — leaving
+  the side nav overlaying the page and the header controls hidden until the
+  window was resized across the breakpoint. Viewport state is now owned by the
+  breakpoint observer alone and is never persisted.

--- a/src/frontend/packages/core/src/core/dashboard-data.service.spec.ts
+++ b/src/frontend/packages/core/src/core/dashboard-data.service.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { DashboardDataService } from './dashboard-data.service';
+
+describe('DashboardDataService', () => {
+  const storageKey = 'stratos-norm-test';
+  let service: DashboardDataService;
+
+  beforeEach(() => {
+    localStorage.removeItem(storageKey);
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection(), DashboardDataService],
+    });
+    service = TestBed.inject(DashboardDataService);
+  });
+
+  describe('hydrateFromStorage', () => {
+    it('restores persisted preferences', () => {
+      service.hydrateFromStorage(storageKey, JSON.stringify({ homeLayout: 3, gravatarEnabled: true }));
+
+      expect(service.homeLayout()).toBe(3);
+      expect(service.gravatarEnabled()).toBe(true);
+    });
+
+    it('keeps the measured viewport state when storage disagrees', () => {
+      // The breakpoint observer runs before SESSION_VERIFIED, so the viewport
+      // is already measured by the time prefs arrive. A stale isMobile in
+      // storage must not put a desktop window back into the mobile layout.
+      service.disableMobileNav();
+
+      service.hydrateFromStorage(storageKey, JSON.stringify({ isMobile: true, isMobileNavOpen: true }));
+
+      expect(service.isMobile()).toBe(false);
+      expect(service.isMobileNavOpen()).toBe(false);
+    });
+
+    it('keeps the measured viewport state on a narrow window too', () => {
+      service.enableMobileNav();
+
+      service.hydrateFromStorage(storageKey, JSON.stringify({ isMobile: false }));
+
+      expect(service.isMobile()).toBe(true);
+    });
+  });
+
+  it('never writes viewport state to storage', () => {
+    service.hydrateFromStorage(storageKey, null);
+    service.enableMobileNav();
+    service.setHomeLayout(2);
+
+    const written = JSON.parse(localStorage.getItem(storageKey) as string);
+    expect(written.homeLayout).toBe(2);
+    expect(written).not.toHaveProperty('isMobile');
+    expect(written).not.toHaveProperty('isMobileNavOpen');
+  });
+});

--- a/src/frontend/packages/core/src/core/dashboard-data.service.ts
+++ b/src/frontend/packages/core/src/core/dashboard-data.service.ts
@@ -17,7 +17,14 @@ export interface DashboardState {
   timeoutSession: boolean;
   pollingEnabled: boolean;
   sidenavOpen: boolean;
+  /**
+   * Measured from the viewport, not chosen by the user. Owned by the
+   * breakpoint observer in `DashboardBaseComponent`: never persisted, and
+   * left untouched by hydration. A user-settable layout preference would be
+   * a new field, not a reuse of these two.
+   */
   isMobile: boolean;
+  /** @see isMobile — viewport-derived, not persisted. */
   isMobileNavOpen: boolean;
   sideNavPinned: boolean;
   /** @deprecated Theme mode now managed by StratosBrandingService via localStorage */
@@ -74,7 +81,11 @@ export class DashboardDataService {
     if (raw) {
       try {
         const parsed = JSON.parse(raw) as Partial<DashboardState>;
-        this._state.set({ ...defaultDashboardState, ...parsed });
+        // Viewport fields are measured, not remembered.
+        // The breakpoint observer has already run by the time prefs arrive,
+        // so the live values win over whatever storage happens to hold.
+        const { isMobile, isMobileNavOpen } = this._state();
+        this._state.set({ ...defaultDashboardState, ...parsed, isMobile, isMobileNavOpen });
       } catch {
         // Ignore malformed prefs — keep defaults.
       }
@@ -152,7 +163,8 @@ export class DashboardDataService {
     this._state.set(next);
     if (this.hydrated && this.storageKey) {
       try {
-        localStorage.setItem(this.storageKey, JSON.stringify(next));
+        const { isMobile, isMobileNavOpen, ...persisted } = next;
+        localStorage.setItem(this.storageKey, JSON.stringify(persisted));
       } catch {
         // Quota / disabled storage — non-fatal.
       }


### PR DESCRIPTION
> **Corrected after merge.** The original description asserted a runtime
> ordering — breakpoint observer first, hydration second — as the cause of a
> user-visible symptom. That ordering did not reproduce through the UI when it
> was tested live afterwards. The code change is unaffected; the description
> below is what the evidence actually supports. The original text and the
> failed reproduction are recorded in a comment on this PR.

`isMobile` and `isMobileNavOpen` are measured from the window by the dashboard's
breakpoint observer in `DashboardBaseComponent`. They were stored in the same
persisted bag as genuine user preferences, and hydration owns that bag:
`hydrateFromStorage` did a blanket `{ ...defaultDashboardState, ...parsed }`,
so whatever the stored copy held was written over the live measurement.

That is the defect this fixes — an ownership error. Two pieces of state that
describe the current window were being remembered across sessions and replayed
over the window's actual size.

The fix gives them a single owner. Hydration preserves the live values, and the
write path strips them so they never enter storage again; entries that already
carry them clear on the next mutation.

I chose this over whitelisting keys at hydration — the same amount of code, but
a whitelist leaves both fields inside the persisted shape, so the next field
added inherits the same ambiguity. Separating measured state from preferences
is also the line mobile work needs: a user-settable compact/mobile layout
becomes a new, deliberately persisted field rather than a reuse of a transient.

Not included: `startWith(false)` on the breakpoint observable
(`dashboard-base.component.ts:97`) looks redundant, since `BreakpointObserver`
already emits synchronously on subscribe. It dates to `6fb95fbadc` (2019, "Fix
mobile nav closing"), well before the signals migration, so it had a reason
once. Left alone here; worth its own change with its own verification.

Tests: new `dashboard-data.service.spec.ts`, 4 cases, red before the fix (3 of
4) and green after. They drive `hydrateFromStorage` directly, in both
directions — a stale `isMobile: true` must not override a measured desktop, and
a stale `false` must not override a measured narrow window. Full `core` project
passes. The two unhandled rxjs errors that surface in
`edit-endpoint-step.component.spec.ts` during a full run are pre-existing and
unrelated: they reproduce with this service reverted to develop's copy.
