### PR TITLE
chore(deps): bump @swimlane/ngx-graph from 11.0.0 to 13.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@angular/platform-browser-dynamic": "22.1.4",
         "@angular/platform-server": "22.1.4",
         "@angular/router": "22.1.4",
-        "@swimlane/ngx-graph": "11.0.0",
+        "@swimlane/ngx-graph": "13.0.0",
         "ajv": "^8.20.0",
         "chart.js": "^4.5.1",
         "core-js": "3.50.0",
@@ -866,7 +866,7 @@
 
     "@stratos/builders": ["@stratos/builders@workspace:tools/builders/prebuild-application"],
 
-    "@swimlane/ngx-graph": ["@swimlane/ngx-graph@11.0.0", "", { "dependencies": { "d3-dispatch": "^3.0.1", "d3-ease": "^3.0.1", "d3-force": "^3.0.0", "d3-scale": "^4.0.2", "d3-selection": "^3.0.0", "d3-shape": "^3.2.0", "d3-timer": "^3.0.1", "d3-transition": "^3.0.1", "dagre": "^0.8.5", "transformation-matrix": "^2.16.1", "tslib": "^2.3.1", "webcola": "^3.4.0" }, "peerDependencies": { "@angular/animations": "18.x || 19.x || 20.x", "@angular/cdk": "18.x || 19.x || 20.x", "@angular/common": "18.x || 19.x || 20.x", "@angular/core": "18.x || 19.x || 20.x", "rxjs": "7.x" } }, "sha512-QmJxh97KlC70eDWGCZcyl5vzNGaRo7rGcNeLAB2o0RKSnMPm/kdMzRKFeu40zvmpyWVw2oTEjhwdVQ/08GqIyQ=="],
+    "@swimlane/ngx-graph": ["@swimlane/ngx-graph@13.0.0", "", { "dependencies": { "d3-dispatch": "^3.0.1", "d3-ease": "^3.0.1", "d3-force": "^3.0.0", "d3-scale": "^4.0.2", "d3-selection": "^3.0.0", "d3-shape": "^3.2.0", "d3-timer": "^3.0.1", "d3-transition": "^3.0.1", "dagre": "^0.8.5", "transformation-matrix": "^2.16.1", "tslib": "^2.3.1", "webcola": "^3.4.0" }, "peerDependencies": { "@angular/animations": ">=19.0.0 <23.0.0", "@angular/cdk": ">=19.0.0 <23.0.0", "@angular/common": ">=19.0.0 <23.0.0", "@angular/core": ">=19.0.0 <23.0.0", "rxjs": "7.x" } }, "sha512-mfpBnIDu/vGUFOjpCHY8P4W9bV8WEB8SPEWhvjuIBgQqe03PpNh8863WlVCwGc52kXAHByOJTfxJmZX+IOhPBw=="],
 
     "@tailwindcss/forms": ["@tailwindcss/forms@0.5.11", "", { "dependencies": { "mini-svg-data-uri": "^1.2.3" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1" } }, "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA=="],
 

--- a/changelog.d/0001-ngx-graph-13.md
+++ b/changelog.d/0001-ngx-graph-13.md
@@ -1,0 +1,8 @@
+[Chores]
+- Dependency bumps: `@swimlane/ngx-graph` 11 to 13, `copy-webpack-plugin` 13
+  to 14, `json-schema-to-typescript` 15 to 16, `eslint` 10.8 to 10.9, `mktemp`
+  2.0.3 to 2.0.4, and `google.golang.org/grpc` 1.82 to 1.83 in jetstream.
+  ngx-graph 12 rewrote its graph component on signal inputs and renamed
+  `draggingEnabled` to `enableDrag`, which the Helm release resource graph
+  binds; the module wrapper it used to import is deprecated, so it now
+  imports the standalone component instead.

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@angular/platform-browser-dynamic": "22.1.4",
     "@angular/platform-server": "22.1.4",
     "@angular/router": "22.1.4",
-    "@swimlane/ngx-graph": "11.0.0",
+    "@swimlane/ngx-graph": "13.0.0",
     "ajv": "^8.20.0",
     "chart.js": "^4.5.1",
     "core-js": "3.50.0",

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.html
@@ -19,7 +19,7 @@
 </app-page-sub-nav>
 
 @if (nodes && nodes.length) {
-  <ngx-graph class="chart-container" [draggingEnabled]="false" [links]="links"
+  <ngx-graph class="chart-container" [enableDrag]="false" [links]="links"
     [nodes]="nodes" [update$]="update$" [zoomToFit$]="fit$" [layout]="layout">
     <ng-template #nodeTemplate let-node>
       <svg:g class="node" (click)="onNodeClick(node)">

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { NgxGraphModule } from '@swimlane/ngx-graph';
+import { GraphComponent } from '@swimlane/ngx-graph';
 import { SidePanelService } from '@stratosui/core';
 
 import { HelmReleaseProviders, KubernetesBaseTestModules, KubeBaseGuidMock } from '../../../../kubernetes.testing.module';
@@ -20,7 +20,7 @@ describe('HelmReleaseResourceGraphComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         KubernetesBaseTestModules,
-        NgxGraphModule,
+        GraphComponent,
 
         HelmReleaseResourceGraphComponent,
         AnalysisReportSelectorComponent,

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.ts
@@ -4,7 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { AppProgressBarComponent } from '../../../../../../../core/src/shared/components/progress-bar/app-progress-bar.component';
 import { CustomIconComponent } from '../../../../../../../core/src/shared/components/custom-material/custom-material.component';
 import { CustomTooltipDirective } from '../../../../../../../core/src/shared/components/custom-tooltip/custom-tooltip.directive';
-import { Edge, NgxGraphModule, NgxGraphZoomOptions } from '@swimlane/ngx-graph';
+import { Edge, GraphComponent, NgxGraphZoomOptions } from '@swimlane/ngx-graph';
 import { SidePanelService } from '@stratosui/core';
 import { combineLatest, Observable, Subject, Subscription } from 'rxjs';
 import { take, distinctUntilChanged, filter, map, publishReplay, refCount, startWith } from 'rxjs/operators';
@@ -73,7 +73,7 @@ interface CustomHelmReleaseGraphNodeData extends HelmReleaseGraphNodeData {
     AppProgressBarComponent,
     CustomIconComponent,
     CustomTooltipDirective,
-    NgxGraphModule,
+    GraphComponent,
     PageSubNavComponent,
     AnalysisReportRunnerComponent,
     AnalysisReportSelectorComponent,


### PR DESCRIPTION
Supersedes #5874, whose Build Check failed:

```
NG8002: Can't bind to 'draggingEnabled' since it isn't a known property of 'ngx-graph'.
```

ngx-graph 12 rewrote `GraphComponent` on signal inputs and renamed
`draggingEnabled`/`panningEnabled` to `enableDrag`/`enablePan`
([changelog](https://github.com/swimlane/ngx-graph/blob/master/CHANGELOG.md#1200)).
The Helm release resource graph is the only consumer and binds only through
the template (`links`, `nodes`, `update$`, `zoomToFit$`, `layout`, the node
and link templates), all of which still exist under the same names in 13. So
the change is:

- `package.json` / `bun.lock`: 11.0.0 to 13.0.0. The lockfile is byte-identical
  to the one Dependabot generated.
- `[draggingEnabled]="false"` to `[enableDrag]="false"` in the template.
- `NgxGraphModule` is deprecated in 12; the component and its spec import the
  standalone `GraphComponent` instead.
- A `[Chores]` fragment covering this bump and the rest of today's Dependabot
  batch (#5872, #5873, #5875, #5876, #5877).

13.0.0 itself only widens the Angular peer range to `<23`.

Verified: `bun run build` (the failing check) passes with no NG8002, the
component spec passes, and `make check gate` is green. Not live-verified:
the graph needs a Kubernetes endpoint with a Helm release, which the dev
stack does not have up right now.
