### PR TITLE
Remove the korifi build modifier and packager mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,19 +182,16 @@ endif
 
 # Default: frontend + backend when none specified (unless e2e),
 # but only for verbs that use these modifiers (not clean/dump).
-# korifi counts as a build modifier here (make build korifi = static
-# backend only), so it must suppress the default like the others;
-# tag/untag/line are stamp modifiers and suppress it the same way, as does
+# tag/untag/line are stamp modifiers and suppress the default, as does
 # cert (make dev cert only writes the TLS key pair).
 ifneq ($(filter build test dev stamp,$(MAKECMDGOALS)),)
-ifeq ($($(_HIDE)WANT_FRONTEND)$($(_HIDE)WANT_BACKEND)$($(_HIDE)WANT_E2E)$($(_HIDE)WANT_WEBSITE)$($(_HIDE)WANT_BOOKLETS)$(filter korifi tag untag line cert,$(MAKECMDGOALS)),)
+ifeq ($($(_HIDE)WANT_FRONTEND)$($(_HIDE)WANT_BACKEND)$($(_HIDE)WANT_E2E)$($(_HIDE)WANT_WEBSITE)$($(_HIDE)WANT_BOOKLETS)$(filter tag untag line cert,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_FRONTEND := yes
   $(_HIDE)WANT_BACKEND  := yes
 endif
 endif
 
 $(_HIDE)WANT_CF     :=
-$(_HIDE)WANT_KORIFI :=
 $(_HIDE)WANT_GITHUB :=
 $(_HIDE)WANT_AIO    :=
 $(_HIDE)WANT_PAGES  :=
@@ -205,9 +202,6 @@ endif
 ifneq ($(filter pages,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_PAGES := yes
 endif
-ifneq ($(filter korifi,$(MAKECMDGOALS)),)
-  $(_HIDE)WANT_KORIFI := yes
-endif
 ifneq ($(filter github,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_GITHUB := yes
 endif
@@ -215,7 +209,7 @@ ifneq ($(filter aio,$(MAKECMDGOALS)),)
   $(_HIDE)WANT_AIO := yes
 endif
 ifneq ($(filter release,$(MAKECMDGOALS)),)
-ifeq ($($(_HIDE)WANT_CF)$($(_HIDE)WANT_KORIFI)$($(_HIDE)WANT_GITHUB)$($(_HIDE)WANT_AIO),)
+ifeq ($($(_HIDE)WANT_CF)$($(_HIDE)WANT_GITHUB)$($(_HIDE)WANT_AIO),)
   $(_HIDE)WANT_CF     := yes
   $(_HIDE)WANT_GITHUB := yes
 endif
@@ -309,19 +303,6 @@ ifeq ($($(_HIDE)WANT_CF),yes)
   endif
 endif
 
-# korifi modifier targets linux at the host arch unless PLATFORM is set
-# (a local kind cluster runs the host arch; real clusters override,
-# e.g. make build korifi PLATFORM=linux/amd64)
-ifeq ($($(_HIDE)WANT_KORIFI),yes)
-  ifndef PLATFORM
-    PLATFORM := linux/$($(_HIDE)HOST_ARCH)
-    $(_HIDE)TARGET_OS   := linux
-    $(_HIDE)TARGET_ARCH := $($(_HIDE)HOST_ARCH)
-    $(_HIDE)GO_ENV      := GOOS=linux GOARCH=$($(_HIDE)HOST_ARCH)
-    $(_HIDE)CURRENT_PLATFORM := linux/$($(_HIDE)HOST_ARCH)
-  endif
-endif
-
 $(_HIDE)WANT_CLEAN_DIST :=
 $(_HIDE)WANT_CLEAN_REPO :=
 $(_HIDE)WANT_LINT       :=
@@ -383,8 +364,8 @@ endif
 
 # No-op targets so modifiers don't error
 # Note: lint has its own standalone recipe — not listed here.
-.PHONY: frontend backend website booklets cf korifi github aio pages dist repo version e2e actions packages secrets gate tests coverage summary dependabot tree history licenses modrot semgrep codeql sarif upload tag untag line cert
-frontend backend website booklets cf korifi github aio pages dist repo version e2e actions packages secrets gate tests coverage summary dependabot tree history licenses modrot semgrep codeql sarif upload tag untag line cert:
+.PHONY: frontend backend website booklets cf github aio pages dist repo version e2e actions packages secrets gate tests coverage summary dependabot tree history licenses modrot semgrep codeql sarif upload tag untag line cert
+frontend backend website booklets cf github aio pages dist repo version e2e actions packages secrets gate tests coverage summary dependabot tree history licenses modrot semgrep codeql sarif upload tag untag line cert:
 	@:
 
 # No-op targets for bump modifiers (consumed by BUMP_MOD filter).
@@ -981,37 +962,6 @@ define release.cf
 endef
 $(call register, release, cf)
 
-# ── Korifi ────────────────────────────────────────────────────
-# Korifi runs droplets on the Paketo jammy run image, which has no
-# glibc loader at the paths a dynamically linked cgo binary expects.
-# This target predates the pure-Go ncruces sqlite driver (see
-# sqlitestore.go) — that was the original reason cgo was needed here,
-# and it no longer applies: a plain CGO_ENABLED=0 build (build.backend's
-# approach) is already static with no glibc dependency, verified against
-# this same GOOS/GOARCH. Left as the static-cgo/zig build for now since
-# Korifi has no active maintainer to validate a change here; the target
-# still needs to build, just isn't worth touching further right now.
-# Korifi also has no binary_buildpack; the package manifest uses
-# paketo-buildpacks/procfile instead.
-
-define build.korifi
-	$(call require_tool,zig,Required for the static cgo cross-compile — install via: brew install zig)
-	@echo "Building static backend for $($(_HIDE)CURRENT_PLATFORM) (Korifi)..."
-	@mkdir -p $($(_HIDE)BIN_DIR)
-	cd src/jetstream && CGO_ENABLED=1 GOOS=linux GOARCH=$($(_HIDE)TARGET_ARCH) \
-		CC="zig cc -target $(if $(filter arm64,$($(_HIDE)TARGET_ARCH)),aarch64,x86_64)-linux-musl" \
-		go build -ldflags "$($(_HIDE)GO_LDFLAGS) -linkmode external -extldflags -static" \
-		-o ../../$($(_HIDE)BIN_DIR)/jetstream
-	@echo "Backend built (static): $($(_HIDE)BIN_DIR)/jetstream"
-endef
-$(call register, build, korifi, $(_HIDE)gen-plugins)
-
-define release.korifi
-	@chmod +x build/release-cf.sh
-	@./build/release-cf.sh "$($(_HIDE)SEMVER_VERSION)" korifi
-endef
-$(call register, release, korifi)
-
 # ── GitHub release ────────────────────────────────────────────
 
 define release.github
@@ -1032,14 +982,14 @@ $(call register, release, aio)
 
 # ── Release checksums ────────────────────────────────────────
 # Checksums are a property of the artifacts: every artifact-producing
-# release invocation ends by staging the loose cf/korifi zips into
+# release invocation ends by staging the loose cf zip into
 # dist/release and regenerating a single SHA256SUMS over everything
 # there. Exact-version filenames so stale zips from earlier builds are
 # never picked up. Standalone regen (post-unpublish asset fix):
 # ./build/create-checksums.sh
 define release.checksums
 	@mkdir -p $($(_HIDE)RELEASE_DIR)
-	@for z in $($(_HIDE)DIST_DIR)/stratos-cf-$($(_HIDE)SEMVER_VERSION).zip $($(_HIDE)DIST_DIR)/stratos-korifi-$($(_HIDE)SEMVER_VERSION).zip; do \
+	@for z in $($(_HIDE)DIST_DIR)/stratos-cf-$($(_HIDE)SEMVER_VERSION).zip; do \
 		if [ -f "$$z" ]; then cp "$$z" $($(_HIDE)RELEASE_DIR)/; fi; \
 	done
 	@chmod +x build/create-checksums.sh
@@ -1049,7 +999,7 @@ $(call register_always, release, checksums)
 # Appended after every artifact modifier registration so it runs last;
 # gated on an artifact actually landing in dist/ (aio only stages a
 # docker build context — nothing to checksum).
-$(_HIDE)DEPS_release += $(if $($(_HIDE)WANT_CF)$($(_HIDE)WANT_KORIFI)$($(_HIDE)WANT_GITHUB),$(_HIDE)release.checksums)
+$(_HIDE)DEPS_release += $(if $($(_HIDE)WANT_CF)$($(_HIDE)WANT_GITHUB),$(_HIDE)release.checksums)
 
 # ── Release lifecycle (tag → publish / unpublish → untag) ────
 #   make stamp tag [VERSION=X]      create + push the annotated release tag
@@ -1334,7 +1284,7 @@ $(_HIDE)finalize-and-reexec:
 	@./build/version-bump.sh bump release
 	@echo "Re-running: $(MAKE) $(MAKECMDGOALS)"
 	@$(MAKE) FINAL= $(MAKECMDGOALS)
-$(filter-out frontend backend cf korifi github dist version e2e actions packages secrets lint gate tests coverage tree history licenses tag untag line,$(MAKECMDGOALS)): $(_HIDE)finalize-and-reexec ; @:
+$(filter-out frontend backend cf github dist version e2e actions packages secrets lint gate tests coverage tree history licenses tag untag line,$(MAKECMDGOALS)): $(_HIDE)finalize-and-reexec ; @:
 else ifneq ($(FINAL),)
 $(error Unknown FINAL value '$(FINAL)' — supported: strip)
 endif
@@ -1380,7 +1330,7 @@ endif
 #                         (defined in the E2E section, above)
 
 define clean.release
-	rm -rf $($(_HIDE)DIST_DIR)/release $($(_HIDE)DIST_DIR)/cf-package $($(_HIDE)DIST_DIR)/korifi-package $($(_HIDE)DIST_DIR)/install $($(_HIDE)DIST_DIR)/stratos-cf-*.zip $($(_HIDE)DIST_DIR)/stratos-korifi-*.zip
+	rm -rf $($(_HIDE)DIST_DIR)/release $($(_HIDE)DIST_DIR)/cf-package $($(_HIDE)DIST_DIR)/install $($(_HIDE)DIST_DIR)/stratos-cf-*.zip
 endef
 
 define clean.dist
@@ -1481,7 +1431,6 @@ help:
 	@echo "  make build frontend       Build frontend only"
 	@echo "  make build backend        Cross-compile all backend platforms"
 	@echo "  make build backend PLATFORM=linux/amd64  Build single platform"
-	@echo "  make build korifi         Static cgo backend for Korifi (linux/host-arch)"
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test                 Run all tests"
@@ -1503,7 +1452,6 @@ help:
 	@echo "Release:"
 	@echo "  make release              Create CF zip + GitHub archives (+ SHA256SUMS)"
 	@echo "  make release cf           CF-pushable zip only"
-	@echo "  make release korifi       Korifi-pushable zip (Paketo procfile manifest)"
 	@echo "  make release github       GitHub release archives only"
 	@echo "  make changelog            Warn about dependency bumps missing from changelog.d"
 	@echo "  make preview              Render the assembled release notes as the release page will show them"

--- a/actions.mk
+++ b/actions.mk
@@ -20,7 +20,6 @@ $(_HIDE)FLAG_backend     := $($(_HIDE)WANT_BACKEND)
 $(_HIDE)FLAG_website     := $($(_HIDE)WANT_WEBSITE)
 $(_HIDE)FLAG_booklets    := $($(_HIDE)WANT_BOOKLETS)
 $(_HIDE)FLAG_cf          := $($(_HIDE)WANT_CF)
-$(_HIDE)FLAG_korifi      := $($(_HIDE)WANT_KORIFI)
 $(_HIDE)FLAG_github      := $($(_HIDE)WANT_GITHUB)
 $(_HIDE)FLAG_aio         := $($(_HIDE)WANT_AIO)
 $(_HIDE)FLAG_pages       := $($(_HIDE)WANT_PAGES)
@@ -51,7 +50,7 @@ $(_HIDE)FLAG_line        := $($(_HIDE)WANT_LINE)
 $(_HIDE)FLAG_cert        := $($(_HIDE)WANT_CERT)
 
 # Known modifiers — the set checked during validation in declare_verb
-$(_HIDE)KNOWN_MODS := frontend backend website booklets cf korifi github aio pages e2e dist repo version actions packages secrets lint gate tests coverage summary dependabot tree history licenses modrot semgrep codeql sarif upload tag untag line cert
+$(_HIDE)KNOWN_MODS := frontend backend website booklets cf github aio pages e2e dist repo version actions packages secrets lint gate tests coverage summary dependabot tree history licenses modrot semgrep codeql sarif upload tag untag line cert
 
 # Known verbs — populated by declare_verb, checked for collisions
 $(_HIDE)KNOWN_VERBS :=

--- a/build/release-cf.sh
+++ b/build/release-cf.sh
@@ -2,11 +2,7 @@
 #
 # Stage and zip Stratos for Cloud Foundry deployment.
 #
-# Usage: ./build/release-cf.sh [VERSION] [MODE]
-#
-# MODE: cf (default) — classic CF manifest (binary_buildpack)
-#       korifi       — Korifi manifest (paketo-buildpacks/procfile;
-#                      requires a statically linked binary — make build korifi)
+# Usage: ./build/release-cf.sh [VERSION]
 #
 # Validates that required build artifacts exist before packaging.
 # Does NOT build anything — run 'make build' first.
@@ -14,18 +10,12 @@
 set -euo pipefail
 
 VERSION="${1:-$(node -p "require('./package.json').version" 2>/dev/null || echo "dev")}"
-MODE="${2:-cf}"
-
-case "${MODE}" in
-  cf|korifi) ;;
-  *) echo "ERROR: unknown mode '${MODE}' — supported: cf, korifi" >&2; exit 1 ;;
-esac
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST_DIR="${ROOT_DIR}/dist"
 BIN_DIR="${DIST_DIR}/bin"
-PKG_DIR="${DIST_DIR}/${MODE}-package"
-ZIP_FILE="${DIST_DIR}/stratos-${MODE}-${VERSION}.zip"
+PKG_DIR="${DIST_DIR}/cf-package"
+ZIP_FILE="${DIST_DIR}/stratos-cf-${VERSION}.zip"
 
 log()   { echo "-----> $1"; }
 error() { echo "ERROR: $1" >&2; }
@@ -47,14 +37,13 @@ else
 fi
 
 # Backend binary — CF requires a Linux ELF binary (amd64 or arm64)
-# Prefer an explicit dist/bin/jetstream (from `make build PLATFORM=linux/amd64`
-# or `make build korifi`); for cf mode, fall back to the cross-compiled
-# artifact from a plain `make build`, so `make build release cf github`
-# composes in one pass. korifi keeps requiring its own static build below.
+# Prefer an explicit dist/bin/jetstream (from `make build PLATFORM=linux/amd64`),
+# falling back to the cross-compiled artifact from a plain `make build`, so
+# `make build release cf github` composes in one pass.
 CF_ARCH="${CF_ARCH:-amd64}"
 jetstream_bin="${BIN_DIR}/jetstream"
 took_fallback=false
-if [[ ! -f "${jetstream_bin}" && "${MODE}" == "cf" && -f "${BIN_DIR}/jetstream-linux-${CF_ARCH}" ]]; then
+if [[ ! -f "${jetstream_bin}" && -f "${BIN_DIR}/jetstream-linux-${CF_ARCH}" ]]; then
   jetstream_bin="${BIN_DIR}/jetstream-linux-${CF_ARCH}"
   took_fallback=true
 fi
@@ -79,11 +68,6 @@ elif ! file "${jetstream_bin}" | grep -q "ELF"; then
   error "Backend binary is not a Linux binary — CF requires a Linux ELF binary"
   error "  Current binary: $(file "${jetstream_bin}")"
   error "  Run: make build PLATFORM=linux/amd64  (or linux/arm64)"
-  fail=1
-elif [[ "${MODE}" == "korifi" ]] && ! file "${jetstream_bin}" | grep -q "statically linked"; then
-  error "Backend binary is dynamically linked — Korifi's run image cannot exec it"
-  error "  Current binary: $(file "${jetstream_bin}")"
-  error "  Run: make build korifi"
   fail=1
 fi
 
@@ -128,38 +112,7 @@ fi
 echo "web: ./jetstream" > "${PKG_DIR}/Procfile"
 
 # CF manifest
-if [[ "${MODE}" == "korifi" ]]; then
-  # Stable per-workstation key, generated once and reused so data the
-  # console encrypted under it (endpoint tokens) survives repackaging.
-  # A shared hardcoded key would be a credential leak; a fresh key per
-  # package would orphan previously encrypted data.
-  KEY_FILE="${DIST_DIR}/.korifi-encryption-key"
-  if [[ ! -f "${KEY_FILE}" ]]; then
-    (umask 077 && openssl rand -hex 32 > "${KEY_FILE}")
-  fi
-  ENCRYPTION_KEY="$(cat "${KEY_FILE}")"
-  cat > "${PKG_DIR}/manifest.yml" <<MANIFEST
-applications:
-  - name: console
-    memory: 512M
-    disk_quota: 1024M
-    timeout: 180
-    buildpacks:
-      - paketo-buildpacks/procfile
-    health-check-type: port
-    env:
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
-      SESSION_STORE_EXPIRY: "240"
-      # The CF API address inferred from VCAP_APPLICATION may not be
-      # reachable from inside the cluster (on kind it is localhost).
-      # Target the Korifi API service directly; its certificate does
-      # not carry the service hostname, hence the SSL skip. Adjust
-      # both for a non-default install.
-      CF_API_URL: https://korifi-api-svc.korifi.svc.cluster.local
-      SKIP_SSL_VALIDATION: "true"
-MANIFEST
-else
-  cat > "${PKG_DIR}/manifest.yml" <<'MANIFEST'
+cat > "${PKG_DIR}/manifest.yml" <<'MANIFEST'
 applications:
   - name: console
     memory: 512M
@@ -176,7 +129,6 @@ applications:
 # Force the console to use secured communication with the Cloud Foundry API endpoint
 #       CF_API_FORCE_SECURE: true
 MANIFEST
-fi
 
 # ── Create zip ────────────────────────────────────────────────
 

--- a/changelog.d/0008-remove-korifi-build-mode.md
+++ b/changelog.d/0008-remove-korifi-build-mode.md
@@ -1,0 +1,9 @@
+[Chores]
+- Removed the `korifi` build modifier and the matching `release-cf.sh`
+  mode. Korifi is retired — RFC-0060 was accepted on 2026-07-10 — and CF
+  on Kubernetes is its replacement. `make build korifi` was the only
+  consumer of `zig` in the build, needed for a static cgo cross-compile
+  back when the sqlite driver required cgo; the pure-Go `ncruces` driver
+  removed that need some time ago, so no build path asks for a C
+  cross-compiler any more. The packager loses its `MODE` parameter along
+  with the alternate Paketo procfile manifest it generated.

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -150,7 +150,7 @@ artifact values produce clear errors from `playwright test` itself.
 | `make release` | All of the above | Create both CF zip and GitHub archives | Both |
 
 Every artifact-producing `release` invocation finishes by staging the
-cf/korifi zip (when present) into `dist/release/` and regenerating a single
+cf zip (when present) into `dist/release/` and regenerating a single
 `SHA256SUMS` over everything there. `./build/create-checksums.sh` remains
 callable standalone for the exceptional regen case (fix an asset after
 `make unpublish`, re-checksum, re-publish).
@@ -336,10 +336,9 @@ hardcodes `CGO_ENABLED=0`, so it never invokes a C cross-compiler — Go's own
 toolchain ships every `GOOS`/`GOARCH` combination self-contained, making
 the build host-arch-independent by construction: an Apple Silicon (arm64)
 machine cross-compiles `linux/amd64` exactly as readily as an amd64 machine
-cross-compiles `linux/arm64`, verified directly. The one exception is
-`build.korifi`, which deliberately uses `CGO_ENABLED=1` + `zig` for a
-static-cgo build — that path does need a real (portable) C cross-compiler,
-which is precisely why it reaches for `zig` instead of the host's own `cc`.
+cross-compiles `linux/arm64`, verified directly. No build path needs a C
+cross-compiler: the sqlite driver is pure Go (`ncruces`), so nothing in the
+tree asks for cgo.
 
 ### Documentation (docs/ → HTML or PDF/epub)
 

--- a/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
+++ b/src/frontend/packages/core/src/features/endpoints/endpoint-helpers.ts
@@ -14,8 +14,8 @@ export function getEndpointUsername(endpoint: EndpointModel) {
 
 // An endpoint is only effectively connected while its stored token is still
 // usable. An expired token must read as Disconnected rather than a broken
-// card — e.g. korifi pasted tokens have no refresh, so every session ends in
-// expiry (#5588). This expiry math now lives in `computeConnectionStatus`
+// card — e.g. pasted Kubernetes tokens have no refresh, so every session
+// ends in expiry (#5588). This expiry math now lives in `computeConnectionStatus`
 // (store package, endpoint.types.ts) and is baked into `connectionStatus` at
 // hydration time — the manual token_renewable/token_expiry check that used
 // to live here is redundant with that computed status. Sole caller is the


### PR DESCRIPTION
Korifi is retired — [RFC-0060](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0060-korifi-retirement.md) was accepted on 2026-07-10 — and CF on Kubernetes is its replacement. The build system still carried a `korifi` modifier and the CF packager still had a matching mode, both targeting a project that is going away.

## What goes

**`make build korifi` / `make release korifi`** — all five modifier registrations (flag declaration, goal parse, default suppression escape list, `actions.mk` FLAG + `KNOWN_MODS`, goal rule), both recipes, the host-arch platform block, the korifi zip in the release checksum glob and its `DEPS_release` gate, the `clean` paths, and the two `make help` lines.

**`build/release-cf.sh`** — korifi was the only mode other than the default, so the `MODE` parameter goes with it: the case guard, the MODE-derived package and zip names, the statically-linked binary check, and the alternate Paketo procfile manifest with its generated `.korifi-encryption-key`. The fallback to the cross-compiled artifact was gated on `MODE == cf` and is now unconditional, which is what it already meant.

**Docs and a stale comment** — `docs/build-and-packaging.md`, plus a connection-status comment in `endpoint-helpers.ts` that cited korifi pasted tokens as its example of tokens with no refresh. Pasted Kubernetes tokens are the shipping example of the same property (`kubernetes/auth/token.go:53` — "Token auth has no token refresh or expiry").

## Incidental: zig is no longer a build dependency

`build.korifi` was the only consumer of `zig` in the build. It needed a static cgo cross-compile back when the sqlite driver required cgo; the pure-Go `ncruces` driver removed that need some time ago, and the recipe's own comment said as much. With it gone there is no build path that asks for a C cross-compiler, and `zig` has zero references left across `Makefile`, `actions.mk`, `docs/` and `build/`. The cross-compilation section of the docs no longer needs its "one exception" caveat.

## Verification

A positive control first, so the empty greps mean something — `make dump actions | grep -c korifi` and `make help | grep -c korifi` both go **2 → 0**.

- `make -n build`, `make -n build backend` and `make -n release cf` diff clean against pre-change baselines, except the intended korifi zip leaving the checksum glob
- `make -n build korifi` now falls through to the unknown-target case
- Ten verb/modifier combinations checked for collision and warning output — zero hits
- `shellcheck` clean on `release-cf.sh`
- `make check gate` green, and the log carries no warnings

The one remaining `korifi` string in the tree is in `changelog.d/0005`, which is shipped history for an already-merged PR and is left alone deliberately.