### PR TITLE
Default the auth form config in the connect dialog

### DIFF
--- a/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.ts
+++ b/src/frontend/packages/core/src/features/endpoints/connect-endpoint/connect-endpoint.component.ts
@@ -199,7 +199,10 @@ export class ConnectEndpointComponent implements OnInit, OnDestroy {
 
     this.authFormComponentRef = this.container.createComponent<IAuthForm>(authType.component);
     this.authFormComponentRef.instance.formGroup = this.endpointForm;
-    this.authFormComponentRef.instance.config = authType.config;
+    // Auth types without a config (e.g. the generic Bearer/Token entries)
+    // must not overwrite the form component's `config = {}` default with
+    // undefined — templates read fields like config.helpText unguarded.
+    this.authFormComponentRef.instance.config = authType.config ?? {};
     if (this.pDisabled) { this.endpointForm.disable(); } else { this.endpointForm.enable(); }
   }
 


### PR DESCRIPTION
`EndpointAuthTypeConfig.config` is optional, and `TokenEndpointComponent` declares `@Input() config: any = {}` precisely so it has something to read when none is supplied. The connect dialog defeated that default:

```ts
this.authFormComponentRef.instance.config = authType.config;   // undefined when omitted
```

Its template then reads `config.helpText` and `config.title` unguarded, so an auth type without a config throws instead of rendering.

## Not reachable today

Worth stating plainly: this fixes nothing user-visible on `develop`. `TokenEndpointComponent` has exactly two registrations — the `github` and `gitlab` subtypes in `git-entity-generator.ts` — and both spread `BaseEndpointAuth.Token`/`.Bearer` and then supply their own `config`. A sweep of every `IAuthForm` implementation in `core` and `kubernetes` confirms it is the only auth form template that reads `config.` at all.

What makes it worth the line is that nothing but coincidence holds it up. The type says the field is optional, the component declares a default for exactly that case, and a new registration that spreads a base auth type without adding a config would throw — which is how this was found.

## No test

The guard is a null-coalesce on a type-optional field. The form-creation path it sits in is private and would need a `ViewContainerRef`/TestBed harness costing considerably more than the line it protects, so I have not added one.

`make check gate` is green.