### PR TITLE
fix(build): install devkit with npm ci

### DIFF
--- a/build/ensure-devkit.cjs
+++ b/build/ensure-devkit.cjs
@@ -23,7 +23,7 @@ function buildDevkit() {
   try {
     // Install devkit dependencies with npm (isolated from workspace)
     log('Installing devkit dependencies...');
-    execSync('npm install --legacy-peer-deps', {
+    execSync('npm ci', {
       cwd: DEVKIT_PKG,
       stdio: 'inherit',
       env: {...process.env, npm_config_workspace: ''}

--- a/changelog.d/0004-devkit-lockfile-consistency.md
+++ b/changelog.d/0004-devkit-lockfile-consistency.md
@@ -1,0 +1,7 @@
+[Chores]
+- The devkit install no longer rewrites its own lockfile. `ensure-devkit`
+  ran `npm install --legacy-peer-deps` against a `package-lock.json`
+  generated without that flag, so every root install — CI included —
+  silently dropped the ten peer entries the lockfile records. It now runs
+  `npm ci`, which installs exactly what the lockfile says and never writes
+  to it.


### PR DESCRIPTION
`build/ensure-devkit.cjs` installs the devkit with
`npm install --legacy-peer-deps`, but the committed
`src/frontend/packages/devkit/package-lock.json` is generated *without*
that flag — Dependabot does not pass it. The two have therefore disagreed
on every run.

`--legacy-peer-deps` makes npm skip peer resolution, so the ten
`"peer": true` entries the lockfile records are dropped each time. That is
152 lines of churn in the working tree after any root `bun install`. It
happens in CI too; the rewrite is simply never committed there, which means
the committed lockfile is not actually what gets installed.

### Measured

Clean worktree, devkit only. All three exit 0:

| install mode | lockfile afterwards |
|---|---|
| `npm install --legacy-peer-deps` (current) | **−152 lines, all 10 peer entries stripped** |
| `npm install` (no flag) | unchanged |
| `npm ci` | unchanged, never written |

So the flag is not load-bearing. It arrived in 2a99a033e6 ("feat: streamline
the build and release workflows") as part of a bulk change rather than as a
fix for a peer conflict, a plain install succeeds without it today, it was
the only occurrence in the repo, and there is no `.npmrc`.

### Why `npm ci` and not a bare `npm install`

`npm install` happens to leave the lockfile alone today, but nothing
guarantees it keeps doing so. `npm ci` installs exactly what the lockfile
records and never writes to it, which makes the disagreement structurally
impossible rather than merely unlikely.

The one behaviour change is that a genuine mismatch between `package.json`
and the lockfile now fails loudly instead of being silently re-resolved:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: qs@6.15.0 from lock file
```

Dependabot updates both files together, so ordinary bumps do not trip this.
A developer who hand-edits `package.json` gets a clear message naming the
package and pointing at `npm install`.

`ensure-devkit` already short-circuits on the `dist-devkit` mtime check, so
`npm ci` wiping `node_modules` is a first-setup cost, not a per-command one.

### Verification

From a genuinely clean tree — `rm -rf node_modules dist-devkit
src/frontend/packages/devkit/node_modules`, then `bun install`, the same
path CI takes:

```
BUN INSTALL EXIT=0
[ensure-devkit] Installing devkit dependencies...
[ensure-devkit] Building devkit package...
[ensure-devkit] ✅ Devkit built successfully

$ git status --short -- src/frontend/packages/devkit/package-lock.json
(empty — unchanged)

peer entries: 10
```

Same run with the old flag is what produced the 152-line rewrite, so the
before/after is confirmed in both directions.