### PR TITLE
Trust an endpoint's CA certificate

### DIFF
--- a/changelog.d/0007-endpoint-ca-trust.md
+++ b/changelog.d/0007-endpoint-ca-trust.md
@@ -1,0 +1,8 @@
+[BugFixes]
+- An endpoint registered with a CA certificate is now reached using it. The CA
+  was stored on the endpoint but never passed to the CF API client or to the
+  OAuth and OIDC token calls, so against a foundation using a private CA —
+  a lab, or Cloud Foundry on Kubernetes — connecting failed and every read
+  returned `x509: certificate signed by unknown authority`. The console
+  reported this as the endpoint being unreachable, which pointed at the network
+  rather than at certificate trust.

--- a/src/jetstream/auth.go
+++ b/src/jetstream/auth.go
@@ -54,14 +54,14 @@ func (p *portalProxy) GetStratosAuthService() api.StratosAuth {
 }
 
 // login is used for both endpoint and direct UAA login
-func (p *portalProxy) login(c *echo.Context, skipSSLValidation bool, client string, clientSecret string, endpoint string) (uaaRes *api.UAAResponse, u *api.JWTUserTokenInfo, err error) {
+func (p *portalProxy) login(c *echo.Context, skipSSLValidation bool, caCert string, client string, clientSecret string, endpoint string) (uaaRes *api.UAAResponse, u *api.JWTUserTokenInfo, err error) {
 	slog.Debug("login")
 	if c.Request().Method == http.MethodGet {
 		code := c.QueryParam("code")
 		state := c.QueryParam("state")
 		// If this is login for a CNSI, then the redirect URL is slightly different
 		cnsiGUID := c.QueryParam("guid")
-		uaaRes, err = p.getUAATokenWithAuthorizationCode(skipSSLValidation, code, client, clientSecret, endpoint, state, cnsiGUID)
+		uaaRes, err = p.getUAATokenWithAuthorizationCode(skipSSLValidation, caCert, code, client, clientSecret, endpoint, state, cnsiGUID)
 	} else {
 		params := new(api.LoginToCNSIParams)
 		bindErr := api.BindOnce(params, c)
@@ -72,7 +72,7 @@ func (p *portalProxy) login(c *echo.Context, skipSSLValidation bool, client stri
 		if len(params.Username) == 0 || len(params.Password) == 0 {
 			return uaaRes, u, errors.New("needs username and password")
 		}
-		uaaRes, err = p.getUAATokenWithCreds(skipSSLValidation, params.Username, params.Password, client, clientSecret, endpoint)
+		uaaRes, err = p.getUAATokenWithCreds(skipSSLValidation, caCert, params.Username, params.Password, client, clientSecret, endpoint)
 	}
 	if err != nil {
 		return uaaRes, u, err

--- a/src/jetstream/authcnsi.go
+++ b/src/jetstream/authcnsi.go
@@ -335,7 +335,7 @@ func (p *portalProxy) FetchOAuth2Token(cnsiRecord api.CNSIRecord, c *echo.Contex
 
 	tokenEndpoint := fmt.Sprintf("%s/oauth/token", endpoint)
 
-	uaaRes, u, err := p.login(c, cnsiRecord.SkipSSLValidation, cnsiRecord.ClientId, cnsiRecord.ClientSecret, tokenEndpoint)
+	uaaRes, u, err := p.login(c, cnsiRecord.SkipSSLValidation, cnsiRecord.CACert, cnsiRecord.ClientId, cnsiRecord.ClientSecret, tokenEndpoint)
 
 	if err != nil {
 		if httpError, ok := err.(api.ErrHTTPRequest); ok {

--- a/src/jetstream/authuaa.go
+++ b/src/jetstream/authuaa.go
@@ -137,7 +137,7 @@ func (a *uaaAuth) VerifySession(c *echo.Context, sessionUser string, sessionExpi
 	if time.Now().After(time.Unix(sessionExpireTime, 0)) {
 
 		// UAA Token has expired, refresh the token, if that fails, fail the request
-		uaaRes, tokenErr := a.p.getUAATokenWithRefreshToken(a.p.Config.ConsoleConfig.SkipSSLValidation, tr.RefreshToken, a.p.Config.ConsoleConfig.ConsoleClient, a.p.Config.ConsoleConfig.ConsoleClientSecret, a.p.getUAAIdentityEndpoint(), "")
+		uaaRes, tokenErr := a.p.getUAATokenWithRefreshToken(a.p.Config.ConsoleConfig.SkipSSLValidation, "", tr.RefreshToken, a.p.Config.ConsoleConfig.ConsoleClient, a.p.Config.ConsoleConfig.ConsoleClientSecret, a.p.getUAAIdentityEndpoint(), "")
 		if tokenErr != nil {
 			msg := "Could not refresh UAA token"
 			slog.Error(msg, "user", sessionUser, "error", tokenErr)
@@ -191,7 +191,7 @@ func (a *uaaAuth) logout(c *echo.Context) error {
 // loginToUAA performs the underlying login to the UAA endpoint
 func (p *portalProxy) loginToUAA(c *echo.Context) (*api.LoginRes, error) {
 	slog.Debug("loginToUAA")
-	uaaRes, u, err := p.login(c, p.Config.ConsoleConfig.SkipSSLValidation, p.Config.ConsoleConfig.ConsoleClient, p.Config.ConsoleConfig.ConsoleClientSecret, p.getUAAIdentityEndpoint())
+	uaaRes, u, err := p.login(c, p.Config.ConsoleConfig.SkipSSLValidation, "", p.Config.ConsoleConfig.ConsoleClient, p.Config.ConsoleConfig.ConsoleClientSecret, p.getUAAIdentityEndpoint())
 	var resp *api.LoginRes
 	if err != nil {
 		// Check the Error
@@ -294,7 +294,7 @@ func (p *portalProxy) setUAATokenRecord(key string, t api.TokenRecord) error {
 // RefreshUAALogin refreshes the UAA login and optionally stores the new token
 func (p *portalProxy) RefreshUAALogin(username, password string, store bool) error {
 	slog.Debug("RefreshUAALogin", "username", username)
-	uaaRes, err := p.getUAATokenWithCreds(p.Config.ConsoleConfig.SkipSSLValidation, username, password, p.Config.ConsoleConfig.ConsoleClient, p.Config.ConsoleConfig.ConsoleClientSecret, p.getUAAIdentityEndpoint())
+	uaaRes, err := p.getUAATokenWithCreds(p.Config.ConsoleConfig.SkipSSLValidation, "", username, password, p.Config.ConsoleConfig.ConsoleClient, p.Config.ConsoleConfig.ConsoleClientSecret, p.getUAAIdentityEndpoint())
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func (p *portalProxy) RefreshUAALogin(username, password string, store bool) err
 }
 
 // getUAATokenWithAuthorizationCode
-func (p *portalProxy) getUAATokenWithAuthorizationCode(skipSSLValidation bool, code, client, clientSecret, authEndpoint string, state string, cnsiGUID string) (*api.UAAResponse, error) {
+func (p *portalProxy) getUAATokenWithAuthorizationCode(skipSSLValidation bool, caCert string, code, client, clientSecret, authEndpoint string, state string, cnsiGUID string) (*api.UAAResponse, error) {
 	slog.Debug("getUAATokenWithAuthorizationCode")
 
 	body := url.Values{}
@@ -325,11 +325,11 @@ func (p *portalProxy) getUAATokenWithAuthorizationCode(skipSSLValidation bool, c
 	body.Set("client_secret", clientSecret)
 	body.Set("redirect_uri", getSSORedirectURI(state, state, cnsiGUID))
 
-	return p.getUAAToken(body, skipSSLValidation, client, clientSecret, authEndpoint)
+	return p.getUAAToken(body, skipSSLValidation, caCert, client, clientSecret, authEndpoint)
 }
 
 // getUAATokenWithCreds
-func (p *portalProxy) getUAATokenWithCreds(skipSSLValidation bool, username, password, client, clientSecret, authEndpoint string) (*api.UAAResponse, error) {
+func (p *portalProxy) getUAATokenWithCreds(skipSSLValidation bool, caCert string, username, password, client, clientSecret, authEndpoint string) (*api.UAAResponse, error) {
 	slog.Debug("getUAATokenWithCreds")
 
 	body := url.Values{}
@@ -338,11 +338,11 @@ func (p *portalProxy) getUAATokenWithCreds(skipSSLValidation bool, username, pas
 	body.Set("password", password)
 	body.Set("response_type", "token")
 
-	return p.getUAAToken(body, skipSSLValidation, client, clientSecret, authEndpoint)
+	return p.getUAAToken(body, skipSSLValidation, caCert, client, clientSecret, authEndpoint)
 }
 
 // getUAATokenWithRefreshToken
-func (p *portalProxy) getUAATokenWithRefreshToken(skipSSLValidation bool, refreshToken, client, clientSecret, authEndpoint string, scopes string) (*api.UAAResponse, error) {
+func (p *portalProxy) getUAATokenWithRefreshToken(skipSSLValidation bool, caCert string, refreshToken, client, clientSecret, authEndpoint string, scopes string) (*api.UAAResponse, error) {
 	slog.Debug("getUAATokenWithRefreshToken")
 
 	body := url.Values{}
@@ -354,7 +354,7 @@ func (p *portalProxy) getUAATokenWithRefreshToken(skipSSLValidation bool, refres
 		body.Set("scope", scopes)
 	}
 
-	return p.getUAAToken(body, skipSSLValidation, client, clientSecret, authEndpoint)
+	return p.getUAAToken(body, skipSSLValidation, caCert, client, clientSecret, authEndpoint)
 }
 
 // tokenEndpointPattern constrains a UAA/OIDC token endpoint to an absolute
@@ -366,7 +366,7 @@ var tokenEndpointPattern = regexp.MustCompile(
 	`^https?://(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~%-]*)*$`)
 
 // getUAAToken
-func (p *portalProxy) getUAAToken(body url.Values, skipSSLValidation bool, client, clientSecret, authEndpoint string) (*api.UAAResponse, error) {
+func (p *portalProxy) getUAAToken(body url.Values, skipSSLValidation bool, caCert string, client, clientSecret, authEndpoint string) (*api.UAAResponse, error) {
 	slog.Debug("getUAAToken", "authEndpoint", authEndpoint)
 
 	// Checked here rather than where the endpoint is built: setupGetAvailableScopes
@@ -387,7 +387,7 @@ func (p *portalProxy) getUAAToken(body url.Values, skipSSLValidation bool, clien
 	req.SetBasicAuth(url.QueryEscape(client), url.QueryEscape(clientSecret))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
 
-	var h = p.GetHttpClientForRequest(req, skipSSLValidation, "")
+	var h = p.GetHttpClientForRequest(req, skipSSLValidation, caCert)
 	res, err := h.Do(req)
 	if err != nil || res.StatusCode != http.StatusOK {
 		slog.Error("error performing the http request", "authEndpoint", authEndpoint, "response", res, "error", err)
@@ -435,7 +435,7 @@ func (p *portalProxy) RefreshUAAToken(userGUID string) (t api.TokenRecord, err e
 		return t, fmt.Errorf("UAA Token info could not be found for user with GUID %s", userGUID)
 	}
 
-	uaaRes, err := p.getUAATokenWithRefreshToken(p.Config.ConsoleConfig.SkipSSLValidation, userToken.RefreshToken,
+	uaaRes, err := p.getUAATokenWithRefreshToken(p.Config.ConsoleConfig.SkipSSLValidation, "", userToken.RefreshToken,
 		p.Config.ConsoleConfig.ConsoleClient, p.Config.ConsoleConfig.ConsoleClientSecret, p.getUAAIdentityEndpoint(), "")
 	if err != nil {
 		err = fmt.Errorf("UAA Token refresh request failed: %v", err)

--- a/src/jetstream/authuaa_tls_test.go
+++ b/src/jetstream/authuaa_tls_test.go
@@ -1,0 +1,41 @@
+// src/jetstream/authuaa_tls_test.go
+package main
+
+import (
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The token endpoint of a foundation with a private CA is reached with the CA
+// the endpoint was registered with. Without it, registering an endpoint with a
+// CA succeeds and connecting to it then fails, because the OAuth call trusts
+// nothing but the system roots.
+func TestGetUAATokenUsesEndpointCACert(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"r","token_type":"bearer","expires_in":100,"scope":"s"}`))
+	}))
+	defer srv.Close()
+
+	caPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.Certificate().Raw,
+	}))
+
+	p := &portalProxy{}
+
+	t.Run("with the CA the request succeeds", func(t *testing.T) {
+		_, err := p.getUAAToken(url.Values{}, false, caPEM, "client", "secret", srv.URL)
+		require.NoError(t, err)
+	})
+
+	t.Run("without the CA it fails verification", func(t *testing.T) {
+		_, err := p.getUAAToken(url.Values{}, false, "", "client", "secret", srv.URL)
+		require.Error(t, err)
+	})
+}

--- a/src/jetstream/oauth_requests.go
+++ b/src/jetstream/oauth_requests.go
@@ -161,7 +161,15 @@ func (p *portalProxy) RefreshOAuthToken(skipSSLValidation bool, cnsiGUID, userGU
 
 	tokenEndpointWithPath := fmt.Sprintf("%s/oauth/token", tokenEndpoint)
 
-	uaaRes, err := p.getUAATokenWithRefreshToken(skipSSLValidation, userToken.RefreshToken, client, clientSecret, tokenEndpointWithPath, "")
+	// A refresh talks to the endpoint's own token server, so it needs the same
+	// CA the endpoint was registered with. Looked up here rather than added to
+	// the signature: RefreshOAuthToken is part of the plugin-facing interface.
+	caCert := ""
+	if rec, recErr := p.GetCNSIRecord(cnsiGUID); recErr == nil {
+		caCert = rec.CACert
+	}
+
+	uaaRes, err := p.getUAATokenWithRefreshToken(skipSSLValidation, caCert, userToken.RefreshToken, client, clientSecret, tokenEndpointWithPath, "")
 	if err != nil {
 		slog.Warn("[diag refresh] UAA call FAILED", "endpoint", cnsiGUID, "user", userGUID, "error", err)
 		// OAUTH TOKENS ONLY: this function is the OAuth refresh path, but it

--- a/src/jetstream/oidc_requests.go
+++ b/src/jetstream/oidc_requests.go
@@ -52,7 +52,14 @@ func (p *portalProxy) RefreshOidcToken(skipSSLValidation bool, cnsiGUID, userGUI
 		}
 	}
 
-	uaaRes, err := p.getUAATokenWithRefreshToken(skipSSLValidation, userToken.RefreshToken, client, clientSecret, tokenEndpointWithPath, scopes)
+	// As in the OAuth refresh path: the endpoint's CA has to reach its token
+	// server, or a foundation with a private CA cannot refresh.
+	caCert := ""
+	if rec, recErr := p.GetCNSIRecord(cnsiGUID); recErr == nil {
+		caCert = rec.CACert
+	}
+
+	uaaRes, err := p.getUAATokenWithRefreshToken(skipSSLValidation, caCert, userToken.RefreshToken, client, clientSecret, tokenEndpointWithPath, scopes)
 	if err != nil {
 		return t, fmt.Errorf("token refresh request failed: %v", err)
 	}

--- a/src/jetstream/plugins/cloudfoundry/native_handlers.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers.go
@@ -67,7 +67,7 @@ func (c *CloudFoundrySpecification) nativeProxy() nativeCFProxy {
 }
 
 // newCapiClient creates a capi client authenticated with Jetstream's stored token.
-// Uses cfclient.NewWithToken so no UAA discovery occurs — the token is passed directly.
+// Uses an explicit AccessToken so no UAA discovery occurs — the token is passed directly.
 //
 // Proactively refreshes the stored token if it has expired before handing it
 // to capi. Without this check, cfclient sends a dead token and CF returns
@@ -102,7 +102,23 @@ func newCapiClient(ctx context.Context, proxy nativeCFProxy, cnsiGUID, userGUID 
 		slog.Info("[diag refresh] OK", "cnsi", cnsiGUID, "user", userGUID, "new_expiry", refreshed.TokenExpiry)
 		tokenRecord = refreshed
 	}
-	client, err := cfclient.NewWithToken(ctx, cnsiRecord.APIEndpoint.String(), tokenRecord.AuthToken)
+	// The endpoint's CA has to travel with the client. Without it a
+	// foundation using a private CA — a lab, or CF on Kubernetes — fails
+	// every native read with "x509: certificate signed by unknown authority"
+	// while the endpoint still shows as connected, so the console reports it
+	// unreachable and points at the network rather than at trust.
+	//
+	// SkipSSLValidation is deliberately NOT forwarded. capi gates
+	// SkipTLSVerify behind CAPI_DEV_MODE and treats CACertPEM as the
+	// supported route for a real foundation, so registering the endpoint
+	// with its CA is what makes these reads work. Setting skip-ssl alone
+	// leaves this path failing on purpose rather than silently disabling
+	// verification for every native call.
+	client, err := cfclient.New(ctx, &capi.Config{
+		APIEndpoint: cnsiRecord.APIEndpoint.String(),
+		AccessToken: tokenRecord.AuthToken,
+		CACertPEM:   cnsiRecord.CACert,
+	})
 	if err != nil {
 		// Raw error so the middleware can classify (e.g. an unreachable API
 		// endpoint surfaces as a transport/net error → unreachable).

--- a/src/jetstream/plugins/cloudfoundry/native_handlers_tls_test.go
+++ b/src/jetstream/plugins/cloudfoundry/native_handlers_tls_test.go
@@ -1,0 +1,82 @@
+// src/jetstream/plugins/cloudfoundry/native_handlers_tls_test.go
+package cloudfoundry
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/stretchr/testify/require"
+)
+
+// A CF with a self-signed CA is the normal case for a lab foundation and for
+// CF on Kubernetes. The endpoint record carries SkipSSLValidation and CACert
+// for exactly this; both have to reach the capi client or every native read
+// fails with "x509: certificate signed by unknown authority" while the
+// endpoint still reports itself connected.
+func newTLSCFStub(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(nil)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func capiClientFor(t *testing.T, rec api.CNSIRecord) error {
+	t.Helper()
+	proxy := &mockNativeCFProxy{
+		userID:      "user-1",
+		cnsiRecord:  rec,
+		tokenRecord: api.TokenRecord{AuthToken: "token", TokenExpiry: 0},
+	}
+	client, err := newCapiClient(context.Background(), proxy, "cnsi-1", "user-1")
+	if err != nil {
+		return err
+	}
+	// Force a real request so the TLS handshake actually happens.
+	_, err = client.Organizations().List(context.Background(), nil)
+	return err
+}
+
+// SkipSSLValidation alone is deliberately not enough on this path. capi gates
+// SkipTLSVerify behind CAPI_DEV_MODE and documents CACertPEM as the supported
+// route for a real foundation, so forwarding skip-ssl here would either fail
+// on that gate or disable verification for every native call. Registering the
+// endpoint with its CA is the fix; this test pins the behaviour so it is not
+// "corrected" back into forwarding the flag.
+func TestNewCapiClientDoesNotForwardSkipSSLValidation(t *testing.T) {
+	srv := newTLSCFStub(t)
+	endpoint, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	err = capiClientFor(t, api.CNSIRecord{
+		APIEndpoint:       endpoint,
+		SkipSSLValidation: true,
+	})
+	require.Error(t, err, "skip-ssl alone must not silence verification")
+	require.Contains(t, err.Error(), "x509",
+		"without a CA the read should still fail verification")
+}
+
+func TestNewCapiClientTrustsEndpointCACert(t *testing.T) {
+	srv := newTLSCFStub(t)
+	endpoint, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.Certificate().Raw,
+	})
+
+	err = capiClientFor(t, api.CNSIRecord{
+		APIEndpoint:       endpoint,
+		SkipSSLValidation: false,
+		CACert:            string(caPEM),
+	})
+	if err != nil {
+		require.NotContains(t, err.Error(), "x509",
+			"the endpoint CACert must be trusted by the capi client")
+	}
+}

--- a/src/jetstream/setup_console.go
+++ b/src/jetstream/setup_console.go
@@ -88,7 +88,7 @@ func (p *portalProxy) setupGetAvailableScopes(c *echo.Context) error {
 
 	// Authenticate with UAA
 	authEndpoint := fmt.Sprintf("%s/oauth/token", consoleConfig.UAAEndpoint)
-	uaaRes, err := p.getUAATokenWithCreds(consoleConfig.SkipSSLValidation, username, password, consoleConfig.ConsoleClient, consoleConfig.ConsoleClientSecret, authEndpoint)
+	uaaRes, err := p.getUAATokenWithCreds(consoleConfig.SkipSSLValidation, "", username, password, consoleConfig.ConsoleClient, consoleConfig.ConsoleClientSecret, authEndpoint)
 	if err != nil {
 		errInfo, ok := err.(api.ErrHTTPRequest)
 		if ok {


### PR DESCRIPTION
## The bug

An endpoint can be registered with a CA certificate, and the record stores it —
but nothing used it. Two paths built their HTTP clients without it:

- `newCapiClient` passed only the endpoint URL and token to the CF API client.
- `getUAAToken` hardcoded an empty CA, so every OAuth and OIDC call to the
  endpoint's token server trusted only the system roots.

Against a foundation with a private CA the result is that registration
succeeds, connecting fails, and any read that does get through returns
`x509: certificate signed by unknown authority`.

What the user sees is worse than the underlying fault: the endpoint shows as
**Connected** with 0 orgs and 0 users and a red *"The endpoint is unreachable or
down"* toast. That points at the network. Only the backend log names TLS.

This was found standing the console up against Cloud Foundry on Kubernetes
(#5918), where the foundation's CA is generated at install time, but it applies
to any lab or internal foundation not using a publicly trusted certificate.

## The fix

Pass the endpoint's `CACert` to the CF API client, and thread it through the
token calls alongside the `skipSSLValidation` flag it already travels with.
Endpoint paths supply `cnsiRecord.CACert`; the console's own UAA has no
endpoint record and supplies none.

The two refresh paths look the record up by GUID rather than taking a new
argument, because `RefreshOAuthToken` is part of the plugin-facing interface.

Most endpoint traffic already did this correctly — `oauth_requests.go`,
`http_basic_requests.go`, `noauth_requests.go`, `metrics`, and
`native_identity_providers.go` all pass `cnsi.CACert`. These two were the
outliers.

### `SkipSSLValidation` is deliberately not forwarded to the CF API client

capi gates `SkipTLSVerify` behind `CAPI_DEV_MODE` and documents `CACertPEM` as
the supported route for a real foundation. Forwarding the flag would either
trip that gate or disable verification for every native call, so registering
the endpoint with its CA is the fix. A test pins this so it is not wired in
later by mistake.

## Verification

Unit tests for both paths, each reverse-tested — reverting the fix turns them
red.

End to end against a real Cloud Foundry on Kubernetes, with no `CAPI_DEV_MODE`
and no CA mounted into the container:

- connect went **500 → 200** — this was the failure that blocked the approach
- x509 errors by endpoint: **12 from an endpoint with no CA, 0 from the endpoint
  registered with one**
- the console renders orgs, spaces, users and a pushed application

Full `make check gate` green.

## Known gap, not addressed here

`AUTO_REG_CF_URL` has no CA counterpart, so an auto-registered endpoint cannot
carry one and still cannot be used against a private-CA foundation. Filed
separately rather than widening this change with a new config surface.