### PR TITLE
fix: keep a pinned dialog inside the viewport and scroll the Add User roles

### DIFF
--- a/changelog.d/0010-fix-pinned-dialog-height.md
+++ b/changelog.d/0010-fix-pinned-dialog-height.md
@@ -2,4 +2,6 @@
 - A dialog with a drag handle, such as Add User, could grow past the
   bottom of the window once its content loaded, leaving its buttons
   unreachable. The panel is now capped at the window edge from where it
-  sits, and scrolls inside instead.
+  sits, and Add User's scope and roles section scrolls on its own, with
+  a visible scrollbar, so every org and space is reachable while the
+  buttons stay in view.

--- a/changelog.d/0010-fix-pinned-dialog-height.md
+++ b/changelog.d/0010-fix-pinned-dialog-height.md
@@ -1,0 +1,5 @@
+[BugFixes]
+- A dialog with a drag handle, such as Add User, could grow past the
+  bottom of the window once its content loaded, leaving its buttons
+  unreachable. The panel is now capped at the window edge from where it
+  sits, and scrolls inside instead.

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/add-user/add-user-dialog.component.html
@@ -66,7 +66,7 @@
   <!-- ── Scope & roles sub-section ─────────────────────────────────────────
        Delegated to the shared RoleAssignmentComponent widget (Phase 4 D7).
        Roles are OPTIONAL (canSubmit gates on identity only). -->
-  <section class="flex flex-col gap-3 border-t pt-3" aria-label="Scope and roles">
+  <section class="flex flex-col gap-3 border-t pt-3 max-h-[45vh] overflow-y-auto custom-scrollbar" aria-label="Scope and roles">
     <div class="text-sm font-medium text-content-text">Scope &amp; roles (optional)</div>
     <app-role-assignment
       [cfGuid]="data.cfGuid"

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.spec.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.spec.ts
@@ -558,6 +558,41 @@ describe('TailwindDialogService', () => {
       vi.useRealTimers();
     });
 
+    it('should cap a pinned panel at the viewport bottom even when not resizable', async () => {
+      // A drag handle pins the panel where it was centred at open; content that
+      // arrives later grows it from there, so the cap must follow the position.
+      const rect = { top: 490, left: 380, width: 640, height: 600, right: 1020, bottom: 1090, x: 380, y: 490, toJSON: () => ({}) } as DOMRect;
+      const spy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect);
+      vi.useFakeTimers();
+      try {
+        const dialogRef = service.open(TestDraggableDialogComponent);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const panel = document.querySelector('.rounded-lg') as HTMLElement;
+        expect(panel.style.resize).toBe('');
+        expect(panel.style.maxHeight).toBe(`${window.innerHeight - 490}px`);
+
+        dialogRef.close();
+        await vi.advanceTimersByTimeAsync(300);
+      } finally {
+        vi.useRealTimers();
+        spy.mockRestore();
+      }
+    });
+
+    it('should keep a configured pixel maxHeight that is smaller than the viewport cap', async () => {
+      vi.useFakeTimers();
+      const dialogRef = service.open(TestDraggableDialogComponent, { maxHeight: '300px' });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const panel = document.querySelector('.rounded-lg') as HTMLElement;
+      expect(panel.style.maxHeight).toBe('300px');
+
+      dialogRef.close();
+      await vi.advanceTimersByTimeAsync(300);
+      vi.useRealTimers();
+    });
+
     it('should be draggable by default (no config)', async () => {
       vi.useFakeTimers();
       const dialogRef = service.open(TestDraggableDialogComponent);

--- a/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
+++ b/src/frontend/packages/core/src/shared/services/tailwind-dialog.service.ts
@@ -459,16 +459,21 @@ export class TailwindDialogService {
     panel.style.left = `${rect.left}px`;
     panel.style.top = `${rect.top}px`;
 
-    // Cap resize at the viewport edge from the panel's current top-left. Native
-    // CSS resize grows down-right from the anchored corner, so a plain
-    // `max-height: 90vh` still lets `top + height` spill past the bottom of the
-    // viewport. Tying the max to (viewport − position) keeps the bottom-right
-    // on-screen. Recomputed after a move (below), since the anchor changes.
+    // Cap the panel at the viewport edge from its pinned top-left. The panel
+    // is pinned where it was centred at open, and content arriving later (a
+    // roles widget, a Monaco editor, a native resize) grows it from there, so
+    // a plain `max-height: 90vh` still lets `top + height` spill past the
+    // bottom of the viewport and put the action buttons out of reach. Tying
+    // the max to (viewport − position) keeps the bottom on-screen; a
+    // configured pixel maxHeight still wins when it is smaller. Recomputed
+    // after a move (below), since the anchor changes.
+    const configuredMaxHeight = /px$/.test(config.maxHeight ?? '') ? parseFloat(config.maxHeight!) : Infinity;
     const clampSizeToViewport = () => {
-      if (!config.resizable) return;
       const r = panel.getBoundingClientRect();
-      panel.style.maxWidth = `${Math.max(0, window.innerWidth - r.left)}px`;
-      panel.style.maxHeight = `${Math.max(0, window.innerHeight - r.top)}px`;
+      panel.style.maxHeight = `${Math.min(configuredMaxHeight, Math.max(0, window.innerHeight - r.top))}px`;
+      if (config.resizable) {
+        panel.style.maxWidth = `${Math.max(0, window.innerWidth - r.left)}px`;
+      }
     };
 
     if (config.resizable) {


### PR DESCRIPTION
Closes #5897.

`TailwindDialogService` pins any dialog with a drag handle to a fixed position measured right after open, while the panel is still small and centred. Content that arrives later grows the panel downward from that pinned top under its 90vh cap, so top plus height spills past the bottom edge of the window and the action buttons end up off screen — the panel's own scroll cannot bring up a footer that lies outside the viewport. Add User on an org with a dozen spaces does this at both 900 and 1600 pixel tall windows; a scripted click on Cancel fails with "element is outside of the viewport" at both sizes.

The service already ties a panel's maximum height to the viewport from its own position, but that clamp only ran for resizable dialogs, and Add User is draggable-only. It now applies to every pinned panel: the smaller of the configured pixel `maxHeight` and `innerHeight − top`. A unit test on the service covers the draggable-only case and the configured-cap-wins case.

With the panel capped, Add User still needed the whole panel scrolled to reach its buttons, and with overlay scrollbars nothing indicated more content existed. The scope and roles section now has its own bounded scroll region (`max-h-[45vh] overflow-y-auto custom-scrollbar`), the pattern the share and entitle dialogs already use, so every org and space is reachable while Add User and Cancel stay in view.

Verified live against the lab: panel bottom at 891 of a 900px window, the roles section scrolls its 923px of content, the scrollbar is visible, and Cancel is clickable. `make check gate` green (3741 tests).
