### PR TITLE
chore: clear the remaining build tooling advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
         "@vitest/coverage-v8": "^4.1.11",
         "@vitest/ui": "4.1.10",
         "acorn": "8.18.0",
-        "adm-zip": "0.6.0",
+        "adm-zip": "0.6.1",
         "angular-eslint": "22.5.0",
         "autoprefixer": "^10.5.5",
         "baseline-browser-mapping": "^2.11.21",
@@ -1088,7 +1088,7 @@
 
     "adjust-sourcemap-loader": ["adjust-sourcemap-loader@4.0.0", "", { "dependencies": { "loader-utils": "^2.0.0", "regex-parser": "^2.2.11" } }, "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A=="],
 
-    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
+    "adm-zip": ["adm-zip@0.6.1", "", {}, "sha512-Xwrja8nx9e5o2N1my4DsKCeKpdrnACyr1wtbPxBDgGzKzKyE9kRtBFA8mWldI+RVlD7CBZNWY/wQ2+ydwOR6kQ=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 

--- a/changelog.d/0003-clear-build-tooling-advisories.md
+++ b/changelog.d/0003-clear-build-tooling-advisories.md
@@ -1,0 +1,10 @@
+[Security Updates]
+- Two CVEs were cleared in the build tooling. The devkit's `js-yaml`
+  override moved 4.3.1 to 4.3.2 (CVE-2026-84375, high): the devkit
+  resolves through its own `package-lock.json`, so the root workspace's
+  earlier move to js-yaml 5 never reached it. `adm-zip` moved 0.6.0 to
+  0.6.1 (CVE-2026-76845): the advisory covers extraction following
+  symlinks at the destination, which the build never does — it only
+  creates archives — but 0.6.1 also stops `addLocalFolder` following
+  symlinks out of the folder being archived, and that is the call the
+  prebuild zip step makes.

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@vitest/coverage-v8": "^4.1.11",
     "@vitest/ui": "4.1.10",
     "acorn": "8.18.0",
-    "adm-zip": "0.6.0",
+    "adm-zip": "0.6.1",
     "angular-eslint": "22.5.0",
     "autoprefixer": "^10.5.5",
     "baseline-browser-mapping": "^2.11.21",

--- a/src/frontend/packages/devkit/package-lock.json
+++ b/src/frontend/packages/devkit/package-lock.json
@@ -9595,9 +9595,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/src/frontend/packages/devkit/package.json
+++ b/src/frontend/packages/devkit/package.json
@@ -26,7 +26,7 @@
     "piscina": "5.2.0",
     "@babel/core": "7.29.6",
     "http-proxy-middleware": "3.0.7",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "qs": "6.16.0",
     "webpack-dev-server": {
       ".": "5.2.6",


### PR DESCRIPTION
The two non-Angular Dependabot alerts. Both are in build tooling, neither
reaches the shipped bundle. With #5914 this takes the repo to zero open
alerts.

### js-yaml 4.3.1 → 4.3.2 (high, CVSS 7.5, CVE-2026-84375)

`maxTotalMergeKeys` does not bound CPU use when the merge sources are
empty, so a crafted document can still burn arbitrary time.

The alert names `src/frontend/packages/devkit/package-lock.json`. The root
workspace is already on js-yaml 5.4.1 — the devkit resolves separately
through its own lockfile, which is why the alert stayed open there after
the root moved. The devkit pins js-yaml through `overrides`, so this is a
patch move on the `v4-legacy` line.

### adm-zip 0.6.0 → 0.6.1 (moderate, CVSS 6.5, CVE-2026-76845)

Extraction follows symlinks at the destination, allowing writes outside the
target directory.

Two things worth stating plainly:

**The advisory is not reachable here.** `build/prebuild-zip.js` is the only
consumer and it never extracts:

```js
var zip = new AdmZip();
zip.addLocalFolder(DIST_DIR);
zip.writeZip(path.join(ZIP_FILE));
```

**GitHub reports no patched version, which is out of date.** 0.6.1 was
published 2026-09-11, above the advisory's `<= 0.6.0` ceiling.

The upgrade earns its place on a different line in the same release. 0.6.1
also fixes `addLocalFolder` following symlinks out of the folder being
archived — and `addLocalFolder` is exactly the call this script makes. That
one is a real bug on our actual code path, and the advisory does not
mention it.

### Verification

Behaviour change confirmed against 0.6.0 on a tree holding one symlink
resolving inside the archived folder and one pointing out of it:

```
adm-zip 0.6.0          adm-zip 0.6.1
  a.txt                  a.txt
  sub/                   sub/
  sub/b.txt              sub/b.txt
  sub/link-inside.txt    sub/link-inside.txt
  sub/link-outside.txt   (excluded)
```

No effect on the real input — `dist/` holds 506 files and zero symlinks, so
the archive content is unchanged.

The devkit lockfile diff is deliberately limited to the three js-yaml lines.
Note for anyone regenerating it: a root `bun install` runs
`build/ensure-devkit.cjs`, which shells out to `npm install
--legacy-peer-deps` and drops the `"peer": true` entries the committed
lockfile carries — 155 lines of unrelated churn. That is worth looking at
separately; it is kept out of this PR.