### PR TITLE
Add the four missing release-notes fragments

### DIFF
--- a/changelog.d/0008-remove-korifi-build-mode.md
+++ b/changelog.d/0008-remove-korifi-build-mode.md
@@ -1,4 +1,4 @@
-[Chores]
+[Maintainability]
 - Removed the `korifi` build modifier and the matching `release-cf.sh`
   mode. Korifi is retired — RFC-0060 was accepted on 2026-07-10 — and CF
   on Kubernetes is its replacement. `make build korifi` was the only

--- a/changelog.d/0010-connect-dialog-auth-config.md
+++ b/changelog.d/0010-connect-dialog-auth-config.md
@@ -1,0 +1,7 @@
+[BugFixes]
+- The endpoint connect dialog overwrote an auth form's default configuration
+  with `undefined` whenever the auth type supplied none, and those templates
+  read fields such as the help text without guarding. Every auth type shipped
+  today supplies a configuration, so nothing was broken in practice — but the
+  field is optional, the form component declares a default for exactly that
+  case, and only coincidence stood between them.

--- a/changelog.d/0011-live-foundation-tests.md
+++ b/changelog.d/0011-live-foundation-tests.md
@@ -1,0 +1,8 @@
+[Chores]
+- Added live-foundation tests for endpoint capability detection. A Cloud
+  Foundry with the V2 API disabled still answers 200 from `/v2/info`, so the
+  behaviour could not be reproduced from fixtures and had to be confirmed
+  against real foundations. Each test skips unless its foundation is named in
+  `STRATOS_LIVE_CF` or `STRATOS_LIVE_CF_V2OFF`, so an ordinary test run is
+  unaffected, and the expectations are read from what the foundation itself
+  advertises rather than any particular installation's values.

--- a/changelog.d/0012-audit-gosec-not-run.md
+++ b/changelog.d/0012-audit-gosec-not-run.md
@@ -1,0 +1,7 @@
+[Chores]
+- `make audit backend` and `make audit tests` reported success when the gosec
+  scanner had not run at all. gosec exits non-zero both when it finds issues
+  and when it cannot start, and every invocation tolerated failure so findings
+  stayed advisory — which also hid a scanner built against an older Go
+  aborting on every package. Findings remain advisory; a scanner that did not
+  run is now an error naming the cause and the rebuild command.

--- a/changelog.d/0013-input-validation-gaps.md
+++ b/changelog.d/0013-input-validation-gaps.md
@@ -1,0 +1,11 @@
+[BugFixes]
+- Jetstream crashed at startup when `ENCRYPTION_KEY_VOLUME` was configured
+  without `ENCRYPTION_KEY_FILENAME`. The filename was indexed before being
+  checked, so an empty one raised an index-out-of-range panic, and the guard
+  meant to require both settings only rejected the case where neither was
+  given. That combination is what the DevOps guide's own example showed. An
+  empty filename is now a clear error.
+- Terminal dimensions sent by the browser to the application SSH session were
+  used without validation, so a negative value wrapped to a very large one and
+  an oversized value was truncated when converted for the window-change
+  request. Rows and columns are now clamped to a sensible range.


### PR DESCRIPTION
`changelog.d/README.md` opens with "Each PR carries its own release-notes fragment here", but four PRs merged this week without one:

| PR | Fragment |
|---|---|
| #5924 connect dialog auth config | `0010-connect-dialog-auth-config.md` |
| #5926 live-foundation tests | `0011-live-foundation-tests.md` |
| #5927 gosec cannot run | `0012-audit-gosec-not-run.md` |
| #5928 input validation gaps | `0013-input-validation-gaps.md` |

The fragment check is advisory, so nothing blocked at merge time — these would simply have been missing from the next release's notes. Nothing has been released since `v5.5.3`, and fragments accumulate until `make sweep` runs at an official release, so adding them now reads identically to having added them per PR.

The entry that most needed writing is the encryption-key one: an operator who hit that startup panic — on the configuration the DevOps guide itself shows — would want to see it in the notes.

## Also: the korifi removal moves to Maintainability

`0008` was filed under `[Chores]`. Per the section table in the README, retiring an archived project is what `[Maintainability]` is for — "retiring an unmaintained or archived dependency" — while `[Chores]` covers routine dependency, CI and docs work. Moving it also makes that section appear in the assembled notes, where Korifi's retirement is more visible than it would be among the chores.

## Verified

`./build/release-notes.sh assemble` produces all five sections — Features, Bug Fixes, Maintainability, Chores, Security Updates — with the new entries in place. `make check gate` is green.