### PR TITLE
test: hold unit-test HTTP in the testing backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,10 +416,10 @@ $(call register, build, frontend, $(_HIDE)stamp.frontend)
 #   PROJECT=<vitest project(s)>  e.g. PROJECT=core or PROJECT="core git"
 #   SCOPE=<path filter(s)>       e.g. SCOPE=src/frontend/packages/core/src/shared/components/stepper
 # The npm `test` script hard-codes every --project, so narrowed runs
-# invoke vitest directly with the same unhandled-errors flag.
+# invoke vitest directly.
 define test.frontend
 	@echo "Running frontend tests..."
-	$(if $(strip $(PROJECT)$(SCOPE)),bun run vitest run --dangerouslyIgnoreUnhandledErrors $(foreach p,$(PROJECT),--project $(p)) $(SCOPE),bun run test)
+	$(if $(strip $(PROJECT)$(SCOPE)),bun run vitest run $(foreach p,$(PROJECT),--project $(p)) $(SCOPE),bun run test)
 endef
 $(call register, test, frontend)
 

--- a/changelog.d/0010-fix-test-http-backend.md
+++ b/changelog.d/0010-fix-test-http-backend.md
@@ -1,0 +1,9 @@
+[Chores]
+- The unit test run printed some two hundred happy-dom AbortError stack
+  traces: Angular gives every injector a root HttpClient on the fetch
+  backend even when nothing provides one, so specs that never mention
+  HttpClient still sent real requests that were aborted at teardown. The
+  test platform now holds every request in the testing backend, the
+  specs that provided their own real client pair it with the testing
+  one, and the narrowed `make test frontend` run no longer ignores
+  unhandled errors.

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-delete/application-delete.component.spec.ts
@@ -1,5 +1,6 @@
 import { DatePipe } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
@@ -95,6 +96,7 @@ describe('ApplicationDeleteComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         generateTestApplicationServiceProvider(appId, cfId),

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application-wall/application-wall.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
@@ -108,6 +109,7 @@ describe('ApplicationWallComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/events-tab/events-tab.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/application/application-tabs-base/tabs/events-tab/events-tab.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { AppDetailDataService } from '../../../../../../features/applications/app-detail-data.service';
@@ -25,6 +26,7 @@ describe('EventsTabComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: AppDetailDataService, useFactory: makeDataStub },
       ],
     })

--- a/src/frontend/packages/cloud-foundry/src/features/applications/cli-info-application/cli-info-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/cli-info-application/cli-info-application.component.spec.ts
@@ -3,6 +3,7 @@ import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/co
 import { describe, it, expect, beforeEach } from 'vitest';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { TabNavService } from '@stratosui/core';
@@ -25,6 +26,7 @@ describe('CliInfoApplicationComponent', () => {
         importProvidersFrom(generateCfStoreModules()),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         generateTestApplicationServiceProvider(cfId, appId),
         ApplicationStateService,
         ApplicationEnvVarsHelper,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/create-application/create-application.component.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, ActivatedRoute } from '@angular/router';
 
@@ -41,6 +42,7 @@ describe('CreateApplicationComponent', () => {
         provideNoopAnimations(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step-source-upload/deploy-application-step-source-upload.component.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
@@ -34,6 +35,7 @@ describe('DeployApplicationStepSourceUploadComponent', () => {
         provideNoopAnimations(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         {
           provide: CATALOGUE_ENTITIES,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step2-1/commit-list-wrapper/commit-list-wrapper.component.spec.ts
@@ -3,6 +3,7 @@ import { DatePipe } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { getGitHubAPIURL, GITHUB_API_URL, GitSCMService } from '@stratosui/git';
 import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
@@ -21,6 +22,7 @@ describe('CommitListWrapperComponent', () => {
       providers: [
         ...STORE_TEST_PROVIDERS,
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideZonelessChangeDetection(),
         DatePipe,
         GitSCMService,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application-step3/deploy-application-step3.component.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 
 import { generateCfBaseTestModulesNoShared } from "@test-framework/cf";
@@ -22,6 +23,7 @@ describe('DeployApplicationStep3Component', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         CfOrgSpaceDataService,

--- a/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/applications/deploy-application/deploy-application.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter, ActivatedRoute } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
@@ -43,6 +44,7 @@ describe('DeployApplicationComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-organization/add-organization.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-organization/add-organization.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter, ActivatedRoute } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
@@ -28,6 +29,7 @@ describe('AddOrganizationComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-organization/create-organization-step/create-organization-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-organization/create-organization-step/create-organization-step.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
@@ -30,6 +31,7 @@ describe('CreateOrganizationStepComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-quota/add-quota.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-quota/add-quota.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { TabNavService } from '@stratosui/core';
@@ -26,6 +27,7 @@ describe('AddQuotaComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         EntityCatalogHelper,
         {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-quota/create-quota-step/create-quota-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-quota/create-quota-step/create-quota-step.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 import { EntityCatalogHelper, EntityCatalogTestModule, TEST_CATALOGUE_ENTITIES, generateStratosEntities } from '@stratosui/store';
@@ -25,6 +26,7 @@ describe('CreateQuotaStepComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         EntityCatalogHelper,
         {
           provide: TEST_CATALOGUE_ENTITIES,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/add-space/create-space-step/create-space-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/add-space/create-space-step/create-space-step.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
@@ -31,6 +32,7 @@ describe('CreateSpaceStepComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/cli-info-cloud-foundry/cli-info-cloud-foundry.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cli-info-cloud-foundry/cli-info-cloud-foundry.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
@@ -92,6 +93,7 @@ describe('CliInfoCloudFoundryComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         TabNavService,
       ]
     })

--- a/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry-tabs-base/cloud-foundry-tabs-base.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/cloud-foundry-tabs-base/cloud-foundry-tabs-base.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
@@ -23,6 +24,7 @@ describe('CloudFoundryTabsBaseComponent', () => {
           provideZonelessChangeDetection(),
           provideRouter([]),
           provideHttpClient(),
+          provideHttpClientTesting(),
           provideNoopAnimations(),
           ...STORE_TEST_PROVIDERS,
           importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization-step/edit-organization-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization-step/edit-organization-step.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter, ActivatedRoute } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -26,6 +27,7 @@ describe('EditOrganizationStepComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-organization/edit-organization.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -41,6 +42,7 @@ describe('EditOrganizationComponent', () => {
         TabNavService,
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideZonelessChangeDetection(),
       ]
     })

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-quota/edit-quota-step/edit-quota-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-quota/edit-quota-step/edit-quota-step.component.spec.ts
@@ -3,6 +3,7 @@ import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { FormGroup, FormControl } from '@angular/forms';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ActivatedRoute } from '@angular/router';
 
@@ -57,6 +58,7 @@ describe('EditQuotaStepComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         EntityCatalogHelper,
         {

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space-step/edit-space-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space-step/edit-space-step.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
@@ -31,6 +32,7 @@ describe('EditSpaceStepComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/edit-space/edit-space.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { of } from 'rxjs';
@@ -54,6 +55,7 @@ describe('EditSpaceComponent', () => {
         TabNavService,
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideZonelessChangeDetection(),
       ]
     })

--- a/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/quota-definition/quota-definition.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, importProvidersFrom, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ActivatedRoute } from '@angular/router';
@@ -31,6 +32,7 @@ describe('QuotaDefinitionComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/space-quota-definition/space-quota-definition.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, importProvidersFrom, signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ActivatedRoute } from '@angular/router';
@@ -34,6 +35,7 @@ describe('SpaceQuotaDefinitionComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(
@@ -98,6 +100,7 @@ describe('SpaceQuotaDefinitionComponent — apply-to-spaces affordance', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-applications/cloud-foundry-applications-signal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -180,6 +181,7 @@ describe('CloudFoundryApplicationsSignalComponent (component)', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-build-packs/cloud-foundry-build-packs.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-build-packs/cloud-foundry-build-packs.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryBuildPacksComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-apps/cloud-foundry-cell-apps.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-apps/cloud-foundry-cell-apps.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -23,6 +24,7 @@ describe('CloudFoundryCellAppsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-charts/cloud-foundry-cell-charts.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-charts/cloud-foundry-cell-charts.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -51,6 +52,7 @@ describe('CloudFoundryCellChartsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(
           createBasicStoreModule(),

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-summary/cloud-foundry-cell-summary.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cell/cloud-foundry-cell-summary/cloud-foundry-cell-summary.component.spec.ts
@@ -2,6 +2,7 @@ import { DatePipe } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -73,6 +74,7 @@ describe('CloudFoundryCellSummaryComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cells-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-cells/cloud-foundry-cells-signal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryCellsSignalComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-events/cloud-foundry-events.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-events/cloud-foundry-events.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryEventsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-feature-flags/cloud-foundry-feature-flags.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-feature-flags/cloud-foundry-feature-flags.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryFeatureFlagsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organization-space-quotas/cloud-foundry-organization-space-quotas.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organization-space-quotas/cloud-foundry-organization-space-quotas.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryOrganizationSpaceQuotasComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-invite-user-link/cloud-foundry-invite-user-link.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-invite-user-link/cloud-foundry-invite-user-link.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
@@ -52,6 +53,7 @@ describe('CloudFoundryInviteUserLinkComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: ActiveRouteCfOrgSpace, useValue: mockActiveRoute },
         { provide: UserInviteService, useValue: mockUserInviteService },
       ]

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-events/cloud-foundry-organization-events.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-events/cloud-foundry-organization-events.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryOrganizationEventsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/cloud-foundry-space-base/cloud-foundry-space-base.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { of } from 'rxjs';
@@ -120,6 +121,7 @@ describe('CloudFoundrySpaceBaseComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: ActiveRouteCfOrgSpace, useValue: mockActiveRoute },
         { provide: CloudFoundrySpaceService, useValue: mockSpaceService },
         { provide: CloudFoundryOrganizationService, useValue: mockOrgService },

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-apps/cloud-foundry-space-apps-signal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -91,6 +92,7 @@ describe('CloudFoundrySpaceAppsSignalComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-events/cloud-foundry-space-events.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-events/cloud-foundry-space-events.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundrySpaceEventsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-routes/cloud-foundry-space-routes-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-routes/cloud-foundry-space-routes-signal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -88,6 +89,7 @@ describe('CloudFoundrySpaceRoutesSignalComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-service-instances/cloud-foundry-space-service-instances-signal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -73,6 +74,7 @@ describe('CloudFoundrySpaceServiceInstancesSignalComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-summary/cloud-foundry-space-summary.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -55,6 +56,7 @@ describe('CloudFoundrySpaceSummaryComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         generateActiveRouteCfOrgSpaceMock(),
         generateCfActiveRouteMock(),
         { provide: CloudFoundrySpaceService, useClass: CloudFoundrySpaceServiceMock },

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-user-service-instances/cloud-foundry-space-user-service-instances-signal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -71,6 +72,7 @@ describe('CloudFoundrySpaceUserServiceInstancesSignalComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-users/cloud-foundry-space-users.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-spaces/tabs/cloud-foundry-space-users/cloud-foundry-space-users.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
@@ -69,6 +70,7 @@ describe('CloudFoundrySpaceUsersComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,
@@ -147,6 +149,7 @@ async function makeSubNavFixture(canReturn: boolean, filteredItems?: StUser[]): 
       provideZonelessChangeDetection(),
       provideRouter([]),
       provideHttpClient(),
+      provideHttpClientTesting(),
       ...STORE_TEST_PROVIDERS,
       importProvidersFrom(generateCfBaseTestModulesNoShared()),
       TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-summary/cloud-foundry-organization-summary.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { of } from 'rxjs';
@@ -85,6 +86,7 @@ describe('CloudFoundryOrganizationSummaryComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: ActiveRouteCfOrgSpace, useValue: mockActiveRoute },
         { provide: CloudFoundryOrganizationService, useValue: mockOrgService },
         { provide: CloudFoundryEndpointService, useValue: mockEndpointService },

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-users/cloud-foundry-organization-users.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-organizations/cf-organization-users/cloud-foundry-organization-users.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
@@ -69,6 +70,7 @@ describe('CloudFoundryOrganizationUsersComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,
@@ -162,6 +164,7 @@ async function makeSubNavFixture(canReturn: boolean, filteredItems?: StUser[]): 
       provideZonelessChangeDetection(),
       provideRouter([]),
       provideHttpClient(),
+      provideHttpClientTesting(),
       ...STORE_TEST_PROVIDERS,
       importProvidersFrom(generateCfBaseTestModulesNoShared()),
       TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-quotas/cloud-foundry-quotas.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-quotas/cloud-foundry-quotas.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryQuotasComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-routes/cloud-foundry-routes-signal.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-routes/cloud-foundry-routes-signal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -94,6 +95,7 @@ describe('CloudFoundryRoutesSignalComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/cloud-foundry-security-groups.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-security-groups/cloud-foundry-security-groups.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundrySecurityGroupsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-stacks/cloud-foundry-stacks.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-stacks/cloud-foundry-stacks.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryStacksComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-summary-tab/cloud-foundry-summary-tab.component.spec.ts
@@ -2,6 +2,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Router, provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundrySummaryTabComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/tabs/cf-users/cloud-foundry-users.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { of } from 'rxjs';
@@ -76,6 +77,7 @@ describe('CloudFoundryUsersComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,
@@ -191,6 +193,7 @@ describe('CloudFoundryUsersComponent — no broken header actions', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,
@@ -229,6 +232,7 @@ async function makeSubNavFixture(canReturn: boolean, filteredItems?: StUser[]): 
       provideZonelessChangeDetection(),
       provideRouter([]),
       provideHttpClient(),
+      provideHttpClientTesting(),
       ...STORE_TEST_PROVIDERS,
       importProvidersFrom(generateCfBaseTestModulesNoShared()),
       TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-confirm/manage-users-confirm.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-confirm/manage-users-confirm.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, importProvidersFrom } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -41,6 +42,7 @@ describe('UsersRolesConfirmComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-modify/manage-users-modify.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-modify/manage-users-modify.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -81,10 +81,10 @@ function buildTestBed(activeRoute: Partial<ActiveRouteCfOrgSpace>) {
       provideZonelessChangeDetection(),
       provideRouter([]),
       provideHttpClient(),
+      provideHttpClientTesting(),
       provideNoopAnimations(),
       ...STORE_TEST_PROVIDERS,
       importProvidersFrom(
-        HttpClientTestingModule,
         EntityCatalogTestModule,
         CloudFoundryReducersModule
       ),

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-select/manage-users-select.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-select/manage-users-select.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 
 import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
@@ -24,6 +25,7 @@ describe('UsersRolesSelectComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         ActiveRouteCfOrgSpace,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users-set-usernames/manage-users-set-usernames.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
@@ -31,6 +32,7 @@ describe('ManageUsersSetUsernamesComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         {
           provide: ActiveRouteCfOrgSpace,

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/manage-users/manage-users.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, importProvidersFrom, NO_ERRORS_SCHEMA } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -33,10 +33,10 @@ describe('UsersRolesComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(
-          HttpClientTestingModule,
           CloudFoundryTestingModule,
           EntityCatalogTestModule,
           AppTestModule

--- a/src/frontend/packages/cloud-foundry/src/features/cf/users/remove-user/remove-user.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/cf/users/remove-user/remove-user.component.spec.ts
@@ -1,6 +1,7 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter, ActivatedRoute } from '@angular/router';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -95,6 +96,7 @@ describe('RemoveUserComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         { provide: ActiveRouteCfOrgSpace, useValue: mockActiveRoute },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },

--- a/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/compact-app-card/compact-app-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/home/card-cf-recent-apps/compact-app-card/compact-app-card.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -25,6 +26,7 @@ describe('CompactAppCardComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         ApplicationStateService,

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-base/service-base.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-base/service-base.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -21,6 +22,7 @@ describe('ServiceBaseComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
       ],
     }).compileComponents();
   });

--- a/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/service-catalog/service-catalog-page/service-catalog-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -81,6 +82,7 @@ describe('ServiceCatalogPageComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-apps/detach-apps.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/detach-service-instance/detach-apps/detach-apps.component.spec.ts
@@ -1,5 +1,6 @@
 import { DatePipe } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
@@ -23,6 +24,7 @@ describe('DetachAppsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         DatePipe,

--- a/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/features/services/services-wall/services-wall.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -89,6 +90,7 @@ describe('ServicesWallComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         TabNavService,

--- a/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-deploy-app-data.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/services/domain-data/cf-deploy-app-data.service.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
@@ -18,6 +19,7 @@ describe('CfDeployAppDataService', () => {
       providers: [
         provideZonelessChangeDetection(),
         provideHttpClient(),
+        provideHttpClientTesting(),
         CfDeployAppDataService,
       ],
     });

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance-base-step/add-service-instance-base-step.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 
@@ -23,6 +24,7 @@ describe('AddServiceInstanceBaseStepComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(
           generateCfBaseTestModulesNoShared(),

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/add-service-instance/add-service-instance.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { of } from 'rxjs';
@@ -25,6 +26,7 @@ describe('AddServiceInstanceComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         CfOrgSpaceDataService,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/add-service-instance/specify-user-provided-details/specify-user-provided-details.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { firstValueFrom, of } from 'rxjs';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -27,6 +28,7 @@ describe('SpecifyUserProvidedDetailsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(
           generateCfBaseTestModulesNoShared(),
@@ -77,6 +79,7 @@ describe('SpecifyUserProvidedDetailsComponent.onNextUpdate', () => {
       provideZonelessChangeDetection(),
       provideRouter([]),
       provideHttpClient(),
+      provideHttpClientTesting(),
       ...STORE_TEST_PROVIDERS,
       importProvidersFrom(generateCfBaseTestModulesNoShared()),
       CsiModeService,
@@ -174,6 +177,7 @@ describe('SpecifyUserProvidedDetailsComponent credentials reveal', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         CsiModeService,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/application-action-bar/application-action-bar.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, inject, provideZonelessChangeDetection, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
 import { describe, it, expect, vi } from 'vitest';
@@ -106,6 +107,7 @@ describe('AppApplicationActionBarComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: ApplicationService, useValue: applicationServiceMock },
         { provide: AppApplicationActionsService, useValue: actionsMock },
         { provide: AppLifecycleProgressService, useValue: { setAnchor: vi.fn() } },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-org-user-details/card-cf-org-user-details.component.spec.ts
@@ -2,6 +2,7 @@ import { provideZonelessChangeDetection, importProvidersFrom } from '@angular/co
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -28,6 +29,7 @@ describe('CardCfOrgUserDetailsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/card-cf-space-details/card-cf-space-details.component.spec.ts
@@ -2,6 +2,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, importProvidersFrom } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -23,6 +24,7 @@ describe('CardCfSpaceDetailsComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         { provide: CloudFoundrySpaceService, useClass: CloudFoundrySpaceServiceMock },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/cf-service-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/cf-service-card/cf-service-card.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, ChangeDetectorRef } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { importProvidersFrom } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -54,6 +55,7 @@ describe('CfServiceCardComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
       ]
     })
       .compileComponents();

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-broker-card/service-broker-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-broker-card/service-broker-card.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -46,6 +47,7 @@ describe('ServiceBrokerCardComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         { provide: ServiceCatalogDataService, useValue: catalogStub },

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-recent-instances-card/service-recent-instances-card.component.spec.ts
@@ -2,6 +2,7 @@ import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -39,6 +40,7 @@ describe('ServiceRecentInstancesCardComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: EndpointDataRegistry, useClass: FakeRegistry },
       ],
     }).compileComponents();

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-summary-card/service-summary-card.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cards/service-summary-card/service-summary-card.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -32,6 +33,7 @@ describe('ServiceSummaryCardComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
       ],

--- a/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/cloud-foundry-events-list/cloud-foundry-events-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -30,6 +31,7 @@ describe('CloudFoundryEventsListComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(

--- a/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/create-application/create-application-step1/create-application-step1.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter, ActivatedRoute } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -22,6 +23,7 @@ describe('CreateApplicationStep1Component', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         CfOrgSpaceDataService,

--- a/src/frontend/packages/cloud-foundry/src/shared/components/running-instances/running-instances.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/running-instances/running-instances.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -20,13 +20,13 @@ describe('RunningInstancesComponent', () => {
       imports: [
         RunningInstancesComponent,
         NoopAnimationsModule,
-        HttpClientTestingModule,
         EntityCatalogModule.forFeature(() => generateCFEntities()),
       ],
       providers: [
         ...STORE_TEST_PROVIDERS,
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideZonelessChangeDetection(),
       ]
     }).compileComponents();

--- a/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/schema-form/schema-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -20,6 +21,7 @@ describe('SchemaFormComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
       ],

--- a/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-public/service-plan-public.component.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/components/service-plan-public/service-plan-public.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
 import { importProvidersFrom, provideZonelessChangeDetection, signal } from '@angular/core';
 import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 
@@ -53,6 +54,7 @@ describe('ServicePlanPublicComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(generateCfBaseTestModulesNoShared()),
         { provide: ServiceCatalogDataService, useValue: catalogStub },

--- a/src/frontend/packages/cloud-foundry/src/shared/services/current-user-permissions-and-cfchecker.service.spec.ts
+++ b/src/frontend/packages/cloud-foundry/src/shared/services/current-user-permissions-and-cfchecker.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { take, timeout } from 'rxjs/operators';
@@ -35,471 +36,501 @@ describe('CurrentUserPermissionsService with CF checker', () => {
   type StoreStateWithRoles = Partial<AppState<BaseEntityValues>> & {
     currentUserRoles: TestUserRolesFixture;
   };
-  function createStoreState(): StoreStateWithRoles {
-    // Data
-    const endpoints: EndpointModel[] = [
-      {
-        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-        name: 'SCF',
-        cnsi_type: 'cf',
-        api_endpoint: {
-          Scheme: 'https',
-          Opaque: '',
-          User: null,
-          Host: 'api.10.84.93.10.nip.io:8443',
-          Path: '',
-          RawPath: '',
-          ForceQuery: false,
-          RawQuery: '',
-          Fragment: ''
-        },
-        authorization_endpoint: 'https://cf.uaa.10.84.93.10.nip.io:2793',
-        token_endpoint: 'https://cf.uaa.10.84.93.10.nip.io:2793',
-        doppler_logging_endpoint: 'wss://doppler.10.84.93.10.nip.io:4443',
-        skip_ssl_validation: true,
-        user: {
-          guid: '670f4618-525e-4784-a56e-a238a0daf63d',
-          name: 'nathan',
-          admin: false,
-          scopes: [
-            CfScopeStrings.CF_WRITE_SCOPE,
-            StratosScopeStrings.STRATOS_CHANGE_PASSWORD,
-            CfScopeStrings.CF_READ_SCOPE,
-          ]
-        },
-        creator: {
-          name: 'admin',
-          admin: true,
-          system: false,
-        },
-        metricsAvailable: false,
-        connectionStatus: 'connected',
-        system_shared_token: false,
-        sso_allowed: false,
+  // Data
+  const endpoints: EndpointModel[] = [
+    {
+      guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+      name: 'SCF',
+      cnsi_type: 'cf',
+      api_endpoint: {
+        Scheme: 'https',
+        Opaque: '',
+        User: null,
+        Host: 'api.10.84.93.10.nip.io:8443',
+        Path: '',
+        RawPath: '',
+        ForceQuery: false,
+        RawQuery: '',
+        Fragment: ''
       },
-      {
-        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-        name: 'MainSCF',
-        cnsi_type: 'cf',
-        api_endpoint: {
-          Scheme: 'https',
-          Opaque: '',
-          User: null,
-          Host: 'api.10.84.93.55.nip.io:8443',
-          Path: '',
-          RawPath: '',
-          ForceQuery: false,
-          RawQuery: '',
-          Fragment: ''
-        },
-        authorization_endpoint: 'https://cf.uaa.10.84.93.55.nip.io:2793',
-        token_endpoint: 'https://cf.uaa.10.84.93.55.nip.io:2793',
-        doppler_logging_endpoint: 'wss://doppler.10.84.93.55.nip.io:4443',
-        skip_ssl_validation: true,
-        user: {
-          guid: '4389dfd6-6048-4149-8b26-5aa6893ac21d',
-          name: 'admin',
-          admin: true,
-          scopes: [
-            CfScopeStrings.CF_WRITE_SCOPE,
-            StratosScopeStrings.STRATOS_CHANGE_PASSWORD,
-            CfScopeStrings.CF_READ_SCOPE,
-            CfScopeStrings.CF_ADMIN_GROUP,
-            CfScopeStrings.CF_READ_ONLY_ADMIN_GROUP,
-            CfScopeStrings.CF_ADMIN_GLOBAL_AUDITOR_GROUP,
-            StratosScopeStrings.SCIM_READ,
-    ]
-        },
-        creator: {
-          name: 'admin',
-          admin: true,
-          system: false,
-        },
-        metricsAvailable: false,
-        connectionStatus: 'connected',
-        system_shared_token: false,
-        sso_allowed: false,
-      }
-    ];
+      authorization_endpoint: 'https://cf.uaa.10.84.93.10.nip.io:2793',
+      token_endpoint: 'https://cf.uaa.10.84.93.10.nip.io:2793',
+      doppler_logging_endpoint: 'wss://doppler.10.84.93.10.nip.io:4443',
+      skip_ssl_validation: true,
+      user: {
+        guid: '670f4618-525e-4784-a56e-a238a0daf63d',
+        name: 'nathan',
+        admin: false,
+        scopes: [
+          CfScopeStrings.CF_WRITE_SCOPE,
+          StratosScopeStrings.STRATOS_CHANGE_PASSWORD,
+          CfScopeStrings.CF_READ_SCOPE,
+        ]
+      },
+      creator: {
+        name: 'admin',
+        admin: true,
+        system: false,
+      },
+      metricsAvailable: false,
+      connectionStatus: 'connected',
+      system_shared_token: false,
+      sso_allowed: false,
+    },
+    {
+      guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+      name: 'MainSCF',
+      cnsi_type: 'cf',
+      api_endpoint: {
+        Scheme: 'https',
+        Opaque: '',
+        User: null,
+        Host: 'api.10.84.93.55.nip.io:8443',
+        Path: '',
+        RawPath: '',
+        ForceQuery: false,
+        RawQuery: '',
+        Fragment: ''
+      },
+      authorization_endpoint: 'https://cf.uaa.10.84.93.55.nip.io:2793',
+      token_endpoint: 'https://cf.uaa.10.84.93.55.nip.io:2793',
+      doppler_logging_endpoint: 'wss://doppler.10.84.93.55.nip.io:4443',
+      skip_ssl_validation: true,
+      user: {
+        guid: '4389dfd6-6048-4149-8b26-5aa6893ac21d',
+        name: 'admin',
+        admin: true,
+        scopes: [
+          CfScopeStrings.CF_WRITE_SCOPE,
+          StratosScopeStrings.STRATOS_CHANGE_PASSWORD,
+          CfScopeStrings.CF_READ_SCOPE,
+          CfScopeStrings.CF_ADMIN_GROUP,
+          CfScopeStrings.CF_READ_ONLY_ADMIN_GROUP,
+          CfScopeStrings.CF_ADMIN_GLOBAL_AUDITOR_GROUP,
+          StratosScopeStrings.SCIM_READ,
+  ]
+      },
+      creator: {
+        name: 'admin',
+        admin: true,
+        system: false,
+      },
+      metricsAvailable: false,
+      connectionStatus: 'connected',
+      system_shared_token: false,
+      sso_allowed: false,
+    }
+  ];
 
-    const featureFlags1: APIResource<IFeatureFlag>[] = [
-      {
-        entity: {
-          name: 'user_org_creation',
-          enabled: false,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/user_org_creation',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-0'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-0',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
+  const featureFlags1: APIResource<IFeatureFlag>[] = [
+    {
+      entity: {
+        name: 'user_org_creation',
+        enabled: false,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/user_org_creation',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-0'
       },
-      {
-        entity: {
-          name: 'private_domain_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/private_domain_creation',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-1'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-1',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'app_bits_upload',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/app_bits_upload',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-2'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-2',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'app_scaling',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/app_scaling',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-3'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-3',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'route_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/route_creation',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-4'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-4',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'service_instance_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/service_instance_creation',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-5'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-5',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'diego_docker',
-          enabled: false,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/diego_docker',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-6'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-6',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'set_roles_by_username',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/set_roles_by_username',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-7'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-7',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'unset_roles_by_username',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/unset_roles_by_username',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-8'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-8',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'env_var_visibility',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/env_var_visibility',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-10'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-10',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'space_scoped_private_broker_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/space_scoped_private_broker_creation',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-11'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-11',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      }, {
-        entity: {
-          name: 'space_developer_env_var_visibility',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/space_developer_env_var_visibility',
-          cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-12'
-        },
-        metadata: {
-          guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-12',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-0',
+        created_at: '',
+        updated_at: '',
+        url: ''
       }
-    ];
-    const featureFlags2: APIResource<IFeatureFlag>[] = [
-      // {
-      //   entity: {
-      //     name: 'user_org_creation',
-      //     enabled: false,
-      //     error_message: null,
-      //     url: '/v2/config/feature_flags/user_org_creation',
-      //     cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-      //     guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-0'
-      //   },
-      //   metadata: {
-      //     guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-0',
-      //     created_at: '',
-      //     updated_at: '',
-      //     url: ''
-      //   }
-      // },
-      {
-        entity: {
-          name: 'private_domain_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/private_domain_creation',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-1'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-1',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
+    },
+    {
+      entity: {
+        name: 'private_domain_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/private_domain_creation',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-1'
       },
-      {
-        entity: {
-          name: 'app_bits_upload',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/app_bits_upload',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-2'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-2',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'app_scaling',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/app_scaling',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-3'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-3',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'route_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/route_creation',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-4'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-4',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'service_instance_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/service_instance_creation',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-5'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-5',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'diego_docker',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/diego_docker',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-6'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-6',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'set_roles_by_username',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/set_roles_by_username',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-7'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-7',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'unset_roles_by_username',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/unset_roles_by_username',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-8'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-8',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'env_var_visibility',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/env_var_visibility',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-10'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-10',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'space_scoped_private_broker_creation',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/space_scoped_private_broker_creation',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-11'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-11',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
-      },
-      {
-        entity: {
-          name: 'space_developer_env_var_visibility',
-          enabled: true,
-          error_message: undefined,
-          url: '/v2/config/feature_flags/space_developer_env_var_visibility',
-          cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-12'
-        },
-        metadata: {
-          guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-12',
-          created_at: '',
-          updated_at: '',
-          url: ''
-        }
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-1',
+        created_at: '',
+        updated_at: '',
+        url: ''
       }
-    ];
+    }, {
+      entity: {
+        name: 'app_bits_upload',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/app_bits_upload',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-2'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-2',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'app_scaling',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/app_scaling',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-3'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-3',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'route_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/route_creation',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-4'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-4',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'service_instance_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/service_instance_creation',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-5'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-5',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'diego_docker',
+        enabled: false,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/diego_docker',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-6'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-6',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'set_roles_by_username',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/set_roles_by_username',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-7'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-7',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'unset_roles_by_username',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/unset_roles_by_username',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-8'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-8',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'env_var_visibility',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/env_var_visibility',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-10'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-10',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'space_scoped_private_broker_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/space_scoped_private_broker_creation',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-11'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-11',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }, {
+      entity: {
+        name: 'space_developer_env_var_visibility',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/space_developer_env_var_visibility',
+        cfGuid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb',
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-12'
+      },
+      metadata: {
+        guid: '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb-12',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }
+  ];
+  const featureFlags2: APIResource<IFeatureFlag>[] = [
+    // {
+    //   entity: {
+    //     name: 'user_org_creation',
+    //     enabled: false,
+    //     error_message: null,
+    //     url: '/v2/config/feature_flags/user_org_creation',
+    //     cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+    //     guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-0'
+    //   },
+    //   metadata: {
+    //     guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-0',
+    //     created_at: '',
+    //     updated_at: '',
+    //     url: ''
+    //   }
+    // },
+    {
+      entity: {
+        name: 'private_domain_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/private_domain_creation',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-1'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-1',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'app_bits_upload',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/app_bits_upload',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-2'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-2',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'app_scaling',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/app_scaling',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-3'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-3',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'route_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/route_creation',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-4'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-4',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'service_instance_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/service_instance_creation',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-5'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-5',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'diego_docker',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/diego_docker',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-6'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-6',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'set_roles_by_username',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/set_roles_by_username',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-7'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-7',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'unset_roles_by_username',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/unset_roles_by_username',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-8'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-8',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'env_var_visibility',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/env_var_visibility',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-10'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-10',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'space_scoped_private_broker_creation',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/space_scoped_private_broker_creation',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-11'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-11',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    },
+    {
+      entity: {
+        name: 'space_developer_env_var_visibility',
+        enabled: true,
+        error_message: undefined,
+        url: '/v2/config/feature_flags/space_developer_env_var_visibility',
+        cfGuid: 'c80420ca-204b-4879-bf69-b6b7a202ad87',
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-12'
+      },
+      metadata: {
+        guid: 'c80420ca-204b-4879-bf69-b6b7a202ad87-12',
+        created_at: '',
+        updated_at: '',
+        url: ''
+      }
+    }
+  ];
+
+  let autoRespond: ReturnType<typeof setInterval>;
+
+  /** The /pp/v1/info payload EndpointsDataService parses, from the fixture endpoints. */
+  function systemInfo() {
+    return {
+      endpoints: {
+        cf: endpoints.reduce((acc, endpoint) => ({ ...acc, [endpoint.guid!]: endpoint }), {}),
+      },
+    };
+  }
+
+  /** One page of feature flags for a CF endpoint, in the handler's wire shape. */
+  function featureFlagsPage(cnsiGuid: string) {
+    const resources = [...featureFlags1, ...featureFlags2]
+      .filter(ff => ff.entity.cfGuid === cnsiGuid)
+      .map(ff => ({ ...ff.entity, cnsiGuid }));
+    return {
+      resources,
+      pagination: {
+        totalResults: resources.length,
+        totalPages: 1,
+        next: null,
+        previous: null,
+        first: null,
+        last: null,
+      },
+    };
+  }
+
+  function createStoreState(): StoreStateWithRoles {
 
     // Pagination
     const pagination = {
@@ -990,6 +1021,34 @@ describe('CurrentUserPermissionsService with CF checker', () => {
     }
 
     service = TestBed.inject(CurrentUserPermissionsService);
+
+    // The permission pipeline is HTTP-backed now: the endpoint list comes from
+    // EndpointsDataService (/pp/v1/info) and each CF endpoint's feature flags
+    // from CnsiFeatureFlagsSource. Both are requested lazily, part way through
+    // a check, so there is no single moment at which every request is already
+    // pending — answer them from the same fixtures the store module is built
+    // from as they arrive. Without this the endpoint list stays empty and the
+    // "all endpoints" checks reduce over nothing.
+    const httpMock = TestBed.inject(HttpTestingController);
+    autoRespond = setInterval(() => {
+      httpMock.match(() => true).forEach(req => {
+        const url = req.request.url;
+        if (url === '/pp/v1/info') {
+          req.flush(systemInfo());
+          return;
+        }
+        const cnsiGuid = url.match(/\/pp\/v1\/cf\/feature_flags\/([^?]+)/)?.[1];
+        if (cnsiGuid) {
+          req.flush(featureFlagsPage(cnsiGuid));
+          return;
+        }
+        req.flush(null, { status: 404, statusText: 'Not Found' });
+      });
+    }, 1);
+  });
+
+  afterEach(() => {
+    clearInterval(autoRespond);
   });
 
   it('should be created', () => {
@@ -1047,6 +1106,19 @@ describe('CurrentUserPermissionsService with CF checker', () => {
       service.can(
         [new PermissionConfig(CfPermissionTypes.FEATURE_FLAG, CFFeatureFlagTypes.private_domain_creation)],
         'c80420ca-204b-4879-bf69-b6b7a202ad87'
+      ).pipe(
+        take(1),
+        timeout(5000)
+      )
+    );
+    expect(can).toBe(true);
+  });
+
+  it('should not allow if feature flag is disabled on that cf', async () => {
+    const can = await firstValueFrom(
+      service.can(
+        [new PermissionConfig(CfPermissionTypes.FEATURE_FLAG, CFFeatureFlagTypes.diego_docker)],
+        '0e934dc8-7ad4-40ff-b85c-53c1b61d2abb'
       ).pipe(
         take(1),
         timeout(5000)

--- a/src/frontend/packages/cloud-foundry/test-framework/cloud-foundry-endpoint-service.helper.ts
+++ b/src/frontend/packages/cloud-foundry/test-framework/cloud-foundry-endpoint-service.helper.ts
@@ -1,3 +1,4 @@
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import {
   provideHttpClient,
   HttpClient,
@@ -160,6 +161,7 @@ export function generateCfBaseTestModulesNoShared() {
 export const CF_BASE_TEST_PROVIDERS = [
   provideRouter([]),
   provideHttpClient(withXhr()),
+  provideHttpClientTesting(),
 ];
 
 export function generateCfBaseTestModules() {

--- a/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.spec.ts
+++ b/src/frontend/packages/core/src/features/about/eula-page/eula-page.component.spec.ts
@@ -1,4 +1,5 @@
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -20,11 +21,12 @@ describe('EulaPageComponent', () => {
         CoreTestingModule,
         RouterTestingModule,
         NoopAnimationsModule,
-        HttpClientTestingModule,
         createBasicStoreModule(),
         EulaPageComponent,
       ],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         TabNavService,
         CurrentUserPermissionsService,
         ...STORE_TEST_PROVIDERS,

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-checkbox-cell/backup-checkbox-cell.component.spec.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-checkbox-cell/backup-checkbox-cell.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { EndpointModel } from '@stratosui/store';
 import { STORE_TEST_PROVIDERS } from '@stratosui/store/testing';
@@ -24,6 +25,7 @@ describe('BackupCheckboxCellComponent', () => {
         BackupEndpointsService,
         provideZonelessChangeDetection(),
         provideHttpClient(),
+        provideHttpClientTesting(),
       ]
     });
     TestBed.compileComponents();

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.spec.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/backup-endpoints/backup-endpoints.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
@@ -48,6 +49,7 @@ describe('BackupEndpointsComponent', () => {
         ...STORE_TEST_PROVIDERS,
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideZonelessChangeDetection(),
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.spec.ts
+++ b/src/frontend/packages/core/src/features/endpoints/backup-restore/restore-endpoints/restore-endpoints.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -25,6 +26,7 @@ describe('RestoreEndpointsComponent', () => {
         TabNavService,
         ...STORE_TEST_PROVIDERS,
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideZonelessChangeDetection(),
       ],
     });

--- a/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.spec.ts
+++ b/src/frontend/packages/core/src/features/home/home/home-page-endpoint-card/home-page-endpoint-card.component.spec.ts
@@ -2,7 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, NO_ERRORS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { of } from 'rxjs';
 import { EndpointModel, UserFavoriteManager, UserFavorite, IEndpointFavMetadata } from '@stratosui/store';
@@ -23,10 +24,11 @@ describe('HomePageEndpointCardComponent', () => {
         createBasicStoreModule(),
         RouterTestingModule,
         NoopAnimationsModule,
-        HttpClientModule,
         HomePageEndpointCardComponent,
       ],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ...(STORE_TEST_PROVIDERS || []),
         SidePanelService,
         UserFavoriteManager,

--- a/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.spec.ts
+++ b/src/frontend/packages/core/src/features/metrics/metrics/metrics.component.spec.ts
@@ -1,4 +1,5 @@
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -38,10 +39,11 @@ describe('MetricsComponent', () => {
         CoreModule,
         SharedModule,
         NoopAnimationsModule,
-        HttpClientModule,
         MetricsComponent,
       ],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         {
           provide: MetricsService,
           useValue: {

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/endpoint-card/endpoint-card.component.spec.ts
@@ -2,7 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { of } from 'rxjs';
 import { EndpointModel, UserFavoriteManager, EntityCatalogTestModuleManualStore, generateStratosEntities, TEST_CATALOGUE_ENTITIES } from '@stratosui/store';
@@ -21,12 +22,13 @@ describe('EndpointCardComponent', () => {
       imports: [
         RouterTestingModule,
         NoopAnimationsModule,
-        HttpClientModule,
         createBasicStoreModule(),
         EntityCatalogTestModuleManualStore,
         EndpointCardComponent,
       ],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         provideZonelessChangeDetection(),
         ...STORE_TEST_PROVIDERS,
         {

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-address/table-cell-endpoint-address.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-address/table-cell-endpoint-address.component.spec.ts
@@ -2,7 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { STORE_TEST_PROVIDERS, createBasicStoreModule } from '@stratosui/store/testing';
 import { CoreTestingModule } from '@test-framework/core-test.modules';
@@ -23,10 +24,11 @@ describe('TableCellEndpointAddressComponent', () => {
         RouterTestingModule,
         CoreModule,
         NoopAnimationsModule,
-        HttpClientModule,
         TableCellEndpointAddressComponent,
       ],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         EndpointListHelper,
         provideZonelessChangeDetection(),

--- a/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-name/table-cell-endpoint-name.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/endpoint-list/table-cell-endpoint-name/table-cell-endpoint-name.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { EndpointModel, entityCatalog, EntityCatalogHelper, EntityCatalogHelpers, generateStratosEntities } from '@stratosui/store';
@@ -31,6 +32,7 @@ describe('TableCellEndpointNameComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         provideNoopAnimations(),
       ]
     });

--- a/src/frontend/packages/core/src/shared/components/sidepanel-preview/sidepanel-preview.component.spec.ts
+++ b/src/frontend/packages/core/src/shared/components/sidepanel-preview/sidepanel-preview.component.spec.ts
@@ -1,5 +1,5 @@
-import { HttpClient, HttpClientModule, HttpHandler } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
@@ -18,15 +18,15 @@ describe('SidepanelPreviewComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        HttpClient, HttpHandler, SidePanelService,
+        SidePanelService,
         provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
       ],
       imports: [
         SidepanelPreviewComponent,
         MDAppModule,
         RouterTestingModule,
-        HttpClientModule,
-        HttpClientTestingModule,
         CoreTestingModule,
         createBasicStoreModule(),
       ]

--- a/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.spec.ts
+++ b/src/frontend/packages/git/src/shared/components/git-registration/git-registration.component.spec.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { provideRouter } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { getGitHubAPIURL, GITHUB_API_URL, GitSCMService, gitEntityCatalog } from '@stratosui/git';
 import { createBasicStoreModule } from '../../../../../store/testing/src/store-test-helper';
 import { EntityCatalogHelper, EntityCatalogHelpers, EntityCatalogTestModule, TEST_CATALOGUE_ENTITIES } from '@stratosui/store';
@@ -36,6 +37,7 @@ describe('GitRegistrationComponent', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideHttpClient(),
+        provideHttpClientTesting(),
         ...STORE_TEST_PROVIDERS,
         importProvidersFrom(
           createBasicStoreModule(),

--- a/src/frontend/vitest.workspace.setup.ts
+++ b/src/frontend/vitest.workspace.setup.ts
@@ -8,6 +8,8 @@ console.log('[WORKSPACE SETUP] Vitest imports loaded');
 import '@angular/compiler';
 console.log('[WORKSPACE SETUP] Angular compiler loaded');
 import { provideZonelessChangeDetection, NgModule } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 console.log('[WORKSPACE SETUP] Angular core loaded');
 import {
   BrowserTestingModule,
@@ -154,7 +156,16 @@ if (typeof window !== 'undefined' && typeof WebSocket !== 'undefined') {
 }
 
 @NgModule({
-  providers: [provideZonelessChangeDetection()],
+  providers: [
+    provideZonelessChangeDetection(),
+    // Angular hands every injector a root HttpClient on the fetch backend even
+    // when nothing provides one, so a spec that never mentions HttpClient still
+    // sends real requests (the branding service's company-config.json, for
+    // one) that happy-dom aborts at teardown with an AbortError trace. Put the
+    // testing backend on the platform so requests are held, never sent.
+    provideHttpClient(),
+    provideHttpClientTesting(),
+  ],
 })
 export class ZonelessTestModule {}
 


### PR DESCRIPTION
Every `make check gate` run has been printing around two hundred happy-dom stack traces of the form `DOMException [AbortError]: The operation was aborted` at the head of the vitest output, with no file attributed. A sequential verbose run attributes them to 56 spec files, and hooking happy-dom's `Fetch.sendRequest` shows what they are: real requests, one per test — `GET /assets/company-config.json` from the branding service and friends — aborted when the window is torn down after each file.

The cause is the test platform. The workspace setup initialises the TestBed platform once for all eight projects, and its module provides only zoneless change detection. Core's own setup does pair `provideHttpClient()` with `provideHttpClientTesting()`, but it never runs, because the platform already exists. Angular hands every injector a root `HttpClient` on the fetch backend even when nothing provides one, so a spec that never mentions HttpClient still reaches the network.

Closing the class rather than the symptom:

- The workspace platform module now provides `provideHttpClient()` and `provideHttpClientTesting()`, so requests are held in the testing backend unless a spec overrides it.
- The specs that provided their own real client pair it with the testing backend, as `CF_BASE_TEST_PROVIDERS` now does — 79 with a bare `provideHttpClient()`, four importing `HttpClientModule`, and six that mixed a deprecated `HttpClientTestingModule` import with a real `provideHttpClient()` provider in the same TestBed, where the real backend won. One of those six (running instances) was still sending an `app-stats` request and was the last AbortError in the log.
- The narrowed `make test frontend PROJECT=... SCOPE=...` run still passed `--dangerouslyIgnoreUnhandledErrors`, which #5890 removed from the full run; it is gone here too, with its stale comment.

Two greps now come back empty and are the standing check: a spec with a real client and no testing backend, and a spec that mixes a deprecated HTTP module with a real provider.

Holding the requests exposed a spec that had been passing on a failed one. `current-user-permissions-and-cfchecker.service.spec.ts` drives the CF permission checkers, which read the connected endpoint list from `EndpointsDataService`. That service fetches `/pp/v1/info`; under the real backend the fetch failed, the endpoint list came back empty, and the "all endpoints" checks reduced over nothing — which `reduceChecks` answers `true` by default. The feature-flag assertions were never reached. The spec now answers `/pp/v1/info` and each endpoint's `/pp/v1/cf/feature_flags/{cnsi}` from the same fixtures the store module is built from, so the checks run over the two CF endpoints and their real flags. With real data the private-domain-creation check on the second endpoint is `true`, not `false` — that fixture enables the flag there — and a new case covers a flag that is disabled on its endpoint (`diego_docker`), so enabled, disabled and absent are each asserted.

`make check gate` green: 3745 passed, 2 skipped, zero AbortError lines.
