### PR TITLE
fix: require a role when a non-admin adds a user

### DIFF
--- a/changelog.d/0010-fix-add-user-roles-required.md
+++ b/changelog.d/0010-fix-add-user-roles-required.md
@@ -1,0 +1,6 @@
+[BugFixes]
+- Add User let an org or space manager submit a username with no role
+  ticked, and the add then failed with "user not found" because Cloud
+  Foundry only lets an administrator add a user without granting a
+  role. The dialog now asks such a user to grant at least one role
+  before it will submit (#5893).

--- a/e2e/tests/roles/org-manager/org-manager.spec.ts
+++ b/e2e/tests/roles/org-manager/org-manager.spec.ts
@@ -80,6 +80,23 @@ test.describe('org manager', () => {
     await expect(page.getByText(name, { exact: true })).toHaveCount(0);
   });
 
+  test('must grant a role to add a user', async ({ roleContext }) => {
+    const { page, cfGuid } = roleContext;
+    const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);
+    await orgPage.navigateTo();
+    await orgPage.goToUsersTab();
+    await page.locator('[data-test="cf-users-add"]').click();
+
+    // Cloud Foundry lets only an admin add a user without a role, so the
+    // dialog says so and refuses to submit until one is ticked.
+    const dialog = page.locator('[role="dialog"]');
+    await dialog.locator('[data-test="stacked-input"]').first().fill(TARGET_USER);
+    await expect(dialog.locator('[data-test="add-user-roles-required"]')).toBeVisible();
+    await expect(dialog.locator('[data-test="add-user-submit"]')).toBeDisabled();
+    await dialog.locator('[data-test="add-user-cancel"]').click();
+    await expect(dialog).toHaveCount(0);
+  });
+
   test('adds a user to the org by username and sees the row at once', async ({ roleContext }) => {
     const { page, cfGuid } = roleContext;
     const orgPage = CfOrgLevelPage.forEndpoint(page, cfGuid, orgGuid);

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
@@ -65,9 +65,14 @@
 
   <!-- ── Scope & roles sub-section ─────────────────────────────────────────
        Delegated to the shared RoleAssignmentComponent widget (Phase 4 D7).
-       Roles are OPTIONAL (canSubmit gates on identity only). -->
+       Roles are optional for a CF admin; anyone else must grant one. -->
   <section class="flex flex-col gap-3 border-t pt-3" aria-label="Scope and roles">
-    <div class="text-sm font-medium text-content-text">Scope &amp; roles (optional)</div>
+    <div class="text-sm font-medium text-content-text">Scope &amp; roles ({{ rolesRequired() ? 'required' : 'optional' }})</div>
+    @if (rolesRequired()) {
+      <p class="text-xs text-content-muted" data-test="add-user-roles-required">
+        Cloud Foundry lets only an administrator add a user without granting a role. Tick at least one role to add this user.
+      </p>
+    }
     <app-role-assignment
       [cfGuid]="data.cfGuid"
       [users]="pendingUsers"

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { of } from 'rxjs';
+import { EndpointsDataService } from '@stratosui/store';
 
 import { MAT_DIALOG_DATA, TailwindDialogRef, TailwindSnackBarService } from '@stratosui/core';
 
@@ -31,6 +32,8 @@ const TEST_HARNESS_CFG = {
 
 interface MakeOpts {
   idpsOrigins?: string[];
+  /** Whether the console user is a CF admin on the endpoint (default true). */
+  admin?: boolean;
 }
 
 function make(data: AddUserDialogData, opts: MakeOpts = {}): {
@@ -56,6 +59,7 @@ function make(data: AddUserDialogData, opts: MakeOpts = {}): {
       { provide: TailwindSnackBarService, useValue: { open: vi.fn(), error: vi.fn() } },
       { provide: CfUsersPagedDataService, useValue: {} },
       { provide: CnsiUsersSnapshotService, useValue: {} },
+      { provide: EndpointsDataService, useValue: { endpointById: () => signal({ user: { admin: opts.admin ?? true } }) } },
       // Real RoleAssignmentComponent services (no stub, no overrideComponent).
       ...provideRoleAssignmentTestDeps(TEST_HARNESS_CFG),
     ],
@@ -93,6 +97,30 @@ describe('AddUserDialogComponent', () => {
   it('canSubmit is false when there are no valid identities', () => {
     const { cmp } = make({ cfGuid: CF_GUID, userInviteAllowed: false });
     expect(cmp.canSubmit()).toBe(false);
+  });
+
+  it('needs a role before a non-admin can submit', () => {
+    const { cmp } = make(
+      { cfGuid: CF_GUID, orgGuid: 'org-1', orgName: 'Org One', userInviteAllowed: false },
+      { admin: false },
+    );
+    const c = cmp as any;
+    c.identities.set(['alice']);
+    c.identitiesValid.set(true);
+    expect(c.rolesRequired()).toBe(true);
+    expect(c.canSubmit()).toBe(false);
+
+    c.onRoleChangeSet([{ userGuid: '', orgGuid: 'org-1', orgName: 'Org One', add: true, role: OrgUserRoleNames.MANAGER }]);
+    expect(c.canSubmit()).toBe(true);
+  });
+
+  it('lets a CF admin submit without a role', () => {
+    const { cmp } = make({ cfGuid: CF_GUID, userInviteAllowed: false }, { admin: true });
+    const c = cmp as any;
+    c.identities.set(['alice']);
+    c.identitiesValid.set(true);
+    expect(c.rolesRequired()).toBe(false);
+    expect(c.canSubmit()).toBe(true);
   });
 
   it('locks org when opened with an orgGuid', () => {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.ts
@@ -25,6 +25,7 @@ import { CfIdentityProvidersService } from '../../../../shared/data-services/cf-
 import { CfUsersRolesDataService } from '../../../../services/domain-data/cf-users-roles-data.service';
 import { UserInviteService } from '../../user-invites/user-invite.service';
 import { TailwindSnackBarService } from '@stratosui/core';
+import { EndpointsDataService } from '@stratosui/store';
 import { CfUsersPagedDataService } from '../../../../shared/data-services/cf-users-paged-data.service';
 import { CnsiUsersSnapshotService } from '../../../../services/endpoint-data/cnsi-users-snapshot.service';
 import { CfRoleChange } from '../../../../store/types/users-roles.types';
@@ -87,6 +88,7 @@ export class AddUserDialogComponent {
   }];
 
   private idps = inject(CfIdentityProvidersService);
+  private endpoints = inject(EndpointsDataService);
 
   // Services assembled into AddUsersDeps for the orchestrator call in submit().
   private rolesData = inject(CfUsersRolesDataService);
@@ -122,11 +124,22 @@ export class AddUserDialogComponent {
   protected spaceLocked: Signal<boolean> = computed(() => !!this.data.spaceGuid);
 
   /**
-   * Submit is enabled once at least one valid identity is entered.
-   * Roles are optional — role selection does NOT gate submission.
+   * Cloud Foundry lets only an admin add a user without granting a role:
+   * POST /v3/users is admin-only, and a manager's only way to bring in an
+   * existing UAA user is a role granted by username. So outside admin,
+   * associate mode needs at least one role before it can submit.
+   */
+  protected rolesRequired: Signal<boolean> = computed(
+    () => this.mode() === 'associate' && !this.endpoints.endpointById(this.data.cfGuid)()?.user?.admin,
+  );
+
+  /**
+   * Submit is enabled once at least one valid identity is entered, plus a
+   * role whenever rolesRequired() says the CF would refuse a role-less add.
    */
   protected canSubmit: Signal<boolean> = computed(
-    () => this.identitiesValid() && this.identities().length > 0 && !this.submitting(),
+    () => this.identitiesValid() && this.identities().length > 0 && !this.submitting()
+      && (!this.rolesRequired() || this.roleChanges().length > 0),
   );
 
   // ── StackedInputActions wiring ────────────────────────────────────────────


### PR DESCRIPTION
Closes #5893.

Add User labelled the roles section optional for everyone. With no role ticked the dialog took the associate-only path, whose backend resolves the username through `GET /v3/users`. Cloud Foundry shows an org manager only the users already affiliated with their orgs, so for anyone else the lookup came back empty and the add reported "user not found" for a user that exists.

Fixing the lookup would not help. The CF API's Create a user endpoint is admin-only by GUID; an org manager may use it only by username and origin, only when `cc.allow_user_creation_by_org_manager` is set, and never for the `uaa` origin. A manager's only way to bring in an existing UAA user is a role granted by username, which the console already does through the roles path when a role is ticked (#5883).

So the dialog now requires at least one role unless the console user is a CF admin on the endpoint (read from the endpoint's user record, the same source the Cells tab uses). The section header says required or optional accordingly, and a short note under it explains why. Invite mode is unchanged. Two unit tests cover the non-admin and admin cases, and the org manager e2e suite checks that the dialog refuses to submit without a role.

Verified live against the lab with the four role suites (`role-*` projects) on the running UAA-auth dev stack.
