### PR TITLE
fix(kubernetes): render the Helm release resource graph

### DIFF
--- a/changelog.d/0001-ngx-graph-13.md
+++ b/changelog.d/0001-ngx-graph-13.md
@@ -1,7 +1,8 @@
 [Chores]
 - Dependency bumps: `@swimlane/ngx-graph` 11 to 13, `copy-webpack-plugin` 13
   to 14, `json-schema-to-typescript` 15 to 16, `eslint` 10.8 to 10.9, `mktemp`
-  2.0.3 to 2.0.4, and `google.golang.org/grpc` 1.82 to 1.83 in jetstream.
+  2.0.3 to 2.0.4, `google.golang.org/grpc` 1.82 to 1.83 in jetstream, and the
+  indirect `fast-uri` 3.1.5 to 3.1.7 in the devkit lockfile.
   ngx-graph 12 rewrote its graph component on signal inputs and renamed
   `draggingEnabled` to `enableDrag`, which the Helm release resource graph
   binds; the module wrapper it used to import is deprecated, so it now

--- a/changelog.d/0002-helm-graph-render.md
+++ b/changelog.d/0002-helm-graph-render.md
@@ -1,0 +1,11 @@
+[BugFixes]
+- The Helm release resource graph (Workloads, a release, Overview) stayed on
+  "Loading resources" after the resources had arrived. The component runs
+  OnPush under zoneless change detection and wrote the nodes and links into
+  plain fields from its socket subscription, so nothing ever marked the view
+  dirty; they are signals now. The graph also fitted itself on a timer that
+  fired before the first layout existed, leaving the right-hand nodes clipped,
+  so it now fits on ngx-graph's `drawComplete`. And the standalone
+  `GraphComponent` that ngx-graph 12 steers consumers toward needs a
+  `LayoutService` only its deprecated module provided, which the component
+  now supplies itself.

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.html
@@ -18,9 +18,10 @@
   <app-workload-live-reload></app-workload-live-reload>
 </app-page-sub-nav>
 
-@if (nodes && nodes.length) {
-  <ngx-graph class="chart-container" [enableDrag]="false" [links]="links"
-    [nodes]="nodes" [update$]="update$" [zoomToFit$]="fit$" [layout]="layout">
+@if (nodes().length) {
+  <ngx-graph class="chart-container" [enableDrag]="false" [links]="links()"
+    [nodes]="nodes()" [update$]="update$" [zoomToFit$]="fit$" [layout]="layout()"
+    (drawComplete)="fitGraph()">
     <ng-template #nodeTemplate let-node>
       <svg:g class="node" (click)="onNodeClick(node)">
         <svg:rect rx="4" ry="4" [attr.width]="node.dimension.width" [attr.height]="node.dimension.height"
@@ -53,7 +54,7 @@
                         </ng-template>
                       </ngx-graph>
                     }
-                    @if (nodes && !nodes.length) {
+                    @if (!nodes().length) {
                       <div class="resources__loading">
                         <div class="resources__loading__content">
                           Loading resources

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { Component, input, output, provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GraphComponent } from '@swimlane/ngx-graph';
 import { SidePanelService } from '@stratosui/core';
@@ -10,7 +10,22 @@ import { KubernetesAnalysisService } from '../../../../services/kubernetes.analy
 import { AnalysisReportSelectorComponent } from '../../../../analysis-report-viewer/analysis-report-selector/analysis-report-selector.component';
 import { AnalysisReportViewerComponent } from '../../../../analysis-report-viewer/analysis-report-viewer.component';
 import { HelmReleaseSocketService } from '../../helm-release-tab-base/helm-release-socket-service';
+import { HelmReleaseDataService } from '../../helm-release-data.service';
+import { HelmReleaseGraph } from '../../../workload.types';
 import { HelmReleaseResourceGraphComponent } from './helm-release-resource-graph.component';
+
+// ngx-graph's real GraphComponent needs a browser layout engine; the tests
+// here cover this component's own rendering, so a stub stands in for it.
+@Component({ selector: 'ngx-graph', standalone: true, template: '' })
+class StubGraphComponent {
+  nodes = input<unknown[]>();
+  links = input<unknown[]>();
+  layout = input<unknown>();
+  enableDrag = input<boolean>();
+  update$ = input<unknown>();
+  zoomToFit$ = input<unknown>();
+  drawComplete = output<void>();
+}
 
 describe('HelmReleaseResourceGraphComponent', () => {
   let component: HelmReleaseResourceGraphComponent;
@@ -36,6 +51,9 @@ describe('HelmReleaseResourceGraphComponent', () => {
 
         provideZonelessChangeDetection(),
       ]
+    }).overrideComponent(HelmReleaseResourceGraphComponent, {
+      remove: { imports: [GraphComponent] },
+      add: { imports: [StubGraphComponent] },
     }).compileComponents();
   });
 
@@ -47,5 +65,27 @@ describe('HelmReleaseResourceGraphComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // Regression: the graph arrives over the release socket, which writes into
+  // HelmReleaseDataService. Under zoneless OnPush the view only re-renders
+  // for signal reads, so this goes red if nodes/links become plain fields.
+  it('renders the graph once the socket-fed signal delivers nodes', async () => {
+    const guid = (component as unknown as { helper: { guid: string } }).helper.guid;
+    const graph = {
+      endpointId: 'kube', releaseTitle: 'rel',
+      nodes: {
+        a: { id: 'a', label: 'web', data: { kind: 'Deployment', status: 'ok', metadata: { name: 'web', namespace: 'ns' } } },
+        b: { id: 'b', label: 'web-1', data: { kind: 'Pod', status: 'ok', metadata: { name: 'web-1', namespace: 'ns' } } },
+      },
+      links: { ab: { id: 'ab', source: 'a', target: 'b' } },
+    } as unknown as HelmReleaseGraph;
+
+    expect(fixture.nativeElement.querySelector('ngx-graph')).toBeNull();
+    TestBed.inject(HelmReleaseDataService).setGraph(guid, graph);
+    await fixture.whenStable();
+
+    expect(component.nodes().length).toBe(2);
+    expect(fixture.nativeElement.querySelector('ngx-graph')).not.toBeNull();
   });
 });

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/release/tabs/helm-release-resource-graph/helm-release-resource-graph.component.ts
@@ -4,7 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { AppProgressBarComponent } from '../../../../../../../core/src/shared/components/progress-bar/app-progress-bar.component';
 import { CustomIconComponent } from '../../../../../../../core/src/shared/components/custom-material/custom-material.component';
 import { CustomTooltipDirective } from '../../../../../../../core/src/shared/components/custom-tooltip/custom-tooltip.directive';
-import { Edge, GraphComponent, NgxGraphZoomOptions } from '@swimlane/ngx-graph';
+import { Edge, GraphComponent, LayoutService, NgxGraphZoomOptions } from '@swimlane/ngx-graph';
 import { SidePanelService } from '@stratosui/core';
 import { combineLatest, Observable, Subject, Subscription } from 'rxjs';
 import { take, distinctUntilChanged, filter, map, publishReplay, refCount, startWith } from 'rxjs/operators';
@@ -68,6 +68,10 @@ interface CustomHelmReleaseGraphNodeData extends HelmReleaseGraphNodeData {
   styleUrls: ['./helm-release-resource-graph.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
+  // ngx-graph 12+ declares LayoutService without providedIn and only the
+  // deprecated NgxGraphModule provides it; the standalone GraphComponent
+  // injects it, so the consumer has to supply it.
+  providers: [LayoutService],
   imports: [
     CommonModule,
     AppProgressBarComponent,
@@ -84,8 +88,10 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
 
   // see: https://swimlane.github.io/ngx-graph/#/#quick-start
 
-  public nodes: CustomHelmReleaseGraphNode[] = [];
-  public links: Edge[] = [];
+  // Signals: the view is OnPush under zoneless change detection, so plain
+  // fields written from the socket subscription never re-rendered the graph.
+  public nodes = signal<CustomHelmReleaseGraphNode[]>([]);
+  public links = signal<Edge[]>([]);
 
   private updateSignal: WritableSignal<boolean> = signal<boolean>(false);
   update$ = toObservable(this.updateSignal);
@@ -95,13 +101,11 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
   private fitSignal: WritableSignal<NgxGraphZoomOptions> = signal<NgxGraphZoomOptions>({});
   fit$ = toObservable(this.fitSignal);
 
-  public layout = 'dagre';
+  public layout = signal('dagre');
 
   public layoutIndex = 0;
 
   private graph?: Subscription;
-
-  private didInitialFit = false;
 
   public path: string;
 
@@ -158,7 +162,7 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
 
         newNodes.push(newNode);
       });
-      this.nodes = newNodes;
+      this.nodes.set(newNodes);
 
       const newLinks: HelmReleaseGraphLink[] = [];
       Object.values(g.links).forEach((link: any) => {
@@ -169,13 +173,8 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
           target: link.target
         });
       });
-      this.links = newLinks;
+      this.links.set(newLinks);
       this.updateSignal.set(true);
-
-      if (!this.didInitialFit) {
-        this.didInitialFit = true;
-        setTimeout(() => this.fitGraph(), 10);
-      }
     });
   }
 
@@ -244,7 +243,7 @@ export class HelmReleaseResourceGraphComponent implements OnInit, OnDestroy {
       this.layoutIndex = 0;
     }
 
-    this.layout = layouts[this.layoutIndex];
+    this.layout.set(layouts[this.layoutIndex]);
   }
 
   private getColor(status: string): Colors {


### PR DESCRIPTION
Found while live-verifying #5878 (ngx-graph 11 to 13) on the dev stack.

The Helm release resource graph (Workloads, a release, Overview) never left
"Loading resources", on develop before the bump as well as after it. The
component is `OnPush` under zoneless change detection and wrote `nodes` and
`links` into plain fields from its `combineLatest(...).subscribe(...)`, so
nothing ever marked the view dirty. `ng.getComponent` showed ten nodes on the
instance while the DOM had no `<ngx-graph>`. It only painted when something
unrelated happened to mark the view (an `| async` emission, a click), which is
why it looked intermittent rather than dead. Broken since the zoneless
migration (`27ef38c852`, 2025-10-31).

Changes:

- `nodes`, `links` and `layout` are signals; the template reads them.
- The initial fit ran on a 10ms timer that fired before the first layout
  existed and clipped the right-hand nodes. It now fits on ngx-graph's
  `drawComplete` output, added in 12 for this purpose.
- #5878 switched the import from the deprecated `NgxGraphModule` to the
  standalone `GraphComponent`, as ngx-graph 12's deprecation notice says to.
  That component injects a `LayoutService` declared without `providedIn`,
  which only the module provided, so the first render threw NG0201. The
  build and the create-only spec were both green. The component now provides
  it itself.
- The spec pushes a graph through `HelmReleaseDataService`, the same service
  the release socket writes, and asserts the element appears. It stubs
  `ngx-graph` (the real one throws NG0203 under happy-dom). Checked both
  ways: red on plain fields, green on signals.
- Adds the indirect `fast-uri` bump (#5879) to the Chores fragment.

Verified live against the k3d test cluster's traefik release: the graph
renders within a few seconds of load, the first paint is fitted, Fit works,
node drag is disabled while background pan still works (the `enableDrag`
rename), and clicking a Deployment node opens a populated preview panel.
`make check gate` green.

Two things seen along the way that are not in this PR: the dev proxy's
`changeOrigin` makes the backend refuse every WebSocket upgrade with 403
unless it is started with `ALLOWED_ORIGINS=https://localhost:5540`; and the
backend polls cluster-scoped release resources (ClusterRole,
ClusterRoleBinding, IngressClass) at a namespaced path and gets 404, so those
nodes open an empty preview panel.
