### PR TITLE
fix: show created service keys and route bindings in place, style their failures

### DIFF
--- a/changelog.d/0006-service-create-no-refetch.md
+++ b/changelog.d/0006-service-create-no-refetch.md
@@ -4,3 +4,10 @@
   broker answers synchronously the create response already carries the
   key or binding, so the page now adds it in place and re-reads only
   when the broker handed back an asynchronous job instead.
+- A failed service key create or route service bind reported its error
+  in an unstyled box showing only the Cloud Foundry error code. The
+  message now uses the same red warning banner as the rest of the console
+  and carries the broker's own explanation, such as the gateway timeout
+  behind a `CF-UnableToPerform`. Two related delete and unbind links and
+  the failed-row highlight on the detach page had the same missing
+  colours.

--- a/changelog.d/0006-service-create-no-refetch.md
+++ b/changelog.d/0006-service-create-no-refetch.md
@@ -11,3 +11,9 @@
   behind a `CF-UnableToPerform`. Two related delete and unbind links and
   the failed-row highlight on the detach page had the same missing
   colours.
+- The failure banner stripped the markup Cloud Foundry embeds when it
+  quotes a broker's raw response, so a router timeout reads as a sentence
+  rather than an HTML page. Expanding a service key whose creation failed
+  said "Failed to load credentials: unknown error"; it now says the key
+  has no credentials and does not offer to copy them, and other credential
+  load failures name the HTTP status instead of "unknown error".

--- a/changelog.d/0006-service-create-no-refetch.md
+++ b/changelog.d/0006-service-create-no-refetch.md
@@ -1,0 +1,6 @@
+[BugFixes]
+- Creating a service key, or binding a route service, showed the new
+  entry only after re-reading the list from Cloud Foundry. When the
+  broker answers synchronously the create response already carries the
+  key or binding, so the page now adds it in place and re-reads only
+  when the broker handed back an asynchronous job instead.

--- a/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-service-instance.component.html
@@ -28,7 +28,7 @@
                       'bg-content-3 text-content-1': row.status === 'pending',
                       'bg-info-subtle text-info-strong animate-pulse': row.status === 'busy',
                       'bg-success-subtle text-success-strong': row.status === 'success',
-                      'bg-danger-subtle text-danger-strong': row.status === 'error'
+                      'bg-danger-shade-50 text-danger-shade-700': row.status === 'error'
                     }"
                     [attr.aria-label]="row.status"
                     [attr.title]="row.errorMessage || row.status">

--- a/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.html
@@ -4,11 +4,8 @@
 
 <div class="px-6 py-4 space-y-4">
   @if (errorMessage(); as err) {
-    <div class="rounded border border-danger-strong bg-danger-subtle px-3 py-2 text-danger-strong" role="alert">
-      {{ err }}
-    </div>
+    <app-dialog-error [show]="true" [message]="err" role="alert" />
   }
-
   @if (loading()) {
     <p class="text-content-muted">Loading route service…</p>
   } @else if (showStepper()) {
@@ -42,7 +39,7 @@
         <div class="flex items-center gap-4">
           <button type="button" class="text-link hover:underline disabled:opacity-50"
             [disabled]="busy()" (click)="startRebind()">Rebind</button>
-          <button type="button" class="text-danger-strong hover:underline disabled:opacity-50"
+          <button type="button" class="text-danger-shade-600 hover:underline disabled:opacity-50"
             [disabled]="busy()" (click)="unbind()">{{ busy() ? 'Unbinding…' : 'Unbind' }}</button>
         </div>
       </div>

--- a/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.spec.ts
@@ -1,0 +1,86 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { RouteServiceComponent } from './route-service.component';
+import { ServiceCatalogDataService } from '../../../services/endpoint-data/service-catalog-data.service';
+
+function source<T>(value: T) {
+  return {
+    value: signal(value).asReadonly(),
+    isLoading: signal(false).asReadonly(),
+    error: signal(null).asReadonly(),
+  };
+}
+
+describe('RouteServiceComponent — bind patches the binding from the response', () => {
+  let component: RouteServiceComponent;
+  let fixture: ComponentFixture<RouteServiceComponent>;
+  let http: HttpTestingController;
+  let bindingFetches: number;
+
+  beforeEach(async () => {
+    bindingFetches = 0;
+    await TestBed.configureTestingModule({
+      imports: [RouteServiceComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { params: { endpointId: 'cf-1', routeGuid: 'r-1' }, queryParams: {}, data: {}, queryParamMap: { get: () => '' } } },
+        },
+        {
+          provide: ServiceCatalogDataService,
+          useValue: {
+            serviceInstancesInSpace: () => source([{ guid: 'si-1', name: 'logger', type: 'managed' }]),
+            routeServiceBinding: () => { bindingFetches++; return source(null); },
+          },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(RouteServiceComponent);
+    component = fixture.componentInstance;
+    http = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  it('shows the created binding from a 201 body without refetching', async () => {
+    component.selectedSiGuid.set('si-1');
+    const done = component.bindStepHandle.submit();
+    http.expectOne(r => r.method === 'POST' && r.url === '/pp/v1/cf/service_route_bindings/cf-1').flush(
+      {
+        guid: 'b-1', route_service_url: 'https://logger.example', last_operation: { state: 'succeeded' },
+        relationships: { route: { data: { guid: 'r-1' } }, service_instance: { data: { guid: 'si-1' } } },
+      },
+      { status: 201, statusText: 'Created' },
+    );
+    await done;
+
+    expect(component.binding()).toEqual({
+      guid: 'b-1', serviceInstanceGuid: 'si-1', routeServiceUrl: 'https://logger.example', lastOperationState: 'succeeded',
+    });
+    expect(component.boundInstanceName()).toBe('logger');
+    expect(bindingFetches).toBe(1);
+  });
+
+  it('falls back to a refetch when the response is a completed job rather than the binding', async () => {
+    component.selectedSiGuid.set('si-1');
+    const done = component.bindStepHandle.submit();
+    http.expectOne(r => r.method === 'POST' && r.url === '/pp/v1/cf/service_route_bindings/cf-1').flush(
+      { state: 'COMPLETE', result: { guid: 'job-9', operation: 'service_route_binding.create', state: 'COMPLETE' } },
+      { status: 200, statusText: 'OK' },
+    );
+    await done;
+
+    expect(component.binding()).toBeNull();
+    expect(bindingFetches).toBe(2);
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.ts
@@ -12,9 +12,11 @@ import {
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
 import {
+  RawRouteServiceBinding,
   RouteServiceBindingView,
   ServiceCatalogDataService,
   SignalSource,
+  toRouteServiceBindingView,
 } from '../../../services/endpoint-data/service-catalog-data.service';
 import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 
@@ -49,7 +51,11 @@ export class RouteServiceComponent {
   private bindingSource = signal<SignalSource<RouteServiceBindingView | null>>(
     { value: signal<RouteServiceBindingView | null>(null).asReadonly(), isLoading: signal(false).asReadonly(), error: signal(null).asReadonly() },
   );
-  readonly binding: Signal<RouteServiceBindingView | null> = computed(() => this.bindingSource().value());
+  // The binding created by the last bind, taken from the create response so
+  // the page updates without a refetch; reload() clears it once the server
+  // binding is re-read.
+  private boundNow = signal<RouteServiceBindingView | null>(null);
+  readonly binding: Signal<RouteServiceBindingView | null> = computed(() => this.boundNow() ?? this.bindingSource().value());
   readonly loading: Signal<boolean> = computed(() => this.bindingSource().isLoading());
 
   // Managed service instances in the route's space — the bind picker, and the
@@ -88,6 +94,7 @@ export class RouteServiceComponent {
   }
 
   reload(): void {
+    this.boundNow.set(null);
     this.bindingSource.set(this.catalog.routeServiceBinding(this.cfGuid, this.routeGuid));
   }
 
@@ -118,13 +125,20 @@ export class RouteServiceComponent {
           service_instance: { data: { guid: siGuid } },
         },
       };
-      await writeWithJob(
+      const r = await writeWithJob<RawRouteServiceBinding>(
         this.http,
         this.http.post(`/pp/v1/cf/service_route_bindings/${this.cfGuid}`, body, { observe: 'response' as const }),
       );
       this.rebinding.set(false);
       this.selectedSiGuid.set(null);
-      this.reload();
+      // A user-provided instance binds synchronously and answers with the
+      // binding; a managed one resolves to the CF job, which carries no
+      // binding fields, so the page re-reads instead.
+      if (r.state?.guid && r.state.relationships?.service_instance?.data?.guid) {
+        this.boundNow.set(toRouteServiceBindingView(r.state));
+      } else {
+        this.reload();
+      }
     } catch (err: unknown) {
       this.errorMessage.set(`Failed to bind service: ${this.messageOf(err)}`);
       throw err instanceof Error ? err : new Error(this.messageOf(err));

--- a/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, Signal, computed, inject, signal } 
 import { ActivatedRoute, Router } from '@angular/router';
 
 import {
+  DialogErrorComponent,
   IHeaderBreadcrumb,
   PageHeaderComponent,
   SignalStepHandle,
@@ -31,7 +32,7 @@ import { StServiceInstance } from '../../../services/endpoint-data/stratos-types
   templateUrl: './route-service.component.html',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [PageHeaderComponent, SteppersComponent, StepComponent],
+  imports: [PageHeaderComponent, SteppersComponent, StepComponent, DialogErrorComponent],
 })
 export class RouteServiceComponent {
   private http = inject(HttpClient);

--- a/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/route-service/route-service.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@stratosui/core';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
+import { httpErrorResponseToSafeString } from '@stratosui/store';
 import {
   RawRouteServiceBinding,
   RouteServiceBindingView,
@@ -167,8 +168,8 @@ export class RouteServiceComponent {
   }
 
   private messageOf(err: unknown): string {
-    if (err instanceof StratosJobError) return err.message;
-    if (err instanceof Error) return err.message;
-    return 'unknown error';
+    if (err instanceof StratosJobError || err instanceof Error) return err.message;
+    // HttpErrorResponse is not an Error: report its body and status.
+    return httpErrorResponseToSafeString(err) || 'unknown error';
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -26,9 +26,7 @@
 
 <div class="px-6 py-4 space-y-4">
   @if (errorMessage(); as err) {
-    <div class="rounded border border-danger-strong bg-danger-subtle px-3 py-2 text-danger-strong" role="alert">
-      {{ err }}
-    </div>
+    <app-dialog-error [show]="true" [message]="err" role="alert" />
   }
 
   @if (notBindable()) {
@@ -70,7 +68,7 @@
               {{ copiedAllGuid() === key.guid ? 'Copied' : 'Copy all (JSON)' }}
             </button>
             <button type="button"
-              class="inline-flex items-center gap-1.5 text-danger-strong hover:underline disabled:opacity-50 shrink-0"
+              class="inline-flex items-center gap-1.5 text-danger-shade-600 hover:underline disabled:opacity-50 shrink-0"
               [disabled]="rowStatus(key.guid) === 'busy'"
               (click)="deleteKey(key.guid)">
               @if (rowStatus(key.guid) === 'busy') {
@@ -89,7 +87,7 @@
                   Loading credentials…
                 </p>
               } @else if (credsError(key.guid); as cerr) {
-                <p class="text-danger-strong">Failed to load credentials: {{ cerr }}</p>
+                <p class="text-danger-shade-700">Failed to load credentials: {{ cerr }}</p>
               } @else if (credentialFields(key.guid).length === 0) {
                 <p class="text-content-muted">No credentials returned for this key.</p>
               } @else {

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.html
@@ -62,11 +62,13 @@
               <span class="text-sm text-content-muted shrink-0">{{ key.createdAt | date:'medium' }}</span>
               <span class="text-sm text-content-muted shrink-0">{{ key.lastOperationState || '—' }}</span>
             </button>
-            <button type="button"
-              class="text-link hover:underline shrink-0"
-              (click)="copyAllCredentials(key.guid)">
-              {{ copiedAllGuid() === key.guid ? 'Copied' : 'Copy all (JSON)' }}
-            </button>
+            @if (!isFailed(key.guid)) {
+              <button type="button"
+                class="text-link hover:underline shrink-0"
+                (click)="copyAllCredentials(key.guid)">
+                {{ copiedAllGuid() === key.guid ? 'Copied' : 'Copy all (JSON)' }}
+              </button>
+            }
             <button type="button"
               class="inline-flex items-center gap-1.5 text-danger-shade-600 hover:underline disabled:opacity-50 shrink-0"
               [disabled]="rowStatus(key.guid) === 'busy'"
@@ -81,7 +83,9 @@
           <!-- Body: credentials, lazily loaded on first expand. -->
           @if (isOpen(key.guid)) {
             <div class="px-4 py-3 border-t border-content-border">
-              @if (credsLoading(key.guid)) {
+              @if (isFailed(key.guid)) {
+                <p class="text-content-muted">This key was not created, so it has no credentials.</p>
+              } @else if (credsLoading(key.guid)) {
                 <p class="flex items-center gap-2 text-content-muted">
                   <app-busy size="1rem" context="service-keys"></app-busy>
                   Loading credentials…

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
@@ -102,6 +102,33 @@ describe('ServiceKeysComponent — busy-state spinners', () => {
     expect(spinner(fixture.nativeElement)).not.toBeNull();
   });
 
+  it('does not fetch credentials for a key whose creation failed, and says so', () => {
+    const http = TestBed.inject(HttpTestingController);
+    keysVal.set([{ guid: 'k-f', name: 'broken', createdAt: '2026-09-05T09:12:29Z', lastOperationState: 'failed' }]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).not.toContain('Copy all (JSON)');
+
+    component.toggleOpen('k-f');
+    fixture.detectChanges();
+    http.expectNone(r => r.url.includes('/details'));
+    expect(fixture.nativeElement.textContent).toContain('This key was not created, so it has no credentials.');
+    expect(fixture.nativeElement.textContent).not.toContain('Failed to load credentials');
+  });
+
+  it('names the HTTP failure when credentials cannot be loaded', async () => {
+    const http = TestBed.inject(HttpTestingController);
+    keysVal.set([{ guid: 'k-1', name: 'ok', createdAt: '2026-09-05T09:12:29Z', lastOperationState: 'succeeded' }]);
+    fixture.detectChanges();
+    component.toggleOpen('k-1');
+    http.expectOne(r => r.url.endsWith('/k-1/details')).flush(
+      { error: 'Service key not found' }, { status: 404, statusText: 'Not Found' },
+    );
+    await new Promise(resolve => setTimeout(resolve, 0));
+    fixture.detectChanges();
+    expect(component.credsError('k-1')).toBe('Service key not found (404)');
+    expect(fixture.nativeElement.textContent).not.toContain('unknown error');
+  });
+
   it('shows a spinner on the delete action while deleting', () => {
     keysVal.set([{ guid: 'k1', name: 'key-one', createdAt: '' }]);
     fixture.detectChanges();

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
@@ -1,6 +1,6 @@
 import { provideZonelessChangeDetection, signal, WritableSignal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -176,5 +176,66 @@ describe('ServiceKeysComponent — context-aware breadcrumbs', () => {
   it('omits the space-services trail until the instance (with its space/org) has loaded', () => {
     const c = setup(null, [{ guid: 'cf-1', name: 'prod-cf' }]);
     expect(c.breadcrumbs().find(b => b.key === 'space-services')).toBeUndefined();
+  });
+});
+
+describe('ServiceKeysComponent — createKey patches the list from the response', () => {
+  let component: ServiceKeysComponent;
+  let fixture: ComponentFixture<ServiceKeysComponent>;
+  let http: HttpTestingController;
+  let listFetches: number;
+  const existing: ServiceKeyView = { guid: 'k-1', name: 'first', createdAt: '2026-01-01T00:00:00Z', lastOperationState: 'succeeded' };
+
+  beforeEach(async () => {
+    listFetches = 0;
+    await TestBed.configureTestingModule({
+      imports: [ServiceKeysComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { endpointId: 'cf-1', serviceInstanceId: 'si-1' } } } },
+        {
+          provide: ServiceCatalogDataService,
+          useValue: {
+            serviceInstance: () => source(null),
+            serviceKeysForInstance: () => { listFetches++; return source([existing]); },
+          },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ServiceKeysComponent);
+    component = fixture.componentInstance;
+    http = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  it('appends the created key from a 201 body without refetching the list', async () => {
+    component.newKeyName.set('second');
+    const done = component.createKey();
+    http.expectOne(r => r.method === 'POST' && r.url === '/pp/v1/cf/service_keys/cf-1').flush(
+      { guid: 'k-2', type: 'key', name: 'second', created_at: '2026-02-02T00:00:00Z', last_operation: { state: 'succeeded' } },
+      { status: 201, statusText: 'Created' },
+    );
+    await done;
+
+    expect(component.keys().map(k => k.guid)).toEqual(['k-1', 'k-2']);
+    expect(component.keys()[1]).toEqual({ guid: 'k-2', name: 'second', createdAt: '2026-02-02T00:00:00Z', lastOperationState: 'succeeded' });
+    expect(listFetches).toBe(1);
+  });
+
+  it('falls back to a refetch when the response is a completed job rather than the key', async () => {
+    component.newKeyName.set('async');
+    const done = component.createKey();
+    http.expectOne(r => r.method === 'POST' && r.url === '/pp/v1/cf/service_keys/cf-1').flush(
+      { state: 'COMPLETE', result: { guid: 'job-9', operation: 'service_key.create', state: 'COMPLETE' } },
+      { status: 200, statusText: 'OK' },
+    );
+    await done;
+
+    expect(component.keys().map(k => k.guid)).toEqual(['k-1']);
+    expect(listFetches).toBe(2);
   });
 });

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.spec.ts
@@ -226,6 +226,32 @@ describe('ServiceKeysComponent — createKey patches the list from the response'
     expect(listFetches).toBe(1);
   });
 
+  it('shows a failed job\'s title and detail in the shared error banner', async () => {
+    component.newKeyName.set('broken');
+    const done = component.createKey();
+    http.expectOne(r => r.method === 'POST' && r.url === '/pp/v1/cf/service_keys/cf-1').flush(
+      { id: 'job-1', kind: 'cf.service_key.create', state: 'RUNNING', startedAt: 't', updatedAt: 't' },
+      { status: 202, statusText: 'Accepted' },
+    );
+    // pollJob waits its first backoff step before the first GET.
+    await new Promise(resolve => setTimeout(resolve, 700));
+    http.expectOne(r => r.method === 'GET' && r.url === '/pp/v1/stratos/jobs/job-1').flush({
+      id: 'job-1', kind: 'cf.service_key.create', state: 'FAILED', startedAt: 't', updatedAt: 't',
+      errors: [{ code: 'cf.v3.10009', message: 'CF-UnableToPerform', detail: 'The service broker returned an invalid response. Status Code: 504 Gateway Timeout' }],
+    });
+    await done;
+    fixture.detectChanges();
+
+    expect(component.errorMessage()).toBe(
+      'Failed to create key: CF-UnableToPerform. The service broker returned an invalid response. Status Code: 504 Gateway Timeout',
+    );
+    const banner = fixture.nativeElement.querySelector('.dialog-error') as HTMLElement | null;
+    expect(banner?.textContent).toContain('CF-UnableToPerform. The service broker');
+    expect(banner?.querySelector('.material-icons')?.textContent).toBe('warning');
+    expect(component.keys().map(k => k.guid)).toEqual(['k-1']);
+    expect(listFetches).toBe(1);
+  });
+
   it('falls back to a refetch when the response is a completed job rather than the key', async () => {
     component.newKeyName.set('async');
     const done = component.createKey();

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -14,6 +14,7 @@ import { StServiceInstance } from '../../../services/endpoint-data/stratos-types
 import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
 import { CredentialField, MaskedCredentialsComponent, toCredentialFields } from '../../../shared/components/masked-credentials/masked-credentials.component';
 import { AppBusyComponent } from '@stratosui/core';
+import { httpErrorResponseToSafeString } from '@stratosui/store';
 
 type RowStatus = 'idle' | 'busy' | 'error';
 
@@ -171,10 +172,13 @@ export class ServiceKeysComponent {
     this.keysSource.set(this.catalog.serviceKeysForInstance(this.cfGuid, this.siGuid));
   }
 
+  /** A key whose create never completed has nothing to fetch. */
+  isFailed = (guid: string): boolean => this.keys().find(k => k.guid === guid)?.lastOperationState === 'failed';
+
   toggleOpen(guid: string): void {
     const opening = !this.isOpen(guid);
     this.openByGuid.update(prev => ({ ...prev, [guid]: opening }));
-    if (opening && this.credsByGuid()[guid] === undefined && !this.credsLoading(guid)) {
+    if (opening && !this.isFailed(guid) && this.credsByGuid()[guid] === undefined && !this.credsLoading(guid)) {
       void this.loadCredentials(guid);
     }
   }
@@ -289,12 +293,10 @@ export class ServiceKeysComponent {
   }
 
   private messageOf(err: unknown): string {
-    if (err instanceof StratosJobError) {
+    if (err instanceof StratosJobError || err instanceof Error) {
       return err.message;
     }
-    if (err instanceof Error) {
-      return err.message;
-    }
-    return 'unknown error';
+    // HttpErrorResponse is not an Error: report its body and status.
+    return httpErrorResponseToSafeString(err) || 'unknown error';
   }
 }

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -4,7 +4,7 @@ import { ChangeDetectionStrategy, Component, Signal, computed, effect, inject, s
 import { ActivatedRoute } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 
-import { IHeaderBreadcrumb, ListSubNavAddAction, ListSubNavComponent, PageHeaderComponent } from '@stratosui/core';
+import { DialogErrorComponent, IHeaderBreadcrumb, ListSubNavAddAction, ListSubNavComponent, PageHeaderComponent } from '@stratosui/core';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
 import {
@@ -37,7 +37,7 @@ interface OfferingBindableResponse {
   templateUrl: './service-keys.component.html',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AppBusyComponent, DatePipe, PageHeaderComponent, ListSubNavComponent, MaskedCredentialsComponent],
+  imports: [AppBusyComponent, DatePipe, PageHeaderComponent, ListSubNavComponent, MaskedCredentialsComponent, DialogErrorComponent],
 })
 export class ServiceKeysComponent {
   private http = inject(HttpClient);

--- a/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/service-keys/service-keys.component.ts
@@ -7,7 +7,9 @@ import { firstValueFrom } from 'rxjs';
 import { IHeaderBreadcrumb, ListSubNavAddAction, ListSubNavComponent, PageHeaderComponent } from '@stratosui/core';
 import { writeWithJob } from '../../../services/async-jobs/write-with-job';
 import { StratosJobError } from '../../../services/async-jobs/async-job.types';
-import { ServiceCatalogDataService, ServiceKeyView, SignalSource } from '../../../services/endpoint-data/service-catalog-data.service';
+import {
+  RawServiceKey, ServiceCatalogDataService, ServiceKeyView, SignalSource, toServiceKeyView,
+} from '../../../services/endpoint-data/service-catalog-data.service';
 import { StServiceInstance } from '../../../services/endpoint-data/stratos-types';
 import { CfEndpointsDataService } from '../../../services/domain-data/cf-endpoints-data.service';
 import { CredentialField, MaskedCredentialsComponent, toCredentialFields } from '../../../shared/components/masked-credentials/masked-credentials.component';
@@ -92,7 +94,11 @@ export class ServiceKeysComponent {
   private keysSource = signal<SignalSource<ServiceKeyView[]>>(
     { value: signal<ServiceKeyView[]>([]).asReadonly(), isLoading: signal(false).asReadonly(), error: signal(null).asReadonly() },
   );
-  readonly keys: Signal<ServiceKeyView[]> = computed(() => this.keysSource().value());
+  // Keys added since the last fetch, appended from the create response so
+  // the list updates without a refetch; reload() drops them once the
+  // server list is re-read.
+  private addedKeys = signal<ServiceKeyView[]>([]);
+  readonly keys: Signal<ServiceKeyView[]> = computed(() => [...this.keysSource().value(), ...this.addedKeys()]);
   readonly loading: Signal<boolean> = computed(() => this.keysSource().isLoading());
 
   readonly newKeyName = signal('');
@@ -161,6 +167,7 @@ export class ServiceKeysComponent {
   }
 
   reload(): void {
+    this.addedKeys.set([]);
     this.keysSource.set(this.catalog.serviceKeysForInstance(this.cfGuid, this.siGuid));
   }
 
@@ -235,13 +242,19 @@ export class ServiceKeysComponent {
       relationships: { service_instance: { data: { guid: this.siGuid } } },
     };
     try {
-      await writeWithJob(
+      const r = await writeWithJob<RawServiceKey>(
         this.http,
         this.http.post(`/pp/v1/cf/service_keys/${this.cfGuid}`, body, { observe: 'response' as const }),
       );
       this.newKeyName.set('');
       this.isAdding.set(false);
-      this.reload();
+      // A sync broker answers with the key itself; an async one resolves to
+      // the CF job, which has no key fields, so the list is re-read instead.
+      if (r.state?.type === 'key' && r.state.guid) {
+        this.addedKeys.update(keys => [...keys, toServiceKeyView(r.state as RawServiceKey)]);
+      } else {
+        this.reload();
+      }
     } catch (err: unknown) {
       this.errorMessage.set(`Failed to create key: ${this.messageOf(err)}`);
     } finally {

--- a/src/frontend/packages/cloud-foundry/src/services/async-jobs/async-job.types.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/async-jobs/async-job.types.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { StratosJobError, StratosJob } from './async-job.types';
+
+const job = (errors: StratosJob['errors']): StratosJob => ({
+  id: 'j-1', kind: 'cf.service_key.create', state: 'FAILED', startedAt: 't', updatedAt: 't', errors,
+});
+
+describe('StratosJobError message', () => {
+  it('reads as the CF title followed by the detail, with any markup in the detail stripped', () => {
+    const err = new StratosJobError(job([{
+      code: 'cf.v3.10009',
+      message: 'CF-UnableToPerform',
+      detail: 'bind could not be completed: Status Code: 504 Gateway Timeout, Body: <html><body><h1>504 Gateway Time-out</h1>\nThe server didn\'t respond in time.\n</body></html>',
+    }]));
+    expect(err.message).toBe(
+      'CF-UnableToPerform. bind could not be completed: Status Code: 504 Gateway Timeout, Body: 504 Gateway Time-out The server didn\'t respond in time.',
+    );
+  });
+
+  it('falls back to code and title when there is no detail', () => {
+    expect(new StratosJobError(job([{ code: 'cf.v3.10010', message: 'CF-ResourceNotFound' }])).message)
+      .toBe('cf.v3.10010: CF-ResourceNotFound');
+    expect(new StratosJobError(job(undefined)).message).toBe('job j-1 failed');
+  });
+});

--- a/src/frontend/packages/cloud-foundry/src/services/async-jobs/async-job.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/async-jobs/async-job.types.ts
@@ -62,7 +62,13 @@ export class StratosJobError extends Error {
 
   constructor(job: StratosJob) {
     const first = job.errors?.[0];
-    super(first ? `${first.code}: ${first.message}` : `job ${job.id} failed`);
+    // Prefer the human detail CF attaches (the broker's own explanation)
+    // over the bare error code; the code stays reachable through `job`.
+    super(
+      !first ? `job ${job.id} failed`
+        : typeof first.detail === 'string' && first.detail ? `${first.message}. ${first.detail}`
+          : `${first.code}: ${first.message}`,
+    );
     this.name = 'StratosJobError';
     this.job = job;
   }

--- a/src/frontend/packages/cloud-foundry/src/services/async-jobs/async-job.types.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/async-jobs/async-job.types.ts
@@ -64,9 +64,14 @@ export class StratosJobError extends Error {
     const first = job.errors?.[0];
     // Prefer the human detail CF attaches (the broker's own explanation)
     // over the bare error code; the code stays reachable through `job`.
+    // CF embeds a broker's raw response body in the detail, markup and all;
+    // keep the words, drop the tags.
+    const detail = typeof first?.detail === 'string'
+      ? first.detail.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+      : '';
     super(
       !first ? `job ${job.id} failed`
-        : typeof first.detail === 'string' && first.detail ? `${first.message}. ${first.detail}`
+        : detail ? `${first.message}. ${detail}`
           : `${first.code}: ${first.message}`,
     );
     this.name = 'StratosJobError';

--- a/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/endpoint-data/service-catalog-data.service.ts
@@ -28,7 +28,7 @@ export interface RouteServiceBindingView {
   lastOperationState?: string;
 }
 
-interface RawRouteServiceBinding {
+export interface RawRouteServiceBinding {
   guid: string;
   route_service_url?: string;
   last_operation?: { state?: string };
@@ -39,7 +39,7 @@ interface RawRouteServiceBindingsResponse {
   resources?: RawRouteServiceBinding[];
 }
 
-function toRouteServiceBindingView(raw: RawRouteServiceBinding): RouteServiceBindingView {
+export function toRouteServiceBindingView(raw: RawRouteServiceBinding): RouteServiceBindingView {
   return {
     guid: raw.guid,
     serviceInstanceGuid: raw.relationships?.service_instance?.data?.guid ?? '',
@@ -58,8 +58,9 @@ export interface ServiceKeyView {
   lastOperationState?: string;
 }
 
-interface RawServiceKey {
+export interface RawServiceKey {
   guid: string;
+  type?: string;
   name?: string;
   created_at?: string;
   last_operation?: { state?: string };
@@ -69,7 +70,7 @@ interface RawServiceKeysResponse {
   resources?: RawServiceKey[];
 }
 
-function toServiceKeyView(raw: RawServiceKey): ServiceKeyView {
+export function toServiceKeyView(raw: RawServiceKey): ServiceKeyView {
   return {
     guid: raw.guid,
     name: raw.name ?? '',


### PR DESCRIPTION
## Summary

Follow-up to #5884, from the same session. Two fixes on the service key and route service pages.

**A created key or binding shows in place.** After creating a service key or binding a route service, the page threw its list away and re-read it from Cloud Foundry before the new entry appeared. When the broker answers synchronously the create response is the key or binding itself, so the page appends it to the list, or sets it as the route's binding, from that body. When the broker handed back an asynchronous job, the resolved result is the CF job, which carries no entity fields, so those cases still re-read as before. A reload clears the locally added entries once the server list is back.

**Failures look like the console's other errors.** A failed create reported its error in a box styled with `danger-subtle` and `danger-strong` classes. Those tokens do not exist in the theme, so the box rendered with the default border and no colour. The detach page's failed-row highlight and two delete and unbind links used the same names. The message now uses the shared dialog-error banner and the theme's `danger-shade` tokens, and reads as the CF title followed by the detail CF attaches, which is the broker's own explanation, instead of the bare error code.

## Verification

- Specs: in-place insert and job fallback for both pages; a failed 202 job driven through the poll path asserting the banner and message text.
- `make check gate` green: lint, 3734 unit tests, production build, Go lint and tests.
- Live on a CF lab: the key create hit a RabbitMQ broker that timed out, which exercised the job fallback and the failure banner. The synchronous branch is spec-covered only, since the lab has no synchronous broker.

## Notes

- The route service page filters user-provided instances out of its picker, so a UPS route service cannot be bound from the UI on that page. Left alone here; it looks worth a separate look.
