### PR TITLE
chore(changelog): describe the viewport-state fix as verified

### DIFF
--- a/changelog.d/0005-dashboard-mobile-layout-persisted.md
+++ b/changelog.d/0005-dashboard-mobile-layout-persisted.md
@@ -1,8 +1,7 @@
 [BugFixes]
-- The console no longer loads in the mobile layout on a desktop window (or the
-  desktop layout on a narrow one). `isMobile` and `isMobileNavOpen` are measured
-  from the viewport, but they were being written to the stored user preferences
-  and then restored over the live measurement when preferences loaded — leaving
-  the side nav overlaying the page and the header controls hidden until the
-  window was resized across the breakpoint. Viewport state is now owned by the
-  breakpoint observer alone and is never persisted.
+- Viewport state is no longer written to the stored user preferences.
+  `isMobile` and `isMobileNavOpen` are measured from the window by the
+  dashboard's breakpoint observer, but they were persisted alongside real
+  preferences and then restored over that measurement when preferences loaded.
+  They are now owned by the observer alone: never stored, and left untouched by
+  hydration.


### PR DESCRIPTION
Follow-up to #5863. That PR's changelog fragment claimed a user-visible symptom
that did not survive live verification, and 5.5.1 should not ship the claim.

The fragment said the console "no longer loads in the mobile layout on a desktop
window (or the desktop layout on a narrow one)", and described the side nav
overlaying the page with the header controls hidden. That symptom was diagnosed
from the stored state of a deployed console, not reproduced.

It was then tested against the dev stack on `c8032dacf2` — #5863's parent, so
the fix absent — at a 1227px viewport with the breakpoint media query
confirming desktop, and `stratos-admin` edited to hold
`"isMobile": true, "isMobileNavOpen": true`:

| Path | Layout | `isMobile` after |
|---|---|---|
| Reload `/home` | correct desktop | rewritten to `false` |
| Full sign out, then log in | correct desktop | rewritten to `false` |

Both self-heal, because `disableMobileNav()` runs after hydration on those paths
and persists the correction. (The run was valid on the point that matters: the
stored version key matched `BUILD_INFO.version`, so `checkVersionAndClear` did
not wipe the key, and hydration genuinely ran on the poisoned value.)

What is verified, and what the fragment now says instead:

- The two fields were being written to the stored user preferences — observed
  directly in `stratos-admin`.
- `hydrateFromStorage`'s blanket spread restored them over the live
  measurement. The unit tests added in #5863 drive that order explicitly and
  were red before the change.

So the fix is right and stays; only the description of it changes. A real
stranding path presumably exists — the deployed console did have `isMobile: true`
stored and did render wrong — but until it is identified, the release notes
should describe the ownership fix rather than a symptom.

#5863's description has been corrected in the same way, with the original text
and this evidence preserved in a comment there.

Changelog fragment only — no code.
