### PR TITLE
fix(kubernetes): fetch Helm release resources at their real API paths

### DIFF
--- a/changelog.d/0003-helm-resource-urls.md
+++ b/changelog.d/0003-helm-resource-urls.md
@@ -1,0 +1,14 @@
+[BugFixes]
+- The Helm release status poller asked the Kubernetes API for the wrong
+  URL for several kinds in a release, got 404 every ten seconds, and dropped
+  those resources from the release, so their preview panel opened empty and
+  their status never updated. Cluster-scoped kinds such as ClusterRole,
+  ClusterRoleBinding and IngressClass were fetched under the release
+  namespace; the plural was guessed by appending an "s", which turns
+  IngressClass into "ingressclasss"; and a "/status" subresource was
+  appended to every non-core kind, which custom resources such as a Traefik
+  IngressRoute do not have. The poller now takes each kind's plural and scope
+  from API discovery, through the same REST mapper Helm itself uses, and
+  fetches the resource itself, which carries its status. When discovery
+  cannot name a kind the fallback guess no longer appends "/status" and
+  pluralises "s", "x", "ch" and "sh" endings with "es".

--- a/src/jetstream/plugins/kubernetes/get_release.go
+++ b/src/jetstream/plugins/kubernetes/get_release.go
@@ -102,7 +102,14 @@ func (c *KubernetesSpecification) GetReleaseStatus(ec *echo.Context) error {
 	// this back incrementally
 
 	// Parse the manifest
-	rel := helm.NewHelmRelease(res, endpointGUID, userID, c.portalProxy)
+	// Discovery gives each kind its real plural and scope; without it the
+	// release falls back to guessing from the kind name.
+	mapper, err := config.RESTClientGetter.ToRESTMapper()
+	if err != nil {
+		slog.Warn("could not build a REST mapper for the Helm release; resource URLs will be guessed", "endpoint", endpointGUID, "release", release, "error", err)
+		mapper = nil
+	}
+	rel := helm.NewHelmRelease(res, endpointGUID, userID, mapper)
 
 	graph := helm.NewHelmReleaseGraph(rel)
 

--- a/src/jetstream/plugins/kubernetes/helm/release.go
+++ b/src/jetstream/plugins/kubernetes/helm/release.go
@@ -18,18 +18,12 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/yaml"
 )
-
-var resourcesWithoutStatus = map[string]bool{
-	"RoleBinding":        false,
-	"Role":               false,
-	"ClusterRole":        false,
-	"ClusterRoleBinding": false,
-	"PodSecurityPolicy":  false,
-}
 
 // HelmRelease represents a Helm Release deployed via Helm
 type HelmRelease struct {
@@ -40,6 +34,9 @@ type HelmRelease struct {
 	Jobs           []KubeResourceJob          `json:"-"`
 	PodJobs        map[string]KubeResourceJob `json:"-"`
 	ManifestErrors bool                       `json:"-"`
+	// mapper resolves a kind's REST plural and scope through API discovery.
+	// nil (tests, discovery failure) falls back to a name-based guess.
+	mapper meta.RESTMapper
 }
 
 // KubeResource is a simple struct to pull out core common metadata for a Kube resource
@@ -59,11 +56,12 @@ func (r *KubeResource) getID() string {
 }
 
 // NewHelmRelease represents extended info about a Helm Release
-func NewHelmRelease(info *release.Release, endpoint, user string, jetstream api.PortalProxy) *HelmRelease {
+func NewHelmRelease(info *release.Release, endpoint, user string, mapper meta.RESTMapper) *HelmRelease {
 	r := &HelmRelease{
 		Release:  info,
 		Endpoint: endpoint,
 		User:     user,
+		mapper:   mapper,
 	}
 	r.Resources = make(map[string]KubeResource)
 	r.PodJobs = make(map[string]KubeResourceJob)
@@ -197,13 +195,16 @@ func (r *HelmRelease) processKubeResource(obj interface{}, t KubeResource) {
 }
 
 func (r *HelmRelease) addJobForResource(namespace, kind, apiVersion, name string) {
+	if r.isClusterScoped(kind, apiVersion) {
+		namespace = ""
+	}
 	job := KubeResourceJob{
 		ID:         fmt.Sprintf("%s-%s#Pods", kind, name),
 		Endpoint:   r.Endpoint,
 		User:       r.User,
 		Namespace:  namespace,
 		Name:       name,
-		URL:        getRestURL(namespace, kind, apiVersion, name),
+		URL:        r.restURL(namespace, kind, apiVersion, name),
 		APIVersion: apiVersion,
 		Kind:       kind,
 	}
@@ -402,33 +403,62 @@ func (r *HelmRelease) UpdateResources(jetstream api.PortalProxy) {
 	}
 }
 
-func getRestURL(namespace, kind, apiVersion, name string) string {
-	var restURL string
-	base := "api"
-	if len(strings.Split(apiVersion, "/")) > 1 {
-		base = "apis"
+// restMapping asks discovery for the kind's plural and scope. ok is false
+// when there is no mapper or the kind is unknown to the cluster.
+func (r *HelmRelease) restMapping(kind, apiVersion string) (*meta.RESTMapping, bool) {
+	if r.mapper == nil {
+		return nil, false
+	}
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return nil, false
+	}
+	m, err := r.mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: kind}, gv.Version)
+	if err != nil {
+		slog.Debug("no REST mapping for kind, guessing its URL", "kind", kind, "apiVersion", apiVersion, "error", err)
+		return nil, false
+	}
+	return m, true
+}
 
-		v, ok := resourcesWithoutStatus[kind]
-		if !ok || v {
-			name += "/status"
+func (r *HelmRelease) isClusterScoped(kind, apiVersion string) bool {
+	m, ok := r.restMapping(kind, apiVersion)
+	return ok && m.Scope.Name() == meta.RESTScopeNameRoot
+}
+
+// restURL builds the API path for one resource. A plain GET on the resource
+// returns its status too, so there is no /status subresource in the path;
+// not every kind has one and those that do not answered 404.
+func (r *HelmRelease) restURL(namespace, kind, apiVersion, name string) string {
+	base := "api"
+	if strings.Contains(apiVersion, "/") {
+		base = "apis"
+	}
+
+	plural := pluralize(strings.ToLower(kind))
+	if m, ok := r.restMapping(kind, apiVersion); ok {
+		plural = m.Resource.Resource
+		if m.Scope.Name() == meta.RESTScopeNameRoot {
+			namespace = ""
 		}
 	}
 
-	kindPlural := pluralize(strings.ToLower(kind))
-	if len(namespace) == 0 {
-		// This is not a namespaced resource
-		restURL = fmt.Sprintf("/%s/%s/%s/%s", base, apiVersion, kindPlural, name)
-	} else {
-		restURL = fmt.Sprintf("/%s/%s/namespaces/%s/%s/%s", base, apiVersion, namespace, kindPlural, name)
+	if namespace == "" {
+		return fmt.Sprintf("/%s/%s/%s/%s", base, apiVersion, plural, name)
 	}
-
-	return restURL
+	return fmt.Sprintf("/%s/%s/namespaces/%s/%s/%s", base, apiVersion, namespace, plural, name)
 }
 
+// pluralize is the fallback when discovery cannot name the resource. It
+// covers the Kubernetes built-ins; anything irregular should come from the
+// mapper.
 func pluralize(resource string) string {
-	if strings.HasSuffix(resource, "y") {
-		return fmt.Sprintf("%sies", resource[:len(resource)-1])
+	switch {
+	case strings.HasSuffix(resource, "y"):
+		return resource[:len(resource)-1] + "ies"
+	case strings.HasSuffix(resource, "s"), strings.HasSuffix(resource, "x"),
+		strings.HasSuffix(resource, "ch"), strings.HasSuffix(resource, "sh"):
+		return resource + "es"
 	}
-
-	return fmt.Sprintf("%ss", resource)
+	return resource + "s"
 }

--- a/src/jetstream/plugins/kubernetes/helm/release_test.go
+++ b/src/jetstream/plugins/kubernetes/helm/release_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // podSelectorToQueryString now takes *metav1.LabelSelector directly.
@@ -38,6 +40,49 @@ func TestPodSelector(t *testing.T) {
 			So(strings.Contains(qs, "environment%3Ddev"), ShouldBeTrue)
 			So(strings.Contains(qs, "app%3Dapi"), ShouldBeTrue)
 			So(strings.Contains(qs, ","), ShouldBeTrue)
+		})
+	})
+}
+
+func TestRestURL(t *testing.T) {
+	Convey("restURL", t, func() {
+		mapper := meta.NewDefaultRESTMapper(nil)
+		mapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
+		mapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}, meta.RESTScopeNamespace)
+		mapper.Add(schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"}, meta.RESTScopeRoot)
+		mapper.Add(schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "IngressClass"}, meta.RESTScopeRoot)
+		mapper.Add(schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"}, meta.RESTScopeNamespace)
+		r := &HelmRelease{mapper: mapper}
+
+		Convey("namespaced resources sit under the namespace, with no /status suffix", func() {
+			So(r.restURL("ns", "Deployment", "apps/v1", "web"), ShouldEqual, "/apis/apps/v1/namespaces/ns/deployments/web")
+			So(r.restURL("ns", "Service", "v1", "web"), ShouldEqual, "/api/v1/namespaces/ns/services/web")
+		})
+
+		Convey("cluster-scoped resources drop the namespace even when one is given", func() {
+			So(r.restURL("ns", "ClusterRole", "rbac.authorization.k8s.io/v1", "admin"), ShouldEqual, "/apis/rbac.authorization.k8s.io/v1/clusterroles/admin")
+			So(r.restURL("ns", "IngressClass", "networking.k8s.io/v1", "traefik"), ShouldEqual, "/apis/networking.k8s.io/v1/ingressclasses/traefik")
+		})
+
+		Convey("the plural comes from discovery, not string surgery", func() {
+			So(r.restURL("ns", "Ingress", "networking.k8s.io/v1", "web"), ShouldEqual, "/apis/networking.k8s.io/v1/namespaces/ns/ingresses/web")
+		})
+
+		Convey("a kind discovery does not know falls back to the heuristic, still without /status", func() {
+			So(r.restURL("ns", "IngressRoute", "traefik.io/v1alpha1", "dash"), ShouldEqual, "/apis/traefik.io/v1alpha1/namespaces/ns/ingressroutes/dash")
+		})
+
+		Convey("with no mapper at all the heuristic pluralises s/x/ch/sh endings with es", func() {
+			bare := &HelmRelease{}
+			So(bare.restURL("ns", "Ingress", "networking.k8s.io/v1", "web"), ShouldEqual, "/apis/networking.k8s.io/v1/namespaces/ns/ingresses/web")
+			So(bare.restURL("ns", "NetworkPolicy", "networking.k8s.io/v1", "deny"), ShouldEqual, "/apis/networking.k8s.io/v1/namespaces/ns/networkpolicies/deny")
+			So(bare.restURL("ns", "ConfigMap", "v1", "cfg"), ShouldEqual, "/api/v1/namespaces/ns/configmaps/cfg")
+		})
+
+		Convey("isClusterScoped follows the mapper and defaults to namespaced", func() {
+			So(r.isClusterScoped("ClusterRole", "rbac.authorization.k8s.io/v1"), ShouldBeTrue)
+			So(r.isClusterScoped("Deployment", "apps/v1"), ShouldBeFalse)
+			So(r.isClusterScoped("IngressRoute", "traefik.io/v1alpha1"), ShouldBeFalse)
 		})
 	})
 }


### PR DESCRIPTION
Follow-on from #5880. While that graph was being verified, the backend log
filled with a passthrough 404 every ten seconds for four resources of the
traefik release, and the affected nodes opened an empty preview panel.

`getRestURL` in the release poller built each URL by hand and got three
things wrong:

- Cluster-scoped kinds were fetched under the release namespace. Helm stamps
  the release namespace onto every manifest resource, and the code took a
  non-empty namespace to mean "namespaced". ClusterRole, ClusterRoleBinding
  and IngressClass all went to `/namespaces/kube-system/...`.
- The plural was the lowercased kind plus `s`, with a single `y` to `ies`
  rule. IngressClass became `ingressclasss`; Ingress would be `ingresss`.
- `/status` was appended to every non-core kind unless it was on a short
  deny list. Custom resources such as Traefik's IngressRoute have no status
  subresource and 404.

A 404 removes the resource from the release on every poll, which is why the
preview stayed empty and the status never moved.

The fix takes each kind's plural and scope from the REST mapper that Helm's
`action.Configuration` already carries. It is discovery-backed, cached, and
covers CRDs. The poller fetches the resource itself, since a plain GET
returns its status, so the `/status` suffix and its deny list are gone.
The name-based guess stays as the fallback when discovery cannot map a kind,
now without `/status` and with `es` plurals for `s`, `x`, `ch` and `sh`
endings. `NewHelmRelease` takes the mapper in place of a `PortalProxy`
parameter it never used.

`TestRestURL` covers namespaced and cluster-scoped kinds through a default
mapper, the discovery-supplied plural, the unknown-kind fallback, the
no-mapper fallback pluraliser, and `isClusterScoped`.

Verified on the k3d test cluster's traefik release: zero passthrough 404s
across the poll window, and ClusterRole, ClusterRoleBinding, IngressClass
and IngressRoute all open a populated preview. `make check gate` green.
