### PR TITLE
fix(endpoints): guard the endpoint catalog lookup

### DIFF
--- a/changelog.d/0006-endpoint-catalog-lookup-guard.md
+++ b/changelog.d/0006-endpoint-catalog-lookup-guard.md
@@ -1,0 +1,11 @@
+[BugFixes]
+- Screens that look up an endpoint's type no longer throw when that type has no
+  registered entity — which happens to an endpoint left behind by a removed or
+  disabled extension, or registered by an older version. `entityCatalog
+  .getEndpoint()` returns nothing for an unknown type, but its signature
+  promised a result, so callers dereferenced it unguarded and the failure
+  surfaced as an uncaught `TypeError` that tore down the surrounding
+  component. The affected paths were endpoint edit, connect, create,
+  backup/restore, the home page, the metrics list, git registration and the
+  Kubernetes summary tab. The signature is now honest about returning nothing
+  and every caller handles it.

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-connection-cell/backup-connection-cell.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-connection-cell/backup-connection-cell.component.ts
@@ -37,9 +37,8 @@ export class BackupConnectionCellComponent extends TableCellCustom<EndpointModel
     if (!this.row.cnsi_type) {
       return;
     }
-    const epType = entityCatalog.getEndpoint(this.row.cnsi_type, this.row.sub_type);
-    const epEntity = epType.definition;
-    this.connectable = !epEntity.unConnectable;
+    const epEntity = entityCatalog.getEndpoint(this.row.cnsi_type, this.row.sub_type)?.definition;
+    this.connectable = !epEntity?.unConnectable;
     if (!this.row.user) {
       this.userConnectionWarning = 'User not connected';
     } else if (this.row.user.guid === SystemSharedUserGuid) {

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints.service.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints.service.ts
@@ -94,9 +94,10 @@ export class BackupEndpointsService {
     if (!endpoint.cnsi_type) {
       return false;
     }
-    const epType = entityCatalog.getEndpoint(endpoint.cnsi_type, endpoint.sub_type).definition;
+    const epType = entityCatalog.getEndpoint(endpoint.cnsi_type, endpoint.sub_type)?.definition;
+    // An unregistered type can't be described, let alone backed up.
     // The endpoint type supports connection details
-    if (epType.unConnectable) {
+    if (!epType || epType.unConnectable) {
       return false;
     }
 

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.ts
@@ -292,6 +292,6 @@ export class BackupEndpointsComponent implements OnDestroy {
     if (!endpoint.cnsi_type) {
       return '';
     }
-    return entityCatalog.getEndpoint(endpoint.cnsi_type, endpoint.sub_type).definition.label ?? endpoint.cnsi_type;
+    return entityCatalog.getEndpoint(endpoint.cnsi_type, endpoint.sub_type)?.definition?.label ?? endpoint.cnsi_type;
   }
 }

--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.ts
@@ -106,7 +106,7 @@ export class ConnectEndpointComponent implements OnInit, OnDestroy {
     }
 
     // Not all endpoint types might allow token sharing - typically types like metrics do
-    this.canShareEndpointToken = endpoint.definition.tokenSharing ?? false;
+    this.canShareEndpointToken = endpoint?.definition?.tokenSharing ?? false;
 
     // Create the endpoint form
     this.autoSelected = (this.authTypesForEndpoint.length > 0) ? this.authTypesForEndpoint[0] : { form: null } as EndpointAuthTypeConfig;

--- a/src/frontend/packages/core/src/features/endpoints/connect.service.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect.service.ts
@@ -51,8 +51,8 @@ export const isEndpointConnected = (endpoint: EndpointModel): boolean => {
   if (!endpoint.cnsi_type) {
     return endpoint.connectionStatus === 'connected';
   }
-  const epType = entityCatalog.getEndpoint(endpoint.cnsi_type, endpoint.sub_type).definition;
-  return endpoint.connectionStatus === 'connected' || !!epType.unConnectable;
+  const epType = entityCatalog.getEndpoint(endpoint.cnsi_type, endpoint.sub_type)?.definition;
+  return endpoint.connectionStatus === 'connected' || !!epType?.unConnectable;
 };
 
 export class ConnectEndpointService {

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.html
@@ -3,7 +3,7 @@
     <!-- Left column: Cloud Foundry Information -->
     <div class="create-endpoint__info-column">
       <h1 class="create-endpoint__section-title text-[var(--content-text)]">
-        {{ endpoint.definition.label }} Information
+        {{ endpoint?.definition?.label }} Information
       </h1>
       <app-form-field class="block w-full">
         <input

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint-cf-step-1/create-endpoint-cf-step-1.component.ts
@@ -92,7 +92,7 @@ export class CreateEndpointCfStep1Component extends CreateEndpointHelperComponen
   clientRedirectURI!: string;
 
   endpointTypeSupportsSSO = false;
-  endpoint: StratosCatalogEndpointEntity;
+  endpoint?: StratosCatalogEndpointEntity;
   show = false;
 
   showCACertField = false;
@@ -142,6 +142,11 @@ export class CreateEndpointCfStep1Component extends CreateEndpointHelperComponen
   // resolves once the busy edge transitions, so we no longer need pairwise/
   // filter/map gymnastics here.
   private async runRegistration(): Promise<StepOnNextResult> {
+    if (!this.endpoint) {
+      // Route named an endpoint type with no registered entity — nothing to
+      // register against, so fail the step rather than throwing.
+      return { success: false, redirect: false, message: 'Unknown endpoint type' };
+    }
     const { subType, type } = this.endpoint.getTypeAndSubtype();
 
     // SSL settings — when a CA cert is provided we trust it as the override
@@ -213,17 +218,17 @@ export class CreateEndpointCfStep1Component extends CreateEndpointHelperComponen
     );
   }
 
-  setUrlValidation(endpoint: StratosCatalogEndpointEntity) {
+  setUrlValidation(endpoint?: StratosCatalogEndpointEntity) {
     this.urlValidation = endpoint ? (endpoint.definition.urlValidationRegexString ?? '') : '';
     this.setAdvancedFields(endpoint);
   }
 
   // Only show the Client ID and Client Secret fields if the endpoint type is Cloud Foundry
-  setAdvancedFields(endpoint: StratosCatalogEndpointEntity) {
-    this.showAdvancedFields = endpoint.definition.type === 'cf';
+  setAdvancedFields(endpoint?: StratosCatalogEndpointEntity) {
+    this.showAdvancedFields = endpoint?.definition?.type === 'cf';
 
     // Only allow SSL if the endpoint type is Cloud Foundry
-    this.endpointTypeSupportsSSO = endpoint.definition.type === 'cf';
+    this.endpointTypeSupportsSSO = endpoint?.definition?.type === 'cf';
   }
 
   toggleAdvancedOptions() {

--- a/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/create-endpoint/create-endpoint.component.ts
@@ -176,9 +176,9 @@ export class CreateEndpointComponent implements OnInit, AfterViewInit, OnDestroy
     const epSubType = getIdFromRoute(activatedRoute, 'subtype');
     const endpoint = entityCatalog.getEndpoint(epType, epSubType);
 
-    this.component = endpoint.definition.registrationComponent;
-    this.showConnectStep = !endpoint.definition.unConnectable ?
-      endpoint.definition.authTypes && !!endpoint.definition.authTypes.length :
+    this.component = endpoint?.definition?.registrationComponent;
+    this.showConnectStep = !endpoint?.definition?.unConnectable ?
+      !!endpoint?.definition?.authTypes?.length :
       false;
   }
 

--- a/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.ts
@@ -143,6 +143,9 @@ export class EditEndpointStepComponent implements OnDestroy, IStepperStep {
       filter((entity): entity is EndpointModel => !!entity && !!entity.cnsi_type),
       // strict: the filter above guarantees cnsi_type is set on every emission.
       map(entity => entityCatalog.getEndpoint(entity.cnsi_type!, entity.sub_type)),
+      // An endpoint type with no registered entity yields no catalog entry —
+      // drop the emission rather than throwing and tearing down the stream.
+      filter(entity => !!entity),
       map(d => d.definition)
     );
 

--- a/src/frontend/packages/core/src/features/home/home/home-page.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page.component.ts
@@ -113,7 +113,7 @@ export class HomePageComponent implements OnInit {
     return ordered.filter(ep => {
       // strict: cnsi_type is populated on every connected endpoint; '' default keeps the lookup well-formed
       const defn = entityCatalog.getEndpoint(ep.cnsi_type ?? '', ep.sub_type);
-      const connected = defn.definition.unConnectable || ep.connectionStatus === 'connected';
+      const connected = defn?.definition?.unConnectable || ep.connectionStatus === 'connected';
       return connected;
     });
   });
@@ -320,13 +320,13 @@ export class HomePageComponent implements OnInit {
     const eps = this.connectedEndpoints().filter(ep => {
       // strict: cnsi_type is populated on every connected endpoint; '' default keeps the lookup well-formed
       const defn = entityCatalog.getEndpoint(ep.cnsi_type ?? '', ep.sub_type);
-      return !!defn.definition.homeCard;
+      return !!defn?.definition?.homeCard;
     });
 
     const wideCount = eps.filter(ep => {
       // strict: cnsi_type is populated on every connected endpoint; '' default keeps the lookup well-formed
       const defn = entityCatalog.getEndpoint(ep.cnsi_type ?? '', ep.sub_type);
-      return (defn.definition.homeCard?.columnSpan || 1) > 1;
+      return (defn?.definition?.homeCard?.columnSpan || 1) > 1;
     }).length;
     const mostlyWide = wideCount > eps.length / 2;
 

--- a/src/frontend/packages/core/src/features/metrics/metrics.helpers.ts
+++ b/src/frontend/packages/core/src/features/metrics/metrics.helpers.ts
@@ -33,9 +33,11 @@ export function mapMetricsData(ep: MetricsEndpointProvider): MetricsEndpointInfo
       known: true,
       name: endpoint.name,
       url: getFullEndpointApiUrl(endpoint),
-      type: catalogEndpoint.definition.label,
+      // An unregistered type has no catalog entry; keep the row, blank the
+      // labelling, rather than hiding a real endpoint.
+      type: catalogEndpoint?.definition?.label,
       icon: {
-        name: catalogEndpoint.definition.icon,
+        name: catalogEndpoint?.definition?.icon,
         font: 'stratos-icons'
       },
       metadata: {

--- a/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.ts
+++ b/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.ts
@@ -226,8 +226,8 @@ export class GitRegistrationComponent extends CreateEndpointHelperComponent impl
     this.userProfileService = userProfileService;
 
     this.epSubType = getIdFromRoute(activatedRoute, 'subtype');
-    const githubLabel = entityCatalog.getEndpoint(GIT_ENDPOINT_TYPE, GIT_ENDPOINT_SUB_TYPES.GITHUB).definition.label || 'Github';
-    const gitlabLabel = entityCatalog.getEndpoint(GIT_ENDPOINT_TYPE, GIT_ENDPOINT_SUB_TYPES.GITLAB).definition.label || 'Gitlab';
+    const githubLabel = entityCatalog.getEndpoint(GIT_ENDPOINT_TYPE, GIT_ENDPOINT_SUB_TYPES.GITHUB)?.definition?.label || 'Github';
+    const gitlabLabel = entityCatalog.getEndpoint(GIT_ENDPOINT_TYPE, GIT_ENDPOINT_SUB_TYPES.GITLAB)?.definition?.label || 'Gitlab';
 
     // No endpoint context here — only getPublicApi() is needed. An empty
     // guid is the falsy "no endpoint" sentinel BaseSCM.getEndpoint() already
@@ -389,7 +389,7 @@ export class GitRegistrationComponent extends CreateEndpointHelperComponent impl
     this.showEndpointFields = !defn.url;
 
     const entityDefn = entityCatalog.getEndpoint(GIT_ENDPOINT_TYPE, this.epSubType);
-    this.urlValidation = entityDefn.definition?.urlValidationRegexString;
+    this.urlValidation = entityDefn?.definition?.urlValidationRegexString;
   }
 
   ngOnDestroy() {

--- a/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.ts
@@ -96,7 +96,7 @@ export class KubernetesSummaryTabComponent implements OnInit, OnDestroy {
       // strict: this view only renders for a connected kubernetes endpoint,
       // so its model always carries a cnsi_type
       const endpointConfig = entityCatalog.getEndpoint(endpoint.entity.cnsi_type!, endpoint.entity.sub_type);
-      const { logoUrl, label } = endpointConfig.definition;
+      const { logoUrl, label } = endpointConfig?.definition ?? {};
       // const { imagePath, label } = entityCatalog.getEndpoint(endpoint.entity.cnsi_type, endpoint.entity.sub_type);
 
       // const { imagePath, label } = getEndpointType(endpoint.entity.cnsi_type, endpoint.entity.sub_type);

--- a/src/frontend/packages/store/src/entity-catalog/entity-catalog.ts
+++ b/src/frontend/packages/store/src/entity-catalog/entity-catalog.ts
@@ -520,7 +520,7 @@ export class EntityCatalog {
       endpointType,
       EntityCatalogHelpers.endpointType,
       subType
-    ) as StratosCatalogEndpointEntity;
+    ) as StratosCatalogEndpointEntity | undefined;
   }
 
   public getAllEntitiesForEndpointType(endpointType: string) {


### PR DESCRIPTION
`entityCatalog.getEndpoint()` ends in `as StratosCatalogEndpointEntity`, but it
resolves through a `Map.get` that misses whenever no entity is registered for
the type. The cast told every caller the result was always present, so callers
dereferenced it unguarded — and an unknown type threw an uncaught `TypeError`
that tore down the surrounding component instead of degrading.

It is visible in the test suite today: two unhandled
`Cannot read properties of undefined (reading 'definition')` errors, from
`edit-endpoint.component.spec.ts` and `edit-endpoint-step.component.spec.ts`.
Both specs pass while the throw escapes into an rxjs subscriber. In a running
console the same throw is reachable wherever an endpoint's `cnsi_type` has no
registered entity — one left behind by a removed or disabled extension, or
registered by an older version.

Rather than guard the line the errors named, this makes the signature honest
(`| undefined`) and lets the compiler enumerate the callers: **20 sites across
11 files in three packages**. That is the whole class, proven by `tsc` rather
than by grep.

Every site keeps the behaviour it already had for a known endpoint type. Where
a caller already carried a fallback, that fallback is reused
(`?? endpoint.cnsi_type`, `|| 'Github'`). Where the surrounding code already
returned early on an endpoint it could not describe, the unknown type takes the
same exit. I have not invented behaviour for unknown types beyond not crashing;
the one place that needed a decision is `runRegistration`, which now fails the
step instead of throwing.

Two of these were half-known already, which is what convinced me to fix the
signature rather than the symptom:

- `connect-endpoint.component.ts` used `endpoint?.definition?.authTypes` at
  line 96 and bare `endpoint.definition` at line 109 — the same function,
  thirteen lines apart. Someone patched the line that bit them.
- `metrics.helpers.ts` guards its second lookup with
  `if (catalogEndpoint) { // Provider metadata could give unknown endpoint`
  and leaves the first one unguarded.

Verification:

- `tsc -p src/tsconfig.app.json` — 20 errors before, 0 after.
- The typecheck was reverse-tested: deleting the new guard in
  `edit-endpoint-step.component.ts` turns `tsc` red at that exact line, and
  restoring it turns it green. TypeScript infers the type predicate from
  `!!entity`, so the narrowing is real rather than an overload accident.
- `core` 1095 pass, and both unhandled `TypeError`s are gone.
- `git` 30 pass. `kubernetes` 311 pass.
- eslint clean on all 14 changed files.
- `kubernetes` also reports 3 `Error: Endpoint anything not found`. These are
  pre-existing and unrelated: they reproduce identically with
  `kubernetes-summary.component.ts` reverted to develop's copy.
