### PR TITLE
fix: repaint OnPush views under zoneless CD and revive the Helm install flow

### DIFF
--- a/changelog.d/0004-zoneless-onpush-sweep.md
+++ b/changelog.d/0004-zoneless-onpush-sweep.md
@@ -1,0 +1,24 @@
+[BugFixes]
+- Several pages kept their first render under zoneless change detection
+  because an OnPush component wrote data that arrived later into plain
+  fields, which never marks the view dirty. The affected fields are
+  signals now. Visible effects fixed: the About page's EULA rendered
+  blank; a Helm chart's details showed no versions and no schema notice;
+  the markdown help panel on the endpoint connect dialogs stayed empty;
+  the Edit Endpoint CA certificate toggle ignored the saved endpoint; the
+  Metrics tab on an application and the Quota tab on a space could be
+  missing; the add-route form's HTTP/TCP switch, a user-provided
+  service's existing tags, a favourite card's invalid state, the profile
+  form's password rules, and a disabled file input all lagged behind
+  their data.
+- Installing or upgrading a Helm release sat on "Loading ..." forever.
+  The values editor built an observable from a signal inside its config
+  input setter, which runs outside an injection context and threw
+  NG0203 before the chart values were ever requested.
+- The Helm chart catalog (Helm, Charts) said "There are no charts" and
+  never requested them, and the Workloads release list had the same
+  latent gap: both list configs compared a signal accessor to null
+  instead of the signal's value, so the first-visit load was skipped.
+- Opening `workloads/install/<endpoint>/<repo>/<chart>` without a version
+  requested `versions/undefined` and failed; the page now resolves the
+  chart's latest version.

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.html
@@ -49,7 +49,7 @@
                     @for (metric of appAutoscalerAppMetricNames$ | async; track metric) {
                       <div class="pr-10">
                         <app-metadata-item class="my-0" label={{metric.name}}>
-                          @if (appAutoscalerAppMetrics[metric.name] | async; as metricData) {
+                          @if (appAutoscalerAppMetrics()[metric.name] | async; as metricData) {
                             <canvas baseChart [type]="'doughnut'"
                               [data]="getGaugeData(metricData)"
                               [options]="gaugeOptions"

--- a/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
+++ b/src/frontend/packages/cf-autoscaler/src/features/autoscaler-tab-extension/autoscaler-tab-extension.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, Injector, OnDestroy, OnInit, Signal, computed, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnDestroy, OnInit, Signal, computed, effect, inject, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BaseChartDirective } from 'ng2-charts';
@@ -175,7 +175,8 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
   private appAutoscalerPolicySnackBarRef!: TailwindSnackBarRef<any>;
   private appAutoscalerScalingHistorySnackBarRef!: TailwindSnackBarRef<any>;
 
-  appAutoscalerAppMetrics: Record<string, Observable<{ entity: AppAutoscalerMetricDataLocal }[]>> = {};
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly appAutoscalerAppMetrics = signal<Record<string, Observable<{ entity: AppAutoscalerMetricDataLocal }[]>>>({});
 
   paramsMetrics: AutoscalerTabPaginationParams = {
     'start-time': ((new Date()).getTime() - 60000).toString() + '000000',
@@ -339,10 +340,10 @@ export class AutoscalerTabExtensionComponent implements OnInit, OnDestroy {
       this.paramsMetrics['start-time'] = ((new Date()).getTime() - 60000).toString() + '000000';
       this.paramsMetrics['end-time'] = (new Date()).getTime().toString() + '000000';
       if (appAutoscalerPolicy.scaling_rules_map) {
-        this.appAutoscalerAppMetrics = Object.keys(appAutoscalerPolicy.scaling_rules_map).reduce((metricMap: Record<string, Observable<{ entity: AppAutoscalerMetricDataLocal }[]>>, metricName: string) => {
+        this.appAutoscalerAppMetrics.set(Object.keys(appAutoscalerPolicy.scaling_rules_map).reduce((metricMap: Record<string, Observable<{ entity: AppAutoscalerMetricDataLocal }[]>>, metricName: string) => {
           metricMap[metricName] = this.getAppMetric(metricName, appAutoscalerPolicy.scaling_rules_map[metricName], this.paramsMetrics);
           return metricMap;
-        }, {});
+        }, {}));
       }
     });
   }

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks" tabsHeader="Application" [favorite]="favorite$ | async">
+<app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks()" tabsHeader="Application" [favorite]="favorite$ | async">
   <h1>{{ (applicationService.application$ | async)?.app?.entity?.name }} </h1>
 </app-page-header>
 <app-loading-page [isLoading]="isFetching$" [text]="loadingText()" class="router-component">

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/application-tabs-base.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, EffectRef, Injector, NgZone, OnDestroy, OnInit, ChangeDetectionStrategy, effect, inject, runInInjectionContext } from '@angular/core';
+import { Component, EffectRef, Injector, NgZone, OnDestroy, OnInit, ChangeDetectionStrategy, effect, inject, runInInjectionContext, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Router, RouterModule } from '@angular/router';
 import { GitSCMService, GitSCMType } from '@stratosui/git';
@@ -129,7 +129,7 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
       map(can => !can),
     );
 
-    this.tabLinks = [
+    this.tabLinks.set([
       { link: 'summary', label: 'Summary', iconFont: 'stratos-icons', icon: 'application' },
       { link: 'log-stream', label: 'Log Stream', icon: 'featured_play_list' },
       { link: 'revisions', label: 'Revisions', icon: 'history' },
@@ -137,25 +137,25 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
       { link: 'variables', label: 'Variables', icon: 'list', hidden$: appDoesNotHaveEnvVars$ },
       { link: 'services', label: 'Services', iconFont: 'stratos-icons', icon: 'service' },
       { link: 'events', label: 'Events', icon: 'watch_later' },
-    ];
+    ]);
 
     this.endpointsService.hasMetrics(applicationService.cfGuid).subscribe((hasMetrics: boolean) => {
       if (hasMetrics) {
-        this.tabLinks = [
-          ...this.tabLinks,
+        this.tabLinks.update(tabs => [
+          ...tabs,
           {
             link: 'metrics',
             label: 'Metrics',
             icon: 'equalizer'
           }
-        ];
+        ]);
       }
     });
 
     // Add any tabs from extensions
     const tabs = getTabsFromExtensions(StratosTabType.Application);
     tabs.map((extensionTab) => {
-      this.tabLinks.push(extensionTab);
+      this.tabLinks.update(tabs => [...tabs, extensionTab]);
     });
 
     // Ensure Git SCM tab gets updated if the app is redeployed from a different SCM Type
@@ -170,15 +170,15 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
           const scm = scmService.getSCM(gitscm as GitSCMType, stratProject.deploySource.endpointGuid);
           const iconInfo = scm.getIcon();
           // Add tab or update existing tab
-          const tab = this.tabLinks.find(t => t.link === 'gitscm');
+          const tab = this.tabLinks().find(t => t.link === 'gitscm');
           if (!tab) {
-            this.tabLinks.push({ link: 'gitscm', label: scm.getLabel(), iconFont: iconInfo.fontName, icon: iconInfo.iconName });
+            this.tabLinks.update(tabs => [...tabs, { link: 'gitscm', label: scm.getLabel(), iconFont: iconInfo.fontName, icon: iconInfo.iconName }]);
           } else {
             tab.label = scm.getLabel();
             tab.iconFont = iconInfo.fontName;
             tab.icon = iconInfo.iconName;
           }
-          this.tabLinks = [...this.tabLinks];
+          this.tabLinks.update(tabs => [...tabs]);
         }
       });
   }
@@ -189,7 +189,8 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
   summaryDataChanging$!: Observable<boolean>;
   stratosProjectSub!: Subscription;
 
-  tabLinks: IPageSideNavTab[];
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly tabLinks = signal<IPageSideNavTab[]>([]);
 
   // Where an app-detail error bounce (app deleted elsewhere / 404 / permission
   // lost) should land: back to the per-CF applications tab when the app was
@@ -354,7 +355,7 @@ export class ApplicationTabsBaseComponent implements OnInit, OnDestroy {
   // the app text for the base route / unknown tabs.
   loadingText(): string {
     const last = this.router.url.split('?')[0].split('/').filter(Boolean).pop();
-    const tab = (this.tabLinks ?? []).find(t => t.link === last);
+    const tab = this.tabLinks().find(t => t.link === last);
     return tab ? `Retrieving ${tab.label}` : 'Retrieving application';
   }
 

--- a/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.html
@@ -11,7 +11,7 @@
       </app-form-field>
     </form>
 
-    @if (!selectedDomain?.supportedProtocols?.includes('tcp')) {
+    @if (!selectedDomain()?.supportedProtocols?.includes('tcp')) {
       <form [formGroup]="addHTTPRoute" class="stepper-form w-1/2">
         <div class="add-route__form-prompt">
           This is an HTTP Domain - an HTTP Route will be created
@@ -42,7 +42,7 @@
         </div>
       </form>
     }
-    @if (selectedDomain?.supportedProtocols?.includes('tcp')) {
+    @if (selectedDomain()?.supportedProtocols?.includes('tcp')) {
       <form [formGroup]="addTCPRoute" class="stepper-form w-1/2">
         <div class="add-route__form-prompt">
           This is a TCP Domain - a TCP Route will be created

--- a/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.spec.ts
@@ -221,8 +221,8 @@ describe('AddRoutesComponent', () => {
   it('submit in HTTP create mode calls createAndAttachRoute with host/path + relationships (no port)', async () => {
     // Wire up the form for an HTTP submission.
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'newhost', path: 'subpath' });
 
     await component.runSubmit();
@@ -238,8 +238,8 @@ describe('AddRoutesComponent', () => {
 
   it('submit in TCP create mode calls createAndAttachRoute with port + relationships (no host/path)', async () => {
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-tcp', supportedProtocols: ['tcp'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-tcp', supportedProtocols: ['tcp'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addTCPRoute.patchValue({ port: '5005', useRandomPort: false });
 
     await component.runSubmit();
@@ -254,8 +254,8 @@ describe('AddRoutesComponent', () => {
 
   it('submit in TCP create mode with useRandomPort=true omits port', async () => {
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-tcp', supportedProtocols: ['tcp'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-tcp', supportedProtocols: ['tcp'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addTCPRoute.patchValue({ port: '', useRandomPort: true });
 
     await component.runSubmit();
@@ -266,8 +266,8 @@ describe('AddRoutesComponent', () => {
 
   it('on createAndAttachRoute success: dataService.addRoute called with returned StRoute, then router navigates back to routes list', async () => {
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'h', path: '' });
 
     const created = makeRoute({ guid: 'created-1', url: 'h.example.com' });
@@ -283,8 +283,8 @@ describe('AddRoutesComponent', () => {
 
   it('on createAndAttachRoute orphan failure: error propagates with Orphan route message; no navigation', async () => {
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'h', path: '' });
 
     createAndAttach.mockRejectedValueOnce(
@@ -299,8 +299,8 @@ describe('AddRoutesComponent', () => {
 
   it('on 422 RouteHostTaken: surfaces generic name-unavailable message', async () => {
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'taken', path: '' });
 
     const httpErr = Object.assign(new Error('Http failure response'), {
@@ -314,8 +314,8 @@ describe('AddRoutesComponent', () => {
 
   it('on 422 with non-uniqueness code: passes CF detail through', async () => {
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'invalid', path: '' });
 
     const httpErr = Object.assign(new Error('Quota exceeded'), {
@@ -349,8 +349,8 @@ describe('AddRoutesComponent', () => {
 
   it('submit gate: valid form + no collision → valid', () => {
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'unique', path: '' });
     fixture.detectChanges();
     expect(component.hostCollision()).toBeNull();
@@ -362,8 +362,8 @@ describe('AddRoutesComponent', () => {
       makeRoute({ guid: 'taken-1', host: 'taken', path: '', domainGuid: 'domain-http', appGuids: [] }),
     ]);
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'taken', path: '' });
     fixture.detectChanges();
     expect(component.hostCollision()?.guid).toBe('taken-1');
@@ -383,8 +383,8 @@ describe('AddRoutesComponent', () => {
       makeRoute({ guid: 'tcp-taken', domainGuid: 'domain-tcp', host: '', path: '', port: 5555, appGuids: [] }),
     ]);
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-tcp', supportedProtocols: ['tcp'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-tcp', supportedProtocols: ['tcp'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addTCPRoute.patchValue({ port: '5555', useRandomPort: false });
     fixture.detectChanges();
     expect(component.hostCollision()?.guid).toBe('tcp-taken');
@@ -398,8 +398,8 @@ describe('AddRoutesComponent', () => {
       makeRoute({ guid: 'mine', host: 'myhost', path: '', domainGuid: 'domain-http', appGuids: ['mockAppGuid'] }),
     ]);
     component.spaceGuid = 'mockSpaceGuid';
-    component.selectedDomain = { guid: 'domain-http', supportedProtocols: ['http'] } as any;
-    component.domainFormGroup.patchValue({ domain: component.selectedDomain });
+    component.selectedDomain.set({ guid: 'domain-http', supportedProtocols: ['http'] } as any);
+    component.domainFormGroup.patchValue({ domain: component.selectedDomain() });
     component.addHTTPRoute.patchValue({ host: 'myhost', path: '' });
     fixture.detectChanges();
     expect(component.hostCollision()).toBeNull();

--- a/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/routes/add-routes/add-routes.component.ts
@@ -135,7 +135,8 @@ export class AddRoutesComponent implements OnInit, OnDestroy {
   appGuid: string;
   cfGuid: string;
   spaceGuid!: string;
-  selectedDomain!: StDomain;
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly selectedDomain = signal<StDomain | undefined>(undefined);
   appUrl: string;
 
   useRandomPort = false;
@@ -418,11 +419,11 @@ export class AddRoutesComponent implements OnInit, OnDestroy {
       this.applicationService.orgDomains$.pipe(
         filter(domains => Array.isArray(domains) && domains.length > 0),
       ).subscribe(domains => {
-        if (this.selectedDomain) {
+        if (this.selectedDomain()) {
           return;
         }
-        this.selectedDomain = domains[0];
-        this.domainFormGroup.patchValue({ domain: this.selectedDomain });
+        this.selectedDomain.set(domains[0]);
+        this.domainFormGroup.patchValue({ domain: domains[0] });
       }),
     );
 
@@ -431,7 +432,7 @@ export class AddRoutesComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.domainFormGroup.controls.domain.valueChanges.subscribe(domain => {
         if (domain && typeof domain !== 'string') {
-          this.selectedDomain = domain;
+          this.selectedDomain.set(domain);
         }
       })
     );

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.html
@@ -1,4 +1,4 @@
-<app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks" tabsHeader="Space"
+<app-page-header [breadcrumbs]="breadcrumbs$ | async" [tabs]="tabLinks()" tabsHeader="Space"
   [favorite]="favorite()">
   <h1>{{ spaceDataService.space()?.name }}</h1>
 </app-page-header>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, computed, Injector, OnInit, Signal, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, Injector, OnInit, Signal, inject, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
@@ -71,7 +71,8 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
   isLoading$ = toObservable(this.spaceDataService.isLoading);
 
 
-  tabLinks: IPageSideNavTab[] = [
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly tabLinks = signal<IPageSideNavTab[]>([
     {
       link: 'summary',
       label: 'Summary',
@@ -111,7 +112,7 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
       label: 'Events',
       icon: 'watch_later'
     }
-  ];
+  ]);
 
   public breadcrumbs$!: Observable<IHeaderBreadcrumb[]>;
 
@@ -153,13 +154,16 @@ export class CloudFoundrySpaceBaseComponent implements OnInit {
       filter(s => !!s),
       take(1),
     ).subscribe(space => {
-      this.tabLinks.push({
-        link: 'space-quota',
-        label: 'Quota',
-        icon: 'data_usage',
-        hidden$: of(!space!.quotaGuid),
-      });
-      this.tabLinks = this.tabLinks.concat(getTabsFromExtensions(StratosTabType.CloudFoundrySpace));
+      this.tabLinks.update(tabs => [
+        ...tabs,
+        {
+          link: 'space-quota',
+          label: 'Quota',
+          icon: 'data_usage',
+          hidden$: of(!space!.quotaGuid),
+        },
+        ...getTabsFromExtensions(StratosTabType.CloudFoundrySpace),
+      ]);
     });
   }
 

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.html
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.html
@@ -73,7 +73,7 @@
     <app-form-field class="stepper-form__tags">
       <app-label>Tags</app-label>
       <div class="flex flex-wrap gap-2 p-2 border border-content-border rounded-md min-h-[42px] bg-content-bg">
-        @for (tag of tags; track tag) {
+        @for (tag of tags(); track tag) {
           <span
             class="inline-flex items-center px-3 py-1 text-sm font-medium text-content-text bg-content-secondary rounded-full hover:bg-content-border"
           >

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.ts
@@ -194,7 +194,8 @@ export class SpecifyUserProvidedDetailsComponent implements OnDestroy {
   public allServiceInstanceNames!: string[];
   public subs: Subscription[] = [];
   public isUpdate: boolean;
-  public tags: { label: string }[] = [];
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly tags = signal<{ label: string }[]>([]);
   public validate = signal(false);
   private subscriptions: Subscription[] = [];
 
@@ -287,7 +288,7 @@ export class SpecifyUserProvidedDetailsComponent implements OnDestroy {
     this.createEditServiceInstance.reset();
     this.bindExistingInstance.reset();
     if (mode === CreateServiceFormMode.CreateServiceInstance) {
-      this.tags = [];
+      this.tags.set([]);
     }
   };
 
@@ -365,7 +366,7 @@ export class SpecifyUserProvidedDetailsComponent implements OnDestroy {
           route_service_url: si.routeServiceUrl ?? '',
           tags: []
         });
-        this.tags = this.tagsArrayToChips(si.tags);
+        this.tags.set(this.tagsArrayToChips(si.tags));
         this.originalFormValue = this.getServiceData();
       });
     }
@@ -484,7 +485,7 @@ export class SpecifyUserProvidedDetailsComponent implements OnDestroy {
 
 
   private getTagsArray() {
-    return this.tags && Array.isArray(this.tags) ? this.tags.map(tag => tag.label) : [];
+    return this.tags().map(tag => tag.label);
   }
 
   private tagsArrayToChips(tagsArray: string[]) {
@@ -499,23 +500,23 @@ export class SpecifyUserProvidedDetailsComponent implements OnDestroy {
     const label = (input.value || '').trim();
 
     if (label) {
-      this.tags.push({ label });
+      this.tags.update(tags => [...tags, { label }]);
       this.updateTagsFormControl();
       input.value = '';
     }
   }
 
   public removeTag(tag: any): void {
-    const index = this.tags.indexOf(tag);
+    const index = this.tags().indexOf(tag);
 
     if (index >= 0) {
-      this.tags.splice(index, 1);
+      this.tags.update(tags => tags.filter((_, i) => i !== index));
       this.updateTagsFormControl();
     }
   }
 
   private updateTagsFormControl(): void {
-    const tagsArray = this.tags.map(t => t.label);
+    const tagsArray = this.tags().map(t => t.label);
     this.createEditServiceInstance.controls.tags.setValue(tagsArray);
     this.createEditServiceInstance.controls.tags.markAsTouched();
     // Mark the form as dirty to trigger change detection

--- a/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.html
+++ b/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.html
@@ -8,4 +8,4 @@
         </span>
     </div>
 </app-page-header>
-<div [innerHtml]='eulaHtml'></div>
+<div [innerHtml]='eulaHtml()'></div>

--- a/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -41,5 +41,17 @@ describe('EulaPageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // Regression: the EULA arrives from an HTTP response after the first render.
+  // Under zoneless change detection an OnPush view only repaints for signal
+  // writes, so a plain field assigned in the subscribe left the page blank.
+  it('renders the EULA once the fetch resolves', async () => {
+    TestBed.inject(HttpTestingController)
+      .expectOne('/core/assets/eula.html')
+      .flush('<p class="eula-body">Licence text</p>');
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('.eula-body')?.textContent).toBe('Licence text');
   });
 });

--- a/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.ts
+++ b/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { CustomTooltipDirective } from '../../../shared/components/custom-tooltip/custom-tooltip.directive';
 import { RouterModule } from '@angular/router';
 
@@ -26,15 +26,16 @@ export class EulaPageComponent {
     }
   ];
 
-  public eulaHtml = '';
+  // A signal so the OnPush view repaints when the fetch resolves under zoneless CD.
+  public readonly eulaHtml = signal('');
 
   // Load the EULA
   constructor() {
     const http = inject(HttpClient);
 
     http.get('/core/assets/eula.html', {responseType: 'text'}).subscribe(
-      (html: string) => this.eulaHtml = html,
-      () => this.eulaHtml = 'An error occurred retrieving the EULA'
+      (html: string) => this.eulaHtml.set(html),
+      () => this.eulaHtml.set('An error occurred retrieving the EULA')
     );
   }
 

--- a/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.html
+++ b/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.html
@@ -18,8 +18,8 @@
         </app-form-field>
         <app-checkbox appInput id="skipSSL" name="skipSSL" formControlName="skipSSL">Skip SSL validation for the endpoint
         </app-checkbox>
-        <app-checkbox appInput id="useCACert" [checked]="showCACertField" (change)="toggleCACertField()">Use a CA Certificate for the endpoint</app-checkbox>
-        <div [ngClass]="{'edit-endpoint__shown': showCACertField}" class="edit-endpoint__advanced" spellcheck=false>
+        <app-checkbox appInput id="useCACert" [checked]="showCACertField()" (change)="toggleCACertField()">Use a CA Certificate for the endpoint</app-checkbox>
+        <div [ngClass]="{'edit-endpoint__shown': showCACertField()}" class="edit-endpoint__advanced" spellcheck=false>
           <span class="edit-endpoint__cacert-title text-sm font-medium text-[var(--content-text)]">Specify CA Certificate:</span>
           <textarea rows="10" class="edit-endpoint__cacert input font-mono text-sm bg-[var(--input-bg)] text-[var(--input-text)] border-[var(--input-border)]" appInput formControlName="caCert" name="caCert"></textarea>
         </div>

--- a/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/edit-endpoint/edit-endpoint-step/edit-endpoint-step.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Injector, OnDestroy, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnDestroy, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormControl, FormGroup, Validators } from '@angular/forms';
@@ -73,7 +73,8 @@ export class EditEndpointStepComponent implements OnDestroy, IStepperStep {
   formChangeSub: Subscription;
   setClientInfo = false;
   show = false;
-  showCACertField = false;
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly showCACertField = signal(false);
   lastSkipSSLValue = false;
 
   // Signal-handle exposed to the parent stepper template (FWT-957)
@@ -156,7 +157,7 @@ export class EditEndpointStepComponent implements OnDestroy, IStepperStep {
     ).subscribe(endpoint => {
       this.setAdvancedFields(endpoint);
       this.lastSkipSSLValue = endpoint.skip_ssl_validation ?? false;
-      this.showCACertField = !!endpoint.caCert;
+      this.showCACertField.set(!!endpoint.caCert);
       this.updateSSLFieldCheckbox();
       this.editEndpoint.setValue({
         name: endpoint.name,
@@ -201,8 +202,8 @@ export class EditEndpointStepComponent implements OnDestroy, IStepperStep {
       filter((endpoint): endpoint is EndpointModel => !!endpoint),
       take(1),
       switchMap(endpoint => {
-        const caCert = this.showCACertField ? this.editEndpoint.value.caCert : undefined;
-        const skipSSL = this.showCACertField ? false : this.editEndpoint.value.skipSSL ?? false;
+        const caCert = this.showCACertField() ? this.editEndpoint.value.caCert : undefined;
+        const skipSSL = this.showCACertField() ? false : this.editEndpoint.value.skipSSL ?? false;
         // W36-B Wave 3: dispatch the update via EndpointsDataService.
         // The service returns Promise<ActionState> with the resolved
         // final state — the previous pairwise+busy-edge dance over the
@@ -242,8 +243,8 @@ export class EditEndpointStepComponent implements OnDestroy, IStepperStep {
   }
 
   toggleCACertField() {
-    this.showCACertField = !this.showCACertField;
-    if (this.showCACertField) {
+    this.showCACertField.update(shown => !shown);
+    if (this.showCACertField()) {
       this.lastSkipSSLValue = this.editEndpoint.value.skipSSL ?? false;
       this.editEndpoint.controls.skipSSL.setValue(false);
     } else {
@@ -253,7 +254,7 @@ export class EditEndpointStepComponent implements OnDestroy, IStepperStep {
   }
 
   private updateSSLFieldCheckbox() {
-    if (this.showCACertField) {
+    if (this.showCACertField()) {
       this.editEndpoint.controls.skipSSL.disable();
     } else {
       this.editEndpoint.controls.skipSSL.enable();

--- a/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.html
+++ b/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.html
@@ -19,7 +19,7 @@
         <div class="text-sm font-medium fav-card__name truncate">{{ displayName() }}</div>
         <div class="text-xs fav-card__type mt-1 truncate">{{ favoriteType }}</div>
       </div>
-      @if (!valid) {
+      @if (!valid()) {
         <span class="material-icons text-warning-shade-500 text-sm shrink-0" title="The entity for this favorite may have been deleted">warning</span>
       }
       <app-entity-favorite-star class="shrink-0" [favorite]="favorite" [confirmRemoval]="true"></app-entity-favorite-star>

--- a/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.ts
+++ b/src/frontend/packages/core/src/features/home/home/favorites-meta-card/favorites-meta-card.component.ts
@@ -48,7 +48,8 @@ export class FavoritesMetaCardComponent {
   // strict: assigned in the @Input set favoriteEntity setter
   public icon!: FavoriteIconData;
 
-  public valid = true;
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly valid = signal(true);
 
   // Reactive favorite, so the rendered name tracks freshly-fetched entity data.
   private readonly favoriteSig = signal<UserFavorite<IFavoriteMetadata> | null>(null);
@@ -152,7 +153,7 @@ export class FavoritesMetaCardComponent {
     const isValidObs = getIsValid ?
     runInInjectionContext(this.injector, () => getIsValid(this.favorite)) : of(true);
     isValidObs.pipe(take(1), defaultIfEmpty(false)).subscribe(isValid => {
-      this.valid = isValid;
+      this.valid.set(isValid);
       if (!isValid) {
         const confirmation = new ConfirmationDialogConfig(
           'Remove this Favorite?',

--- a/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.html
+++ b/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.html
@@ -19,18 +19,18 @@
         <app-form-field>
           <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Primary Email Address" formControlName="emailAddress">
         </app-form-field>
-        @if ((canChangePassword | async) === false && needsPasswordForEmailChange) {
+        @if ((canChangePassword | async) === false && needsPasswordForEmailChange()) {
           <p>Current password is required when
           changing email address</p>
         }
-        @if ((canChangePassword | async) && needsPasswordForEmailChange) {
+        @if ((canChangePassword | async) && needsPasswordForEmailChange()) {
           <p>Current password is required when changing
           email address or password</p>
         }
-        @if (needsPasswordForEmailChange) {
+        @if (needsPasswordForEmailChange()) {
           <app-form-field>
             <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Current Password" [type]="!showPassword[1] ? 'password' : 'text'"
-              formControlName="currentPassword" [required]="passwordRequired">
+              formControlName="currentPassword" [required]="passwordRequired()">
             <span matSuffix>
               <app-show-hide-button (changed)="showPassword[1] = $event"></app-show-hide-button>
             </span>
@@ -39,10 +39,10 @@
         @if ((canChangePassword | async)) {
           <div class="flex flex-col max-w-full">
             <p>Change Password (Leave blank to keep current password)</p>
-            @if (!needsPasswordForEmailChange) {
+            @if (!needsPasswordForEmailChange()) {
               <app-form-field>
                 <input class="w-full placeholder:!text-transparent focus:outline-none" appInput placeholder="Current Password" [type]="!showPassword[2] ? 'password' : 'text'"
-                  formControlName="currentPassword" [required]="passwordRequired">
+                  formControlName="currentPassword" [required]="passwordRequired()">
                 <span matSuffix>
                   <app-show-hide-button (changed)="showPassword[2] = $event"></app-show-hide-button>
                 </span>

--- a/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.ts
+++ b/src/frontend/packages/core/src/features/user-profile/edit-profile-info/edit-profile-info.component.ts
@@ -59,7 +59,8 @@ export class EditProfileInfoComponent implements OnInit, OnDestroy {
   editProfileForm: FormGroup<EditProfileForm>;
   showPassword: boolean[] = [];
 
-  needsPasswordForEmailChange: boolean;
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly needsPasswordForEmailChange = signal(false);
 
   // FWT-957: signal-native step handle. Form-edit step (Shape 2):
   // valid tracks `form.valid && form.dirty`; submit awaits the legacy
@@ -77,7 +78,6 @@ export class EditProfileInfoComponent implements OnInit, OnDestroy {
       newPassword: new FormControl('', { nonNullable: true }),
       confirmPassword: new FormControl('', { nonNullable: true }) });
 
-    this.needsPasswordForEmailChange = false;
 
     // Track form validity + dirty as a signal so the step's Next button
     // mirrors the legacy `[valid]="editProfileForm.valid && editProfileForm.dirty"`.
@@ -126,14 +126,14 @@ export class EditProfileInfoComponent implements OnInit, OnDestroy {
   // Only allow password change if user has the 'password.write' group
   public canChangePassword = this.currentUserPermissionsService.can(StratosCurrentUserPermissions.PASSWORD_CHANGE);
 
-  public passwordRequired = false;
+  readonly passwordRequired = signal(false);
 
   ngOnInit() {
     this.userProfileService.userProfile$.pipe(take(1), defaultIfEmpty(null)).subscribe(profile => {
       if (!profile) { return; }
       // UAA needs the user's password for email changes. Local user does not
       // Both need it for password change
-      this.needsPasswordForEmailChange = (profile.origin === 'uaa');
+      this.needsPasswordForEmailChange.set(profile.origin === 'uaa');
       this.profile = profile;
       this.emailAddress = this.userProfileService.getPrimaryEmailAddress(profile);
       this.editProfileForm.patchValue({
@@ -155,9 +155,9 @@ export class EditProfileInfoComponent implements OnInit, OnDestroy {
     this.sub = this.editProfileForm.valueChanges.subscribe(values => {
       // Old password is required if either email or new pw is specified (uaa)
       // or only if new pw is specified (local account)
-      const required = this.needsPasswordForEmailChange ?
+      const required = this.needsPasswordForEmailChange() ?
         (values.emailAddress !== this.emailAddress || !!(values.newPassword ?? '').length) : !!(values.newPassword ?? '').length;
-      this.passwordRequired = required;
+      this.passwordRequired.set(required);
       if (required !== this.lastRequired) {
         this.lastRequired = required;
         const validators = required ? [Validators.required] : [];

--- a/src/frontend/packages/core/src/shared/components/file-input/file-input.component.html
+++ b/src/frontend/packages/core/src/shared/components/file-input/file-input.component.html
@@ -1,24 +1,24 @@
-<div class="flex flex-col" [class.opacity-50]="disabled" [class.pointer-events-none]="disabled">
+<div class="flex flex-col" [class.opacity-50]="disabled()" [class.pointer-events-none]="disabled()">
   <input [accept]="accept" type="file" (change)="onNativeInputFileSelect($event)" #inputFile hidden />
   @if (!buttonLabel) {
     <div class="form-field file-input__form-field">
       <div class="file-input__field input flex items-center justify-between"
-        [class.opacity-50]="disabled"
-        [class.cursor-not-allowed]="disabled">
+        [class.opacity-50]="disabled()"
+        [class.cursor-not-allowed]="disabled()">
         <input type="text" class="flex-1 bg-transparent border-none outline-none text-[inherit] font-[inherit] p-0 min-w-0"
           [placeholder]="placeholder || 'No file selected'"
           [value]="name"
-          [disabled]="disabled"
+          [disabled]="disabled()"
           (change)="onPathInput($event)" />
         @if (fileCount) {
           <button class="btn btn-sm btn-secondary ml-1 flex-none leading-[inherit] min-w-[auto] px-1" type="button"
-            [disabled]="disabled" (click)="clearFile($event)"
+            [disabled]="disabled()" (click)="clearFile($event)"
             title="Clear file">
             <span class="material-icons text-sm">close</span>
           </button>
         }
         <button class="btn btn-sm btn-secondary ml-1 flex-none leading-[inherit] min-w-[auto] px-1" type="button"
-          [disabled]="disabled" (click)="selectFile($event)"
+          [disabled]="disabled()" (click)="selectFile($event)"
           title="Browse for file">
           <span class="material-icons text-sm">more_horiz</span>
         </button>
@@ -26,7 +26,7 @@
     </div>
   }
   @if (buttonLabel) {
-    <button (click)="selectFile($event)" class="btn btn-primary" [disabled]="disabled">
+    <button (click)="selectFile($event)" class="btn btn-primary" [disabled]="disabled()">
       {{ buttonLabel }}
     </button>
   }

--- a/src/frontend/packages/core/src/shared/components/file-input/file-input.component.ts
+++ b/src/frontend/packages/core/src/shared/components/file-input/file-input.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, inject, signal } from '@angular/core';
 import { ControlContainer, FormGroupName } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
@@ -35,15 +35,16 @@ export class FileInputComponent implements OnInit, OnDestroy {
   public name = '';
 
   private formGroupControl!: FormGroupName;
-  public disabled = false;
+  // Signal: written after the first render; an OnPush view under zoneless CD only repaints for signal writes.
+  readonly disabled = signal(false);
   private sub?: Subscription;
 
   ngOnInit(): void {
     if (this.parent instanceof FormGroupName) {
       this.formGroupControl = this.parent as FormGroupName;
-      this.disabled = this.formGroupControl.control.disabled;
+      this.disabled.set(this.formGroupControl.control.disabled);
       this.sub = this.formGroupControl.control.statusChanges.subscribe(a => {
-        this.disabled = a === 'DISABLED';
+        this.disabled.set(a === 'DISABLED');
       });
     }
   }

--- a/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.html
+++ b/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.html
@@ -1,3 +1,3 @@
-<app-sidepanel-preview [title]="title">
-  <div #markdown class="markdown-preview__content" [innerHtml]="markdownHtml" appMarkdownContentObserver (innerHtmlRendered)="markdownRendered()"></div>
+<app-sidepanel-preview [title]="title()">
+  <div #markdown class="markdown-preview__content" [innerHtml]="markdownHtml()" appMarkdownContentObserver (innerHtmlRendered)="markdownRendered()"></div>
 </app-sidepanel-preview>

--- a/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.spec.ts
@@ -1,5 +1,5 @@
-import { HttpClient, HttpClientModule, HttpHandler } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
@@ -19,16 +19,16 @@ describe('MarkdownPreviewComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        HttpClient, HttpHandler, SidePanelService,
+        SidePanelService,
         provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
       ],
       imports: [
         MarkdownPreviewComponent,
         SidepanelPreviewComponent,
         MDAppModule,
         RouterTestingModule,
-        HttpClientModule,
-        HttpClientTestingModule,
         CoreTestingModule,
         createBasicStoreModule(),
       ]
@@ -44,5 +44,17 @@ describe('MarkdownPreviewComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // Regression: the document arrives from an HTTP response after the first
+  // render. Under zoneless change detection an OnPush view only repaints for
+  // signal writes, so a plain field assigned in the subscribe left the help
+  // panel empty.
+  it('renders the fetched markdown', async () => {
+    component.setProps({ documentUrl: '/help.md' });
+    TestBed.inject(HttpTestingController).expectOne('/help.md').flush('Some **help** text');
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('.markdown-preview__content')?.textContent).toContain('Some help text');
   });
 });

--- a/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.ts
+++ b/src/frontend/packages/core/src/shared/components/markdown-preview/markdown-preview.component.ts
@@ -1,6 +1,6 @@
 
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, ElementRef, Input, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, ViewChild, inject, signal } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { PreviewableComponent } from '../../previewable-component';
@@ -24,16 +24,18 @@ export class MarkdownPreviewComponent implements PreviewableComponent {
   private domSanitizer = inject(DomSanitizer);
 
 
-  markdownHtml!: string;
+  // Signals: both are written asynchronously (HTTP response, a timeout) and an
+  // OnPush view under zoneless CD only repaints for signal writes.
+  readonly markdownHtml = signal('');
   private _documentUrl!: string;
   // null is a sentinel meaning "title not yet derived from the document"
-  title: string | null = '';
+  readonly title = signal<string | null>('');
 
   @Input()
   set documentUrl(value: string) {
     if (value && this._documentUrl !== value) {
       this._documentUrl = value;
-      this.title = null;
+      this.title.set(null);
       this.loadDocument();
     }
   }
@@ -66,7 +68,7 @@ export class MarkdownPreviewComponent implements PreviewableComponent {
             return `<a target="_blank" href="${href}" ${title ? `title="${title}"` : ''}>${text}</a>`;
           };
           const result = marked(markText, { renderer });
-          this.markdownHtml = typeof result === 'string' ? result : '';
+          this.markdownHtml.set(typeof result === 'string' ? result : '');
         }
       },
       (error: any) => console.warn(`Failed to fetch markdown with url ${this._documentUrl}: `, error));
@@ -75,16 +77,16 @@ export class MarkdownPreviewComponent implements PreviewableComponent {
   public markdownRendered() {
     // Find the page title and move it to the header
     const h1 = this.markdown.nativeElement.getElementsByTagName('h1');
-    if (this.title === null) {
+    if (this.title() === null) {
       if (h1.length > 0) {
         window.setTimeout(() => {
           const titleElement = h1[0];
           const titleText = titleElement.innerText;
           titleElement.remove();
-          this.title = titleText;
+          this.title.set(titleText);
         }, 100);
       } else {
-        this.title = 'Help';
+        this.title.set('Help');
       }
     }
   }

--- a/src/frontend/packages/kubernetes/src/helm/list-types/monocular-charts-signal-config.service.spec.ts
+++ b/src/frontend/packages/kubernetes/src/helm/list-types/monocular-charts-signal-config.service.spec.ts
@@ -62,6 +62,20 @@ describe('MonocularChartsSignalConfigService', () => {
     expect(svc.view.pagedItems()).toHaveLength(3);
   });
 
+  // Regression: the data service's *LastFetched() accessors return a Signal,
+  // so comparing the accessor result itself to null never matched and
+  // loadAll() silently skipped the initial fetch (the catalog rendered
+  // "There are no charts" with no request ever made).
+  it('loadAll fetches on first call and skips once fetched', async () => {
+    svc.initialize();
+    const first = svc.loadAll();
+    httpMock.expectOne(CHARTS_URL).flush(chartsPayload);
+    await first;
+    expect(svc.view.pagedItems()).toHaveLength(3);
+    await svc.loadAll();
+    httpMock.expectNone(CHARTS_URL);
+  });
+
   it('filters by nameFilter', async () => {
     svc.initialize();
     const loading = svc.refresh();

--- a/src/frontend/packages/kubernetes/src/helm/list-types/monocular-charts-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/helm/list-types/monocular-charts-signal-config.service.ts
@@ -182,7 +182,7 @@ export class MonocularChartsSignalConfigService {
   });
 
   async loadAll(): Promise<void> {
-    if (this.helmData.chartsLastFetched() === null) {
+    if (this.helmData.chartsLastFetched()() === null) {
       await this.helmData.loadCharts();
     }
   }

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-info/chart-details-info.component.html
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-info/chart-details-info.component.html
@@ -7,7 +7,7 @@
 
   <app-card class="overflow-auto block mb-8 max-w-[260px]">
     <div>
-      <app-chart-details-versions [versions]=versions [currentVersion]=currentVersion></app-chart-details-versions>
+      <app-chart-details-versions [versions]="versions()" [currentVersion]=currentVersion></app-chart-details-versions>
     </div>
     @if (chart.attributes.home) {
       <div>
@@ -37,7 +37,7 @@
         }
       </div>
     }
-    @if (schema) {
+    @if (schema()) {
       <div>
         <h1 class="text-base">Schema</h1>
         <div class="text-sm">This chart contains a values schema</div>

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-info/chart-details-info.component.spec.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-info/chart-details-info.component.spec.ts
@@ -1,6 +1,7 @@
 import {  NO_ERRORS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { Subject } from 'rxjs';
 
 import { MockChartService } from '../../shared/services/chart.service.mock';
 import { ChartsService } from '../../shared/services/charts.service';
@@ -26,5 +27,33 @@ describe('Component: ChartDetailsInfo', () => {
   it('should create an instance', () => {
     const component = TestBed.createComponent(ChartDetailsInfoComponent);
     expect(component).toBeTruthy();
+  });
+
+  // Regression: versions and the schema arrive from HTTP after the first
+  // render. Under zoneless change detection an OnPush view only repaints for
+  // signal writes, so plain fields assigned in the subscribes left the
+  // versions list empty and the schema notice missing.
+  it('renders versions and the schema notice once they arrive', async () => {
+    const versions$ = new Subject<any[]>();
+    const schema$ = new Subject<unknown>();
+    const charts: any = new MockChartService();
+    charts.getVersions = () => versions$;
+    charts.getChartSchema = () => schema$;
+    TestBed.overrideProvider(ChartsService, { useValue: charts });
+    const fixture = TestBed.createComponent(ChartDetailsInfoComponent);
+    const chart: any = { attributes: { name: 'c', repo: { name: 'r', url: '' }, sources: [], maintainers: [] } };
+    const version: any = { attributes: { version: '1.0.0', urls: [] }, relationships: { chart: { data: { name: 'c', repo: { name: 'r' } } } } };
+    fixture.componentRef.setInput('chart', chart);
+    fixture.componentRef.setInput('currentVersion', version);
+    fixture.detectChanges();
+
+    versions$.next([version]);
+    schema$.next({ type: 'object' });
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.textContent).toContain('This chart contains a values schema');
+    const child = fixture.nativeElement.querySelector('app-chart-details-versions');
+    expect(child).not.toBeNull();
+    expect(fixture.componentInstance.versions()).toHaveLength(1);
   });
 });

--- a/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-info/chart-details-info.component.ts
+++ b/src/frontend/packages/kubernetes/src/helm/monocular/chart-details/chart-details-info/chart-details-info.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, Input, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, OnInit, inject, ChangeDetectionStrategy, signal } from '@angular/core';
 import { CardWrapperComponent } from '@stratosui/core';
 import { of } from 'rxjs';
 import { take, catchError,  } from 'rxjs/operators';
@@ -24,8 +24,10 @@ import { ChartDetailsVersionsComponent } from '../chart-details-versions/chart-d
 })
 export class ChartDetailsInfoComponent implements OnInit {
   @Input() chart!: Chart;
-  versions!: ChartVersion[];
-  schema: unknown = null;
+  // Signals: both arrive from HTTP after the first render, and an OnPush view
+  // under zoneless CD only repaints for signal writes.
+  readonly versions = signal<ChartVersion[]>([]);
+  readonly schema = signal<unknown>(null);
 
   private pCurrentVersion!: ChartVersion;
 
@@ -58,7 +60,7 @@ export class ChartDetailsInfoComponent implements OnInit {
     this.chartsService
       .getVersions(chart.attributes.repo.name, chart.attributes.name)
       .subscribe(versions => {
-        this.versions = versions;
+        this.versions.set(versions);
       });
   }
 
@@ -84,7 +86,7 @@ export class ChartDetailsInfoComponent implements OnInit {
       take(1),
       catchError(() => of(null))
     ).subscribe(schema => {
-      this.schema = schema;
+      this.schema.set(schema);
     });
   }
 

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.spec.ts
@@ -1,5 +1,5 @@
-import { HttpClient, HttpClientModule, HttpHandler } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
@@ -20,20 +20,16 @@ describe('ChartValuesEditorComponent', () => {
   let fixture: ComponentFixture<ChartValuesEditorComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({providers: [
-
-        HttpClient,
-        HttpHandler,
+    await TestBed.configureTestingModule({
+      providers: [
         ConfirmationDialogService,
-
-      provideZonelessChangeDetection(),
-    ],
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
       imports: [
         MDAppModule,
-        HttpClientModule,
-        HttpClientTestingModule,
         createBasicStoreModule(),
-
         ChartValuesEditorComponent,
       ]
     }).compileComponents();
@@ -43,6 +39,21 @@ describe('ChartValuesEditorComponent', () => {
     fixture = TestBed.createComponent(ChartValuesEditorComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  // Regression: `config` is set through an @Input setter, which Angular
+  // invokes during change detection - outside any injection context. The
+  // monaco-loaded observable must therefore be built as a field, not inside
+  // the setter path, or init() throws NG0203 before it ever requests the
+  // chart values and the editor sits on "Loading ..." forever.
+  it('requests the chart values when config arrives through the input setter', () => {
+    const http = TestBed.inject(HttpTestingController);
+
+    fixture.componentRef.setInput('config', { valuesUrl: '/values.yaml', schemaUrl: null });
+    expect(() => fixture.detectChanges()).not.toThrow();
+
+    expect(component.initing).toBe(false);
+    http.expectOne('/values.yaml').flush('replicas: 1\n');
   });
 
   it('should create', () => {

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.ts
@@ -118,6 +118,9 @@ export class ChartValuesEditorComponent implements OnInit, OnDestroy, AfterViewI
 
   // Signal for tracking if the Monaco editor has loaded
   private monacoLoaded = signal<boolean>(false);
+  // Built here, in a field initializer, because init() runs from the `config`
+  // input setter - outside any injection context - where toObservable() throws.
+  private readonly monacoLoaded$ = toObservable(this.monacoLoaded);
 
   private resizeSub?: Subscription;
 
@@ -177,7 +180,7 @@ export class ChartValuesEditorComponent implements OnInit, OnDestroy, AfterViewI
     );
 
     // We need the schame, value sand the monaco editor to be all loaded before we're ready
-    this.loading$ = combineLatest(schema$, values$, toObservable(this.monacoLoaded)).pipe(
+    this.loading$ = combineLatest(schema$, values$, this.monacoLoaded$).pipe(
       filter(([schema, values, loaded]: [any, any, boolean]) => schema !== undefined && values !== undefined && loaded),
       tap(([schema, values, _loaded]: [any, any, boolean]) => {
         this.schema = schema;

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/chart-values-editor/chart-values-editor.component.ts
@@ -53,7 +53,7 @@ enum EditorMode {
 })
 export class ChartValuesEditorComponent implements OnInit, OnDestroy, AfterViewInit {
 
-  @Input() set config(config: ChartValuesConfig) {
+  @Input() set config(config: ChartValuesConfig | undefined) {
     if (config) {
       this.schemaUrl = config.schemaUrl;
       this.valuesUrl = config.valuesUrl;

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.html
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.html
@@ -61,6 +61,6 @@
       </form>
     </app-step>
     <app-step [title]="'Overrides'" [signalHandle]="overridesStepHandle">
-      <app-chart-values-editor #editor [config]="config"></app-chart-values-editor>
+      <app-chart-values-editor #editor [config]="config()"></app-chart-values-editor>
     </app-step>
   </app-steppers>

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.spec.ts
@@ -187,3 +187,62 @@ describe('CreateReleaseComponent', () => {
     httpMock.verify();
   });
 });
+
+describe('CreateReleaseComponent without a version in the route', () => {
+  const namespaceDataStub = {
+    create: vi.fn(),
+    refresh: vi.fn(),
+    allNamespacesAcrossEndpoints: (_g: readonly string[]) => signal([]) as Signal<unknown[]>,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        CreateReleaseComponent,
+        AppTestModule,
+        createBasicStoreModule(),
+        KubernetesTestingModule,
+        HelmTestingModule,
+        MockChartValuesEditorComponent,
+      ],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        TabNavService,
+        ConfirmationDialogService,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: { endpoint: 'ep', repo: 'test-repo', name: 'test-chart' },
+              queryParams: {}
+            }
+          }
+        },
+        { provide: ChartsService, useValue: new MockChartService() },
+        { provide: ConfigService, useValue: { appName: 'appName' } },
+        { provide: KubeNamespaceDataService, useValue: namespaceDataStub },
+        provideZonelessChangeDetection(),
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+
+  // Regression: `install/:endpoint/:repo/:name` (no version) used to request
+  // `versions/undefined` and 500. Resolve the chart's latest version instead.
+  it('resolves the latest chart version for the values URL', () => {
+    const fixture = TestBed.createComponent(CreateReleaseComponent);
+    fixture.detectChanges();
+
+    // The component provides its own ChartsService, so drive it over HTTP.
+    const httpMock = TestBed.inject(HttpTestingController);
+    httpMock.expectOne('/pp/v1/chartsvc/v1/charts/test-repo/test-chart')
+      .flush({ data: { relationships: { latestChartVersion: { data: { version: '9.9.9' } } } } });
+    httpMock.expectOne('/pp/v1/chartsvc/v1/charts/test-repo/test-chart/versions/9.9.9')
+      .flush({ data: { attributes: { version: '9.9.9', urls: [] }, relationships: { chart: { data: { name: 'test-chart', repo: { name: 'test-repo' } } } } } });
+
+    expect(fixture.componentInstance.config()?.valuesUrl).toBe('/pp/v1/monocular/values/ep/test-repo/test-chart/9.9.9');
+  });
+});

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/create-release/create-release.component.ts
@@ -90,7 +90,9 @@ export class CreateReleaseComponent implements OnInit, OnDestroy {
   private createdNamespace = false;
 
   private chart: HelmChartReference;
-  public config!: ChartValuesConfig; // strict: assigned from the chart-version fetch in the constructor before the editor renders
+  // Signal: resolved from the chart-version fetch after construction; an OnPush
+  // view under zoneless CD only repaints for signal writes.
+  readonly config = signal<ChartValuesConfig | undefined>(undefined);
   private route = inject(ActivatedRoute);
   public endpointsService = inject(EndpointsService);
   private chartsService = inject(ChartsService);
@@ -116,12 +118,23 @@ export class CreateReleaseComponent implements OnInit, OnDestroy {
     this.cancelUrl = this.chartsService.getChartSummaryRoute(chart.repo, chart.name, chart.version, this.route);
     this.chart = chart;
 
+    // The route may omit the version (`install/:endpoint/:repo/:name`); resolve
+    // the chart's latest version in that case rather than requesting
+    // `versions/undefined`.
+    const version$: Observable<string> = chart.version
+      ? of(chart.version)
+      : this.chartsService.getChart(chart.repo, chart.name).pipe(map(c => c.relationships.latestChartVersion.data.version));
+
     // Fetch the Chart Version metadata so we can get the correct URL for the Chart's JSON Schema
-    this.chartsService.getVersion(this.chart.repo, this.chart.name, this.chart.version).pipe(take(1)).subscribe(ch => {
-      this.config = {
-        valuesUrl: `/pp/v1/monocular/values/${this.chart.endpoint}/${this.chart.repo}/${chart.name}/${this.chart.version}`,
+    version$.pipe(
+      take(1),
+      switchMap(version => this.chartsService.getVersion(chart.repo, chart.name, version).pipe(map(ch => ({ ch, version })))),
+    ).subscribe(({ ch, version }) => {
+      this.chart = { ...chart, version };
+      this.config.set({
+        valuesUrl: `/pp/v1/monocular/values/${chart.endpoint}/${chart.repo}/${chart.name}/${version}`,
         schemaUrl: this.chartsService.getChartSchemaURL(ch, ch.relationships.chart.data.name, ch.relationships.chart.data.repo)
-      };
+      });
     });
 
     this.setupDetailsStep();

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-releases-signal-config.service.spec.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-releases-signal-config.service.spec.ts
@@ -64,6 +64,20 @@ describe('HelmReleasesSignalConfigService', () => {
     expect(svc.view.pagedItems()).toHaveLength(3);
   });
 
+  // Regression: the data service's *LastFetched() accessors return a Signal,
+  // so comparing the accessor result itself to null never matched and
+  // loadAll() silently skipped the initial fetch (the catalog rendered
+  // "There are no charts" with no request ever made).
+  it('loadAll fetches on first call and skips once fetched', async () => {
+    svc.initialize();
+    const first = svc.loadAll();
+    httpMock.expectOne(RELEASES_URL).flush(releasesPayload);
+    await first;
+    expect(svc.view.pagedItems().length).toBeGreaterThan(0);
+    await svc.loadAll();
+    httpMock.expectNone(RELEASES_URL);
+  });
+
   it('filters by nameFilter', async () => {
     svc.initialize();
     const loading = svc.refresh();

--- a/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-releases-signal-config.service.ts
+++ b/src/frontend/packages/kubernetes/src/kubernetes/workloads/list-types/helm-releases-signal-config.service.ts
@@ -166,7 +166,7 @@ export class HelmReleasesSignalConfigService {
   }
 
   async loadAll(): Promise<void> {
-    if (this.helmData.releasesLastFetched() === null) {
+    if (this.helmData.releasesLastFetched()() === null) {
       await this.helmData.loadReleases();
     }
   }


### PR DESCRIPTION
## Summary

A sweep for the zoneless/OnPush repaint class found while fixing the Helm resource graph (#5880), plus three Helm defects the sweep uncovered on the way.

Under zoneless change detection an OnPush view only repaints for signal writes. A static scan of the 442 OnPush components found 19 that assign template-read plain fields from a subscription; 14 of those never call `markForCheck`. Each was triaged by hand and the affected fields are signals now.

### Confirmed live before the fix

- About → EULA rendered blank (component had the HTML, DOM had none).
- Helm chart details showed no versions and no schema notice (347 versions sat in the component).
- The markdown help panel on the endpoint dialogs has the identical code path.

### Same class, fixed by inspection

Application Metrics tab and Space Quota tab (`tabLinks`), add-route HTTP/TCP switch (`selectedDomain`), user-provided service tags, favourite card invalid state, Edit Endpoint CA certificate toggle, profile form password rules, file input disabled state, autoscaler metric map, create-release editor config.

### Helm defects found on the way

- **Install/upgrade was dead since 2025-10-30.** The values editor called `toObservable()` inside its `config` input setter, outside an injection context; NG0203 aborted `init()` before the values were ever requested, so the editor sat on "Loading ...". The observable is a field now.
- **The chart catalog never requested charts.** Both the charts and releases list configs compared a signal accessor to `null` instead of the signal's value, so `loadAll()` skipped the first-visit fetch.
- `workloads/install/:endpoint/:repo/:name` (no version) requested `versions/undefined` and failed; it resolves the chart's latest version now.

## Verification

- Every commit carries a spec that fails on the previous code and passes on the fix (verified by reverting each).
- `make check gate` green: lint, 3726 unit tests, production build.
- Live on the dev stack against a Helm repo endpoint: catalog lists charts, chart details render versions and the schema notice, the install flow loads 84 KB of values into the schema form, and the versionless route resolves the latest version.
- Not live-verified: the CF-side items (both CF endpoints were down) and the two dialog-hosted panels.

## Notes

- `/core/assets/eula.html` does not exist in the repo or the built dist. The About page's "View EULA" button is gated by `customizations.hasEula`, so a stock build only reaches the page by URL, where it now renders the SPA fallback inline. Left as-is; it belongs to whoever ships an EULA.
- With the values editor alive again, monaco-yaml logs "Failed to register chart values schema … Missing requestHandler or method: doValidation": the YAML validation worker is not wired. Editing works; validation is a follow-up.
