### PR TITLE
fix(home): fit endpoint card counts to their container, and give Kubernetes parity with Cloud Foundry

### DIFF
--- a/changelog.d/0001-home-card-tile-columns.md
+++ b/changelog.d/0001-home-card-tile-columns.md
@@ -13,3 +13,7 @@
   summary page was previously reachable only by clicking the card's header,
   which nothing advertised, and its own counts are now laid out to match the
   card they are reached from.
+- The Kubernetes page now offers the same interface as the Cloud Foundry one.
+  Cluster names are links in both card and line mode — they were plain text, so
+  the page listed clusters without giving any way to open one — and a `User`
+  column has been added to match.

--- a/changelog.d/0001-home-card-tile-columns.md
+++ b/changelog.d/0001-home-card-tile-columns.md
@@ -8,3 +8,8 @@
   fitted to the group's own width, so they wrap instead of overflowing, and the
   Kubernetes card's counts line up with the Favorites and Shortcuts panel below
   them the way the Cloud Foundry card's line up with its recent applications.
+- The Kubernetes endpoint card now offers a `View Kubernetes Info` shortcut,
+  matching the Cloud Foundry card's `View Cloud Foundry Info`. The cluster
+  summary page was previously reachable only by clicking the card's header,
+  which nothing advertised, and its own counts are now laid out to match the
+  card they are reached from.

--- a/changelog.d/0001-home-card-tile-columns.md
+++ b/changelog.d/0001-home-card-tile-columns.md
@@ -1,0 +1,10 @@
+[BugFixes]
+- Counts on the home page endpoint cards no longer overflow into a horizontal
+  scrollbar. Tile groups chose their column count from viewport media queries,
+  so a card only 292px wide still laid its three counts out in three columns
+  once the browser window passed 1024px — leaving each count 79px of a track it
+  needed 161px for. The labels ran into one another and the remainder scrolled
+  out of sight behind a scrollbar that reads as a divider. Columns are now
+  fitted to the group's own width, so they wrap instead of overflowing, and the
+  Kubernetes card's counts line up with the Favorites and Shortcuts panel below
+  them the way the Cloud Foundry card's line up with its recent applications.

--- a/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.html
+++ b/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.html
@@ -3,7 +3,7 @@
     @if (!textOnly) {
       <div
         class="card p-4 relative"
-        [ngClass]="{'border-0 shadow-none bg-transparent': mode === 'plain'}">
+        [ngClass]="{'border-0 shadow-none bg-transparent number-metric-card__plain': mode === 'plain'}">
         <app-card-status [status$]="status$"></app-card-status>
         <div class="flex items-start space-x-4">
           @if (icon) {

--- a/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.scss
+++ b/src/frontend/packages/core/src/shared/components/cards/card-number-metric/card-number-metric.component.scss
@@ -68,7 +68,10 @@
 .number-metric-card__plain.card {
   border-radius: 0;
   box-shadow: none;
-  padding: 6px 12px;
+  // No side padding: plain mode draws no card chrome, so horizontal padding
+  // only inflates the metric's min-content width (161px -> 129px without it)
+  // and costs a column when these are tiled in a narrow card.
+  padding: 16px 0;
 
   .number-metric-card__usage-count {
     font-size: 20px;

--- a/src/frontend/packages/core/src/shared/components/tile/tile-grid/tile-grid.component.scss
+++ b/src/frontend/packages/core/src/shared/components/tile/tile-grid/tile-grid.component.scss
@@ -1,4 +1,8 @@
 app-tile-grid {
+  // Establishes the query container the tile groups size themselves against,
+  // so a group in a narrow card steps its columns down instead of taking its
+  // count from the viewport. Inline-size only: block size stays content-driven.
+  container-type: inline-size;
   display: grid;
   grid-template-columns: 1fr;
   grid-auto-rows: min-content;

--- a/src/frontend/packages/core/src/shared/components/tile/tile-group/tile-group.component.scss
+++ b/src/frontend/packages/core/src/shared/components/tile/tile-group/tile-group.component.scss
@@ -1,28 +1,51 @@
 $tile-grid-gap: 1.5rem;
 
+// Thresholds below are container widths and must be absolute lengths (a
+// container query condition cannot read a custom property), so the gaps are
+// repeated here in px: 1.5rem and 0.5rem at the default root size.
+$gap-px: 24px;
+$gap-px-compact: 8px;
+
+// The narrowest a column can be while its tile still reads properly, measured
+// from the widest tile of each kind:
+//   default  a bordered number metric needs 228px to keep "Memory Usage" and
+//            its "/ 100 GB" on one line; below ~220px the labels wrap and the
+//            row goes ragged.
+//   compact  a plain (chromeless) metric has no card padding and measures
+//            129px with a five-digit count.
+$col-min: 220px;
+$col-min-compact: 130px;
+
+// A group declares how many columns it wants (tile-group-<n>-cols, set by the
+// template or host-bound from the tile count). That declaration is the design
+// intent and is kept; all that changes is that it is now conditional on the
+// group's OWN width rather than the viewport's, so a group in a narrow card
+// steps down instead of overflowing. Steps are emitted 2..n ascending, so the
+// widest matching rule wins.
+@mixin fit-columns($max, $min, $gap) {
+  @for $n from 2 through $max {
+    @container (min-width: #{$n * $min + ($n - 1) * $gap}) {
+      grid-template-columns: repeat($n, 1fr);
+    }
+  }
+}
+
 app-tile-group {
   display: grid;
   gap: $tile-grid-gap;
   width: 100%;
 
-  // Columns are fitted to the group's own width, not the viewport's. auto-fit
-  // collapses the tracks it cannot fill, so a group of N tiles renders as N
-  // equal columns wherever there is room and folds down as the container
-  // narrows — which is what the tile-group-<n>-cols classes were for. Those
-  // classes are still set (TileGroupComponent host-binds them from the tile
-  // count) but no longer need a rule each; keying them off viewport media
-  // queries gave a home card in a 292px box three 79px columns.
-  //
-  // 130px is the measured min-content of the widest number metric (a
-  // "Namespaces" label above a 5-digit count), so a fitted column can never
-  // be narrower than the content it holds.
-  grid-template-columns: repeat(auto-fit, minmax(min(130px, 100%), 1fr));
+  // Narrower than the first step, and the no-container fallback: one column.
+  grid-template-columns: 1fr;
 
-  // Single column is an explicit layout choice, not a fitting result: these
-  // groups hold full-width content (lists, tables) that must never sit
-  // side-by-side.
   &.tile-group-1-cols {
     grid-template-columns: 1fr;
+  }
+
+  @for $n from 2 through 6 {
+    &.tile-group-#{$n}-cols {
+      @include fit-columns($n, $col-min, $gap-px);
+    }
   }
 
   // Legacy gutter support (converted to gap)
@@ -30,10 +53,17 @@ app-tile-group {
     gap: $tile-grid-gap;
   }
 
-  // Compact gap variant. Declared after the gutter rule because
-  // TileGroupComponent host-binds tile-group-gutters on every group, so an
-  // earlier declaration would never win and compact would be a no-op.
+  // Compact groups hold chromeless tiles, so they fit more per row and are
+  // declared after the gutter rule — TileGroupComponent host-binds
+  // tile-group-gutters on every group, so an earlier declaration never won and
+  // compact was silently a no-op.
   &.tile-group-compact {
     gap: 0.5rem;
+
+    @for $n from 2 through 6 {
+      &.tile-group-#{$n}-cols {
+        @include fit-columns($n, $col-min-compact, $gap-px-compact);
+      }
+    }
   }
 }

--- a/src/frontend/packages/core/src/shared/components/tile/tile-group/tile-group.component.scss
+++ b/src/frontend/packages/core/src/shared/components/tile/tile-group/tile-group.component.scss
@@ -5,90 +5,35 @@ app-tile-group {
   gap: $tile-grid-gap;
   width: 100%;
 
-  // Default: 1 column (mobile-first)
-  grid-template-columns: 1fr;
+  // Columns are fitted to the group's own width, not the viewport's. auto-fit
+  // collapses the tracks it cannot fill, so a group of N tiles renders as N
+  // equal columns wherever there is room and folds down as the container
+  // narrows — which is what the tile-group-<n>-cols classes were for. Those
+  // classes are still set (TileGroupComponent host-binds them from the tile
+  // count) but no longer need a rule each; keying them off viewport media
+  // queries gave a home card in a 292px box three 79px columns.
+  //
+  // 130px is the measured min-content of the widest number metric (a
+  // "Namespaces" label above a 5-digit count), so a fitted column can never
+  // be narrower than the content it holds.
+  grid-template-columns: repeat(auto-fit, minmax(min(130px, 100%), 1fr));
 
-  // Auto-fit fallback — MUST come before specific column rules so they take precedence
-  &.tile-group-auto {
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  }
-
-  // Specific column classes (override auto when both present)
+  // Single column is an explicit layout choice, not a fitting result: these
+  // groups hold full-width content (lists, tables) that must never sit
+  // side-by-side.
   &.tile-group-1-cols {
     grid-template-columns: 1fr;
-  }
-
-  &.tile-group-2-cols {
-    grid-template-columns: 1fr;
-
-    @media (min-width: 768px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  &.tile-group-3-cols {
-    grid-template-columns: 1fr;
-
-    @media (min-width: 640px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    @media (min-width: 1024px) {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
-  &.tile-group-4-cols {
-    grid-template-columns: 1fr;
-
-    @media (min-width: 640px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    @media (min-width: 1024px) {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
-
-  &.tile-group-5-cols {
-    grid-template-columns: 1fr;
-
-    @media (min-width: 640px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    @media (min-width: 768px) {
-      grid-template-columns: repeat(3, 1fr);
-    }
-
-    @media (min-width: 1024px) {
-      grid-template-columns: repeat(5, 1fr);
-    }
-  }
-
-  &.tile-group-6-cols {
-    grid-template-columns: 1fr;
-
-    @media (min-width: 640px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    @media (min-width: 768px) {
-      grid-template-columns: repeat(3, 1fr);
-    }
-
-    @media (min-width: 1280px) {
-      grid-template-columns: repeat(6, 1fr);
-    }
-  }
-
-  // Compact gap variant
-  &.tile-group-compact {
-    gap: 1rem;
   }
 
   // Legacy gutter support (converted to gap)
   &.tile-group-gutters {
     gap: $tile-grid-gap;
+  }
+
+  // Compact gap variant. Declared after the gutter rule because
+  // TileGroupComponent host-binds tile-group-gutters on every group, so an
+  // earlier declaration would never win and compact would be a no-op.
+  &.tile-group-compact {
+    gap: 0.5rem;
   }
 }

--- a/src/frontend/packages/core/src/shared/components/tile/tile/tile.component.scss
+++ b/src/frontend/packages/core/src/shared/components/tile/tile/tile.component.scss
@@ -1,4 +1,8 @@
 app-tile {
+  // Also a query container: a tile group is not always inside an app-tile-grid
+  // (a routed template may nest one directly in an app-tile), and without a
+  // container ancestor every container query silently fails to match.
+  container-type: inline-size;
   display: flex;
   flex-direction: column;
   min-width: 0; // Prevent grid blowout

--- a/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.scss
+++ b/src/frontend/packages/kubernetes/src/kubernetes/home/kubernetes-home-card.component.scss
@@ -2,3 +2,19 @@
   display: block;
   width: 100%;
 }
+
+// Line the counts up with the Favorites/Shortcuts panel below them, the way
+// the CF card's counts line up with its recent-apps panel. That panel is a
+// sibling of this card's content wrapper, so it starts at the card-body edge
+// while this grid is inset by the wrapper's 24px padding plus its own 16px.
+// Cancelling both also buys back 80px, which is what lets three counts share
+// a row instead of two.
+app-tile-grid {
+  // width:auto (not the inherited 100%) so the negative margins widen the grid
+  // rather than just shifting it left.
+  margin-left: -24px;
+  margin-right: -24px;
+  padding-left: 0;
+  padding-right: 0;
+  width: auto;
+}

--- a/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-entity-generator.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/kubernetes-entity-generator.ts
@@ -327,6 +327,16 @@ export class KubeEntityCatalog {
             link: ['/kubernetes', endpointID, 'resource', 'namespace'],
             icon: 'namespace',
             iconFont: 'stratos-icons'
+          },
+          {
+            // Mirrors CF's 'View Cloud Foundry Info'. Without it the cluster
+            // summary has no named route from the card — the endpoint page is
+            // only reachable by clicking the card header, which nothing
+            // advertises.
+            title: 'View Kubernetes Info',
+            link: ['/kubernetes', endpointID],
+            icon: 'kubernetes',
+            iconFont: 'stratos-icons'
           }
         ],
         fullView: false,

--- a/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-endpoints/kubernetes-endpoints-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/list-types/kubernetes-endpoints/kubernetes-endpoints-signal-config.service.ts
@@ -151,14 +151,18 @@ export class KubernetesEndpointsSignalConfigService {
     };
 
     const columns: SignalListColumn<EndpointModel>[] = [
-      // Name, Address, Status, and Actions below all match the
-      // /cloud-foundry picker's columns exactly, so both surfaces render
-      // identically in card and table mode.
+      // Name, Address, User, Status and Actions mirror the /cloud-foundry
+      // picker, so both surfaces render identically in card and table mode.
+      // Name is a link there and must be one here: it is the only route from
+      // this page into a cluster, and as plain text the page listed clusters
+      // it gave you no way to open. 'link' is rendered by both the card and
+      // the table renderer, so the one column serves both modes.
       {
         header: 'Name',
         key: 'name',
         sortField: 'name',
-        kind: 'text',
+        kind: 'link',
+        link: (ep: EndpointModel) => ['/kubernetes', ep.guid ?? ''],
         render: (ep: EndpointModel) => ep.name ?? '',
         widthHint: '24rem',
       },
@@ -169,6 +173,14 @@ export class KubernetesEndpointsSignalConfigService {
         kind: 'text',
         render: (ep: EndpointModel) => ep.api_endpoint?.Host ?? '—',
         widthHint: '32rem',
+      },
+      {
+        header: 'User',
+        key: 'user',
+        sortField: (ep: EndpointModel) => ep.user?.name ?? '',
+        kind: 'text',
+        render: (ep: EndpointModel) => ep.user?.name ?? '—',
+        widthHint: '12rem',
       },
       {
         header: 'Status', key: 'status',
@@ -203,8 +215,8 @@ export class KubernetesEndpointsSignalConfigService {
       columns,
       // strict: registered endpoint rows always carry a guid (matches backup-endpoints getRowKey)
       getRowKey: (ep: EndpointModel) => ep.guid!,
-      emptyMessage: 'There are no endpoints',
-      emptyFilterMessage: 'No endpoints match the current filters',
+      emptyMessage: 'There are no connected or expired Kubernetes endpoints',
+      emptyFilterMessage: 'No Kubernetes endpoints match the current filters',
       pageSizeOptions: {
         table: [10, 25, 50, 100],
         card: [6, 12, 24, 48, 96],

--- a/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/tabs/kubernetes-summary-tab/kubernetes-summary.component.html
@@ -18,7 +18,7 @@
     @if (endpointDetails$ | async; as details) {
       <app-entity-summary-title [imagePath]="details.imagePath ?? null"
         [title]="details.name" [subTitle]="details.label">
-        <app-tile-grid class="max-w-[350px]">
+        <app-tile-grid class="max-w-[760px]">
           <app-tile-group class="tile-group-3-cols">
             <app-tile>
               <app-card-number-metric [textOnly]="true" link="/kubernetes/{{kubeEndpointService.baseKube.guid}}/nodes"


### PR DESCRIPTION
## What

Counts on the home page endpoint cards overflowed into a horizontal scrollbar. Fixing that turned up two further gaps where the Kubernetes surfaces did not behave like the Cloud Foundry ones.

## The scrollbar

`TileGroupComponent` host-binds `tile-group-<n>-cols` from its tile count, and templates also declare it directly. Those classes chose their column count from **viewport** media queries, so a group rendered N columns whenever the *window* was wide, regardless of how narrow its own container was.

The Kubernetes home card is 292px wide. Once the browser passed 1024px it laid three counts out in three 79px columns for content whose min-content is 161px. Labels ran into each other and the remainder became a horizontal scrollbar — one that inherits the vertical bar's track colours and sets no height, so it renders as a flat grey rule exactly where a divider would sit. It reads as decoration, not as hidden data.

**The declared column count was never wrong — only what it was measured against.** The media queries become container queries, with `container-type: inline-size` on `app-tile-grid` and on `app-tile` (a routed template can nest a group in a tile with no grid above it, and a container query with no container ancestor never matches). Steps are generated from measured tile widths: 220px a column for a bordered metric (the widest needs 228px to keep its label on one line), 130px for a chromeless one — a distinction `tile-group-compact` already draws.

An earlier commit here fitted the columns with `auto-fit` instead. That fixed the overflow but discarded each group's declared intent, giving the organization summary 7 columns of 150px where it had had 4 of 280px and wrapping labels onto three lines. The later commit corrects it; the history keeps both so the reasoning is visible.

## Chromeless metrics

`mode="plain"` already removes the card's border, shadow and background, but the box kept `p-4` — 32px of padding decorating a card that is never drawn, inflating min-content from 129px to 161px. The component SCSS already carried a `.number-metric-card__plain.card` rule written for this and never applied to anything; it is now applied, keeping vertical padding so the rhythm is unchanged.

## Kubernetes parity

Two gaps, both of which left the cluster summary effectively unreachable:

- **The Kubernetes page listed clusters you could not open.** `/cloud-foundry` renders its Name column as a link into the endpoint; `/kubernetes` rendered the same column as plain text. Name is now a link and a `User` column is added, so the two pickers carry the same columns (bar CF's Stacks, which has no Kubernetes equivalent). `kind: 'link'` is handled by the card and table renderers alike, so card and line mode both pick it up.
- **The Kubernetes card had no `View Kubernetes Info`.** The CF card links to its endpoint page; the Kubernetes card offered only View Nodes and View Namespaces, so the only route in was the card's unlabelled header. Mirrors `cfShortcuts`.

The summary page those routes lead to had its counts grid capped at 350px — a 318px container for three 113px tiles, which never fitted. Raised to 760px (less the grid's own 32px padding, clearing the 708px three-column step) so the counts read the same way as on the card you arrive from. The cap is not removed: uncapped, `textOnly` tiles strand themselves across 400px tracks with no card to fill them.

## Verification

Measured live in a browser at several widths, before and after:

| | before | after |
|---|---|---|
| k8s home card | 3 × 79px (content needs 161px) | 3 × 131px |
| group overflow | 12px, scrollbar shown | 0 |
| alignment vs panel | 40px out | left 0, right 0 |
| org summary | 4 × 280px | 4 × 280px (unchanged) |

Degrades cleanly — 3 across → 2 → 1 as the card narrows, no clipping at any width. Re-checked the pages that share the tile stylesheet (CF summary tab, CF organization summary, Kubernetes summary) since it is used by 19 templates.

`make check gate` green: lint + 3718 tests passed (663 files, 2 skipped) + production build.

## Note on Tailwind

The Kubernetes card override is component SCSS rather than template utilities deliberately. The utility form (`-mx-6 px-0 w-auto`) was tried and measured: only `-mx-6` applied. `app-tile-grid` is `ViewEncapsulation.None`, so its `padding: 1rem` and `width: 100%` are unlayered and beat layered utilities regardless of specificity — `px-0` and `w-auto` were dropped silently, leaving the layout worse than unfixed. This is rule 1 of `docs/tailwind-usage.md`.

Making utilities work on the tile components would mean moving their rules into `@layer components`, which changes override behaviour for every consumer and belongs in its own change (see #5539).