### PR TITLE
Validate two unchecked inputs found in the gosec pass

### DIFF
--- a/src/jetstream/crypto/aes.go
+++ b/src/jetstream/crypto/aes.go
@@ -78,8 +78,15 @@ func Decrypt(key, ciphertext []byte) (plaintext []byte, err error) {
 func ReadEncryptionKey(v, f string) ([]byte, error) {
 	slog.Debug("ReadEncryptionKey")
 
+	// Indexing f[0] to spot an absolute path panics when the filename is
+	// empty, which main.go reaches whenever the volume is configured and the
+	// filename is not.
+	if f == "" {
+		return nil, errors.New("no encryption key filename was configured")
+	}
+
 	encryptionKey := fmt.Sprintf("/%s/%s", v, f)
-	if string(f[0]) == "/" {
+	if strings.HasPrefix(f, "/") {
 		encryptionKey = fmt.Sprintf("%s/%s", v, f)
 	}
 	key64chars, err := os.ReadFile(encryptionKey)

--- a/src/jetstream/crypto/crypto_test.go
+++ b/src/jetstream/crypto/crypto_test.go
@@ -103,3 +103,39 @@ func writeFakeEncryptionKey() error {
 
 	return nil
 }
+
+// ReadEncryptionKey indexed the filename as f[0] to detect an absolute path,
+// which panics on an empty string. main.go reaches it whenever the volume is
+// set and the filename is not — the configuration docs/devops_guide.md shows,
+// since its guard errors only when *neither* is set despite a comment saying
+// it requires both.
+func TestReadEncryptionKeyFilenameHandling(t *testing.T) {
+
+	Convey("Given an encryption key filename that is empty", t, func() {
+
+		Convey("reading it should error rather than panic", func() {
+			So(func() { _, _ = ReadEncryptionKey("/srv/secrets", "") }, ShouldNotPanic)
+
+			_, err := ReadEncryptionKey("/srv/secrets", "")
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "filename")
+		})
+	})
+
+	Convey("Given an absolute encryption key filename", t, func() {
+
+		if err := writeFakeEncryptionKey(); err != nil {
+			log.Fatal(err)
+		}
+
+		Convey("it should resolve without an extra leading separator", func() {
+			result, err := ReadEncryptionKey("", filepath.Join(FakeVolumeName, FakeKeyName))
+			So(err, ShouldBeNil)
+			So(strings.ToUpper(hex.EncodeToString(result)), ShouldResemble, FakeKeyValue)
+		})
+
+		Reset(func() {
+			_ = os.RemoveAll(FakeVolumeName)
+		})
+	})
+}

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -224,13 +224,35 @@ type windowChangeRequestMsg struct {
 	Height  uint32
 }
 
+// maxTerminalDimension caps rows and columns. Well beyond any real terminal,
+// small enough that the pixel size below cannot overflow uint32.
+const maxTerminalDimension = 10000
+
+// windowDimensions clamps the browser-supplied row and column counts. They
+// arrive as JSON over the websocket and are otherwise unvalidated, so a
+// negative value would wrap when converted (-1 becomes 4294967295) and a large
+// one would truncate once multiplied by the cell size.
+func windowDimensions(h, w int) (uint32, uint32) {
+	clamp := func(v int) uint32 {
+		if v < 1 {
+			return 1
+		}
+		if v > maxTerminalDimension {
+			return maxTerminalDimension
+		}
+		return uint32(v)
+	}
+	return clamp(h), clamp(w)
+}
+
 func windowChange(s *ssh.Session, h, w int) error {
+	rows, cols := windowDimensions(h, w)
 
 	req := windowChangeRequestMsg{
-		Columns: uint32(w),
-		Rows:    uint32(h),
-		Width:   uint32(w * 8),
-		Height:  uint32(h * 8),
+		Columns: cols,
+		Rows:    rows,
+		Width:   cols * 8,
+		Height:  rows * 8,
 	}
 	ok, err := s.SendRequest("window-change", true, ssh.Marshal(&req))
 	if err == nil && !ok {

--- a/src/jetstream/plugins/cfappssh/window_change_test.go
+++ b/src/jetstream/plugins/cfappssh/window_change_test.go
@@ -1,0 +1,43 @@
+package cfappssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Rows and Cols arrive as JSON from the browser over the websocket and were
+// converted straight to uint32 with no validation, so a negative value wrapped
+// to a huge one (-1 becomes 4294967295) and a large one truncated once
+// multiplied by the 8-pixel cell size. Clamp instead, so the window-change
+// request sent onward always describes a plausible terminal.
+func TestWindowDimensionsClampsOutOfRangeValues(t *testing.T) {
+	cases := []struct {
+		name       string
+		rows, cols int
+		wantRows   uint32
+		wantCols   uint32
+	}{
+		{"ordinary terminal", 24, 80, 24, 80},
+		{"negative rows", -1, 80, 1, 80},
+		{"negative cols", 24, -1, 24, 1},
+		{"zero rows", 0, 80, 1, 80},
+		{"absurdly large", 1 << 20, 1 << 20, maxTerminalDimension, maxTerminalDimension},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, cols := windowDimensions(tc.rows, tc.cols)
+			require.Equal(t, tc.wantRows, rows)
+			require.Equal(t, tc.wantCols, cols)
+		})
+	}
+}
+
+// The pixel size is the cell count times 8; clamping the count first is what
+// keeps that multiplication from overflowing uint32.
+func TestWindowDimensionsPixelSizeCannotOverflow(t *testing.T) {
+	rows, cols := windowDimensions(1<<20, 1<<20)
+	require.LessOrEqual(t, uint64(cols)*8, uint64(^uint32(0)))
+	require.LessOrEqual(t, uint64(rows)*8, uint64(^uint32(0)))
+}


### PR DESCRIPTION
Two input-validation gaps found while doing the severity pass on the gosec baseline recorded in #5927. Both are unvalidated input reaching a conversion or an index; neither is a privilege issue, but one is a startup crash on a documented configuration.

## An empty encryption key filename panics at startup

`ReadEncryptionKey` indexed the filename as `f[0]` to detect an absolute path, which panics when the filename is empty:

```
runtime error: index out of range [0] with length 0
```

`main.go` reaches it whenever the volume is configured and the filename is not. Its guard errors only when **neither** is set —

```go
// Check we have volume and filename
if len(pc.EncryptionKeyVolume) == 0 && len(pc.EncryptionKeyFilename) == 0 {
```

— despite the comment saying it requires both. And `docs/devops_guide.md` documents exactly the configuration that slips through: `ENCRYPTION_KEY_VOLUME=/srv/secrets` with no `ENCRYPTION_KEY_FILENAME` beside it.

An empty filename is now an error, and the absolute-path test uses `strings.HasPrefix`, so no filename length is assumed. The fix is in `ReadEncryptionKey` rather than the caller, so every route in is covered.

## Terminal dimensions from the browser were unvalidated

`Rows` and `Cols` arrive as JSON from the browser over the app-SSH websocket and went straight into `uint32`:

```go
Columns: uint32(w),
Width:   uint32(w * 8),
```

A negative value wraps — `-1` becomes `4294967295` — and a large one truncates once multiplied by the 8-pixel cell size. gosec flagged the conversions as `G115`; that the input is unvalidated is what made them worth flagging rather than noise.

Clamped to `1..10000` before conversion, which also makes the pixel-size multiplication unable to overflow. `G115` in that package goes from 4 to 0.

The practical impact is small — the result is a malformed window-change request on the user's own authenticated SSH session — but it is unvalidated client input at a trust boundary and the guard is cheap.

## Verified

Both were written as failing tests first and then reverse-tested, since a guard only ever seen passing is unvalidated:

- restoring `f[0]` → the crypto test fails with the original panic
- removing the clamp → four of the five dimension cases fail

`make check gate` is green.

## Also from that pass, needing no change

The remaining `G304` file-inclusion findings are the server reading its own operator-configured files — the encryption key, the TLS cert and key, `index.html`, the config file. Read individually; nothing attacker-controlled.