### PR TITLE
Hash the documentation search index against the docs

### DIFF
--- a/changelog.d/0002-search-index-hashing.md
+++ b/changelog.d/0002-search-index-hashing.md
@@ -1,0 +1,7 @@
+[BugFixes]
+- Fixed the documentation site serving a stale search index. The search
+  plugin derives the index's cache-busting hash by scanning `docsDir` and
+  `blogDir`, which were left at their defaults and pointed at directories
+  this site does not have. With no files to scan the hash came back empty
+  and the index was fetched from an unversioned URL, so a returning
+  visitor kept whatever their browser had cached from an earlier build.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -158,6 +158,14 @@ const config = {
       {
         indexPages: true,
         docsRouteBasePath: '/docs',
+        // docsDir/blogDir feed the index content hash, and are resolved
+        // against website/. They are NOT the indexing paths — routes are
+        // indexed from the build output regardless. Left at their defaults
+        // ('docs', 'blog') they point at directories this site does not
+        // have, so the hash came back null and the index shipped at a
+        // stable URL that caches stale across a docs change.
+        docsDir: '../docs',
+        indexBlog: false,
         hashed: true,
         language: ['en'],
         highlightSearchTermsOnTargetPage: false,


### PR DESCRIPTION
The documentation site can serve a stale search index. A returning visitor
keeps whatever their browser cached from an earlier build, so a docs change
never reaches their search results.

## Cause

The search plugin runs with `hashed: true`, but it does not derive that hash
from the index it just built. It derives it by scanning the `docsDir` and
`blogDir` options, which are resolved against `website/` and default to `docs`
and `blog`. This site keeps its docs at the repository root and has no blog, so
neither directory exists — both scans find nothing, `getIndexHash` returns
null, and the index is emitted at an unversioned URL.

The build has been saying so on every run:

```
Warn: `docsDir` doesn't exist: ".../website/docs".
Warn: `blogDir` doesn't exist: ".../website/blog".
```

## Fix

Point `docsDir` at `../docs` and turn off blog indexing.

Worth being explicit about what these two options are not: they do not control
what gets indexed. Routes are indexed from the build output regardless, which
is why search has worked correctly all along and only the cache behaviour was
wrong. They feed the content hash and nothing else. A comment in the config
now says so, since the names invite the opposite reading.

## Verification

`make check gate` and `make build website` both pass.

| State | Warnings | Emitted index URL |
|---|---|---|
| Before | 2 | `search-index{dir}.json` |
| After | 0 | `search-index{dir}.json?_=36c44971` |
| After appending one line to a doc | 0 | `...?_=4a045143` |
| After reverting that line | 0 | `...?_=36c44971` |

The last two rows are the point: the hash now tracks the content of the docs,
so a docs change invalidates the cached index. The first row was observed by
reverting the config and rebuilding, not inferred from the code.