### PR TITLE
Publish the all-in-one image for arm64 too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,13 +218,14 @@ jobs:
 
       # Built and pushed for prereleases too, so rc/alpha/beta tags get a
       # runnable all-in-one image.
-      # linux/amd64 only for now — the staged jetstream is amd64.
+      # The payload carries a Linux binary per architecture and the Dockerfile
+      # selects on TARGETARCH, so both platforms build from the one context.
       - name: Build and push all-in-one image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: aio-package
           file: aio-package/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/changelog.d/0006-aio-multiarch.md
+++ b/changelog.d/0006-aio-multiarch.md
@@ -1,0 +1,6 @@
+[Features]
+- The all-in-one container image is now published for `linux/arm64` as well
+  as `linux/amd64`. It previously ran only on amd64, so it could not be used
+  on arm64 Kubernetes nodes or on Apple Silicon without building it locally.
+  The release payload now carries one Linux binary per architecture and the
+  Dockerfile selects on `TARGETARCH`.

--- a/deploy/all-in-one/Dockerfile
+++ b/deploy/all-in-one/Dockerfile
@@ -11,6 +11,10 @@
 #   ./deploy/all-in-one/stage-aio.sh
 #   docker build -f deploy/all-in-one/Dockerfile -t stratos-aio dist/aio-package
 #
+# The payload carries one Linux binary per architecture; TARGETARCH selects
+# which becomes ./jetstream, so the same context builds linux/amd64 and
+# linux/arm64. A plain `docker build` sets TARGETARCH to the host arch.
+#
 # One image serves both `docker run` (no VCAP -> HTTPS :5443 with dev-certs)
 # and `cf push -o <image>` (the cloudfoundryhosting plugin detects
 # VCAP_APPLICATION -> HTTP on $PORT). Same binary; runtime decides.
@@ -25,7 +29,8 @@ RUN apt-get update \
 
 WORKDIR /srv
 
-COPY --chown=jetstream:jetstream jetstream ./jetstream
+ARG TARGETARCH
+COPY --chown=jetstream:jetstream jetstream-linux-${TARGETARCH} ./jetstream
 COPY --chown=jetstream:jetstream ui ./ui
 COPY --chown=jetstream:jetstream templates ./templates
 COPY --chown=jetstream:jetstream plugins.yaml ./plugins.yaml

--- a/deploy/all-in-one/stage-aio.sh
+++ b/deploy/all-in-one/stage-aio.sh
@@ -9,12 +9,14 @@
 # frontend') first. Produces dist/aio-package/, which is the Docker build
 # context for deploy/all-in-one/Dockerfile.
 #
-# The all-in-one image is linux/amd64 only for now (the cf zip is too).
+# The image is multi-arch (linux/amd64 and linux/arm64); the cf zip is not.
 
 set -euo pipefail
 
 VERSION="${1:-$(node -p "require('./package.json').version" 2>/dev/null || echo "dev")}"
 AIO_ARCH="${AIO_ARCH:-amd64}"
+# Architectures to stage when their binaries are present.
+AIO_ARCHES="${AIO_ARCHES:-amd64 arm64}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DIST_DIR="${ROOT_DIR}/dist"
@@ -40,21 +42,30 @@ else
   fail=1
 fi
 
-# Backend binary — the AIO image is Linux; prefer an explicit dist/bin/jetstream
-# (from make build PLATFORM=linux/amd64), fall back to the cross-compiled one.
-jetstream_bin="${BIN_DIR}/jetstream"
-if [[ ! -f "${jetstream_bin}" ]] && [[ -f "${BIN_DIR}/jetstream-linux-${AIO_ARCH}" ]]; then
-  jetstream_bin="${BIN_DIR}/jetstream-linux-${AIO_ARCH}"
-fi
+# Backend binaries — the image is multi-arch, so stage one Linux ELF per
+# architecture as jetstream-linux-<arch>; the Dockerfile picks by TARGETARCH.
+# `make build` cross-compiles all of them; `make build backend
+# PLATFORM=linux/<arch>` produces only dist/bin/jetstream, which is used for
+# AIO_ARCH when no per-arch binary is present.
+staged_arches=()
+for arch in ${AIO_ARCHES}; do
+  candidate="${BIN_DIR}/jetstream-linux-${arch}"
+  if [[ ! -f "${candidate}" ]] && [[ "${arch}" == "${AIO_ARCH}" ]]; then
+    # Single-platform local build: dist/bin/jetstream, but only if it is
+    # actually a Linux ELF (a plain `make build backend` leaves a host binary).
+    if [[ -f "${BIN_DIR}/jetstream" ]] && file "${BIN_DIR}/jetstream" | grep -q "ELF"; then
+      candidate="${BIN_DIR}/jetstream"
+    fi
+  fi
+  if [[ -f "${candidate}" ]] && file "${candidate}" | grep -q "ELF"; then
+    staged_arches+=("${arch}:${candidate}")
+  fi
+done
 
-if [[ ! -f "${jetstream_bin}" ]]; then
-  error "Backend binary not found at dist/bin/jetstream"
-  error "  Run: make build backend PLATFORM=linux/${AIO_ARCH}"
-  fail=1
-elif ! file "${jetstream_bin}" | grep -q "ELF"; then
-  error "Backend binary is not a Linux binary — the AIO image needs a Linux ELF"
-  error "  Current binary: $(file "${jetstream_bin}")"
-  error "  Run: make build backend PLATFORM=linux/${AIO_ARCH}"
+if [[ ${#staged_arches[@]} -eq 0 ]]; then
+  error "No Linux backend binary found for any of: ${AIO_ARCHES}"
+  error "  Run: make build            (cross-compiles every platform)"
+  error "  or:  make build backend PLATFORM=linux/${AIO_ARCH}"
   fail=1
 fi
 
@@ -71,9 +82,12 @@ log "Staging all-in-one package (${VERSION})..."
 rm -rf "${PKG_DIR}"
 mkdir -p "${PKG_DIR}"
 
-# Backend binary (ENTRYPOINT runs ./jetstream from /srv)
-cp "${jetstream_bin}" "${PKG_DIR}/jetstream"
-chmod +x "${PKG_DIR}/jetstream"
+# Backend binaries, one per architecture (the Dockerfile copies the one
+# matching TARGETARCH to ./jetstream, which the ENTRYPOINT runs from /srv)
+for entry in "${staged_arches[@]}"; do
+  cp "${entry#*:}" "${PKG_DIR}/jetstream-linux-${entry%%:*}"
+done
+chmod +x "${PKG_DIR}"/jetstream-linux-*
 
 # Frontend assets
 cp -r "${ui_src}" "${PKG_DIR}/ui"

--- a/deploy/all-in-one/stage-aio.sh
+++ b/deploy/all-in-one/stage-aio.sh
@@ -49,15 +49,19 @@ fi
 # AIO_ARCH when no per-arch binary is present.
 staged_arches=()
 for arch in ${AIO_ARCHES}; do
-  candidate="${BIN_DIR}/jetstream-linux-${arch}"
-  if [[ ! -f "${candidate}" ]] && [[ "${arch}" == "${AIO_ARCH}" ]]; then
-    # Single-platform local build: dist/bin/jetstream, but only if it is
-    # actually a Linux ELF (a plain `make build backend` leaves a host binary).
-    if [[ -f "${BIN_DIR}/jetstream" ]] && file "${BIN_DIR}/jetstream" | grep -q "ELF"; then
-      candidate="${BIN_DIR}/jetstream"
-    fi
+  candidate=""
+  # An explicit dist/bin/jetstream wins for AIO_ARCH: it is what
+  # `make build backend PLATFORM=linux/<arch>` just produced, and it must not
+  # be shadowed by an older cross-compiled jetstream-linux-<arch> beside it.
+  # Only usable if it is a Linux ELF — a plain `make build backend` leaves a
+  # host binary there.
+  if [[ "${arch}" == "${AIO_ARCH}" ]] && [[ -f "${BIN_DIR}/jetstream" ]] \
+     && file "${BIN_DIR}/jetstream" | grep -q "ELF"; then
+    candidate="${BIN_DIR}/jetstream"
+  elif [[ -f "${BIN_DIR}/jetstream-linux-${arch}" ]]; then
+    candidate="${BIN_DIR}/jetstream-linux-${arch}"
   fi
-  if [[ -f "${candidate}" ]] && file "${candidate}" | grep -q "ELF"; then
+  if [[ -n "${candidate}" ]] && file "${candidate}" | grep -q "ELF"; then
     staged_arches+=("${arch}:${candidate}")
   fi
 done


### PR DESCRIPTION
## What

The all-in-one image is built `linux/amd64` only, so it cannot run on an arm64
node. That rules out arm64 Kubernetes and every Apple Silicon `kind` cluster,
and `docker run` on an M-series Mac needs emulation.

`make build` already cross-compiles `jetstream-linux-arm64` via
`build/cross-compile.sh`. Only the image build was single-platform.

## How

- `stage-aio.sh` stages one Linux binary per architecture as
  `jetstream-linux-<arch>` instead of a single `jetstream`.
- The Dockerfile takes `ARG TARGETARCH` and copies the matching binary to
  `./jetstream`, so one build context serves both platforms. A plain
  `docker build` still works — TARGETARCH defaults to the host architecture.
- `release.yml` builds `linux/amd64,linux/arm64`.

`stage-aio.sh` also now falls back to a per-arch binary when `dist/bin/jetstream`
exists but is not a Linux ELF, which is what a plain `make build backend` leaves
behind. Previously that combination failed staging rather than using the
cross-compiled binary sitting beside it.

## Verification

Each platform image carries the correct binary, by sha256:

```
staged amd64 sha: f4c3814e27dff58a   in linux/amd64 image: f4c3814e27dff58a
staged arm64 sha: e17d886a82ae0fd8   in linux/arm64 image: e17d886a82ae0fd8
```

`docker buildx build --platform linux/amd64,linux/arm64` succeeds, and a plain
single-platform `docker build` produces a host-arch image that serves HTTP 200.

This came out of standing the console up on a local CF-on-Kubernetes cluster,
where the published image could not be used at all — see #5918.