### PR TITLE
Give auto-registration a CA certificate

### DIFF
--- a/changelog.d/0009-auto-register-ca-cert.md
+++ b/changelog.d/0009-auto-register-ca-cert.md
@@ -1,0 +1,13 @@
+[BugFixes]
+- `AUTO_REG_CF_URL` had no way to supply a CA certificate, so on a foundation
+  using a private authority the auto-registered endpoint reported itself
+  connected and then failed every read with
+  `x509: certificate signed by unknown authority`, while the same endpoint
+  registered by hand with its CA worked. `SKIP_SSL_VALIDATION` was not a
+  substitute: the CF API client will not honour it.
+  `AUTO_REG_CF_CA_CERT` now takes the PEM inline and `AUTO_REG_CF_CA_CERT_PATH`
+  reads it from a file, mirroring `CONSOLE_PROXY_CERT` and
+  `CONSOLE_PROXY_CERT_PATH`. The path form is what a Kubernetes deployment
+  wants, where the CA is a mounted secret; it wins over the inline value, and a
+  path that cannot be read fails the registration rather than silently creating
+  a CA-less endpoint.

--- a/docs/developer/backend.md
+++ b/docs/developer/backend.md
@@ -112,9 +112,29 @@ To automatically register a Cloud Foundry add the environment variable/config se
 
 ```
 AUTO_REG_CF_URL=<api url of cf>
+AUTO_REG_CF_NAME=<name shown in the console>
 ```
 
 Jetstream will then attempt to auto-connect to it with the credentials supplied when logging into Stratos.
+
+If the foundation uses a private certificate authority, give the endpoint its CA
+as well. Without one the endpoint registers, reports itself connected, and then
+fails every read with `x509: certificate signed by unknown authority`;
+`SKIP_SSL_VALIDATION` is not a substitute, because the CF API client will not
+honour it.
+
+```
+AUTO_REG_CF_CA_CERT=<PEM>
+AUTO_REG_CF_CA_CERT_PATH=<path to a PEM file>
+```
+
+The path form is what a Kubernetes deployment wants, where the CA arrives as a
+mounted secret. It takes precedence over the inline value, and a path that
+cannot be read is an error rather than a silent fall back to no CA.
+
+These apply when the endpoint is first registered. An endpoint already
+auto-registered without a CA keeps the empty one — remove it from the console
+and let it register again.
 
 #### Running Jetstream in a container
 

--- a/docs/devops_guide.md
+++ b/docs/devops_guide.md
@@ -390,6 +390,7 @@ LOG_LEVEL=info|debug|warn|error
 
 # Features
 AUTO_REG_CF_URL=https://api.cf.example.com
+AUTO_REG_CF_CA_CERT_PATH=/srv/certs/ca.crt
 SSO_LOGIN=true|false
 SSO_OPTIONS=provider1,provider2
 ```

--- a/src/jetstream/api/structs.go
+++ b/src/jetstream/api/structs.go
@@ -451,6 +451,8 @@ type PortalConfig struct {
 	EncryptionKey                      string   `configName:"ENCRYPTION_KEY"`
 	AutoRegisterCFUrl                  string   `configName:"AUTO_REG_CF_URL"`
 	AutoRegisterCFName                 string   `configName:"AUTO_REG_CF_NAME"`
+	AutoRegisterCFCACert               string   `configName:"AUTO_REG_CF_CA_CERT"`
+	AutoRegisterCFCACertPath           string   `configName:"AUTO_REG_CF_CA_CERT_PATH"`
 	SSOLogin                           bool     `configName:"SSO_LOGIN"`
 	SSOOptions                         string   `configName:"SSO_OPTIONS"`
 	SSOAllowList                       string   `configName:"SSO_ALLOWLIST,SSO_WHITELIST"`

--- a/src/jetstream/plugins/cloudfoundry/auto_register_ca_test.go
+++ b/src/jetstream/plugins/cloudfoundry/auto_register_ca_test.go
@@ -1,0 +1,150 @@
+// src/jetstream/plugins/cloudfoundry/auto_register_ca_test.go
+package cloudfoundry
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/api"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// AUTO_REG_CF_URL registers an endpoint at startup but had no way to give it a
+// CA, so on a foundation with a private authority the auto-registered endpoint
+// reported itself connected and then failed every read with x509 (#5922). The
+// CA is the only route: capi will not honour skip-ssl (see
+// native_handlers_tls_test.go).
+//
+// The value can arrive inline or as a file, mirroring CONSOLE_PROXY_CERT and
+// CONSOLE_PROXY_CERT_PATH, because on Kubernetes the CA is a mounted secret.
+
+const testCAPEM = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+
+func TestResolveAutoRegisterCACertUnsetIsEmpty(t *testing.T) {
+	ca, err := resolveAutoRegisterCACert(api.PortalConfig{})
+	require.NoError(t, err)
+	require.Empty(t, ca, "no CA configured must stay empty, not error")
+}
+
+func TestResolveAutoRegisterCACertInline(t *testing.T) {
+	ca, err := resolveAutoRegisterCACert(api.PortalConfig{
+		AutoRegisterCFCACert: testCAPEM,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testCAPEM, ca)
+}
+
+func TestResolveAutoRegisterCACertFromPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(path, []byte(testCAPEM), 0600))
+
+	ca, err := resolveAutoRegisterCACert(api.PortalConfig{
+		AutoRegisterCFCACertPath: path,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testCAPEM, ca)
+}
+
+// Same precedence as detectTLSCert: the file is what a Kubernetes deployment
+// mounts, so it wins over an inline value that may be a leftover default.
+func TestResolveAutoRegisterCACertPathWinsOverInline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(path, []byte(testCAPEM), 0600))
+
+	ca, err := resolveAutoRegisterCACert(api.PortalConfig{
+		AutoRegisterCFCACert:     "-----BEGIN CERTIFICATE-----\nSTALE\n-----END CERTIFICATE-----\n",
+		AutoRegisterCFCACertPath: path,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testCAPEM, ca)
+}
+
+// A configured path that cannot be read is an operator error and must be loud.
+// Falling back to no CA would reproduce exactly the silent x509 failure this
+// exists to prevent.
+func TestResolveAutoRegisterCACertMissingPathErrors(t *testing.T) {
+	_, err := resolveAutoRegisterCACert(api.PortalConfig{
+		AutoRegisterCFCACertPath: filepath.Join(t.TempDir(), "absent.crt"),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absent.crt", "the error must name the file")
+}
+
+// The defect was not that the CA could not be resolved but that it never
+// reached the endpoint: DoRegisterEndpoint takes the CA as the tenth of eleven
+// positional arguments and auto-registration passed a literal "". Resolving the
+// value is useless if it is dropped on the way, so pin the argument itself.
+type autoRegProxy struct {
+	api.PortalProxy
+	config       api.PortalConfig
+	registeredCA string
+	registered   bool
+}
+
+func (m *autoRegProxy) GetConfig() *api.PortalConfig { return &m.config }
+
+func (m *autoRegProxy) GetSessionStringValue(_ *echo.Context, _ string) (string, error) {
+	return "user-1", nil
+}
+
+func (m *autoRegProxy) GetEndpointTypeSpec(_ string) (api.EndpointPlugin, error) {
+	return &CloudFoundrySpecification{}, nil
+}
+
+// No existing record, so the hook takes the auto-register path.
+func (m *autoRegProxy) GetAdminCNSIRecordByEndpoint(_ string) (api.CNSIRecord, error) {
+	return api.CNSIRecord{}, errors.New("not found")
+}
+
+func (m *autoRegProxy) DoRegisterEndpoint(_ string, _ string, _ bool, _ string, _ string, _ string,
+	_ bool, _ string, _ bool, caCert string, _ api.InfoFunc) (api.CNSIRecord, error) {
+	m.registered = true
+	m.registeredCA = caCert
+	return api.CNSIRecord{GUID: "cnsi-1", CNSIType: "cf"}, nil
+}
+
+// Stop after registration — auto-connect is not what is under test.
+func (m *autoRegProxy) GetCNSITokenRecordWithDisconnected(_, _ string) (api.TokenRecord, bool) {
+	return api.TokenRecord{Disconnected: true}, true
+}
+
+func runAutoRegister(t *testing.T, pc api.PortalConfig) *autoRegProxy {
+	t.Helper()
+	pc.AutoRegisterCFUrl = "https://api.cf.example.com"
+
+	proxy := &autoRegProxy{config: pc}
+	ctx := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/", nil), httptest.NewRecorder())
+
+	require.NoError(t, (&CloudFoundrySpecification{portalProxy: proxy}).cfLoginHook(ctx))
+	return proxy
+}
+
+func TestAutoRegisterPassesTheCACert(t *testing.T) {
+	proxy := runAutoRegister(t, api.PortalConfig{AutoRegisterCFCACert: testCAPEM})
+
+	require.True(t, proxy.registered, "the endpoint should have been auto-registered")
+	require.Equal(t, testCAPEM, proxy.registeredCA,
+		"the configured CA must reach the endpoint record, or every read fails with x509")
+}
+
+func TestAutoRegisterWithoutACACertIsUnchanged(t *testing.T) {
+	proxy := runAutoRegister(t, api.PortalConfig{})
+
+	require.True(t, proxy.registered)
+	require.Empty(t, proxy.registeredCA, "no CA configured must stay the previous behaviour")
+}
+
+// An unreadable CA must not register a CA-less endpoint that then fails every
+// read; the hook logs and declines to register.
+func TestAutoRegisterSkipsRegistrationWhenTheCACertIsUnreadable(t *testing.T) {
+	proxy := runAutoRegister(t, api.PortalConfig{
+		AutoRegisterCFCACertPath: filepath.Join(t.TempDir(), "absent.crt"),
+	})
+
+	require.False(t, proxy.registered, "a misconfigured CA must not register a CA-less endpoint")
+}

--- a/src/jetstream/plugins/cloudfoundry/main.go
+++ b/src/jetstream/plugins/cloudfoundry/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/url"
+	"os"
 	"strings"
 
 	"errors"
@@ -249,10 +250,16 @@ func (c *CloudFoundrySpecification) cfLoginHook(context *echo.Context) error {
 			autoRegName = "Cloud Foundry"
 		}
 
-		slog.Info("Auto-registering the Cloud Foundry endpoint", "url", cfAPI, "name", autoRegName)
+		caCert, err := resolveAutoRegisterCACert(*c.portalProxy.GetConfig())
+		if err != nil {
+			slog.Error("could not auto-register the Cloud Foundry endpoint", "url", cfAPI, "err", err)
+			return nil
+		}
+
+		slog.Info("Auto-registering the Cloud Foundry endpoint", "url", cfAPI, "name", autoRegName, "withCACert", caCert != "")
 
 		// Auto-register the Cloud Foundry
-		cfCnsi, err = c.portalProxy.DoRegisterEndpoint(autoRegName, cfAPI, true, c.portalProxy.GetConfig().CFClient, c.portalProxy.GetConfig().CFClientSecret, "", false, "", false, "", cfEndpointSpec.Info)
+		cfCnsi, err = c.portalProxy.DoRegisterEndpoint(autoRegName, cfAPI, true, c.portalProxy.GetConfig().CFClient, c.portalProxy.GetConfig().CFClientSecret, "", false, "", false, caCert, cfEndpointSpec.Info)
 		if err != nil {
 			slog.Error("could not auto-register the Cloud Foundry endpoint", "url", cfAPI, "err", err)
 			return nil
@@ -293,6 +300,28 @@ func (c *CloudFoundrySpecification) cfLoginHook(context *echo.Context) error {
 		}
 	}
 	return nil
+}
+
+// resolveAutoRegisterCACert returns the CA the auto-registered endpoint should
+// trust. Without one, a foundation using a private authority registers fine and
+// then fails every read with x509 while still reporting itself connected
+// (#5922); skip-ssl is not a substitute, as capi will not honour it.
+//
+// A path wins over an inline value and is what a Kubernetes deployment uses,
+// where the CA arrives as a mounted secret — the same precedence detectTLSCert
+// applies to CONSOLE_PROXY_CERT_PATH. A configured path that cannot be read is
+// an error rather than a fallback to no CA, which would resurrect the silent
+// failure this prevents.
+func resolveAutoRegisterCACert(pc api.PortalConfig) (string, error) {
+	if pc.AutoRegisterCFCACertPath == "" {
+		return pc.AutoRegisterCFCACert, nil
+	}
+
+	caPEM, err := os.ReadFile(pc.AutoRegisterCFCACertPath)
+	if err != nil {
+		return "", fmt.Errorf("could not read the auto-registration CA certificate: %w", err)
+	}
+	return string(caPEM), nil
 }
 
 func (c *CloudFoundrySpecification) fetchAutoRegisterEndpoint() (string, api.CNSIRecord, error) {


### PR DESCRIPTION
Closes #5922.

`AUTO_REG_CF_URL` registers a Cloud Foundry endpoint at startup, but there was no way to give that endpoint a CA — `DoRegisterEndpoint` takes the CA as the tenth of eleven positional arguments and auto-registration passed a literal `""`.

On a foundation using a private certificate authority the result is the failure mode #5921 describes: the endpoint registers, reports itself **Connected**, and then fails every read with `x509: certificate signed by unknown authority`, while the same endpoint registered by hand with its CA works. `SKIP_SSL_VALIDATION` is not a substitute — the CF API client gates `SkipTLSVerify` behind `CAPI_DEV_MODE` and documents `CACertPEM` as the supported route, which is why #5921 deliberately does not forward the flag.

## The settings

| Setting | Form |
|---|---|
| `AUTO_REG_CF_CA_CERT` | PEM inline |
| `AUTO_REG_CF_CA_CERT_PATH` | path to a PEM file — takes precedence |

Two settings rather than one value that sniffs its own format follows `CONSOLE_PROXY_CERT` / `CONSOLE_PROXY_CERT_PATH`, which already live in the same config struct, and the precedence matches `detectTLSCert`: the file wins, because that is what a Kubernetes deployment mounts.

A configured path that cannot be read fails the registration rather than falling back to no CA. Falling back would recreate precisely the silent x509 failure this exists to prevent.

## Tests

Written before the change and reverse-tested afterwards, since a test that has only ever been seen passing is unvalidated:

- restoring the hardcoded `""` → `TestAutoRegisterPassesTheCACert` fails
- making the read error fall back silently → both the resolver and the wiring test fail

Five tests cover resolution (unset, inline, path, precedence, unreadable) and three cover the wiring, because resolving a value is useless if it is dropped on the way — and the dropped argument was the entire defect. The wiring tests embed `api.PortalProxy` so only the methods the hook actually calls need bodies.

`make check gate` is green.

## Not in scope here

- **The Helm chart has no CA handling at all** — no secret, no mount, no value. That is the main use case, but wiring it is a separate change, and with the chart's future unsettled (#5907) it would be premature.
- **Auto-registration passes `skipSSLValidation: true`** (third argument, long-standing). Per #5921 that does nothing for native CAPI reads, but it does affect passthrough, so changing it could break existing setups. Left alone deliberately.
- These settings apply when the endpoint is **first registered**. An endpoint already auto-registered without a CA keeps the empty one and must be removed so it registers again — documented.