### PR TITLE
Fail the audit when gosec cannot run at all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -759,14 +759,31 @@ define audit.website
 endef
 $(call register, audit, website)
 
+# gosec exits non-zero both when it finds issues (advisory here, hence the
+# tolerated failure) and when it cannot run at all. Those are not the same
+# thing: a gosec built against an older Go fails every package with
+# "internal error: package ... without types", and `|| true` reported that as
+# a clean audit while nothing was scanned. Findings stay advisory; a scanner
+# that did not run is an error.
+define run_gosec
+	@out=$$(cd $(1) && gosec $(2) ./... 2>&1); \
+	printf '%s\n' "$$out"; \
+	if printf '%s' "$$out" | grep -q 'internal error:'; then \
+		echo "ERROR: gosec could not scan $(1) — it is likely built against an older Go than $$(go env GOVERSION)." >&2; \
+		echo "       Rebuild it: go install github.com/securego/gosec/v2/cmd/gosec@latest" >&2; \
+		exit 1; \
+	fi; \
+	exit 0
+endef
+
 define audit.backend
 	@echo "Running backend security scans..."
 	$(call require_tool,gosec,Run: go install github.com/securego/gosec/v2/cmd/gosec@latest)
 	$(call require_tool,trivy,See https://github.com/aquasecurity/trivy)
 	$(call require_tool,govulncheck,Run: go install golang.org/x/vuln/cmd/govulncheck@latest)
 	@echo "── gosec ──"
-	cd src/jetstream && gosec -quiet ./... || true
-	cd src/jetstream/api && gosec -quiet ./... || true
+	$(call run_gosec,src/jetstream,-quiet)
+	$(call run_gosec,src/jetstream/api,-quiet)
 	@echo "── trivy ──"
 	trivy fs --scanners vuln,misconfig src/jetstream || true
 	@echo "── govulncheck ──"
@@ -890,8 +907,8 @@ $(call register, audit, secrets)
 define audit.tests
 	@echo "Running gosec including test files..."
 	$(call require_tool,gosec,Run: go install github.com/securego/gosec/v2/cmd/gosec@latest)
-	cd src/jetstream && gosec -quiet -tests -track-suppressions ./... || true
-	cd src/jetstream/api && gosec -quiet -tests -track-suppressions ./... || true
+	$(call run_gosec,src/jetstream,-quiet -tests -track-suppressions)
+	$(call run_gosec,src/jetstream/api,-quiet -tests -track-suppressions)
 endef
 $(call register, audit, tests)
 


### PR DESCRIPTION
`make audit backend` and `make audit tests` have been reporting success while scanning **nothing**.

gosec exits non-zero in two very different situations: when it finds issues, and when it cannot run. All four invocations ended in `|| true`, which is right for the first case — findings here are advisory — but it also swallowed the second. A gosec built against an older Go aborts every package with:

```
internal error: package "context" without types was imported from "command-line-arguments"
```

`|| true` turned that into a clean audit. The summary was not "no issues", it was "no scan", and the two are indistinguishable from the output. CI does not run gosec, so nothing else would have caught it.

## The change

Findings stay advisory. A scanner that did not run is now an error, naming the likely cause and the fix:

```
ERROR: gosec could not scan src/jetstream — it is likely built against an older Go than go1.27.0.
       Rebuild it: go install github.com/securego/gosec/v2/cmd/gosec@latest
```

One helper replaces the four repeated invocations.

## Verified both ways

A guard only ever seen passing is unvalidated, so both directions were exercised:

- against the broken gosec → fails, with the diagnostic above (previously: exit 0, silent)
- against a stub producing healthy output → exit 0, guard does not fire

## What it was hiding

Rebuilding gosec and rescanning gives **391 findings in `src/jetstream`** and 2 in `src/jetstream/api`. They are consistent with the last recorded baseline and are dominated by the known noise floor — 261 `G104` unhandled-error plus 84 `G101` hardcoded-credential false positives on constant names, 88% of the total between them.

The HIGH-severity/HIGH-confidence bucket has been reviewed and contains nothing actionable. Worth noting one, since it reads alarming and is not: `G407` on `crypto/aes.go:40` reports a hardcoded IV. gosec traces `make` → slice → IV and misses the `io.ReadFull(rand.Reader, iv)` between them; the IV is random. The remaining HIGH/HIGH hits are the `SKIP_SSL_VALIDATION` feature, a test, and three `G704` "SSRF" findings on endpoint URLs an administrator deliberately registers — which is what a proxy console does.

Findings below that bucket have not had a severity pass yet.