### PR TITLE
test(e2e): run suites as CF roles and assert what each may and may not do

### DIFF
--- a/changelog.d/0009-role-e2e.md
+++ b/changelog.d/0009-role-e2e.md
@@ -1,0 +1,11 @@
+[BugFixes]
+- The org Spaces tab no longer offers Create Space to roles that cannot create
+  one; only an org manager sees it, matching the other create actions.
+
+[Maintainability]
+- The e2e suite can run as CF roles: org manager, space manager, org auditor
+  and space auditor each get their own console session and a suite asserting
+  what the console lets them do and what it refuses, with canary tests that
+  must fail so a leaked control turns the run red. Role-gated controls carry
+  stable test hooks; app creation in the API helper no longer names a stack
+  the foundation may not have.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -83,6 +83,29 @@ test('should display applications', async ({ page }) => {
 });
 ```
 
+## Role suites
+
+`e2e/tests/roles/` holds one directory per CF role plus `every-role.spec.ts`,
+run by the `role-*` projects in `playwright.config.ts`, each on its own saved
+session (`e2e/.auth/role-<role>.json`, written by `e2e/auth.roles.setup.ts`).
+They assert what a role can do, what the console must refuse, and carry a
+canary per file written to assert the leak and marked with `test.fail()`, so
+the run only stays green while the refusal holds.
+
+The console must use UAA auth (`AUTH_ENDPOINT_TYPE=remote`), where a console
+user is a CF user: local auth has one console user and cannot express roles.
+jetstream reads the environment before `config.properties`, so:
+
+```bash
+AUTH_ENDPOINT_TYPE=remote UAA_ENDPOINT=https://uaa.example.com \
+CONSOLE_CLIENT=cf CONSOLE_ADMIN_SCOPE=cloud_controller.admin SKIP_SSL_VALIDATION=true \
+E2E_PROFILE=<profile> bunx playwright test --project='role-*'
+```
+
+Each CF endpoint entry in the profile needs a `creds.roles` block (see
+`secrets.yaml.template`); a role whose entry is missing fails its setup
+rather than running as another identity.
+
 ## Migration History
 
 This project migrated from Protractor to Playwright in 2024 during the Angular 20 upgrade. Legacy Protractor artifacts may still exist in `src/test-e2e/` but are no longer active.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -106,6 +106,11 @@ Each CF endpoint entry in the profile needs a `creds.roles` block (see
 `secrets.yaml.template`); a role whose entry is missing fails its setup
 rather than running as another identity.
 
+The suite reads `secrets.yaml` from the repo root (git-ignored), not a copy
+under `e2e/`. After a `@playwright/test` bump, run `bunx playwright install
+chromium` once: each Playwright version wants its own browser build, and a
+missing one fails every project at the admin setup.
+
 ## Migration History
 
 This project migrated from Protractor to Playwright in 2024 during the Angular 20 upgrade. Legacy Protractor artifacts may still exist in `src/test-e2e/` but are no longer active.

--- a/e2e/auth.constants.ts
+++ b/e2e/auth.constants.ts
@@ -7,3 +7,23 @@ export const USER_STATE = 'e2e/.auth/user.json';
  * Keyed by CF endpoint name: { "<endpointName>": { orgGuid, spaceGuid } }.
  */
 export const CF_GUIDS_FILE = 'e2e/.auth/cf-guids.json';
+
+/**
+ * The CF roles the role projects log in as (see auth.roles.setup.ts and the
+ * `role-*` projects in playwright.config.ts). Each has its own saved session.
+ */
+export const CF_ROLES = ['orgManager', 'spaceManager', 'orgAuditor', 'spaceAuditor'] as const;
+export type CfRole = typeof CF_ROLES[number];
+
+/** Saved session for a role project, e.g. e2e/.auth/role-orgManager.json */
+export const roleStatePath = (role: CfRole): string => `e2e/.auth/role-${role}.json`;
+
+/** Playwright project name for a role, e.g. 'role-org-manager'. */
+export const roleProjectName = (role: CfRole): string =>
+  'role-' + role.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
+
+/** Spec directory under e2e/tests/roles/ for a role, e.g. 'org-manager'. */
+export const roleSpecDir = (role: CfRole): string => roleProjectName(role).slice('role-'.length);
+
+export const roleFromProjectName = (name: string): CfRole | undefined =>
+  CF_ROLES.find(role => roleProjectName(role) === name);

--- a/e2e/auth.roles.setup.ts
+++ b/e2e/auth.roles.setup.ts
@@ -1,0 +1,47 @@
+import { test as setup } from '@playwright/test';
+
+import { CF_ROLES, roleStatePath } from './auth.constants';
+import { detectAuthType, browserLogin } from './helpers/auth.helper';
+import { EndpointManagementHelper } from './helpers/endpoint-management.helper';
+import { RequestHelper } from './helpers/request.helper';
+import { SecretsHelper } from './helpers/secrets-helpers';
+
+/**
+ * One saved session per CF role, consumed by the `role-*` projects in
+ * playwright.config.ts.
+ *
+ * Each test logs the console in as the role's own CF user and then connects
+ * the CF endpoint with the same credentials, so the role's token is the one
+ * every proxied call in that project carries. That needs UAA
+ * (`AUTH_ENDPOINT_TYPE=remote`) auth, where a console user *is* a CF user:
+ * local auth has exactly one console user and cannot express roles.
+ *
+ * Runs after 'setup', which registered the endpoint as admin; nothing here
+ * registers anything, so the four tests are safe to run in parallel. A role
+ * whose credentials are missing from the secrets profile fails here, loudly,
+ * rather than running its suite as some other identity.
+ */
+for (const role of CF_ROLES) {
+  setup(`authenticate as ${role}`, async ({ page, baseURL }) => {
+    const url = baseURL || 'https://localhost:5540';
+    const endpoint = SecretsHelper.load().cloudFoundry[0];
+    const creds = SecretsHelper.roleCreds(endpoint.name, role);
+
+    const authType = await detectAuthType(url);
+    if (authType === 'sso') {
+      throw new Error(
+        `E2E_ROLE_NEEDS_PASSWORD_AUTH: the ${role} session logs in with the role user's password, but this console uses SSO`
+      );
+    }
+
+    const request = new RequestHelper(url);
+    await request.init();
+    await request.createSessionWithCredentials(creds.username, creds.password);
+    await new EndpointManagementHelper(url).connectAllEndpointsWithCredentials(request, creds);
+    await request.dispose();
+
+    await browserLogin(page, creds.username, creds.password, authType);
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+    await page.context().storageState({ path: roleStatePath(role) });
+  });
+}

--- a/e2e/helpers/cf-api.helper.ts
+++ b/e2e/helpers/cf-api.helper.ts
@@ -237,7 +237,10 @@ export class CFApiHelper {
         type: 'buildpack',
         data: {
           buildpacks: params.buildpacks || [],
-          stack: params.stack || 'cflinuxfs3'
+          // No stack unless asked for: the CF then applies its own default,
+          // whatever that foundation ships (cflinuxfs3 no longer exists on
+          // current ones, and naming a missing stack is a 422).
+          ...(params.stack ? { stack: params.stack } : {})
         }
       },
       metadata: {

--- a/e2e/helpers/endpoint-management.helper.ts
+++ b/e2e/helpers/endpoint-management.helper.ts
@@ -211,6 +211,28 @@ export class EndpointManagementHelper {
   }
 
   /**
+   * Connect every registered CF endpoint for an already-authenticated session
+   * with explicit CF credentials — the role projects' identities, which are
+   * neither the admin nor the nonAdmin console user. Needs password-grant
+   * auth: under SSO the token POST is refused, and that is the right outcome
+   * (a role suite must never fall back to another identity).
+   */
+  async connectAllEndpointsWithCredentials(
+    request: RequestHelper,
+    creds: { username: string; password: string },
+  ): Promise<void> {
+    const endpoints = await request.get('/api/v1/endpoints');
+    for (const endpoint of endpoints || []) {
+      if (endpoint.cnsi_type !== 'cf') continue;
+      await request.postForm('/api/v1/tokens', {
+        cnsi_guid: endpoint.guid,
+        username: creds.username,
+        password: creds.password,
+      });
+    }
+  }
+
+  /**
    * Connect a specific endpoint by name
    */
   async connectEndpoint(endpointName: string, userType: ConsoleUserType = ConsoleUserType.admin): Promise<void> {

--- a/e2e/helpers/request.helper.ts
+++ b/e2e/helpers/request.helper.ts
@@ -94,19 +94,25 @@ export class RequestHelper {
    * is extracted and used to recreate the API request context.
    */
   async createSession(userType: ConsoleUserType): Promise<void> {
-    if (!this.context) {
-      await this.init();
-    }
-
     const creds = userType === ConsoleUserType.admin
       ? { username: this.secrets.console.admin.username, password: this.secrets.console.admin.password }
       : { username: this.secrets.console.user.username, password: this.secrets.console.user.password };
+    await this.createSessionWithCredentials(creds.username, creds.password);
+  }
 
+  /**
+   * Log in as any console identity — the role projects use the CF users the
+   * secrets profile lists under creds.roles, which are neither console user.
+   */
+  async createSessionWithCredentials(username: string, password: string): Promise<void> {
+    if (!this.context) {
+      await this.init();
+    }
     const result = await apiLogin(
       this.context!,
       this.baseURL,
-      creds.username,
-      creds.password,
+      username,
+      password,
       this.authType || 'local'
     );
 

--- a/e2e/helpers/secrets-helpers.ts
+++ b/e2e/helpers/secrets-helpers.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
-import { CF_GUIDS_FILE } from '../auth.constants';
+import { CF_GUIDS_FILE, CfRole } from '../auth.constants';
 
 /**
  * Secrets Helper
@@ -273,6 +273,24 @@ export class SecretsHelper {
         return secrets;
       },
     };
+  }
+
+  /**
+   * Credentials for one of the CF role identities the role projects log in
+   * as, read straight off the endpoint's `creds.roles.<role>` entry. A
+   * missing or placeholder entry throws so a role suite never runs as some
+   * other identity (the same stance as E2E_NO_NONADMIN_CREDS in
+   * endpoint-management.helper.ts).
+   */
+  static roleCreds(endpointName: string, role: CfRole): { username: string; password: string } {
+    const endpoint = this.load().cloudFoundry.find((ep: any) => ep.name === endpointName);
+    const creds = endpoint?.creds?.roles?.[role];
+    if (!creds?.username || !creds?.password || /^<.*>$/.test(creds.password)) {
+      throw new Error(
+        `E2E_NO_ROLE_CREDS: profile has no cloudFoundry creds.roles.${role} for endpoint '${endpointName}' — refusing to run the ${role} suite as another identity`
+      );
+    }
+    return { username: creds.username, password: creds.password };
   }
 
   /**

--- a/e2e/secrets.yaml.template
+++ b/e2e/secrets.yaml.template
@@ -54,6 +54,35 @@ endpoints:
         username: <CF_USER_USERNAME>        # CF regular user
         password: <CF_USER_PASSWORD>        # CF user password
 
+      # CF role identities [OPTIONAL] - the role-* Playwright projects log the
+      # console in as each of these (needs UAA auth: AUTH_ENDPOINT_TYPE=remote)
+      # and assert what that role can and cannot do. A missing entry fails the
+      # role suite loudly; it never falls back to another identity.
+      # Create with, as CF admin (prompted password, nothing on the command line):
+      #   cf create-user e2e-org-mgr --password-prompt
+      #   cf set-org-role e2e-org-mgr e2e OrgManager
+      #   cf create-user e2e-space-mgr --password-prompt
+      #   cf set-org-role e2e-space-mgr e2e OrgUser
+      #   cf set-space-role e2e-space-mgr e2e e2e SpaceManager
+      #   cf create-user e2e-org-auditor --password-prompt
+      #   cf set-org-role e2e-org-auditor e2e OrgAuditor
+      #   cf create-user e2e-space-auditor --password-prompt
+      #   cf set-org-role e2e-space-auditor e2e OrgUser
+      #   cf set-space-role e2e-space-auditor e2e e2e SpaceAuditor
+      # roles:
+      #   orgManager:
+      #     username: e2e-org-mgr
+      #     password: <ORG_MANAGER_PASSWORD>
+      #   spaceManager:
+      #     username: e2e-space-mgr
+      #     password: <SPACE_MANAGER_PASSWORD>
+      #   orgAuditor:
+      #     username: e2e-org-auditor
+      #     password: <ORG_AUDITOR_PASSWORD>
+      #   spaceAuditor:
+      #     username: e2e-space-auditor
+      #     password: <SPACE_AUDITOR_PASSWORD>
+
       # User for removal tests [OPTIONAL]
       # Create with: cf create-user e2e-remove-user <password>
       # removeUser:

--- a/e2e/tests/roles/every-role.spec.ts
+++ b/e2e/tests/roles/every-role.spec.ts
@@ -1,5 +1,5 @@
 import { CfTopLevelPage } from '../../pages/cloud-foundry/cf-level/cf-top-level.page';
-import { expect, expectAbsent, proxied, test } from './roles.fixture';
+import { connectedUser, expect, expectAbsent, proxied, test } from './roles.fixture';
 
 /**
  * Checks every role project runs, each as its own session. The canary is
@@ -30,8 +30,7 @@ test.describe('every role', () => {
 
   test('canary: the session is the admin user', async ({ roleContext, secrets }) => {
     test.fail(true, 'a role project must never run on the admin identity');
-    const endpoints: any[] = await (await roleContext.page.request.get('/api/v1/endpoints')).json();
-    const cf = endpoints.find(ep => ep.guid === roleContext.cfGuid);
-    expect(cf.user?.name).toBe(secrets.console.admin.username);
+    const tokenUser = await connectedUser(roleContext.page, { guid: roleContext.cfGuid, cnsi_type: 'cf' });
+    expect(tokenUser).toBe(secrets.console.admin.username);
   });
 });

--- a/e2e/tests/roles/every-role.spec.ts
+++ b/e2e/tests/roles/every-role.spec.ts
@@ -1,0 +1,37 @@
+import { CfTopLevelPage } from '../../pages/cloud-foundry/cf-level/cf-top-level.page';
+import { expect, expectAbsent, proxied, test } from './roles.fixture';
+
+/**
+ * Checks every role project runs, each as its own session. The canary is
+ * written to assert the one thing that must never be true here — the
+ * session being the admin's — and is marked as expected to fail, so a role
+ * project silently running on the admin state turns the run red.
+ */
+test.describe('every role', () => {
+  test('the CF endpoint is connected as the role user', async ({ roleContext }) => {
+    const { page, username } = roleContext;
+    await page.goto('/endpoints');
+    await expect(page.getByText(username, { exact: true }).first()).toBeVisible();
+  });
+
+  test('Create Organization follows the user_org_creation feature flag', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const flag = await (await proxied(page, cfGuid, 'GET', '/feature_flags/user_org_creation')).json();
+    const cfPage = CfTopLevelPage.forEndpoint(page, cfGuid);
+    await cfPage.navigateTo();
+    await cfPage.goToOrgTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    if (flag.enabled) {
+      await expect(page.locator('[data-test="list-sub-nav-add"]')).toBeVisible();
+    } else {
+      await expectAbsent(page, 'list-sub-nav-add');
+    }
+  });
+
+  test('canary: the session is the admin user', async ({ roleContext, secrets }) => {
+    test.fail(true, 'a role project must never run on the admin identity');
+    const endpoints: any[] = await (await roleContext.page.request.get('/api/v1/endpoints')).json();
+    const cf = endpoints.find(ep => ep.guid === roleContext.cfGuid);
+    expect(cf.user?.name).toBe(secrets.console.admin.username);
+  });
+});

--- a/e2e/tests/roles/org-auditor/org-auditor.spec.ts
+++ b/e2e/tests/roles/org-auditor/org-auditor.spec.ts
@@ -1,0 +1,96 @@
+import { SecretsHelper } from '../../../helpers/secrets-helpers';
+import { CfOrgLevelPage } from '../../../pages/cloud-foundry/org-level/cf-org-level.page';
+import { adminCfApi, consoleUrl, expect, expectAbsent, proxied, runName, test } from '../roles.fixture';
+
+/**
+ * Org auditor on org e2e: read-only at org level. The console's permission
+ * model lists the org auditor in no allow list at all, and the CF does not
+ * show it apps in spaces it holds no role in, so the seeded app must stay
+ * invisible on the applications wall.
+ */
+test.describe('org auditor', () => {
+  let admin: Awaited<ReturnType<typeof adminCfApi>>;
+  let appGuid: string;
+  let appName: string;
+  let orgGuid: string;
+  let spaceGuid: string;
+
+  test.beforeAll(async () => {
+    admin = await adminCfApi(consoleUrl());
+    ({ testOrgGuid: orgGuid, testSpaceGuid: spaceGuid } = SecretsHelper.load().cloudFoundry[0]);
+    appName = runName('orgAuditor', 'app');
+    appGuid = (await admin.api.createApp({ name: appName, spaceGuid })).guid;
+  });
+
+  test.afterAll(async () => {
+    await admin.api.deleteApp(appGuid).catch(() => {});
+    await admin.dispose();
+  });
+
+  test('sees the org summary, its spaces and its users', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.waitForPage();
+    await orgPage.goToSpacesTab();
+    await expect(page.getByText('e2e', { exact: true }).first()).toBeVisible();
+    await orgPage.goToUsersTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+  });
+
+  test('does not see the seeded app on the applications wall', async ({ roleContext }) => {
+    const { page } = roleContext;
+    await page.goto('/applications');
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expect(page.getByText(appName, { exact: true })).toHaveCount(0);
+  });
+
+  test('cannot add users or change roles', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToUsersTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'cf-users-add');
+    await expectAbsent(page, 'cf-org-users-bulk-manage-roles');
+  });
+
+  test('cannot create a space', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToSpacesTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'list-sub-nav-add');
+  });
+
+  test('cannot edit or delete the org, or add a space quota', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.waitForPage();
+    await expectAbsent(page, 'org-edit');
+    await expectAbsent(page, 'org-delete');
+    await orgPage.goToSpaceQuotasTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'list-sub-nav-add');
+  });
+
+  test('the CF refuses a space create from this token', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const response = await proxied(page, cfGuid, 'POST', '/spaces', {
+      name: runName('orgAuditor', 'denied'),
+      relationships: { organization: { data: { guid: orgGuid } } },
+    });
+    expect(response.status()).toBe(403);
+  });
+
+  test('canary: sees Manage Roles', async ({ roleContext }) => {
+    test.fail(true, 'an auditor changes nothing; passing here means the control leaked');
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToUsersTab();
+    await expect(page.locator('[data-test="cf-org-users-bulk-manage-roles"]')).toBeVisible();
+  });
+});

--- a/e2e/tests/roles/org-auditor/org-auditor.spec.ts
+++ b/e2e/tests/roles/org-auditor/org-auditor.spec.ts
@@ -52,7 +52,9 @@ test.describe('org auditor', () => {
     await orgPage.goToUsersTab();
     await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
     await expectAbsent(page, 'cf-users-add');
-    await expectAbsent(page, 'cf-org-users-bulk-manage-roles');
+    // Bulk Manage Roles stays in the toolbar for every role and is disabled
+    // until the role may change roles; here it may not, so it never enables.
+    await expect(page.locator('[data-test="cf-org-users-bulk-manage-roles"]')).toBeDisabled();
   });
 
   test('cannot create a space', async ({ roleContext }) => {
@@ -85,12 +87,13 @@ test.describe('org auditor', () => {
     expect(response.status()).toBe(403);
   });
 
-  test('canary: sees Manage Roles', async ({ roleContext }) => {
+  test('canary: sees Add User', async ({ roleContext }) => {
     test.fail(true, 'an auditor changes nothing; passing here means the control leaked');
     const { page, cfGuid } = roleContext;
     const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
     await orgPage.navigateTo();
     await orgPage.goToUsersTab();
-    await expect(page.locator('[data-test="cf-org-users-bulk-manage-roles"]')).toBeVisible();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expect(page.locator('[data-test="cf-users-add"]')).toBeVisible();
   });
 });

--- a/e2e/tests/roles/org-manager/org-manager.spec.ts
+++ b/e2e/tests/roles/org-manager/org-manager.spec.ts
@@ -1,4 +1,3 @@
-import { StepperBase } from '../../../helpers/stepper-base';
 import { SecretsHelper } from '../../../helpers/secrets-helpers';
 import { CfOrgLevelPage } from '../../../pages/cloud-foundry/org-level/cf-org-level.page';
 import { CfSpaceLevelPage } from '../../../pages/cloud-foundry/space-level/cf-space-level.page';
@@ -64,7 +63,7 @@ test.describe('org manager', () => {
     await orgPage.goToSpacesTab();
     await page.locator('[data-test="list-sub-nav-add"]').click();
     await page.waitForURL(/\/add-space/);
-    await new StepperBase(page).fillStepperField('spaceName', name);
+    await page.locator('[formcontrolname="spaceName"]').fill(name);
     await page.locator('#stepper_next').click();
     await page.waitForURL(/\/spaces$/);
     const spaceLink = page.getByText(name, { exact: true }).first();
@@ -74,6 +73,8 @@ test.describe('org manager', () => {
     await spaceLink.click();
     await page.waitForURL(/\/spaces\/[^/]+/);
     await page.locator('[data-test="space-delete"]').click();
+    // Deleting a space is type-to-confirm.
+    await page.locator('#typeToConfirm').fill(name);
     await page.locator('[data-test="confirm-dialog-confirm"]').click();
     await page.waitForURL(/\/spaces$/);
     await expect(page.getByText(name, { exact: true })).toHaveCount(0);
@@ -86,9 +87,13 @@ test.describe('org manager', () => {
     await orgPage.goToUsersTab();
     await page.locator('[data-test="cf-users-add"]').click();
 
+    // Tick the org User role so the add goes through the by-username roles
+    // path (the dialog's no-role path calls a separate associate route).
     const dialog = page.locator('[role="dialog"]');
     await dialog.locator('[data-test="stacked-input"]').first().fill(TARGET_USER);
-    await dialog.getByTestId('org-role-cell').filter({ hasText: /^\s*User\s*$/ }).locator('input[type="checkbox"]').click();
+    const userCell = dialog.getByTestId('org-role-cell').filter({ hasText: /^\s*User\s*$/ });
+    await userCell.locator('[role="checkbox"]').click();
+    await expect(userCell.locator('[role="checkbox"]')).toHaveAttribute('aria-checked', 'true');
     await dialog.locator('[data-test="add-user-submit"]').click();
     await expect(dialog).toHaveCount(0);
 

--- a/e2e/tests/roles/org-manager/org-manager.spec.ts
+++ b/e2e/tests/roles/org-manager/org-manager.spec.ts
@@ -1,0 +1,142 @@
+import { StepperBase } from '../../../helpers/stepper-base';
+import { SecretsHelper } from '../../../helpers/secrets-helpers';
+import { CfOrgLevelPage } from '../../../pages/cloud-foundry/org-level/cf-org-level.page';
+import { CfSpaceLevelPage } from '../../../pages/cloud-foundry/space-level/cf-space-level.page';
+import {
+  adminCfApi, clearUserRoles, expect, expectAbsent, proxied, runName, test, userRoles, consoleUrl,
+} from '../roles.fixture';
+
+/**
+ * Org manager on org e2e: may shape the org (spaces, space quotas, roles)
+ * and read its apps, but is not a space developer, so the app-level writes
+ * and env vars stay out of reach; org quotas and the org itself are the CF
+ * admin's alone.
+ *
+ * Seeded as admin: an app in e2e/e2e to read against, and org-01-dev-1
+ * stripped of every role in the org so the add-by-username flow starts clean.
+ */
+const TARGET_USER = 'org-01-dev-1';
+
+test.describe('org manager', () => {
+  let admin: Awaited<ReturnType<typeof adminCfApi>>;
+  let appGuid: string;
+  let appName: string;
+  let targetGuid: string;
+  let orgGuid: string;
+  let spaceGuid: string;
+  const createdSpaces: string[] = [];
+
+  test.beforeAll(async () => {
+    admin = await adminCfApi(consoleUrl());
+    ({ testOrgGuid: orgGuid, testSpaceGuid: spaceGuid } = SecretsHelper.load().cloudFoundry[0]);
+    appName = runName('orgManager', 'app');
+    appGuid = (await admin.api.createApp({ name: appName, spaceGuid })).guid;
+    targetGuid = await clearUserRoles(admin, TARGET_USER, orgGuid, spaceGuid);
+  });
+
+  test.afterAll(async () => {
+    for (const name of createdSpaces) {
+      const space = await admin.api.findSpaceByName(orgGuid, name).catch(() => null);
+      if (space) await admin.api.deleteSpace(space.guid).catch(() => {});
+    }
+    await clearUserRoles(admin, TARGET_USER, orgGuid, spaceGuid).catch(() => {});
+    await admin.api.deleteApp(appGuid).catch(() => {});
+    await admin.dispose();
+  });
+
+  test('sees the org and its spaces', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.waitForPage();
+    await orgPage.goToSpacesTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expect(page.getByText('e2e', { exact: true }).first()).toBeVisible();
+  });
+
+  test('creates a space and deletes it again', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const name = runName('orgManager', 'space');
+    createdSpaces.push(name);
+
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToSpacesTab();
+    await page.locator('[data-test="list-sub-nav-add"]').click();
+    await page.waitForURL(/\/add-space/);
+    await new StepperBase(page).fillStepperField('spaceName', name);
+    await page.locator('#stepper_next').click();
+    await page.waitForURL(/\/spaces$/);
+    const spaceLink = page.getByText(name, { exact: true }).first();
+    await expect(spaceLink).toBeVisible();
+
+    // Delete from the space's own summary, the way the console offers it.
+    await spaceLink.click();
+    await page.waitForURL(/\/spaces\/[^/]+/);
+    await page.locator('[data-test="space-delete"]').click();
+    await page.locator('[data-test="confirm-dialog-confirm"]').click();
+    await page.waitForURL(/\/spaces$/);
+    await expect(page.getByText(name, { exact: true })).toHaveCount(0);
+  });
+
+  test('adds a user to the org by username and sees the row at once', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToUsersTab();
+    await page.locator('[data-test="cf-users-add"]').click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await dialog.locator('[data-test="stacked-input"]').first().fill(TARGET_USER);
+    await dialog.getByTestId('org-role-cell').filter({ hasText: /^\s*User\s*$/ }).locator('input[type="checkbox"]').click();
+    await dialog.locator('[data-test="add-user-submit"]').click();
+    await expect(dialog).toHaveCount(0);
+
+    // The list shows the new row without a reload.
+    await expect(page.getByText(TARGET_USER, { exact: true }).first()).toBeVisible();
+    await expect.poll(() => userRoles(admin, targetGuid, orgGuid, spaceGuid)).toContain('organization_user');
+  });
+
+  test('cannot create an application in the space', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.goToAppsTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'list-sub-nav-add');
+  });
+
+  test('cannot edit or delete the org', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.waitForPage();
+    await expectAbsent(page, 'org-edit');
+    await expectAbsent(page, 'org-delete');
+  });
+
+  test("cannot see an app's environment variables", async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    await page.goto(`/applications/${cfGuid}/${appGuid}/summary`);
+    await expect(page.locator('[data-test="page-tab-Summary"]')).toBeVisible();
+    await expectAbsent(page, 'page-tab-Variables');
+  });
+
+  test('the CF refuses an app create from this token', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const response = await proxied(page, cfGuid, 'POST', '/apps', {
+      name: runName('orgManager', 'denied'),
+      relationships: { space: { data: { guid: spaceGuid } } },
+    });
+    expect(response.status()).toBe(403);
+  });
+
+  test('canary: sees Delete Organization', async ({ roleContext }) => {
+    test.fail(true, 'deleting the org is the CF admin\'s alone; passing here means the control leaked');
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.waitForPage();
+    await expect(page.locator('[data-test="org-delete"]')).toBeVisible();
+  });
+});

--- a/e2e/tests/roles/roles.fixture.ts
+++ b/e2e/tests/roles/roles.fixture.ts
@@ -1,0 +1,173 @@
+import { APIResponse, expect, Page } from '@playwright/test';
+
+import { ADMIN_STATE, CfRole, roleFromProjectName } from '../../auth.constants';
+import { test as base } from '../../fixtures/test-base';
+import { CFApiHelper } from '../../helpers/cf-api.helper';
+import { RequestHelper } from '../../helpers/request.helper';
+import { SecretsHelper } from '../../helpers/secrets-helpers';
+
+/**
+ * Shared ground for the role suites (e2e/tests/roles/**), which run once per
+ * CF role as that role's saved console session — see the `role-*` projects
+ * in playwright.config.ts and e2e/auth.roles.setup.ts.
+ */
+
+export interface RoleContext {
+  page: Page;
+  role: CfRole;
+  /** The CF username this session's token belongs to. */
+  username: string;
+  cfGuid: string;
+  orgGuid: string;
+  spaceGuid: string;
+}
+
+export const test = base.extend<{ roleContext: RoleContext }>({
+  /**
+   * The role's page, with the CF endpoint resolved and its token checked:
+   * a role suite must never run on a missing or foreign token, so both
+   * fail here rather than passing vacuously downstream.
+   */
+  roleContext: async ({ page, secrets }, use, testInfo) => {
+    const role = roleFromProjectName(testInfo.project.name);
+    if (!role) {
+      throw new Error(`E2E_NOT_A_ROLE_PROJECT: '${testInfo.project.name}' — role specs run only under the role-* projects`);
+    }
+    const cfConfig = secrets.cloudFoundry[0];
+    const { username } = SecretsHelper.roleCreds(cfConfig.name, role);
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+    const endpoints: any[] = await (await page.request.get('/api/v1/endpoints')).json();
+    const cf = endpoints.find(ep => ep.cnsi_type === 'cf');
+    if (!cf) {
+      throw new Error('E2E_NO_CF_ENDPOINT: no CF endpoint is registered');
+    }
+    if (cf.connectionStatus !== 'connected') {
+      throw new Error(`E2E_NO_CF_TOKEN: the ${role} session has no connected CF token — auth.roles.setup.ts did not connect it`);
+    }
+    if (cf.user?.name && cf.user.name !== username) {
+      throw new Error(`E2E_WRONG_IDENTITY: the CF token belongs to '${cf.user.name}', expected '${username}'`);
+    }
+
+    await use({ page, role, username, cfGuid: cf.guid, orgGuid: cfConfig.testOrgGuid, spaceGuid: cfConfig.testSpaceGuid });
+  },
+});
+
+export { expect };
+
+/** A permission-gated control must not be rendered at all for this role. */
+export async function expectAbsent(page: Page, dataTest: string): Promise<void> {
+  await expect(page.locator(`[data-test="${dataTest}"]`)).toHaveCount(0);
+}
+
+/**
+ * A CF v3 call proxied through jetstream as the current session — the way
+ * to attempt what the UI (correctly) offers no control for.
+ */
+export async function proxied(
+  page: Page,
+  cfGuid: string,
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  path: string,
+  data?: unknown,
+): Promise<APIResponse> {
+  const verify = await page.request.get('/api/v1/auth/verify');
+  const xsrf = verify.headers()['x-xsrf-token'];
+  return page.request.fetch(`/pp/v1/proxy/v3${path}`, {
+    method,
+    data,
+    headers: {
+      'x-cap-cnsi-list': cfGuid,
+      'x-cap-passthrough': 'true',
+      'Content-Type': 'application/json',
+      ...(xsrf ? { 'x-xsrf-token': xsrf } : {}),
+    },
+  });
+}
+
+/**
+ * CF API as admin, for seeding and cleanup the role itself may not do.
+ * Reuses the admin session the 'setup' project saved.
+ */
+export async function adminCfApi(baseURL: string): Promise<{
+  api: CFApiHelper;
+  cfGuid: string;
+  /** Proxied CF call as admin for what CFApiHelper has no method for. */
+  call: (method: 'GET' | 'POST' | 'PATCH' | 'DELETE', path: string, data?: unknown) => Promise<any>;
+  dispose: () => Promise<void>;
+}> {
+  const request = new RequestHelper(baseURL);
+  await request.initFromStorageState(ADMIN_STATE);
+  const endpoints = await request.get('/api/v1/endpoints');
+  const cf = endpoints.find((ep: any) => ep.cnsi_type === 'cf');
+  if (!cf) {
+    throw new Error('E2E_NO_CF_ENDPOINT: no CF endpoint is registered');
+  }
+  const api = new CFApiHelper(request, cf.guid);
+  await api.init();
+  const headers = { 'x-cap-cnsi-list': cf.guid, 'x-cap-passthrough': 'true' };
+  const call = (method: 'GET' | 'POST' | 'PATCH' | 'DELETE', path: string, data?: unknown) => {
+    const url = `/pp/v1/proxy/v3${path}`;
+    switch (method) {
+      case 'GET': return request.get(url, headers);
+      case 'POST': return request.post(url, data, headers);
+      case 'PATCH': return request.patch(url, data, headers);
+      case 'DELETE': return request.delete(url, headers);
+    }
+  };
+  return { api, cfGuid: cf.guid, call, dispose: () => request.dispose() };
+}
+
+/** Strip a user of every role in the test org and space, as admin. */
+export async function clearUserRoles(
+  admin: Awaited<ReturnType<typeof adminCfApi>>,
+  username: string,
+  orgGuid: string,
+  spaceGuid: string,
+): Promise<string> {
+  const users = await admin.call('GET', `/users?usernames=${encodeURIComponent(username)}`);
+  const userGuid = users?.resources?.[0]?.guid;
+  if (!userGuid) {
+    throw new Error(`E2E_NO_SUCH_USER: '${username}' does not exist on the CF`);
+  }
+  // Space roles first: CF refuses to drop the org user role while any remain.
+  for (const scope of [`space_guids=${spaceGuid}`, `organization_guids=${orgGuid}`]) {
+    const roles = await admin.call('GET', `/roles?user_guids=${userGuid}&${scope}&per_page=100`);
+    for (const role of roles?.resources ?? []) {
+      await admin.call('DELETE', `/roles/${role.guid}`);
+    }
+  }
+  return userGuid;
+}
+
+/** Names of the roles a user holds in the test org and space, as admin. */
+export async function userRoles(
+  admin: Awaited<ReturnType<typeof adminCfApi>>,
+  userGuid: string,
+  orgGuid: string,
+  spaceGuid: string,
+): Promise<string[]> {
+  const roles = await admin.call('GET', `/roles?user_guids=${userGuid}&organization_guids=${orgGuid}&space_guids=${spaceGuid}&per_page=100`);
+  return (roles?.resources ?? []).map((r: any) => r.type as string).sort();
+}
+
+/** Unique, role-tagged name for anything a run creates. */
+export const runName = (role: CfRole, what: string): string =>
+  `role-${role}-${what}-${Date.now().toString(36)}`;
+
+/** Grant one CF role to a user in the test org or space, as admin. */
+export async function grantRole(
+  admin: Awaited<ReturnType<typeof adminCfApi>>,
+  type: 'organization_user' | 'organization_manager' | 'organization_auditor' | 'space_developer' | 'space_manager' | 'space_auditor',
+  userGuid: string,
+  target: { orgGuid?: string; spaceGuid?: string },
+): Promise<void> {
+  const relationships = type.startsWith('organization_')
+    ? { user: { data: { guid: userGuid } }, organization: { data: { guid: target.orgGuid } } }
+    : { user: { data: { guid: userGuid } }, space: { data: { guid: target.spaceGuid } } };
+  await admin.call('POST', '/roles', { type, relationships });
+}
+
+/** The console base URL, for hooks that run outside a test's fixtures. */
+export const consoleUrl = (): string => process.env.E2E_BASE_URL || 'https://localhost:5540';

--- a/e2e/tests/roles/roles.fixture.ts
+++ b/e2e/tests/roles/roles.fixture.ts
@@ -43,11 +43,15 @@ export const test = base.extend<{ roleContext: RoleContext }>({
     if (!cf) {
       throw new Error('E2E_NO_CF_ENDPOINT: no CF endpoint is registered');
     }
-    if (cf.connectionStatus !== 'connected') {
+    // /api/v1/endpoints carries no per-identity token state; /pp/v1/info
+    // does (endpoints[type][guid].user exists only when this session holds a
+    // token for it), and names the CF user the token belongs to.
+    const tokenUser = await connectedUser(page, cf);
+    if (!tokenUser) {
       throw new Error(`E2E_NO_CF_TOKEN: the ${role} session has no connected CF token — auth.roles.setup.ts did not connect it`);
     }
-    if (cf.user?.name && cf.user.name !== username) {
-      throw new Error(`E2E_WRONG_IDENTITY: the CF token belongs to '${cf.user.name}', expected '${username}'`);
+    if (tokenUser !== username) {
+      throw new Error(`E2E_WRONG_IDENTITY: the CF token belongs to '${tokenUser}', expected '${username}'`);
     }
 
     await use({ page, role, username, cfGuid: cf.guid, orgGuid: cfConfig.testOrgGuid, spaceGuid: cfConfig.testSpaceGuid });
@@ -55,6 +59,12 @@ export const test = base.extend<{ roleContext: RoleContext }>({
 });
 
 export { expect };
+
+/** The CF username this session's token for `cf` belongs to, or undefined. */
+export async function connectedUser(page: Page, cf: { guid: string; cnsi_type: string }): Promise<string | undefined> {
+  const info = await (await page.request.get('/pp/v1/info')).json();
+  return info?.endpoints?.[cf.cnsi_type]?.[cf.guid]?.user?.name;
+}
 
 /** A permission-gated control must not be rendered at all for this role. */
 export async function expectAbsent(page: Page, dataTest: string): Promise<void> {
@@ -74,7 +84,7 @@ export async function proxied(
 ): Promise<APIResponse> {
   const verify = await page.request.get('/api/v1/auth/verify');
   const xsrf = verify.headers()['x-xsrf-token'];
-  return page.request.fetch(`/pp/v1/proxy/v3${path}`, {
+  const send = () => page.request.fetch(`/pp/v1/proxy/v3${path}`, {
     method,
     data,
     headers: {
@@ -84,6 +94,14 @@ export async function proxied(
       ...(xsrf ? { 'x-xsrf-token': xsrf } : {}),
     },
   });
+  let response = await send();
+  if (response.status() >= 500) {
+    // A 5xx here is jetstream failing to reach the CF, not the CF's verdict
+    // on the role; give the upstream one more chance before judging.
+    await new Promise(r => setTimeout(r, 1000));
+    response = await send();
+  }
+  return response;
 }
 
 /**
@@ -119,24 +137,40 @@ export async function adminCfApi(baseURL: string): Promise<{
   return { api, cfGuid: cf.guid, call, dispose: () => request.dispose() };
 }
 
-/** Strip a user of every role in the test org and space, as admin. */
+/**
+ * Strip a user of every role in the test org, as admin: space roles across
+ * the org's spaces first (CF refuses to drop the org user role while any
+ * remain), then the org roles. Deletion is a CF job, so the list is polled
+ * until it reads empty before returning, so a caller may re-grant at once.
+ */
 export async function clearUserRoles(
   admin: Awaited<ReturnType<typeof adminCfApi>>,
   username: string,
   orgGuid: string,
-  spaceGuid: string,
+  _spaceGuid: string,
 ): Promise<string> {
   const users = await admin.call('GET', `/users?usernames=${encodeURIComponent(username)}`);
   const userGuid = users?.resources?.[0]?.guid;
   if (!userGuid) {
     throw new Error(`E2E_NO_SUCH_USER: '${username}' does not exist on the CF`);
   }
-  // Space roles first: CF refuses to drop the org user role while any remain.
-  for (const scope of [`space_guids=${spaceGuid}`, `organization_guids=${orgGuid}`]) {
-    const roles = await admin.call('GET', `/roles?user_guids=${userGuid}&${scope}&per_page=100`);
-    for (const role of roles?.resources ?? []) {
-      await admin.call('DELETE', `/roles/${role.guid}`);
+  const spaces = await admin.call('GET', `/spaces?organization_guids=${orgGuid}&per_page=100`);
+  const orgSpaces = new Set<string>((spaces?.resources ?? []).map((sp: any) => sp.guid as string));
+  const inOrg = (role: any): boolean =>
+    role.relationships?.organization?.data?.guid === orgGuid || orgSpaces.has(role.relationships?.space?.data?.guid);
+  const remaining = async (): Promise<any[]> =>
+    ((await admin.call('GET', `/roles?user_guids=${userGuid}&per_page=200`))?.resources ?? []).filter(inOrg);
+
+  const deadline = Date.now() + 60000;
+  for (let roles = await remaining(); roles.length > 0; roles = await remaining()) {
+    const spaceRoles = roles.filter(r => r.relationships?.space?.data?.guid);
+    for (const role of spaceRoles.length > 0 ? spaceRoles : roles) {
+      await admin.call('DELETE', `/roles/${role.guid}`).catch(() => { /* gone already, or blocked until the next pass */ });
     }
+    if (Date.now() > deadline) {
+      throw new Error(`E2E_ROLE_CLEANUP_TIMEOUT: '${username}' still holds ${roles.length} role(s) in the org 60s on`);
+    }
+    await new Promise(r => setTimeout(r, 1000));
   }
   return userGuid;
 }
@@ -148,13 +182,18 @@ export async function userRoles(
   orgGuid: string,
   spaceGuid: string,
 ): Promise<string[]> {
-  const roles = await admin.call('GET', `/roles?user_guids=${userGuid}&organization_guids=${orgGuid}&space_guids=${spaceGuid}&per_page=100`);
-  return (roles?.resources ?? []).map((r: any) => r.type as string).sort();
+  // One listing, filtered here: the CF ANDs organization_guids with
+  // space_guids, and a role belongs to one or the other, never both.
+  const roles = await admin.call('GET', `/roles?user_guids=${userGuid}&per_page=200`);
+  return (roles?.resources ?? [])
+    .filter((r: any) => r.relationships?.organization?.data?.guid === orgGuid || r.relationships?.space?.data?.guid === spaceGuid)
+    .map((r: any) => r.type as string)
+    .sort();
 }
 
 /** Unique, role-tagged name for anything a run creates. */
 export const runName = (role: CfRole, what: string): string =>
-  `role-${role}-${what}-${Date.now().toString(36)}`;
+  `role-${role}-${what}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 
 /** Grant one CF role to a user in the test org or space, as admin. */
 export async function grantRole(

--- a/e2e/tests/roles/space-auditor/space-auditor.spec.ts
+++ b/e2e/tests/roles/space-auditor/space-auditor.spec.ts
@@ -1,0 +1,89 @@
+import { SecretsHelper } from '../../../helpers/secrets-helpers';
+import { CfSpaceLevelPage } from '../../../pages/cloud-foundry/space-level/cf-space-level.page';
+import { adminCfApi, consoleUrl, expect, expectAbsent, proxied, runName, test } from '../roles.fixture';
+
+/**
+ * Space auditor on e2e/e2e: reads the space's apps, routes and services and
+ * writes nothing. Env vars are the space developer's, so the Variables tab
+ * must not appear on the seeded app.
+ */
+test.describe('space auditor', () => {
+  let admin: Awaited<ReturnType<typeof adminCfApi>>;
+  let appGuid: string;
+  let appName: string;
+  let orgGuid: string;
+  let spaceGuid: string;
+
+  test.beforeAll(async () => {
+    admin = await adminCfApi(consoleUrl());
+    ({ testOrgGuid: orgGuid, testSpaceGuid: spaceGuid } = SecretsHelper.load().cloudFoundry[0]);
+    appName = runName('spaceAuditor', 'app');
+    appGuid = (await admin.api.createApp({ name: appName, spaceGuid })).guid;
+  });
+
+  test.afterAll(async () => {
+    await admin.api.deleteApp(appGuid).catch(() => {});
+    await admin.dispose();
+  });
+
+  test("sees the space's applications, routes and services", async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.waitForPage();
+    await spacePage.goToAppsTab();
+    await expect(page.getByText(appName, { exact: true }).first()).toBeVisible();
+    await spacePage.goToRoutesTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await spacePage.goToSITab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+  });
+
+  test('cannot create an application', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.goToAppsTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'list-sub-nav-add');
+  });
+
+  test('cannot add users or manage space roles', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.goToUsersTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'cf-users-add');
+    await expectAbsent(page, 'cf-space-users-bulk-manage-roles');
+  });
+
+  test('cannot edit or delete the space', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.waitForPage();
+    await expectAbsent(page, 'space-edit');
+    await expectAbsent(page, 'space-delete');
+  });
+
+  test("cannot see the app's environment variables", async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    await page.goto(`/applications/${cfGuid}/${appGuid}/summary`);
+    await expect(page.locator('[data-test="page-tab-Summary"]')).toBeVisible();
+    await expectAbsent(page, 'page-tab-Variables');
+  });
+
+  test('the CF refuses a space rename from this token', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const response = await proxied(page, cfGuid, 'PATCH', `/spaces/${spaceGuid}`, { name: runName('spaceAuditor', 'denied') });
+    expect(response.status()).toBe(403);
+  });
+
+  test("canary: sees the app's Variables tab", async ({ roleContext }) => {
+    test.fail(true, 'env vars are the space developer\'s; passing here means the tab leaked');
+    const { page, cfGuid } = roleContext;
+    await page.goto(`/applications/${cfGuid}/${appGuid}/summary`);
+    await expect(page.locator('[data-test="page-tab-Variables"]')).toBeVisible();
+  });
+});

--- a/e2e/tests/roles/space-auditor/space-auditor.spec.ts
+++ b/e2e/tests/roles/space-auditor/space-auditor.spec.ts
@@ -55,7 +55,9 @@ test.describe('space auditor', () => {
     await spacePage.goToUsersTab();
     await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
     await expectAbsent(page, 'cf-users-add');
-    await expectAbsent(page, 'cf-space-users-bulk-manage-roles');
+    // Bulk Manage Roles stays in the toolbar for every role and is disabled
+    // until the role may change roles; here it may not, so it never enables.
+    await expect(page.locator('[data-test="cf-space-users-bulk-manage-roles"]')).toBeDisabled();
   });
 
   test('cannot edit or delete the space', async ({ roleContext }) => {
@@ -84,6 +86,10 @@ test.describe('space auditor', () => {
     test.fail(true, 'env vars are the space developer\'s; passing here means the tab leaked');
     const { page, cfGuid } = roleContext;
     await page.goto(`/applications/${cfGuid}/${appGuid}/summary`);
-    await expect(page.locator('[data-test="page-tab-Variables"]')).toBeVisible();
+    // The tab list renders before the permission check answers, so settle
+    // first: the leak this guards against is the tab staying once it has.
+    await expect(page.locator('[data-test="page-tab-Summary"]')).toBeVisible();
+    await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+    await expect(page.locator('[data-test="page-tab-Variables"]')).toBeVisible({ timeout: 2000 });
   });
 });

--- a/e2e/tests/roles/space-manager/space-manager.spec.ts
+++ b/e2e/tests/roles/space-manager/space-manager.spec.ts
@@ -42,7 +42,7 @@ test.describe('space manager', () => {
     await expect(page.getByText(TARGET_USER, { exact: true }).first()).toBeVisible();
   });
 
-  test('grants a space role through Manage Roles', async ({ roleContext }) => {
+  test('grants a space role through Manage Roles, org roles locked', async ({ roleContext }) => {
     const { page, cfGuid } = roleContext;
     const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
     await spacePage.navigateTo();
@@ -51,8 +51,14 @@ test.describe('space manager', () => {
     await page.locator('[data-test="cf-space-users-bulk-manage-roles"]').click();
     await page.waitForURL(/\/users\/manage/);
 
+    // Org roles are the org manager's: every org role cell is disabled for
+    // this role, while the space's own cells are live.
+    const orgCells = page.getByTestId('org-role-cell').locator('[role="checkbox"]');
+    await expect(orgCells.first()).toBeVisible();
+    await expect(orgCells.locator('xpath=self::*[not(contains(@class, "disabled"))]')).toHaveCount(0);
+
     const cell = page.locator(`[data-space="${spaceGuid}"]`).getByTestId('space-role-cell').filter({ hasText: /Auditor/ });
-    await cell.locator('input[type="checkbox"]').click();
+    await cell.locator('[role="checkbox"]').click();
     await page.locator('#stepper_next').click(); // Select Roles -> Confirm
     await page.locator('#stepper_next').click(); // Confirm -> apply
     await expect.poll(() => userRoles(admin, targetGuid, orgGuid, spaceGuid), { timeout: 30000 })
@@ -75,16 +81,6 @@ test.describe('space manager', () => {
     await orgPage.goToSpacesTab();
     await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
     await expectAbsent(page, 'list-sub-nav-add');
-  });
-
-  test('cannot manage org roles or add org users', async ({ roleContext }) => {
-    const { page, cfGuid } = roleContext;
-    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
-    await orgPage.navigateTo();
-    await orgPage.goToUsersTab();
-    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
-    await expectAbsent(page, 'cf-users-add');
-    await expectAbsent(page, 'cf-org-users-bulk-manage-roles');
   });
 
   test('cannot create an application or a space quota', async ({ roleContext }) => {

--- a/e2e/tests/roles/space-manager/space-manager.spec.ts
+++ b/e2e/tests/roles/space-manager/space-manager.spec.ts
@@ -1,0 +1,122 @@
+import { SecretsHelper } from '../../../helpers/secrets-helpers';
+import { CfOrgLevelPage } from '../../../pages/cloud-foundry/org-level/cf-org-level.page';
+import { CfSpaceLevelPage } from '../../../pages/cloud-foundry/space-level/cf-space-level.page';
+import {
+  adminCfApi, clearUserRoles, consoleUrl, expect, expectAbsent, grantRole, proxied, runName, test, userRoles,
+} from '../roles.fixture';
+
+/**
+ * Space manager on e2e/e2e: may edit the space and change roles inside it,
+ * nothing at org level and none of the developer writes.
+ *
+ * Seeded as admin: org-01-dev-2 as a space developer so the space users
+ * list has the row this role will grant a further role to.
+ */
+const TARGET_USER = 'org-01-dev-2';
+
+test.describe('space manager', () => {
+  let admin: Awaited<ReturnType<typeof adminCfApi>>;
+  let targetGuid: string;
+  let orgGuid: string;
+  let spaceGuid: string;
+
+  test.beforeAll(async () => {
+    admin = await adminCfApi(consoleUrl());
+    ({ testOrgGuid: orgGuid, testSpaceGuid: spaceGuid } = SecretsHelper.load().cloudFoundry[0]);
+    targetGuid = await clearUserRoles(admin, TARGET_USER, orgGuid, spaceGuid);
+    await grantRole(admin, 'organization_user', targetGuid, { orgGuid });
+    await grantRole(admin, 'space_developer', targetGuid, { spaceGuid });
+  });
+
+  test.afterAll(async () => {
+    await clearUserRoles(admin, TARGET_USER, orgGuid, spaceGuid).catch(() => {});
+    await admin.dispose();
+  });
+
+  test('sees the space and its users', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.waitForPage();
+    await spacePage.goToUsersTab();
+    await expect(page.getByText(TARGET_USER, { exact: true }).first()).toBeVisible();
+  });
+
+  test('grants a space role through Manage Roles', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.goToUsersTab();
+    await page.locator('tr', { hasText: TARGET_USER }).locator('[data-test="row-checkbox"]').click();
+    await page.locator('[data-test="cf-space-users-bulk-manage-roles"]').click();
+    await page.waitForURL(/\/users\/manage/);
+
+    const cell = page.locator(`[data-space="${spaceGuid}"]`).getByTestId('space-role-cell').filter({ hasText: /Auditor/ });
+    await cell.locator('input[type="checkbox"]').click();
+    await page.locator('#stepper_next').click(); // Select Roles -> Confirm
+    await page.locator('#stepper_next').click(); // Confirm -> apply
+    await expect.poll(() => userRoles(admin, targetGuid, orgGuid, spaceGuid), { timeout: 30000 })
+      .toEqual(expect.arrayContaining(['space_auditor', 'space_developer']));
+  });
+
+  test('cannot delete the space', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.waitForPage();
+    await expect(page.locator('[data-test="space-edit"]')).toBeVisible();
+    await expectAbsent(page, 'space-delete');
+  });
+
+  test('cannot create a space', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToSpacesTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'list-sub-nav-add');
+  });
+
+  test('cannot manage org roles or add org users', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToUsersTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'cf-users-add');
+    await expectAbsent(page, 'cf-org-users-bulk-manage-roles');
+  });
+
+  test('cannot create an application or a space quota', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.goToAppsTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'list-sub-nav-add');
+
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToSpaceQuotasTab();
+    await expect(page.locator('[data-test="list-sub-nav"]')).toBeVisible();
+    await expectAbsent(page, 'list-sub-nav-add');
+  });
+
+  test('the CF refuses a space create from this token', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const response = await proxied(page, cfGuid, 'POST', '/spaces', {
+      name: runName('spaceManager', 'denied'),
+      relationships: { organization: { data: { guid: orgGuid } } },
+    });
+    expect(response.status()).toBe(403);
+  });
+
+  test('canary: sees Delete Space', async ({ roleContext }) => {
+    test.fail(true, 'deleting a space is the org manager\'s; passing here means the control leaked');
+    const { page, cfGuid } = roleContext;
+    const spacePage = CfSpaceLevelPage.forEndpoint(page, cfGuid, orgGuid, spaceGuid);
+    await spacePage.navigateTo();
+    await spacePage.waitForPage();
+    await expect(page.locator('[data-test="space-delete"]')).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,6 +35,10 @@ const ROLE_TESTS = /tests\/roles\//;
 const roleProjects = () => CF_ROLES.map(role => ({
   name: roleProjectName(role),
   dependencies: ['setup-roles'],
+  // A role file seeds shared state (an app, a target user's roles) in
+  // beforeAll, so its tests run in order on one worker; the four role
+  // projects still run alongside each other.
+  fullyParallel: false,
   testMatch: [new RegExp(`tests/roles/${roleSpecDir(role)}/`), /tests\/roles\/every-role\.spec\.ts/],
   use: {
     ...devices['Desktop Chrome'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { CF_ROLES, roleProjectName, roleSpecDir, roleStatePath } from './e2e/auth.constants';
+
 // Default secrets profile — auto-detect from base URL, fall back to 'local'
 if (!process.env.E2E_PROFILE) {
   const baseUrl = process.env.E2E_BASE_URL || '';
@@ -12,6 +14,34 @@ if (!process.env.E2E_PROFILE) {
 if (!process.env.E2E_RUN_START) {
   process.env.E2E_RUN_START = String(Date.now());
 }
+
+// Auth mode passthrough for the e2e backend. The role projects need UAA
+// (`AUTH_ENDPOINT_TYPE=remote`) auth, where a console user is a CF user;
+// jetstream reads the process environment before config.properties, so
+// exporting these before the run switches only the e2e backend.
+const AUTH_ENV_KEYS = ['AUTH_ENDPOINT_TYPE', 'UAA_ENDPOINT', 'CONSOLE_CLIENT', 'CONSOLE_ADMIN_SCOPE', 'SSO_LOGIN', 'SKIP_SSL_VALIDATION'];
+const AUTH_ENV: Record<string, string> = Object.fromEntries(
+  AUTH_ENV_KEYS.filter(k => process.env[k] !== undefined).map(k => [k, process.env[k] as string])
+);
+
+const CHROME_LAUNCH_ARGS = ['--no-sandbox', '--disable-dev-shm-usage', '--disable-infobars', '--allow-insecure-localhost'];
+
+// The browser projects run everything under e2e/tests on the admin session,
+// so the role suites are kept out of them and run once per role instead.
+const ROLE_TESTS = /tests\/roles\//;
+
+// Role suites: e2e/tests/roles/<role>/ plus the every-role spec, run as that
+// role's saved session (see e2e/auth.roles.setup.ts).
+const roleProjects = () => CF_ROLES.map(role => ({
+  name: roleProjectName(role),
+  dependencies: ['setup-roles'],
+  testMatch: [new RegExp(`tests/roles/${roleSpecDir(role)}/`), /tests\/roles\/every-role\.spec\.ts/],
+  use: {
+    ...devices['Desktop Chrome'],
+    storageState: roleStatePath(role),
+    launchOptions: { args: CHROME_LAUNCH_ARGS },
+  },
+}));
 
 // Test environment ports (separate from dev to avoid conflicts)
 const BACKEND_PORT = process.env.BACKEND_PORT || '5543';
@@ -116,33 +146,39 @@ export default defineConfig({
       use: { storageState: undefined },
     },
     {
+      // One saved session per CF role; see e2e/auth.roles.setup.ts. Nothing
+      // here registers endpoints, so the four tests can run in parallel.
+      name: 'setup-roles',
+      testDir: './e2e',
+      testMatch: /auth\.roles\.setup\.ts/,
+      dependencies: ['setup'],
+      use: { storageState: undefined },
+    },
+    ...roleProjects(),
+    {
       name: 'chromium',
       dependencies: ['setup'],
+      testIgnore: ROLE_TESTS,
       use: {
         ...devices['Desktop Chrome'],
         // Default to admin state — fixtures override per-test as needed
         storageState: 'e2e/.auth/admin.json',
         // Chrome-specific options matching Protractor config
-        launchOptions: {
-          args: [
-            '--no-sandbox',
-            '--disable-dev-shm-usage',
-            '--disable-infobars',
-            '--allow-insecure-localhost',
-          ],
-        },
+        launchOptions: { args: CHROME_LAUNCH_ARGS },
       },
     },
 
     {
       name: 'firefox',
       dependencies: ['setup'],
+      testIgnore: ROLE_TESTS,
       use: { ...devices['Desktop Firefox'], storageState: 'e2e/.auth/admin.json' },
     },
 
     {
       name: 'webkit',
       dependencies: ['setup'],
+      testIgnore: ROLE_TESTS,
       use: { ...devices['Desktop Safari'], storageState: 'e2e/.auth/admin.json' },
     },
   ],
@@ -177,6 +213,7 @@ export default defineConfig({
         timeout: 30000,
         env: {
           SESSION_STORE_EXPIRY: '360',
+          ...AUTH_ENV,
         },
       },
       {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-organization-spaces-signal.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-organization-spaces-signal.component.ts
@@ -19,7 +19,9 @@ import {
   UserFavoriteManager,
 } from '@stratosui/store';
 
+import { CurrentUserPermissionsService } from '../../../../../../../core/src/core/permissions/current-user-permissions.service';
 import { CfSpacesSignalConfigService } from '../../../../../shared/signal-list-configs/space/cf-spaces-signal-config.service';
+import { CfCurrentUserPermissions } from '../../../../../user-permissions/cf-user-permissions-checkers';
 import { CloudFoundryEndpointService } from '../../../services/cloud-foundry-endpoint.service';
 import { CloudFoundryOrganizationService } from '../../../services/cloud-foundry-organization.service';
 import type { StSpace } from '../../../../../services/endpoint-data/stratos-types';
@@ -91,9 +93,16 @@ export class CloudFoundryOrganizationSpacesSignalComponent {
     this.spacesConfig.initialize(cfGuid, orgGuid);
     (this as { totalSpaces: Signal<number> }).totalSpaces =
       this.spacesConfig.view.totalItems;
+    // Creating a space is the org manager's; every other role sees the list
+    // without the action, as the sibling create actions already do.
+    const canCreateSpace = toSignal(
+      inject(CurrentUserPermissionsService).can(CfCurrentUserPermissions.SPACE_CREATE, cfGuid, orgGuid),
+      { initialValue: false },
+    );
     this.createSpaceAction = {
       label: 'Create Space',
       icon: 'add',
+      visible: canCreateSpace,
       invoke: () => router.navigate([
         '/cloud-foundry', cfGuid, 'organizations', orgGuid, 'add-space',
       ]),

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.html
@@ -1,11 +1,11 @@
 <app-page-sub-nav>
-  <button class="btn btn-icon" name="rename"
+  <button class="btn btn-icon" name="rename" data-test="space-edit"
     *appCfUserPermission="permsSpaceEdit;endpointGuid:cfOrgService.cfGuid;organizationGuid:cfOrgService.orgGuid;spaceGuid:cfSpaceService.spaceGuid"
     routerLink="/cloud-foundry/{{cfEndpointService.cfGuid}}/organizations/{{cfSpaceService.orgGuid}}/spaces/{{cfSpaceService.spaceGuid}}/edit-space"
     matTooltip="Edit Space">
     <span class="material-icons">edit</span>
   </button>
-  <button class="btn btn-icon" name="delete"
+  <button class="btn btn-icon" name="delete" data-test="space-delete"
     *appCfUserPermission="permsSpaceDelete;endpointGuid:cfOrgService.cfGuid;organizationGuid:cfOrgService.orgGuid;"
     (click)="deleteSpaceWarn()" matTooltip="Delete Space">
     <span class="material-icons">delete</span>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.html
@@ -1,10 +1,10 @@
 <app-page-sub-nav>
-  <button class="btn btn-icon" name="edit-org" *appCfUserPermission="permsOrgEdit;endpointGuid:cfEndpointService.cfGuid"
+  <button class="btn btn-icon" name="edit-org" data-test="org-edit" *appCfUserPermission="permsOrgEdit;endpointGuid:cfEndpointService.cfGuid"
     routerLink="/cloud-foundry/{{cfEndpointService.cfGuid}}/organizations/{{cfOrgService.orgGuid}}/edit-org"
     matTooltip="Edit Organization">
     <span class="material-icons">mode_edit</span>
   </button>
-  <button class="btn btn-icon" name="delete"
+  <button class="btn btn-icon" name="delete" data-test="org-delete"
     *appCfUserPermission="permsOrgDelete;endpointGuid:cfOrgService.cfGuid;organizationGuid:cfOrgService.orgGuid;"
     (click)="deleteOrgWarn()" matTooltip="Delete Organization">
     <span class="material-icons">delete</span>

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
@@ -84,12 +84,14 @@
       class="px-4 py-2 text-sm rounded border"
       [disabled]="submitting()"
       (click)="cancel()"
+      data-test="add-user-cancel"
     >Cancel</button>
     <button
       type="button"
       class="px-4 py-2 text-sm rounded bg-primary text-white disabled:opacity-50"
       [disabled]="!canSubmit()"
       (click)="submit()"
+      data-test="add-user-submit"
     >Add User{{ identities().length > 1 ? 's' : '' }}</button>
   </div>
 </div>

--- a/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html
+++ b/src/frontend/packages/core/src/shared/components/dialog-confirm/dialog-confirm.component.html
@@ -24,9 +24,9 @@
     </div>
   }
   <div class="confirm-dialog__actions flex gap-2 justify-end mt-6">
-    <button class="btn btn-secondary" (click)="onNoClick()" cdkFocusInitial>Cancel</button>
+    <button class="btn btn-secondary" (click)="onNoClick()" cdkFocusInitial data-test="confirm-dialog-cancel">Cancel</button>
     @if (data.confirm) {
-      <button class="confirm-dialog__confirm"
+      <button class="confirm-dialog__confirm" data-test="confirm-dialog-confirm"
         [class]="data.critical || textToMatch ? 'btn btn-danger' : 'btn btn-primary'"
         (click)="onConfirmClick()"
         [disabled]="textToMatch && textToMatch !== matchValue">{{

--- a/src/frontend/packages/core/src/shared/components/stacked-input-actions/stacked-input-action/stacked-input-action.component.html
+++ b/src/frontend/packages/core/src/shared/components/stacked-input-actions/stacked-input-action/stacked-input-action.component.html
@@ -2,7 +2,7 @@
   <form class="input-action__form stepper-form">
     <app-form-field>
       <input appInput class="w-full placeholder:!text-transparent focus:outline-none" [placeholder]="config.text.placeholder"
-        [formControl]="textFormControl" #inputElement [name]="position">
+        [formControl]="textFormControl" #inputElement [name]="position" data-test="stacked-input">
       @if (textFormControl.hasError('email') && !textFormControl.hasError('required')) {
         <app-error>
           Please enter a valid email address


### PR DESCRIPTION
Runs the e2e suite as four CF roles and asserts, per role, what the console lets them do and what it refuses.

**Identity model.** A console user holds one CF token per endpoint, so each role gets its own console session: `e2e/auth.roles.setup.ts` logs the console in as the role's CF user and connects the endpoint with the same credentials, and four `role-*` projects run `e2e/tests/roles/<role>/` plus a shared every-role spec on those sessions, in parallel. That needs UAA auth (`AUTH_ENDPOINT_TYPE=remote`), where a console user is a CF user; local auth has one console user and cannot express roles. The browser projects ignore the roles directory, so nothing there ever runs on the admin session. Credentials come from a `creds.roles` block on the endpoint entry; a missing one fails the role's setup rather than falling back to another identity.

**Suites.** Org manager (creates and deletes a space, adds a user by username, space quotas), space manager (grants a space role through Manage Roles with the org role cells locked), org auditor and space auditor (reads only). Refusals assert the control is not rendered, or rendered disabled where the console does that, and for the API that the CF answers 403 through the proxy. Every file carries a canary written to assert the leak and marked `test.fail()`, so the run only stays green while the refusal holds; a harness canary per project asserts the session is admin, which must fail. Seeded data (an app, a target user's roles) is created as admin in `beforeAll` and cleared afterwards.

**Live result.** 47/47 against the OCF lab. Reverse-tested: granting the space auditor developer rights turns exactly its developer-gated refusals red and nothing else.

**What the suites found**
- The org Spaces tab offered Create Space to every role, unlike its sibling create actions. Fixed here: gated on `SPACE_CREATE`.
- Add User with no roles ticked goes through jetstream's associate route, which resolves the username via the users list the CF filters by visibility, so a non-admin gets a 404 for a user outside their orgs. The by-username roles path has no such limit. Not fixed here.
- The app Variables tab renders before its permission answer and hides once it lands. Cosmetic; the canary settles first.

**Smaller changes.** Nine data-test hooks on the org and space summary buttons, the add-user dialog, the confirm dialog and the shared username input, none of which had a stable selector. The API helper no longer names `cflinuxfs3` when creating an app; the CF applies its own default. The Playwright config passes the UAA auth variables through to the e2e backend, which reads its environment before config.properties.

Gate: lint clean (including the e2e hook and ratchet checks), 3739 unit tests, production build with an empty warning set.
