### PR TITLE
fix: keep permission-gated tabs out of the side nav until the gate answers

### DIFF
--- a/changelog.d/0010-fix-tabs-hidden-until-known.md
+++ b/changelog.d/0010-fix-tabs-hidden-until-known.md
@@ -1,0 +1,6 @@
+[BugFixes]
+- A tab the user may not see, such as Variables on an application for
+  anyone who is not a space developer, was drawn on page load and then
+  removed once the permission check answered. Tabs gated on a permission
+  or endpoint capability now stay out of the side nav until the answer is
+  known (#5894).

--- a/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.html
+++ b/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.html
@@ -13,7 +13,8 @@
         @if (tab && !tab.link) {
           <div class="page-side-nav__item-sep">{{ tab?.label }}</div>
         }
-        @if (tab && tab.link && (tab.hidden$ | async) !== true) {
+        <!-- null = the gate has not answered yet; keep the tab out until it does. -->
+        @if (tab && tab.link && (tab.hidden$ | async) === false) {
           <a class="page-side-nav__item"
             [attr.data-test]="'page-tab-' + tab.label"
             [routerLink]="[tab.link]" queryParamsHandling="preserve"

--- a/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.spec.ts
+++ b/src/frontend/packages/core/src/features/dashboard/page-side-nav/page-side-nav.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { Subject } from 'rxjs';
 import { STORE_TEST_PROVIDERS, BASE_TEST_PROVIDERS } from "@test-framework/core-test.helper";
 
 import { BaseTestModulesNoShared } from "@test-framework/core-test.helper";
@@ -37,5 +38,27 @@ describe('PageSideNavComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders a gated tab only once hidden$ has answered false', () => {
+    const hidden$ = new Subject<boolean>();
+    fixture.componentRef.setInput('tabs', [
+      { link: 'summary', label: 'Summary' },
+      { link: 'variables', label: 'Variables', hidden$ },
+    ]);
+    fixture.detectChanges();
+    const gated = () => fixture.nativeElement.querySelector('[data-test="page-tab-Variables"]');
+
+    // An ungated tab shows at once; a gated one waits for its answer.
+    expect(fixture.nativeElement.querySelector('[data-test="page-tab-Summary"]')).not.toBeNull();
+    expect(gated()).toBeNull();
+
+    hidden$.next(false);
+    fixture.detectChanges();
+    expect(gated()).not.toBeNull();
+
+    hidden$.next(true);
+    fixture.detectChanges();
+    expect(gated()).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #5894.

The side nav rendered a tab whenever its `hidden$` stream had not yet emitted `true`. The async pipe yields `null` before the first value, so any tab gated on a permission or an endpoint capability was drawn on page load and removed once the check answered. Variables on an application did this for every user who is not a space developer; Firehose, Cells and Autoscale have the same shape. The pre-Tailwind template had the same test (`!(tab.hidden$ | async)`), so this is not a migration regression.

The template now renders a tab only once `hidden$` has answered `false`. Every producer in the tree emits (permission checks, `hasMetrics`, the analysis and tech-preview flags, the autoscaler's app fetch, and the `of(false)` default), so no tab is lost. A unit test on the side nav drives a `Subject` through unknown, `false` and `true` and checks the anchor's presence at each step.

Verified live against the lab with the four role suites (`role-*` projects, 48 tests) on the running UAA-auth dev stack.
